### PR TITLE
Convert stories to CSF3

### DIFF
--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
@@ -71,20 +71,22 @@ class MockPanelCatalog implements PanelCatalog {
   }
 }
 
-export const Basic: StoryFn = (): JSX.Element => {
-  const providers = [
-    /* eslint-disable react/jsx-key */
-    <PanelSetup>{undefined}</PanelSetup>,
-    <EventsProvider />,
-    <PanelCatalogContext.Provider value={new MockPanelCatalog()} />,
-    <MockCurrentLayoutProvider initialState={{ layout: "Fake" }} />,
-    /* eslint-enable react/jsx-key */
-  ];
-  return (
-    <MultiProvider providers={providers}>
-      <Workspace />
-    </MultiProvider>
-  );
+export const Basic: StoryObj = {
+  render: (): JSX.Element => {
+    const providers = [
+      /* eslint-disable react/jsx-key */
+      <PanelSetup>{undefined}</PanelSetup>,
+      <EventsProvider />,
+      <PanelCatalogContext.Provider value={new MockPanelCatalog()} />,
+      <MockCurrentLayoutProvider initialState={{ layout: "Fake" }} />,
+      /* eslint-enable react/jsx-key */
+    ];
+    return (
+      <MultiProvider providers={providers}>
+        <Workspace />
+      </MultiProvider>
+    );
+  },
 };
 
 export const FullscreenPanel = {

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
@@ -29,13 +29,13 @@ export default {
     colorScheme: "light",
   },
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       const storage = new MockLayoutStorage(LayoutManager.LOCAL_STORAGE_NAMESPACE, []);
 
       return (
         <LayoutStorageContext.Provider value={storage}>
           <LayoutManagerProvider>
-            <StoryFn />
+            <Wrapped />
           </LayoutManagerProvider>
         </LayoutStorageContext.Provider>
       );
@@ -87,7 +87,9 @@ export function Basic(): JSX.Element {
   );
 }
 
-export const FullscreenPanel = Basic.bind({});
+export const FullscreenPanel = {
+  render: Basic,
+};
 Object.assign(FullscreenPanel, {
   play: async () => {
     fireEvent.click(await screen.findByTestId("panel-menu"));

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -71,7 +71,7 @@ class MockPanelCatalog implements PanelCatalog {
   }
 }
 
-export function Basic(): JSX.Element {
+export const Basic: StoryFn = (): JSX.Element => {
   const providers = [
     /* eslint-disable react/jsx-key */
     <PanelSetup>{undefined}</PanelSetup>,
@@ -85,7 +85,7 @@ export function Basic(): JSX.Element {
       <Workspace />
     </MultiProvider>
   );
-}
+};
 
 export const FullscreenPanel = {
   render: Basic,

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -72,7 +72,7 @@ class MockPanelCatalog implements PanelCatalog {
 }
 
 export const Basic: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     const providers = [
       /* eslint-disable react/jsx-key */
       <PanelSetup>{undefined}</PanelSetup>,
@@ -89,12 +89,10 @@ export const Basic: StoryObj = {
   },
 };
 
-export const FullscreenPanel = {
-  render: Basic,
-};
-Object.assign(FullscreenPanel, {
+export const FullscreenPanel: StoryObj = {
+  ...Basic,
   play: async () => {
     fireEvent.click(await screen.findByTestId("panel-menu"));
     fireEvent.click(await screen.findByTestId("panel-menu-fullscreen"));
   },
-});
+};

--- a/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.stories.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.stories.tsx
@@ -11,25 +11,27 @@ export default {
   component: AccountInfo,
 };
 
-export const SignedIn = (): JSX.Element => {
-  const org: User["org"] = {
-    id: "fake-orgid",
-    slug: "fake-org",
-    displayName: "Fake Org",
-    isEnterprise: false,
-    allowsUploads: false,
-    supportsEdgeSites: false,
-  };
+export const SignedIn = {
+  render: (): JSX.Element => {
+    const org: User["org"] = {
+      id: "fake-orgid",
+      slug: "fake-org",
+      displayName: "Fake Org",
+      isEnterprise: false,
+      allowsUploads: false,
+      supportsEdgeSites: false,
+    };
 
-  const me = {
-    id: "fake-userid",
-    orgId: org.id,
-    orgDisplayName: org.displayName,
-    orgSlug: org.slug,
-    orgPaid: false,
-    email: "foo@example.com",
-    org,
-  };
+    const me = {
+      id: "fake-userid",
+      orgId: org.id,
+      orgDisplayName: org.displayName,
+      orgSlug: org.slug,
+      orgPaid: false,
+      email: "foo@example.com",
+      org,
+    };
 
-  return <AccountInfo currentUser={me} />;
+    return <AccountInfo currentUser={me} />;
+  },
 };

--- a/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.stories.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
+
 import { User } from "@foxglove/studio-base/context/CurrentUserContext";
 
 import AccountInfo from "./AccountInfo";
@@ -11,8 +13,8 @@ export default {
   component: AccountInfo,
 };
 
-export const SignedIn = {
-  render: (): JSX.Element => {
+export const SignedIn: StoryObj = {
+  render: () => {
     const org: User["org"] = {
       id: "fake-orgid",
       slug: "fake-org",

--- a/packages/studio-base/src/components/AppBar/AddPanel.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/AddPanel.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <>
         <AddPanelMenu

--- a/packages/studio-base/src/components/AppBar/AddPanel.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/AddPanel.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { AddPanelMenu } from "./AddPanelMenu";
 import { StorybookDecorator } from "./StorybookDecorator.stories";
@@ -13,18 +13,20 @@ export default {
   decorators: [StorybookDecorator],
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <>
-      <AddPanelMenu
-        open
-        anchorReference="anchorPosition"
-        anchorPosition={{ left: 0, top: 0 }}
-        disablePortal
-        handleClose={() => {
-          // no-op
-        }}
-      />
-    </>
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <>
+        <AddPanelMenu
+          open
+          anchorReference="anchorPosition"
+          anchorPosition={{ left: 0, top: 0 }}
+          disablePortal
+          handleClose={() => {
+            // no-op
+          }}
+        />
+      </>
+    );
+  },
 };

--- a/packages/studio-base/src/components/AppBar/AddPanel.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/AddPanel.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { AddPanelMenu } from "./AddPanelMenu";
 import { StorybookDecorator } from "./StorybookDecorator.stories";
 
@@ -11,7 +13,7 @@ export default {
   decorators: [StorybookDecorator],
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <>
       <AddPanelMenu
@@ -25,4 +27,4 @@ export function Default(): JSX.Element {
       />
     </>
   );
-}
+};

--- a/packages/studio-base/src/components/AppBar/Help.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/Help.stories.tsx
@@ -14,7 +14,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <>
         <HelpMenu

--- a/packages/studio-base/src/components/AppBar/Help.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/Help.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { HelpMenu } from "./HelpMenu";
 import { StorybookDecorator } from "./StorybookDecorator.stories";
 
@@ -11,7 +13,7 @@ export default {
   decorators: [StorybookDecorator],
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <>
       <HelpMenu
@@ -25,4 +27,4 @@ export function Default(): JSX.Element {
       />
     </>
   );
-}
+};

--- a/packages/studio-base/src/components/AppBar/Help.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/Help.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { HelpMenu } from "./HelpMenu";
 import { StorybookDecorator } from "./StorybookDecorator.stories";
@@ -13,18 +13,20 @@ export default {
   decorators: [StorybookDecorator],
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <>
-      <HelpMenu
-        open
-        anchorReference="anchorPosition"
-        anchorPosition={{ left: 0, top: 0 }}
-        disablePortal
-        handleClose={() => {
-          // no-op
-        }}
-      />
-    </>
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <>
+        <HelpMenu
+          open
+          anchorReference="anchorPosition"
+          anchorPosition={{ left: 0, top: 0 }}
+          disablePortal
+          handleClose={() => {
+            // no-op
+          }}
+        />
+      </>
+    );
+  },
 };

--- a/packages/studio-base/src/components/AppBar/StorybookDecorator.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/StorybookDecorator.stories.tsx
@@ -4,7 +4,7 @@
 
 /* eslint-disable storybook/story-exports */
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -65,14 +65,14 @@ export default {
   excludeStories: ["StorybookDecorator"],
 };
 
-export function StorybookDecorator(StoryFn: Story): JSX.Element {
+export function StorybookDecorator(Wrapped: StoryFn): JSX.Element {
   return (
     <DndProvider backend={HTML5Backend}>
       <WorkspaceContextProvider>
         <PanelCatalogContext.Provider value={new MockPanelCatalog()}>
           <MockCurrentLayoutProvider>
             <MockMessagePipelineProvider>
-              <StoryFn />
+              <Wrapped />
             </MockMessagePipelineProvider>
           </MockCurrentLayoutProvider>
         </PanelCatalogContext.Provider>

--- a/packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
+
 import { AppBar } from "@foxglove/studio-base/components/AppBar";
 import { StorybookDecorator } from "@foxglove/studio-base/components/AppBar/StorybookDecorator.stories";
 import { UserMenu } from "@foxglove/studio-base/components/AppBar/UserMenu";
@@ -73,12 +75,12 @@ function SignInStates(): JSX.Element {
   );
 }
 
-export const Dark = {
-  render: (): JSX.Element => <SignInStates />,
+export const Dark: StoryObj = {
+  render: () => <SignInStates />,
   parameters: { colorScheme: "dark" },
 };
 
-export const Light = {
-  render: (): JSX.Element => <SignInStates />,
+export const Light: StoryObj = {
+  render: () => <SignInStates />,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
@@ -73,8 +73,12 @@ function SignInStates(): JSX.Element {
   );
 }
 
-export const Dark = (): JSX.Element => <SignInStates />;
-Dark.parameters = { colorScheme: "dark" };
+export const Dark = {
+  render: (): JSX.Element => <SignInStates />,
+  parameters: { colorScheme: "dark" },
+};
 
-export const Light = (): JSX.Element => <SignInStates />;
-Light.parameters = { colorScheme: "light" };
+export const Light = {
+  render: (): JSX.Element => <SignInStates />,
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -37,9 +37,7 @@ export const Default: StoryFn = (): JSX.Element => {
   return <AppBar {...actions} />;
 };
 
-export const DefaultChinese = Object.assign(Default.bind(undefined), {
-  parameters: { forceLanguage: "zh" },
-});
+export const DefaultChinese = { ...Default, parameters: { forceLanguage: "zh" } };
 
 export const CustomWindowControls: StoryFn = (): JSX.Element => {
   return <AppBar showCustomWindowControls {...actions} />;
@@ -120,9 +118,7 @@ export const SignInStates: StoryFn = (): JSX.Element => {
   );
 };
 
-export const SignInStatesChinese = Object.assign(SignInStates.bind(undefined), {
-  parameters: { forceLanguage: "zh" },
-});
+export const SignInStatesChinese = { ...SignInStates, parameters: { forceLanguage: "zh" } };
 
 export const PlayerStates: StoryObj = {
   render: function Story(): JSX.Element {
@@ -183,9 +179,10 @@ export const PlayerStates: StoryObj = {
   parameters: { colorScheme: "light" },
 };
 
-export const PlayerStatesChinese = Object.assign(PlayerStates.bind(undefined), {
-  parameters: { olorScheme: "light", forceLanguage: "zh" },
-});
+export const PlayerStatesChinese = {
+  ...PlayerStates,
+  parameters: { colorScheme: "light", forceLanguage: "zh" },
+};
 
 export const DataSources: StoryObj = {
   render: function Story(): JSX.Element {
@@ -252,6 +249,7 @@ export const DataSources: StoryObj = {
   parameters: { colorScheme: "light" },
 };
 
-export const DataSourcesChinese = Object.assign(DataSources.bind(undefined), {
+export const DataSourcesChinese = {
+  ...DataSources,
   parameters: { colorScheme: "light", forceLanguage: "zh" },
-});
+};

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
+import { StoryFn } from "@storybook/react";
 
 import { AppBar } from "@foxglove/studio-base/components/AppBar";
 import { StorybookDecorator } from "@foxglove/studio-base/components/AppBar/StorybookDecorator.stories";
@@ -32,24 +33,24 @@ const actions = {
   setPrefsDialogOpen: action("setPrefsDialogOpen"),
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return <AppBar {...actions} />;
-}
+};
 export const DefaultChinese = Object.assign(Default.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
 
-export function CustomWindowControls(): JSX.Element {
+export const CustomWindowControls: StoryFn = (): JSX.Element => {
   return <AppBar showCustomWindowControls {...actions} />;
-}
+};
 
-export function CustomWindowControlsMaximized(): JSX.Element {
+export const CustomWindowControlsMaximized: StoryFn = (): JSX.Element => {
   return <AppBar showCustomWindowControls isMaximized {...actions} />;
-}
+};
 
-export function CustomWindowControlsDragRegion(): JSX.Element {
+export const CustomWindowControlsDragRegion: StoryFn = (): JSX.Element => {
   return <AppBar showCustomWindowControls debugDragRegion {...actions} />;
-}
+};
 
 function LabeledAppBar({ label }: React.PropsWithChildren<{ label: string }>) {
   return (
@@ -62,7 +63,7 @@ function LabeledAppBar({ label }: React.PropsWithChildren<{ label: string }>) {
   );
 }
 
-export function SignInStates(): JSX.Element {
+export const SignInStates: StoryFn = (): JSX.Element => {
   const currentUser: User = {
     id: "user-1",
     email: "user@example.com",
@@ -116,12 +117,12 @@ export function SignInStates(): JSX.Element {
       </CurrentUserContext.Provider>
     </div>
   );
-}
+};
 export const SignInStatesChinese = Object.assign(SignInStates.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
 
-export function PlayerStates(): JSX.Element {
+export const PlayerStates: StoryFn = (): JSX.Element => {
   return (
     <Stack overflowY="auto">
       <div
@@ -174,13 +175,13 @@ export function PlayerStates(): JSX.Element {
       </div>
     </Stack>
   );
-}
+};
 PlayerStates.parameters = { colorScheme: "light" };
 export const PlayerStatesChinese = Object.assign(PlayerStates.bind(undefined), {
   parameters: { olorScheme: "light", forceLanguage: "zh" },
 });
 
-export function DataSources(): JSX.Element {
+export const DataSources: StoryFn = (): JSX.Element => {
   return (
     <Stack overflowY="auto">
       <div
@@ -239,7 +240,7 @@ export function DataSources(): JSX.Element {
       </div>
     </Stack>
   );
-}
+};
 DataSources.parameters = { colorScheme: "light" };
 export const DataSourcesChinese = Object.assign(DataSources.bind(undefined), {
   parameters: { colorScheme: "light", forceLanguage: "zh" },

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -34,27 +34,27 @@ const actions = {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppBar {...actions} />;
   },
 };
 
-export const DefaultChinese = { ...Default, parameters: { forceLanguage: "zh" } };
+export const DefaultChinese: StoryObj = { ...Default, parameters: { forceLanguage: "zh" } };
 
 export const CustomWindowControls: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppBar showCustomWindowControls {...actions} />;
   },
 };
 
 export const CustomWindowControlsMaximized: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppBar showCustomWindowControls isMaximized {...actions} />;
   },
 };
 
 export const CustomWindowControlsDragRegion: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppBar showCustomWindowControls debugDragRegion {...actions} />;
   },
 };
@@ -71,7 +71,7 @@ function LabeledAppBar({ label }: React.PropsWithChildren<{ label: string }>) {
 }
 
 export const SignInStates: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     const currentUser: User = {
       id: "user-1",
       email: "user@example.com",
@@ -130,10 +130,13 @@ export const SignInStates: StoryObj = {
   },
 };
 
-export const SignInStatesChinese = { ...SignInStates, parameters: { forceLanguage: "zh" } };
+export const SignInStatesChinese: StoryObj = {
+  ...SignInStates,
+  parameters: { forceLanguage: "zh" },
+};
 
 export const PlayerStates: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <Stack overflowY="auto">
         <div
@@ -191,13 +194,13 @@ export const PlayerStates: StoryObj = {
   parameters: { colorScheme: "light" },
 };
 
-export const PlayerStatesChinese = {
+export const PlayerStatesChinese: StoryObj = {
   ...PlayerStates,
   parameters: { colorScheme: "light", forceLanguage: "zh" },
 };
 
 export const DataSources: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <Stack overflowY="auto">
         <div
@@ -261,7 +264,7 @@ export const DataSources: StoryObj = {
   parameters: { colorScheme: "light" },
 };
 
-export const DataSourcesChinese = {
+export const DataSourcesChinese: StoryObj = {
   ...DataSources,
   parameters: { colorScheme: "light", forceLanguage: "zh" },
 };

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { AppBar } from "@foxglove/studio-base/components/AppBar";
 import { StorybookDecorator } from "@foxglove/studio-base/components/AppBar/StorybookDecorator.stories";
@@ -33,22 +33,30 @@ const actions = {
   setPrefsDialogOpen: action("setPrefsDialogOpen"),
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return <AppBar {...actions} />;
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppBar {...actions} />;
+  },
 };
 
 export const DefaultChinese = { ...Default, parameters: { forceLanguage: "zh" } };
 
-export const CustomWindowControls: StoryFn = (): JSX.Element => {
-  return <AppBar showCustomWindowControls {...actions} />;
+export const CustomWindowControls: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppBar showCustomWindowControls {...actions} />;
+  },
 };
 
-export const CustomWindowControlsMaximized: StoryFn = (): JSX.Element => {
-  return <AppBar showCustomWindowControls isMaximized {...actions} />;
+export const CustomWindowControlsMaximized: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppBar showCustomWindowControls isMaximized {...actions} />;
+  },
 };
 
-export const CustomWindowControlsDragRegion: StoryFn = (): JSX.Element => {
-  return <AppBar showCustomWindowControls debugDragRegion {...actions} />;
+export const CustomWindowControlsDragRegion: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppBar showCustomWindowControls debugDragRegion {...actions} />;
+  },
 };
 
 function LabeledAppBar({ label }: React.PropsWithChildren<{ label: string }>) {
@@ -62,60 +70,64 @@ function LabeledAppBar({ label }: React.PropsWithChildren<{ label: string }>) {
   );
 }
 
-export const SignInStates: StoryFn = (): JSX.Element => {
-  const currentUser: User = {
-    id: "user-1",
-    email: "user@example.com",
-    orgId: "org_id",
-    orgDisplayName: "Orgalorg",
-    orgSlug: "org",
-    orgPaid: false,
-    org: {
-      id: "org_id",
-      slug: "org",
-      displayName: "Orgalorg",
-      isEnterprise: false,
-      allowsUploads: true,
-      supportsEdgeSites: false,
-    },
-  };
+export const SignInStates: StoryObj = {
+  render: (): JSX.Element => {
+    const currentUser: User = {
+      id: "user-1",
+      email: "user@example.com",
+      orgId: "org_id",
+      orgDisplayName: "Orgalorg",
+      orgSlug: "org",
+      orgPaid: false,
+      org: {
+        id: "org_id",
+        slug: "org",
+        displayName: "Orgalorg",
+        isEnterprise: false,
+        allowsUploads: true,
+        supportsEdgeSites: false,
+      },
+    };
 
-  return (
-    <div style={{ display: "grid", gridTemplateColumns: "max-content auto", alignItems: "center" }}>
-      <LabeledAppBar label="sign in undefined" />
-      <CurrentUserContext.Provider
-        value={{
-          currentUser: undefined,
-          signIn: () => undefined,
-          signOut: async () => undefined,
-        }}
+    return (
+      <div
+        style={{ display: "grid", gridTemplateColumns: "max-content auto", alignItems: "center" }}
       >
-        <LabeledAppBar label="no user present" />
-      </CurrentUserContext.Provider>
-      <CurrentUserContext.Provider
-        value={{
-          currentUser,
-          signIn: () => undefined,
-          signOut: async () => undefined,
-        }}
-      >
-        <LabeledAppBar label="user present" />
-      </CurrentUserContext.Provider>
-      <CurrentUserContext.Provider
-        value={{
-          currentUser: {
-            ...currentUser,
-            avatarImageUrl:
-              "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCARXhpZgAATU0AKgAAAAgABAESAAMAAAABAAEAAAEaAAUAAAABAAAAPgEbAAUAAAABAAAARodpAAQAAAABAAAATgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAECgAwAEAAAAAQAAAEAAAAAA/8AAEQgAQABAAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMAAgICAgICAwICAwUDAwMFBgUFBQUGCAYGBgYGCAoICAgICAgKCgoKCgoKCgwMDAwMDA4ODg4ODw8PDw8PDw8PD//bAEMBAgICBAQEBwQEBxALCQsQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEP/dAAQABP/aAAwDAQACEQMRAD8A8VIAoApT0pNwr89SPyC9wwDwOtchoes3Gp+Ib2NpFFts3W8X8XkxOYTMRgHEswcL1BWMEHmutlLRQPc+WzpHjJUdN2cfyP0Aya8Vkh8VeF/FD+JvEGlzaZbXNjFpNlHIo3tIjGbeQOikH5CerELgMQD3YXD80Zd+h72V5fKpSqT5emmnnqex3uqabp2wXtykTSyLCinJd5XBKRoigszsASqqCxAJAxVt7fVbe4li1LTptPRSBH9owksuQCW8rJdFGQP3m1ic/Ljk6vgO8Om+JIb3SJYb/UdCt5baKGA+YYL6/wBsl5cSNgjzAgSG3Tl1jBZ2AfAk1lrybUp5L/mfcdwzuK+xPc9ye5ya5asOV8tjtzHLsNhsOlJ81V/cvu6/8OY+31pJU+Q/Spcc0kn3GPsaxPmGj//Q8UPWjy3lZUTJPovU1MVBr6//AGcPhVpGvbPFmuRCYW82YlLkAFPVOh57mvzqtiFSi5s/M8kyyrjK6oUt3+CPju18RaRo+jPb/EDwpqkN5odpdB7tYGkt7xtQlMcEqxRFpmRUwBmIAOOGwOflrUvF3hf4r3uo6Zq2o3ujaujS3qaktpLcMJbWDy4tyofNEjxt5e0ABcB8qRz+qf7XfjfWtL8RT6V4T8JXWrXek2USRzWvkxhZZgZIxKzukixAjhow4J3DAIBr8jNV8C+KE0HVNc13xWtg+oySRy29sPLtmj3FVQkbSqsCQfm+YcEt1r28kqxqQ9pLRvbW9r66fn2P1TG0YYblpbpaaK17eh+3H7KvwT8Bah8I/B/jGGB4k1vTLa9+z7fLCCdQ20nqec/Nn5vvHrXrXxD/AGevCuu2Mp0eNNPndf8AWZBAIOeFx1PrXwp+xB+2vpv9mQfCD4362LTWIZ1t9G1G8Ty47m2YYignlGFWRSpETsqCRCoGXDZ/X10MybiBzivhs2+s0MRL2l97rs1+p9BhMnwFXDqEYJp797+u5+Mfj7wHq3gHWW0nVCjk/MkkZyGUk49Oa4J8BGB6YNfdP7VvhyGKGDWYQ0spb5ztGEQcZZjzgk4AHevhO4JEbfQ16uEre0pqR+L8Q5YsJi50I7Lb0Z//0fHU5Ir1jR/jh8SvC+g6x4T+GWkwR6TpcbTz+KrsvJGsGzzG+zQCMq0gG7CbmaMKWkUZUN5MDg8cV9zfBbR/BPjr4dReC/GmnWmu2Yka4+yXkazIrZIztPHIzkdwcHOa/Nq9anCPNUhzL+tfP56dz5XgVc2JlTi+WTWj/T5999ND8otb+L2uaHod/rWq3niXX4fE0rhNbvUnihvNm4+TaXMgUGHOSFR/UgBBtHzxrfxHk1XQLPTYUYuS/nb8lVIOEKZ4OVPPHBBI61/TH8Qfhh4P+Jfw31H4X6/B5OjX9v5EYtlRGtSuDHJANpVHiYBkwMDFfmW/7FXw8s5tQ0ERFdT0mcv9oWdpVnwNyBwWGF5BZOAOnANeplvE2EabnHld/XTo+h+g5jw5WUlyvm/zPzn8H/DUeLLafWNWvircgqjhpGO35g4cHjGPlyeMZ44r9Kf2Bf2tvFCeK4/2fvipqU2oWV2zQeHb26VjPDLErMLOWU8vFJGpaBnyysChZgY6+eb74b638ONYuIPGJt9YaeN2E8RUrgj5xtbLLwPuEnjuRivln4q3LeF/EcfiDw/ftbahp9zHcWhDfPEbUeZAyJyP3cgUqcdBjpwfWxVCnjqcqbd01o+x4mAxVTDYi34H9A/7VEUj+D/MVJXw6jhlCAZySQeSR6DtX5v3J/dPj0NfYHxP+Kw8dfCXQ9ccoo8UabYX0alTvBuI0lbb3BPIPtXx/ccwvj0NfF5dRlTpckt0fMccV4VMe5Q7I//S8aPBFeseDfjHH4J02axt0c3KxuqkFVAY4PXGTjrz9K8owetc1faCLuWSQy4VyTjbyMjBwQa/P6dOlP3ar0PzDK8dKhU54Ssz7i079qawjjeS6BiKFjvbmNVGSCemAABnPOe1fHf7LnjXTYdW8VTapeFPFmuanJNfvPN+7n3yPKJNjHCgq4JwM7QqEkKK8Y8d/D/xb43vreZdUtdMigyrmCGVWlT5Nm5fM2AoEwpA7sepNWPD/wAOT4RKT6FY6fJe9JL26M0ty+ep3kEjPoOO1b08BhYUZwhLWVvlb9D7+HFzjKLnU57bdDM+K3xMu7DxJrum6pG63cV480N1tMiy20x3B/YnlMD05x0r4d8QatFqupzXLDYk5YH+JyGBBPJHQHIXOPpkmvq34z6Rda/riL4b0q/1G6dBvu7eGe2MYBH7uQSkRSlhkkqPl6ZJrg/DXwn8Y+TqVrqvhgvBqVqkALSxQyxyLJ5iz7hu+df7uMMOG4r6nC1qUKSd0n6pCni6UZObkr+q/wAz768C/tJeF/jRrN98PdO0JNI8J+HdAX+yvtSxtfm4tkRHld4iyRqAQoRWPqTlsDMlLeQxPXb/AEr5++E3w017wFc3V35SJPeJ5Ukry78RZzsVEAHJ5JJzX0PMAYmwe1fKY2jRpytRenr+PzPm+JcfTxFSEotNq92vlZfI/9k=",
-          },
-          signIn: () => undefined,
-          signOut: async () => undefined,
-        }}
-      >
-        <LabeledAppBar label="user present with avatar" />
-      </CurrentUserContext.Provider>
-    </div>
-  );
+        <LabeledAppBar label="sign in undefined" />
+        <CurrentUserContext.Provider
+          value={{
+            currentUser: undefined,
+            signIn: () => undefined,
+            signOut: async () => undefined,
+          }}
+        >
+          <LabeledAppBar label="no user present" />
+        </CurrentUserContext.Provider>
+        <CurrentUserContext.Provider
+          value={{
+            currentUser,
+            signIn: () => undefined,
+            signOut: async () => undefined,
+          }}
+        >
+          <LabeledAppBar label="user present" />
+        </CurrentUserContext.Provider>
+        <CurrentUserContext.Provider
+          value={{
+            currentUser: {
+              ...currentUser,
+              avatarImageUrl:
+                "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QCARXhpZgAATU0AKgAAAAgABAESAAMAAAABAAEAAAEaAAUAAAABAAAAPgEbAAUAAAABAAAARodpAAQAAAABAAAATgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAECgAwAEAAAAAQAAAEAAAAAA/8AAEQgAQABAAwEiAAIRAQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMBAQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYSQVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNUVVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMAAgICAgICAwICAwUDAwMFBgUFBQUGCAYGBgYGCAoICAgICAgKCgoKCgoKCgwMDAwMDA4ODg4ODw8PDw8PDw8PD//bAEMBAgICBAQEBwQEBxALCQsQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEP/dAAQABP/aAAwDAQACEQMRAD8A8VIAoApT0pNwr89SPyC9wwDwOtchoes3Gp+Ib2NpFFts3W8X8XkxOYTMRgHEswcL1BWMEHmutlLRQPc+WzpHjJUdN2cfyP0Aya8Vkh8VeF/FD+JvEGlzaZbXNjFpNlHIo3tIjGbeQOikH5CerELgMQD3YXD80Zd+h72V5fKpSqT5emmnnqex3uqabp2wXtykTSyLCinJd5XBKRoigszsASqqCxAJAxVt7fVbe4li1LTptPRSBH9owksuQCW8rJdFGQP3m1ic/Ljk6vgO8Om+JIb3SJYb/UdCt5baKGA+YYL6/wBsl5cSNgjzAgSG3Tl1jBZ2AfAk1lrybUp5L/mfcdwzuK+xPc9ye5ya5asOV8tjtzHLsNhsOlJ81V/cvu6/8OY+31pJU+Q/Spcc0kn3GPsaxPmGj//Q8UPWjy3lZUTJPovU1MVBr6//AGcPhVpGvbPFmuRCYW82YlLkAFPVOh57mvzqtiFSi5s/M8kyyrjK6oUt3+CPju18RaRo+jPb/EDwpqkN5odpdB7tYGkt7xtQlMcEqxRFpmRUwBmIAOOGwOflrUvF3hf4r3uo6Zq2o3ujaujS3qaktpLcMJbWDy4tyofNEjxt5e0ABcB8qRz+qf7XfjfWtL8RT6V4T8JXWrXek2USRzWvkxhZZgZIxKzukixAjhow4J3DAIBr8jNV8C+KE0HVNc13xWtg+oySRy29sPLtmj3FVQkbSqsCQfm+YcEt1r28kqxqQ9pLRvbW9r66fn2P1TG0YYblpbpaaK17eh+3H7KvwT8Bah8I/B/jGGB4k1vTLa9+z7fLCCdQ20nqec/Nn5vvHrXrXxD/AGevCuu2Mp0eNNPndf8AWZBAIOeFx1PrXwp+xB+2vpv9mQfCD4362LTWIZ1t9G1G8Ty47m2YYignlGFWRSpETsqCRCoGXDZ/X10MybiBzivhs2+s0MRL2l97rs1+p9BhMnwFXDqEYJp797+u5+Mfj7wHq3gHWW0nVCjk/MkkZyGUk49Oa4J8BGB6YNfdP7VvhyGKGDWYQ0spb5ztGEQcZZjzgk4AHevhO4JEbfQ16uEre0pqR+L8Q5YsJi50I7Lb0Z//0fHU5Ir1jR/jh8SvC+g6x4T+GWkwR6TpcbTz+KrsvJGsGzzG+zQCMq0gG7CbmaMKWkUZUN5MDg8cV9zfBbR/BPjr4dReC/GmnWmu2Yka4+yXkazIrZIztPHIzkdwcHOa/Nq9anCPNUhzL+tfP56dz5XgVc2JlTi+WTWj/T5999ND8otb+L2uaHod/rWq3niXX4fE0rhNbvUnihvNm4+TaXMgUGHOSFR/UgBBtHzxrfxHk1XQLPTYUYuS/nb8lVIOEKZ4OVPPHBBI61/TH8Qfhh4P+Jfw31H4X6/B5OjX9v5EYtlRGtSuDHJANpVHiYBkwMDFfmW/7FXw8s5tQ0ERFdT0mcv9oWdpVnwNyBwWGF5BZOAOnANeplvE2EabnHld/XTo+h+g5jw5WUlyvm/zPzn8H/DUeLLafWNWvircgqjhpGO35g4cHjGPlyeMZ44r9Kf2Bf2tvFCeK4/2fvipqU2oWV2zQeHb26VjPDLErMLOWU8vFJGpaBnyysChZgY6+eb74b638ONYuIPGJt9YaeN2E8RUrgj5xtbLLwPuEnjuRivln4q3LeF/EcfiDw/ftbahp9zHcWhDfPEbUeZAyJyP3cgUqcdBjpwfWxVCnjqcqbd01o+x4mAxVTDYi34H9A/7VEUj+D/MVJXw6jhlCAZySQeSR6DtX5v3J/dPj0NfYHxP+Kw8dfCXQ9ccoo8UabYX0alTvBuI0lbb3BPIPtXx/ccwvj0NfF5dRlTpckt0fMccV4VMe5Q7I//S8aPBFeseDfjHH4J02axt0c3KxuqkFVAY4PXGTjrz9K8owetc1faCLuWSQy4VyTjbyMjBwQa/P6dOlP3ar0PzDK8dKhU54Ssz7i079qawjjeS6BiKFjvbmNVGSCemAABnPOe1fHf7LnjXTYdW8VTapeFPFmuanJNfvPN+7n3yPKJNjHCgq4JwM7QqEkKK8Y8d/D/xb43vreZdUtdMigyrmCGVWlT5Nm5fM2AoEwpA7sepNWPD/wAOT4RKT6FY6fJe9JL26M0ty+ep3kEjPoOO1b08BhYUZwhLWVvlb9D7+HFzjKLnU57bdDM+K3xMu7DxJrum6pG63cV480N1tMiy20x3B/YnlMD05x0r4d8QatFqupzXLDYk5YH+JyGBBPJHQHIXOPpkmvq34z6Rda/riL4b0q/1G6dBvu7eGe2MYBH7uQSkRSlhkkqPl6ZJrg/DXwn8Y+TqVrqvhgvBqVqkALSxQyxyLJ5iz7hu+df7uMMOG4r6nC1qUKSd0n6pCni6UZObkr+q/wAz768C/tJeF/jRrN98PdO0JNI8J+HdAX+yvtSxtfm4tkRHld4iyRqAQoRWPqTlsDMlLeQxPXb/AEr5++E3w017wFc3V35SJPeJ5Ukry78RZzsVEAHJ5JJzX0PMAYmwe1fKY2jRpytRenr+PzPm+JcfTxFSEotNq92vlZfI/9k=",
+            },
+            signIn: () => undefined,
+            signOut: async () => undefined,
+          }}
+        >
+          <LabeledAppBar label="user present with avatar" />
+        </CurrentUserContext.Provider>
+      </div>
+    );
+  },
 };
 
 export const SignInStatesChinese = { ...SignInStates, parameters: { forceLanguage: "zh" } };

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import { AppBar } from "@foxglove/studio-base/components/AppBar";
 import { StorybookDecorator } from "@foxglove/studio-base/components/AppBar/StorybookDecorator.stories";
@@ -36,6 +36,7 @@ const actions = {
 export const Default: StoryFn = (): JSX.Element => {
   return <AppBar {...actions} />;
 };
+
 export const DefaultChinese = Object.assign(Default.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
@@ -118,130 +119,139 @@ export const SignInStates: StoryFn = (): JSX.Element => {
     </div>
   );
 };
+
 export const SignInStatesChinese = Object.assign(SignInStates.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
 
-export const PlayerStates: StoryFn = (): JSX.Element => {
-  return (
-    <Stack overflowY="auto">
-      <div
-        style={{ display: "grid", gridTemplateColumns: "max-content auto", alignItems: "center" }}
-      >
-        {[
-          PlayerPresence.NOT_PRESENT,
-          PlayerPresence.INITIALIZING,
-          PlayerPresence.RECONNECTING,
-          PlayerPresence.BUFFERING,
-          PlayerPresence.PRESENT,
-          PlayerPresence.ERROR,
-        ].map((presence) => (
+export const PlayerStates: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <Stack overflowY="auto">
+        <div
+          style={{ display: "grid", gridTemplateColumns: "max-content auto", alignItems: "center" }}
+        >
+          {[
+            PlayerPresence.NOT_PRESENT,
+            PlayerPresence.INITIALIZING,
+            PlayerPresence.RECONNECTING,
+            PlayerPresence.BUFFERING,
+            PlayerPresence.PRESENT,
+            PlayerPresence.ERROR,
+          ].map((presence) => (
+            <MockMessagePipelineProvider
+              key={presence}
+              name="https://exampleurl:2002"
+              presence={presence}
+              problems={
+                presence === PlayerPresence.ERROR
+                  ? [
+                      { severity: "error", message: "example error" },
+                      { severity: "warn", message: "example warn" },
+                    ]
+                  : undefined
+              }
+            >
+              <LabeledAppBar label={presence} {...actions} />
+            </MockMessagePipelineProvider>
+          ))}
           <MockMessagePipelineProvider
-            key={presence}
             name="https://exampleurl:2002"
-            presence={presence}
-            problems={
-              presence === PlayerPresence.ERROR
-                ? [
-                    { severity: "error", message: "example error" },
-                    { severity: "warn", message: "example warn" },
-                  ]
-                : undefined
-            }
+            presence={PlayerPresence.INITIALIZING}
+            problems={[
+              { severity: "error", message: "example error" },
+              { severity: "warn", message: "example warn" },
+            ]}
           >
-            <LabeledAppBar label={presence} {...actions} />
+            <LabeledAppBar label="INITIALIZING + problems" {...actions} />
           </MockMessagePipelineProvider>
-        ))}
-        <MockMessagePipelineProvider
-          name="https://exampleurl:2002"
-          presence={PlayerPresence.INITIALIZING}
-          problems={[
-            { severity: "error", message: "example error" },
-            { severity: "warn", message: "example warn" },
-          ]}
-        >
-          <LabeledAppBar label="INITIALIZING + problems" {...actions} />
-        </MockMessagePipelineProvider>
-        <MockMessagePipelineProvider
-          name={undefined}
-          presence={PlayerPresence.INITIALIZING}
-          problems={[
-            { severity: "error", message: "example error" },
-            { severity: "warn", message: "example warn" },
-          ]}
-        >
-          <LabeledAppBar label="INITIALIZING + no name" {...actions} />
-        </MockMessagePipelineProvider>
-      </div>
-    </Stack>
-  );
+          <MockMessagePipelineProvider
+            name={undefined}
+            presence={PlayerPresence.INITIALIZING}
+            problems={[
+              { severity: "error", message: "example error" },
+              { severity: "warn", message: "example warn" },
+            ]}
+          >
+            <LabeledAppBar label="INITIALIZING + no name" {...actions} />
+          </MockMessagePipelineProvider>
+        </div>
+      </Stack>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
 };
-PlayerStates.parameters = { colorScheme: "light" };
+
 export const PlayerStatesChinese = Object.assign(PlayerStates.bind(undefined), {
   parameters: { olorScheme: "light", forceLanguage: "zh" },
 });
 
-export const DataSources: StoryFn = (): JSX.Element => {
-  return (
-    <Stack overflowY="auto">
-      <div
-        style={{ display: "grid", gridTemplateColumns: "max-content auto", alignItems: "center" }}
-      >
-        <MockMessagePipelineProvider
-          name="Adapted from nuScenes dataset. Copyright © 2020 nuScenes. https://www.nuscenes.org/terms-of-use"
-          presence={PlayerPresence.PRESENT}
-          urlState={{ sourceId: "sample-nuscenes" }}
+export const DataSources: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <Stack overflowY="auto">
+        <div
+          style={{ display: "grid", gridTemplateColumns: "max-content auto", alignItems: "center" }}
         >
-          <LabeledAppBar label="sample-nuscenes" {...actions} />
-        </MockMessagePipelineProvider>
-        {[
-          "mcap-local-file",
-          "ros1-local-bagfile",
-          "ros2-local-bagfile",
-          "ulog-local-file",
-          "remote-file",
-        ].map((sourceId) => (
           <MockMessagePipelineProvider
-            key={sourceId}
-            name="longexampleurlwith_specialcharaters-and-portnumber.ext"
+            name="Adapted from nuScenes dataset. Copyright © 2020 nuScenes. https://www.nuscenes.org/terms-of-use"
             presence={PlayerPresence.PRESENT}
-            urlState={{ sourceId }}
+            urlState={{ sourceId: "sample-nuscenes" }}
           >
-            <LabeledAppBar label={sourceId} {...actions} />
+            <LabeledAppBar label="sample-nuscenes" {...actions} />
           </MockMessagePipelineProvider>
-        ))}
-        {[
-          "ros1-socket",
-          "ros2-socket",
-          "rosbridge-websocket",
-          "foxglove-websocket",
-          "velodyne-device",
-          "some other source type",
-        ].map((sourceId) => (
+          {[
+            "mcap-local-file",
+            "ros1-local-bagfile",
+            "ros2-local-bagfile",
+            "ulog-local-file",
+            "remote-file",
+          ].map((sourceId) => (
+            <MockMessagePipelineProvider
+              key={sourceId}
+              name="longexampleurlwith_specialcharaters-and-portnumber.ext"
+              presence={PlayerPresence.PRESENT}
+              urlState={{ sourceId }}
+            >
+              <LabeledAppBar label={sourceId} {...actions} />
+            </MockMessagePipelineProvider>
+          ))}
+          {[
+            "ros1-socket",
+            "ros2-socket",
+            "rosbridge-websocket",
+            "foxglove-websocket",
+            "velodyne-device",
+            "some other source type",
+          ].map((sourceId) => (
+            <MockMessagePipelineProvider
+              key={sourceId}
+              name="https://longexampleurlwith_specialcharaters-and-portnumber:3030"
+              presence={PlayerPresence.PRESENT}
+              urlState={{ sourceId }}
+            >
+              <LabeledAppBar label={sourceId} {...actions} />
+            </MockMessagePipelineProvider>
+          ))}
           <MockMessagePipelineProvider
-            key={sourceId}
-            name="https://longexampleurlwith_specialcharaters-and-portnumber:3030"
+            name="https://longexampleurlwith_error-and-portnumber:3030"
             presence={PlayerPresence.PRESENT}
-            urlState={{ sourceId }}
+            problems={[
+              { severity: "error", message: "example error" },
+              { severity: "warn", message: "example warn" },
+            ]}
           >
-            <LabeledAppBar label={sourceId} {...actions} />
+            <LabeledAppBar label="with problems" {...actions} />
           </MockMessagePipelineProvider>
-        ))}
-        <MockMessagePipelineProvider
-          name="https://longexampleurlwith_error-and-portnumber:3030"
-          presence={PlayerPresence.PRESENT}
-          problems={[
-            { severity: "error", message: "example error" },
-            { severity: "warn", message: "example warn" },
-          ]}
-        >
-          <LabeledAppBar label="with problems" {...actions} />
-        </MockMessagePipelineProvider>
-      </div>
-    </Stack>
-  );
+        </div>
+      </Stack>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
 };
-DataSources.parameters = { colorScheme: "light" };
+
 export const DataSourcesChinese = Object.assign(DataSources.bind(undefined), {
   parameters: { colorScheme: "light", forceLanguage: "zh" },
 });

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { range } from "lodash";
 
@@ -60,7 +60,7 @@ const MockExtensionMarketplace: ExtensionMarketplace = {
 Mock markdown rendering for URL [${url}](${url}).`,
 };
 
-function Wrapper(StoryComponent: Story): JSX.Element {
+function Wrapper(StoryComponent: StoryFn): JSX.Element {
   return (
     <WorkspaceContextProvider>
       <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
@@ -82,8 +82,11 @@ export default {
 export function Default(): JSX.Element {
   return <AppSettingsDialog open />;
 }
-export const DefaultChinese = (): JSX.Element => <Default />;
-DefaultChinese.parameters = { forceLanguage: "zh" };
+
+export const DefaultChinese = {
+  render: (): JSX.Element => <Default />,
+  parameters: { forceLanguage: "zh" },
+};
 
 export function ChangingLanguage(): JSX.Element {
   return <AppSettingsDialog open />;
@@ -100,29 +103,44 @@ ChangingLanguage.play = async () => {
 export function General(): JSX.Element {
   return <AppSettingsDialog open activeTab="general" />;
 }
-export const GeneralChinese = (): JSX.Element => <General />;
-GeneralChinese.parameters = { forceLanguage: "zh" };
+
+export const GeneralChinese = {
+  render: (): JSX.Element => <General />,
+  parameters: { forceLanguage: "zh" },
+};
 
 export function Privacy(): JSX.Element {
   return <AppSettingsDialog open activeTab="privacy" />;
 }
-export const PrivacyChinese = (): JSX.Element => <Privacy />;
-PrivacyChinese.parameters = { forceLanguage: "zh" };
+
+export const PrivacyChinese = {
+  render: (): JSX.Element => <Privacy />,
+  parameters: { forceLanguage: "zh" },
+};
 
 export function Extensions(): JSX.Element {
   return <AppSettingsDialog open activeTab="extensions" />;
 }
-export const ExtensionsChinese = (): JSX.Element => <Extensions />;
-ExtensionsChinese.parameters = { forceLanguage: "zh" };
+
+export const ExtensionsChinese = {
+  render: (): JSX.Element => <Extensions />,
+  parameters: { forceLanguage: "zh" },
+};
 
 export function Experimental(): JSX.Element {
   return <AppSettingsDialog open activeTab="experimental-features" />;
 }
-export const ExperimentalChinese = (): JSX.Element => <Experimental />;
-ExperimentalChinese.parameters = { forceLanguage: "zh" };
+
+export const ExperimentalChinese = {
+  render: (): JSX.Element => <Experimental />,
+  parameters: { forceLanguage: "zh" },
+};
 
 export function About(): JSX.Element {
   return <AppSettingsDialog open activeTab="about" />;
 }
-export const AboutChinese = (): JSX.Element => <About />;
-AboutChinese.parameters = { forceLanguage: "zh" };
+
+export const AboutChinese = {
+  render: (): JSX.Element => <About />,
+  parameters: { forceLanguage: "zh" },
+};

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { range } from "lodash";
 
@@ -79,12 +79,14 @@ export default {
   decorators: [Wrapper],
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open />;
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppSettingsDialog open />;
+  },
 };
 
 export const DefaultChinese = {
-  render: (): JSX.Element => <Default />,
+  ...Default,
   parameters: { forceLanguage: "zh" },
 };
 
@@ -103,47 +105,57 @@ export const ChangingLanguage: StoryObj = {
   },
 };
 
-export const General: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open activeTab="general" />;
+export const General: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppSettingsDialog open activeTab="general" />;
+  },
 };
 
 export const GeneralChinese = {
-  render: (): JSX.Element => <General />,
+  ...General,
   parameters: { forceLanguage: "zh" },
 };
 
-export const Privacy: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open activeTab="privacy" />;
+export const Privacy: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppSettingsDialog open activeTab="privacy" />;
+  },
 };
 
 export const PrivacyChinese = {
-  render: (): JSX.Element => <Privacy />,
+  ...Privacy,
   parameters: { forceLanguage: "zh" },
 };
 
-export const Extensions: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open activeTab="extensions" />;
+export const Extensions: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppSettingsDialog open activeTab="extensions" />;
+  },
 };
 
 export const ExtensionsChinese = {
-  render: (): JSX.Element => <Extensions />,
+  ...Extensions,
   parameters: { forceLanguage: "zh" },
 };
 
-export const Experimental: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open activeTab="experimental-features" />;
+export const Experimental: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppSettingsDialog open activeTab="experimental-features" />;
+  },
 };
 
 export const ExperimentalChinese = {
-  render: (): JSX.Element => <Experimental />,
+  ...Experimental,
   parameters: { forceLanguage: "zh" },
 };
 
-export const About: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open activeTab="about" />;
+export const About: StoryObj = {
+  render: (): JSX.Element => {
+    return <AppSettingsDialog open activeTab="about" />;
+  },
 };
 
 export const AboutChinese = {
-  render: (): JSX.Element => <About />,
+  ...About,
   parameters: { forceLanguage: "zh" },
 };

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
@@ -80,18 +80,18 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppSettingsDialog open />;
   },
 };
 
-export const DefaultChinese = {
+export const DefaultChinese: StoryObj = {
   ...Default,
   parameters: { forceLanguage: "zh" },
 };
 
 export const ChangingLanguage: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <AppSettingsDialog open />;
   },
 
@@ -106,56 +106,56 @@ export const ChangingLanguage: StoryObj = {
 };
 
 export const General: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppSettingsDialog open activeTab="general" />;
   },
 };
 
-export const GeneralChinese = {
+export const GeneralChinese: StoryObj = {
   ...General,
   parameters: { forceLanguage: "zh" },
 };
 
 export const Privacy: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppSettingsDialog open activeTab="privacy" />;
   },
 };
 
-export const PrivacyChinese = {
+export const PrivacyChinese: StoryObj = {
   ...Privacy,
   parameters: { forceLanguage: "zh" },
 };
 
 export const Extensions: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppSettingsDialog open activeTab="extensions" />;
   },
 };
 
-export const ExtensionsChinese = {
+export const ExtensionsChinese: StoryObj = {
   ...Extensions,
   parameters: { forceLanguage: "zh" },
 };
 
 export const Experimental: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppSettingsDialog open activeTab="experimental-features" />;
   },
 };
 
-export const ExperimentalChinese = {
+export const ExperimentalChinese: StoryObj = {
   ...Experimental,
   parameters: { forceLanguage: "zh" },
 };
 
 export const About: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <AppSettingsDialog open activeTab="about" />;
   },
 };
 
-export const AboutChinese = {
+export const AboutChinese: StoryObj = {
   ...About,
   parameters: { forceLanguage: "zh" },
 };

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { range } from "lodash";
 
@@ -88,16 +88,19 @@ export const DefaultChinese = {
   parameters: { forceLanguage: "zh" },
 };
 
-export const ChangingLanguage: StoryFn = (): JSX.Element => {
-  return <AppSettingsDialog open />;
-};
-ChangingLanguage.play = async () => {
-  const input = await screen.findByText("English", { exact: false });
-  userEvent.click(input);
+export const ChangingLanguage: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <AppSettingsDialog open />;
+  },
 
-  userEvent.keyboard("中文");
-  const item = await screen.findByText("中文", { exact: false });
-  userEvent.click(item);
+  play: async () => {
+    const input = await screen.findByText("English", { exact: false });
+    userEvent.click(input);
+
+    userEvent.keyboard("中文");
+    const item = await screen.findByText("中文", { exact: false });
+    userEvent.click(item);
+  },
 };
 
 export const General: StoryFn = (): JSX.Element => {

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.stories.tsx
@@ -79,18 +79,18 @@ export default {
   decorators: [Wrapper],
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open />;
-}
+};
 
 export const DefaultChinese = {
   render: (): JSX.Element => <Default />,
   parameters: { forceLanguage: "zh" },
 };
 
-export function ChangingLanguage(): JSX.Element {
+export const ChangingLanguage: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open />;
-}
+};
 ChangingLanguage.play = async () => {
   const input = await screen.findByText("English", { exact: false });
   userEvent.click(input);
@@ -100,45 +100,45 @@ ChangingLanguage.play = async () => {
   userEvent.click(item);
 };
 
-export function General(): JSX.Element {
+export const General: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open activeTab="general" />;
-}
+};
 
 export const GeneralChinese = {
   render: (): JSX.Element => <General />,
   parameters: { forceLanguage: "zh" },
 };
 
-export function Privacy(): JSX.Element {
+export const Privacy: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open activeTab="privacy" />;
-}
+};
 
 export const PrivacyChinese = {
   render: (): JSX.Element => <Privacy />,
   parameters: { forceLanguage: "zh" },
 };
 
-export function Extensions(): JSX.Element {
+export const Extensions: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open activeTab="extensions" />;
-}
+};
 
 export const ExtensionsChinese = {
   render: (): JSX.Element => <Extensions />,
   parameters: { forceLanguage: "zh" },
 };
 
-export function Experimental(): JSX.Element {
+export const Experimental: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open activeTab="experimental-features" />;
-}
+};
 
 export const ExperimentalChinese = {
   render: (): JSX.Element => <Experimental />,
   parameters: { forceLanguage: "zh" },
 };
 
-export function About(): JSX.Element {
+export const About: StoryFn = (): JSX.Element => {
   return <AppSettingsDialog open activeTab="about" />;
-}
+};
 
 export const AboutChinese = {
   render: (): JSX.Element => <About />,

--- a/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useState, useEffect } from "react";
 
 import AutoSizingCanvas from ".";

--- a/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useState, useEffect } from "react";
 
 import AutoSizingCanvas from ".";
@@ -69,18 +69,22 @@ export default {
   title: "components/AutoSizingCanvas",
 };
 
-export const Static: StoryFn = () => <Example />;
+export const Static: StoryObj = {
+  render: () => <Example />,
+  name: "static",
+};
 
-Static.storyName = "static";
+export const ChangingSize: StoryObj = {
+  render: () => <Example changeSize />,
+  name: "changing size",
+};
 
-export const ChangingSize: StoryFn = () => <Example changeSize />;
+export const PixelRatio2: StoryObj = {
+  render: () => <Example devicePixelRatio={2} />,
+  name: "pixel ratio 2",
+};
 
-ChangingSize.storyName = "changing size";
-
-export const PixelRatio2: StoryFn = () => <Example devicePixelRatio={2} />;
-
-PixelRatio2.storyName = "pixel ratio 2";
-
-export const ChangingPixelRatio: StoryFn = () => <Example changePixelRatio />;
-
-ChangingPixelRatio.storyName = "changing pixel ratio";
+export const ChangingPixelRatio: StoryObj = {
+  render: () => <Example changePixelRatio />,
+  name: "changing pixel ratio",
+};

--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { range } from "lodash";
 import { Component } from "react";
 import TestUtils from "react-dom/test-utils";

--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { range } from "lodash";
 import { Component } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -35,202 +35,221 @@ export default {
   },
 };
 
-export const FilteringToO: StoryFn = () => {
-  class Example extends Component {
-    public override render() {
-      return (
-        <div style={{ padding: 20 }} ref={focusInput}>
-          <Autocomplete
-            items={["one", "two", "three"]}
-            filterText="o"
-            value="o"
-            onSelect={() => {}}
-            hasError
-          />
-        </div>
-      );
+export const FilteringToO: StoryObj = {
+  render: () => {
+    class Example extends Component {
+      public override render() {
+        return (
+          <div style={{ padding: 20 }} ref={focusInput}>
+            <Autocomplete
+              items={["one", "two", "three"]}
+              filterText="o"
+              value="o"
+              onSelect={() => {}}
+              hasError
+            />
+          </div>
+        );
+      }
     }
-  }
-  return <Example />;
+    return <Example />;
+  },
+
+  name: "filtering to 'o'",
 };
 
-FilteringToO.storyName = "filtering to 'o'";
-
-export const FilteringToOLight: StoryFn = () => {
-  class Example extends Component {
-    public override render() {
-      return (
-        <div style={{ padding: 20 }} ref={focusInput}>
-          <Autocomplete
-            items={["one", "two", "three"]}
-            filterText="o"
-            value="o"
-            onSelect={() => {}}
-            hasError
-          />
-        </div>
-      );
+export const FilteringToOLight: StoryObj = {
+  render: () => {
+    class Example extends Component {
+      public override render() {
+        return (
+          <div style={{ padding: 20 }} ref={focusInput}>
+            <Autocomplete
+              items={["one", "two", "three"]}
+              filterText="o"
+              value="o"
+              onSelect={() => {}}
+              hasError
+            />
+          </div>
+        );
+      }
     }
-  }
-  return <Example />;
+    return <Example />;
+  },
+
+  name: "filtering to 'o' light",
+  parameters: { colorScheme: "light" },
 };
 
-FilteringToOLight.storyName = "filtering to 'o' light";
-FilteringToOLight.parameters = { colorScheme: "light" };
+export const WithNonStringItemsAndLeadingWhitespace: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ padding: 20 }} ref={focusInput}>
+        <Autocomplete
+          items={[
+            { value: "one", text: "ONE" },
+            { value: "two", text: "    TWO" },
+            { value: "three", text: "THREE" },
+          ]}
+          getItemText={({ text }: any) => text}
+          filterText="o"
+          value="o"
+          onSelect={() => {}}
+        />
+      </div>
+    );
+  },
 
-export const WithNonStringItemsAndLeadingWhitespace: StoryFn = () => {
-  return (
-    <div style={{ padding: 20 }} ref={focusInput}>
-      <Autocomplete
-        items={[
-          { value: "one", text: "ONE" },
-          { value: "two", text: "    TWO" },
-          { value: "three", text: "THREE" },
-        ]}
-        getItemText={({ text }: any) => text}
-        filterText="o"
-        value="o"
-        onSelect={() => {}}
-      />
-    </div>
-  );
+  name: "with non-string items and leading whitespace",
 };
 
-WithNonStringItemsAndLeadingWhitespace.storyName = "with non-string items and leading whitespace";
-
-export const UncontrolledValue: StoryFn = () => {
-  return (
-    <div
-      style={{ padding: 20 }}
-      ref={(el) => {
-        if (el) {
-          const input: HTMLInputElement | undefined = el.querySelector("input") as any;
-          if (input) {
-            input.focus();
-            input.value = "h";
-            TestUtils.Simulate.change(input);
+export const UncontrolledValue: StoryObj = {
+  render: () => {
+    return (
+      <div
+        style={{ padding: 20 }}
+        ref={(el) => {
+          if (el) {
+            const input: HTMLInputElement | undefined = el.querySelector("input") as any;
+            if (input) {
+              input.focus();
+              input.value = "h";
+              TestUtils.Simulate.change(input);
+            }
           }
-        }
-      }}
-    >
-      <Autocomplete
-        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-        onSelect={() => {}}
-      />
-    </div>
-  );
+        }}
+      >
+        <Autocomplete
+          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+          onSelect={() => {}}
+        />
+      </div>
+    );
+  },
+
+  name: "uncontrolled value",
 };
 
-UncontrolledValue.storyName = "uncontrolled value";
-
-export const UncontrolledValueLight: StoryFn = () => {
-  return (
-    <div
-      style={{ padding: 20 }}
-      ref={(el) => {
-        if (el) {
-          const input: HTMLInputElement | undefined = el.querySelector("input") as any;
-          if (input) {
-            input.focus();
-            input.value = "h";
-            TestUtils.Simulate.change(input);
+export const UncontrolledValueLight: StoryObj = {
+  render: () => {
+    return (
+      <div
+        style={{ padding: 20 }}
+        ref={(el) => {
+          if (el) {
+            const input: HTMLInputElement | undefined = el.querySelector("input") as any;
+            if (input) {
+              input.focus();
+              input.value = "h";
+              TestUtils.Simulate.change(input);
+            }
           }
-        }
-      }}
-    >
-      <Autocomplete
-        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-        onSelect={() => {}}
-      />
-    </div>
-  );
+        }}
+      >
+        <Autocomplete
+          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+          onSelect={() => {}}
+        />
+      </div>
+    );
+  },
+
+  name: "uncontrolled value light",
+  parameters: { colorScheme: "light" },
 };
 
-UncontrolledValueLight.storyName = "uncontrolled value light";
-UncontrolledValueLight.parameters = { colorScheme: "light" };
+export const UncontrolledValueWithSelectedItem: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ padding: 20 }} ref={focusInput}>
+        <Autocomplete
+          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+          selectedItem={{ value: "two" }}
+          onSelect={() => {}}
+        />
+      </div>
+    );
+  },
 
-export const UncontrolledValueWithSelectedItem: StoryFn = () => {
-  return (
-    <div style={{ padding: 20 }} ref={focusInput}>
-      <Autocomplete
-        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-        selectedItem={{ value: "two" }}
-        onSelect={() => {}}
-      />
-    </div>
-  );
+  name: "uncontrolled value with selected item",
 };
 
-UncontrolledValueWithSelectedItem.storyName = "uncontrolled value with selected item";
+export const UncontrolledValueWithSelectedItemAndClearOnFocus: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ padding: 20 }} ref={focusInput}>
+        <Autocomplete
+          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+          selectedItem={{ value: "two" }}
+          onSelect={() => {}}
+          selectOnFocus
+        />
+      </div>
+    );
+  },
 
-export const UncontrolledValueWithSelectedItemAndClearOnFocus: StoryFn = () => {
-  return (
-    <div style={{ padding: 20 }} ref={focusInput}>
-      <Autocomplete
-        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-        selectedItem={{ value: "two" }}
-        onSelect={() => {}}
-        selectOnFocus
-      />
-    </div>
-  );
+  name: "uncontrolled value with selected item and clearOnFocus",
 };
 
-UncontrolledValueWithSelectedItemAndClearOnFocus.storyName =
-  "uncontrolled value with selected item and clearOnFocus";
+export const SortWhenFilteringFalse: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ padding: 20 }} ref={focusInput}>
+        <Autocomplete
+          items={[{ value: "bab" }, { value: "bb" }, { value: "a2" }, { value: "a1" }]}
+          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+          value="b"
+          onSelect={() => {}}
+          sortWhenFiltering={false}
+        />
+      </div>
+    );
+  },
 
-export const SortWhenFilteringFalse: StoryFn = () => {
-  return (
-    <div style={{ padding: 20 }} ref={focusInput}>
-      <Autocomplete
-        items={[{ value: "bab" }, { value: "bb" }, { value: "a2" }, { value: "a1" }]}
-        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-        value="b"
-        onSelect={() => {}}
-        sortWhenFiltering={false}
-      />
-    </div>
-  );
+  name: "sortWhenFiltering=false",
 };
 
-SortWhenFilteringFalse.storyName = "sortWhenFiltering=false";
-
-export const WithALongTruncatedPathAndAutoSize: StoryFn = () => {
-  class Example extends Component {
-    public override render() {
-      return (
-        <div style={{ maxWidth: 200 }} ref={focusInput}>
-          <Autocomplete
-            items={[]}
-            value="/abcdefghi_jklmnop.abcdefghi_jklmnop[:]{some_id==1297193}.isSomething"
-            onSelect={() => {}}
-            autoSize
-          />
-        </div>
-      );
+export const WithALongTruncatedPathAndAutoSize: StoryObj = {
+  render: () => {
+    class Example extends Component {
+      public override render() {
+        return (
+          <div style={{ maxWidth: 200 }} ref={focusInput}>
+            <Autocomplete
+              items={[]}
+              value="/abcdefghi_jklmnop.abcdefghi_jklmnop[:]{some_id==1297193}.isSomething"
+              onSelect={() => {}}
+              autoSize
+            />
+          </div>
+        );
+      }
     }
-  }
-  return <Example />;
+    return <Example />;
+  },
+
+  name: "with a long truncated path (and autoSize)",
 };
 
-WithALongTruncatedPathAndAutoSize.storyName = "with a long truncated path (and autoSize)";
-
-export const ManyItems: StoryFn = () => {
-  const items = range(1, 1000).map((i) => `item_${i}`);
-  class Example extends Component {
-    public override render() {
-      return (
-        <div style={{ maxWidth: 200 }} ref={focusInput}>
-          <Autocomplete items={items} onSelect={() => {}} autoSize />
-        </div>
-      );
+export const ManyItems: StoryObj = {
+  render: () => {
+    const items = range(1, 1000).map((i) => `item_${i}`);
+    class Example extends Component {
+      public override render() {
+        return (
+          <div style={{ maxWidth: 200 }} ref={focusInput}>
+            <Autocomplete items={items} onSelect={() => {}} autoSize />
+          </div>
+        );
+      }
     }
-  }
-  return <Example />;
-};
+    return <Example />;
+  },
 
-ManyItems.storyName = "many items";
+  name: "many items",
+};

--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -10,7 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback, ComponentProps, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -124,75 +124,87 @@ export default {
   },
 };
 
-export const Basic: Story = (_args) => {
-  const readySignal = useReadySignal();
+export const Basic: StoryObj = {
+  render: (_args) => {
+    const readySignal = useReadySignal();
 
-  return (
-    <div style={divStyle}>
-      <ChartComponent {...props} onFinishRender={readySignal} />
-    </div>
-  );
-};
-Basic.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-Basic.parameters = {
-  useReadySignal: true,
-};
-
-export const WithDatalabels: Story = (_args) => {
-  const readySignal = useReadySignal();
-
-  return (
-    <div style={divStyle}>
-      <ChartComponent {...propsWithDatalabels} onFinishRender={readySignal} />
-    </div>
-  );
-};
-WithDatalabels.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-WithDatalabels.parameters = {
-  useReadySignal: true,
-};
-
-export const AllowsClickingOnDatalabels: Story = (_args) => {
-  const [clickedDatalabel, setClickedDatalabel] = useState<unknown>(undefined);
-  const readySignal = useReadySignal();
-
-  const doClick = useCallback(() => {
-    if (clickedDatalabel == undefined) {
-      const [canvas] = document.getElementsByTagName("canvas");
-      TestUtils.Simulate.click(canvas!.parentElement!, { clientX: 304, clientY: 378 });
-    }
-  }, [clickedDatalabel]);
-
-  const onClick = useCallback((ev: OnClickArg) => {
-    setClickedDatalabel(ev.datalabel);
-  }, []);
-
-  useEffect(() => {
-    if (clickedDatalabel != undefined) {
-      readySignal();
-    }
-  }, [clickedDatalabel, readySignal]);
-
-  return (
-    <div style={divStyle}>
-      <div style={{ padding: 6, fontSize: 16 }}>
-        {clickedDatalabel != undefined
-          ? `Clicked datalabel with selection id: ${String(
-              (clickedDatalabel as Record<string, unknown>).selectionObj,
-            )}`
-          : "Have not clicked datalabel"}
+    return (
+      <div style={divStyle}>
+        <ChartComponent {...props} onFinishRender={readySignal} />
       </div>
-      <ChartComponent {...propsWithDatalabels} onFinishRender={doClick} onClick={onClick} />
-    </div>
-  );
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
-AllowsClickingOnDatalabels.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+
+export const WithDatalabels: StoryObj = {
+  render: (_args) => {
+    const readySignal = useReadySignal();
+
+    return (
+      <div style={divStyle}>
+        <ChartComponent {...propsWithDatalabels} onFinishRender={readySignal} />
+      </div>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
-AllowsClickingOnDatalabels.parameters = {
-  useReadySignal: true,
+
+export const AllowsClickingOnDatalabels: StoryObj = {
+  render: (_args) => {
+    const [clickedDatalabel, setClickedDatalabel] = useState<unknown>(undefined);
+    const readySignal = useReadySignal();
+
+    const doClick = useCallback(() => {
+      if (clickedDatalabel == undefined) {
+        const [canvas] = document.getElementsByTagName("canvas");
+        TestUtils.Simulate.click(canvas!.parentElement!, { clientX: 304, clientY: 378 });
+      }
+    }, [clickedDatalabel]);
+
+    const onClick = useCallback((ev: OnClickArg) => {
+      setClickedDatalabel(ev.datalabel);
+    }, []);
+
+    useEffect(() => {
+      if (clickedDatalabel != undefined) {
+        readySignal();
+      }
+    }, [clickedDatalabel, readySignal]);
+
+    return (
+      <div style={divStyle}>
+        <div style={{ padding: 6, fontSize: 16 }}>
+          {clickedDatalabel != undefined
+            ? `Clicked datalabel with selection id: ${String(
+                (clickedDatalabel as Record<string, unknown>).selectionObj,
+              )}`
+            : "Have not clicked datalabel"}
+        </div>
+        <ChartComponent {...propsWithDatalabels} onFinishRender={doClick} onClick={onClick} />
+      </div>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    useReadySignal: true,
+  },
 };

--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -10,7 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback, ComponentProps, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -125,7 +125,7 @@ export default {
 };
 
 export const Basic: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const readySignal = useReadySignal();
 
     return (
@@ -145,7 +145,7 @@ export const Basic: StoryObj = {
 };
 
 export const WithDatalabels: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const readySignal = useReadySignal();
 
     return (
@@ -165,7 +165,7 @@ export const WithDatalabels: StoryObj = {
 };
 
 export const AllowsClickingOnDatalabels: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const [clickedDatalabel, setClickedDatalabel] = useState<unknown>(undefined);
     const readySignal = useReadySignal();
 

--- a/packages/studio-base/src/components/CreateEventDialog.stories.tsx
+++ b/packages/studio-base/src/components/CreateEventDialog.stories.tsx
@@ -30,7 +30,7 @@ export default {
 };
 
 export const Empty: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <CreateEventDialog onClose={() => undefined} />;
   },
 };

--- a/packages/studio-base/src/components/CreateEventDialog.stories.tsx
+++ b/packages/studio-base/src/components/CreateEventDialog.stories.tsx
@@ -29,9 +29,9 @@ export default {
   },
 };
 
-export function Empty(): JSX.Element {
+export const Empty: StoryFn = (): JSX.Element => {
   return <CreateEventDialog onClose={() => undefined} />;
-}
+};
 
 export const Normal: StoryObj = {
   render: () => {

--- a/packages/studio-base/src/components/CreateEventDialog.stories.tsx
+++ b/packages/studio-base/src/components/CreateEventDialog.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
@@ -14,11 +14,11 @@ export default {
   component: CreateEventDialog,
   title: "components/CreateEventDialog",
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       return (
         <EventsProvider>
           <MockMessagePipelineProvider>
-            <StoryFn />
+            <Wrapped />
           </MockMessagePipelineProvider>
         </EventsProvider>
       );
@@ -33,52 +33,56 @@ export function Empty(): JSX.Element {
   return <CreateEventDialog onClose={() => undefined} />;
 }
 
-export const Normal: Story = () => {
-  return <CreateEventDialog onClose={() => {}} />;
+export const Normal: StoryObj = {
+  render: () => {
+    return <CreateEventDialog onClose={() => {}} />;
+  },
+
+  play: async () => {
+    const firstKey = await screen.findByPlaceholderText("Key (string)");
+    userEvent.click(firstKey);
+    userEvent.keyboard("1");
+
+    const firstValue = await screen.findByPlaceholderText("Value (string)");
+    userEvent.click(firstValue);
+    userEvent.keyboard("2");
+
+    const firstPlus = await screen.findByTestId("add");
+    userEvent.click(firstPlus);
+
+    const secondKey = await screen.findAllByPlaceholderText("Key (string)");
+    userEvent.click(secondKey[1]!);
+    userEvent.keyboard("3");
+
+    const secondValue = await screen.findAllByPlaceholderText("Value (string)");
+    userEvent.click(secondValue[1]!);
+    userEvent.keyboard("4");
+  },
 };
 
-Normal.play = async () => {
-  const firstKey = await screen.findByPlaceholderText("Key (string)");
-  userEvent.click(firstKey);
-  userEvent.keyboard("1");
+export const WithDuplicates: StoryObj = {
+  render: () => {
+    return <CreateEventDialog onClose={() => {}} />;
+  },
 
-  const firstValue = await screen.findByPlaceholderText("Value (string)");
-  userEvent.click(firstValue);
-  userEvent.keyboard("2");
+  play: async () => {
+    const firstKey = await screen.findByPlaceholderText("Key (string)");
+    userEvent.click(firstKey);
+    userEvent.keyboard("1");
 
-  const firstPlus = await screen.findByTestId("add");
-  userEvent.click(firstPlus);
+    const firstValue = await screen.findByPlaceholderText("Value (string)");
+    userEvent.click(firstValue);
+    userEvent.keyboard("2");
 
-  const secondKey = await screen.findAllByPlaceholderText("Key (string)");
-  userEvent.click(secondKey[1]!);
-  userEvent.keyboard("3");
+    const firstPlus = await screen.findByTestId("add");
+    userEvent.click(firstPlus);
 
-  const secondValue = await screen.findAllByPlaceholderText("Value (string)");
-  userEvent.click(secondValue[1]!);
-  userEvent.keyboard("4");
-};
+    const secondKey = await screen.findAllByPlaceholderText("Key (string)");
+    userEvent.click(secondKey[1]!);
+    userEvent.keyboard("1");
 
-export const WithDuplicates: Story = () => {
-  return <CreateEventDialog onClose={() => {}} />;
-};
-
-WithDuplicates.play = async () => {
-  const firstKey = await screen.findByPlaceholderText("Key (string)");
-  userEvent.click(firstKey);
-  userEvent.keyboard("1");
-
-  const firstValue = await screen.findByPlaceholderText("Value (string)");
-  userEvent.click(firstValue);
-  userEvent.keyboard("2");
-
-  const firstPlus = await screen.findByTestId("add");
-  userEvent.click(firstPlus);
-
-  const secondKey = await screen.findAllByPlaceholderText("Key (string)");
-  userEvent.click(secondKey[1]!);
-  userEvent.keyboard("1");
-
-  const secondValue = await screen.findAllByPlaceholderText("Value (string)");
-  userEvent.click(secondValue[1]!);
-  userEvent.keyboard("2");
+    const secondValue = await screen.findAllByPlaceholderText("Value (string)");
+    userEvent.click(secondValue[1]!);
+    userEvent.keyboard("2");
+  },
 };

--- a/packages/studio-base/src/components/CreateEventDialog.stories.tsx
+++ b/packages/studio-base/src/components/CreateEventDialog.stories.tsx
@@ -29,8 +29,10 @@ export default {
   },
 };
 
-export const Empty: StoryFn = (): JSX.Element => {
-  return <CreateEventDialog onClose={() => undefined} />;
+export const Empty: StoryObj = {
+  render: (): JSX.Element => {
+    return <CreateEventDialog onClose={() => undefined} />;
+  },
 };
 
 export const Normal: StoryObj = {

--- a/packages/studio-base/src/components/CssBaseline.stories.tsx
+++ b/packages/studio-base/src/components/CssBaseline.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 
 import CssBaseline from "./CssBaseline";
 
@@ -14,7 +14,7 @@ export default {
   },
 };
 
-export const Scrollbars: Story = () => {
+export const Scrollbars: StoryFn = () => {
   return (
     <CssBaseline>
       <div

--- a/packages/studio-base/src/components/CssBaseline.stories.tsx
+++ b/packages/studio-base/src/components/CssBaseline.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import CssBaseline from "./CssBaseline";
 
@@ -14,14 +14,16 @@ export default {
   },
 };
 
-export const Scrollbars: StoryFn = () => {
-  return (
-    <CssBaseline>
-      <div
-        style={{ width: "200px", height: "200px", border: "1px solid black", overflow: "scroll" }}
-      >
-        <div style={{ width: "400px", height: "400px" }}>Should have both scrollbars</div>
-      </div>
-    </CssBaseline>
-  );
+export const Scrollbars: StoryObj = {
+  render: () => {
+    return (
+      <CssBaseline>
+        <div
+          style={{ width: "200px", height: "200px", border: "1px solid black", overflow: "scroll" }}
+        >
+          <div style={{ width: "400px", height: "400px" }}>Should have both scrollbars</div>
+        </div>
+      </CssBaseline>
+    );
+  },
 };

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
@@ -97,9 +97,7 @@ export const PlayerNotPresent = (): JSX.Element => {
     </MockMessagePipelineProvider>
   );
 };
-export const PlayerNotPresentChinese = Object.assign(PlayerNotPresent.bind(undefined), {
-  parameters: { forceLanguage: "zh" },
-});
+export const PlayerNotPresentChinese = { ...PlayerNotPresent, parameters: { forceLanguage: "zh" } };
 
 export const PlayerIntializing = (): JSX.Element => {
   return (
@@ -114,9 +112,10 @@ export const PlayerIntializing = (): JSX.Element => {
     </MockMessagePipelineProvider>
   );
 };
-export const PlayerIntializingChinese = Object.assign(PlayerIntializing.bind(undefined), {
+export const PlayerIntializingChinese = {
+  ...PlayerIntializing,
   parameters: { forceLanguage: "zh" },
-});
+};
 
 export const PlayerReconnecting = (): JSX.Element => {
   return (
@@ -140,9 +139,10 @@ export const PlayerReconnecting = (): JSX.Element => {
     </MockMessagePipelineProvider>
   );
 };
-export const PlayerReconnectingChinese = Object.assign(PlayerReconnecting.bind(undefined), {
+export const PlayerReconnectingChinese = {
+  ...PlayerReconnecting,
   parameters: { forceLanguage: "zh" },
-});
+};
 
 export const PlayerPresent = (): JSX.Element => {
   return (
@@ -158,9 +158,7 @@ export const PlayerPresent = (): JSX.Element => {
     </MockMessagePipelineProvider>
   );
 };
-export const PlayerPresentChinese = Object.assign(PlayerPresent.bind(undefined), {
-  parameters: { forceLanguage: "zh" },
-});
+export const PlayerPresentChinese = { ...PlayerPresent, parameters: { forceLanguage: "zh" } };
 
 export const PlayerPresentWithCustomTimezone = (): JSX.Element => {
   const [_, setTimezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
@@ -214,9 +212,7 @@ export const WithEvents = (): JSX.Element => {
     </MockMessagePipelineProvider>
   );
 };
-export const WithEventsChinese = Object.assign(WithEvents.bind(undefined), {
-  parameters: { forceLanguage: "zh" },
-});
+export const WithEventsChinese = { ...WithEvents, parameters: { forceLanguage: "zh" } };
 
 export const PlayerWithError = (): JSX.Element => {
   return (
@@ -256,6 +252,4 @@ export const PlayerWithError = (): JSX.Element => {
     </MockMessagePipelineProvider>
   );
 };
-export const PlayerWithErrorChinese = Object.assign(PlayerWithError.bind(undefined), {
-  parameters: { forceLanguage: "zh" },
-});
+export const PlayerWithErrorChinese = { ...PlayerWithError, parameters: { forceLanguage: "zh" } };

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 
 import { fromDate } from "@foxglove/rostime";
@@ -88,8 +88,8 @@ const TOPICS: Topic[] = [
   },
 ];
 
-export const PlayerNotPresent = {
-  render: function Story(): JSX.Element {
+export const PlayerNotPresent: StoryObj = {
+  render: function Story() {
     return (
       <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
         <Box height="100%" bgcolor="background.paper">
@@ -100,10 +100,13 @@ export const PlayerNotPresent = {
   },
 };
 
-export const PlayerNotPresentChinese = { ...PlayerNotPresent, parameters: { forceLanguage: "zh" } };
+export const PlayerNotPresentChinese: StoryObj = {
+  ...PlayerNotPresent,
+  parameters: { forceLanguage: "zh" },
+};
 
-export const PlayerIntializing = {
-  render: function Story(): JSX.Element {
+export const PlayerIntializing: StoryObj = {
+  render: function Story() {
     return (
       <MockMessagePipelineProvider
         startTime={START_TIME}
@@ -118,13 +121,13 @@ export const PlayerIntializing = {
   },
 };
 
-export const PlayerIntializingChinese = {
+export const PlayerIntializingChinese: StoryObj = {
   ...PlayerIntializing,
   parameters: { forceLanguage: "zh" },
 };
 
-export const PlayerReconnecting = {
-  render: function Story(): JSX.Element {
+export const PlayerReconnecting: StoryObj = {
+  render: function Story() {
     return (
       <MockMessagePipelineProvider
         startTime={START_TIME}
@@ -148,13 +151,13 @@ export const PlayerReconnecting = {
   },
 };
 
-export const PlayerReconnectingChinese = {
+export const PlayerReconnectingChinese: StoryObj = {
   ...PlayerReconnecting,
   parameters: { forceLanguage: "zh" },
 };
 
-export const PlayerPresent = {
-  render: function Story(): JSX.Element {
+export const PlayerPresent: StoryObj = {
+  render: function Story() {
     return (
       <MockMessagePipelineProvider
         startTime={START_TIME}
@@ -170,10 +173,13 @@ export const PlayerPresent = {
   },
 };
 
-export const PlayerPresentChinese = { ...PlayerPresent, parameters: { forceLanguage: "zh" } };
+export const PlayerPresentChinese: StoryObj = {
+  ...PlayerPresent,
+  parameters: { forceLanguage: "zh" },
+};
 
-export const PlayerPresentWithCustomTimezone = {
-  render: function Story(): JSX.Element {
+export const PlayerPresentWithCustomTimezone: StoryObj = {
+  render: function Story() {
     const [_, setTimezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
 
     useEffect(() => {
@@ -195,13 +201,13 @@ export const PlayerPresentWithCustomTimezone = {
   },
 };
 
-export const PlayerPresentWithCustomTimezoneChinese = {
+export const PlayerPresentWithCustomTimezoneChinese: StoryObj = {
   ...PlayerPresentWithCustomTimezone,
   parameters: { forceLanguage: "zh" },
 };
 
-export const WithEvents = {
-  render: function Story(): JSX.Element {
+export const WithEvents: StoryObj = {
+  render: function Story() {
     const userContextValue = {
       currentUser: { id: "ok" } as User,
       signIn: () => undefined,
@@ -230,10 +236,10 @@ export const WithEvents = {
   },
 };
 
-export const WithEventsChinese = { ...WithEvents, parameters: { forceLanguage: "zh" } };
+export const WithEventsChinese: StoryObj = { ...WithEvents, parameters: { forceLanguage: "zh" } };
 
-export const PlayerWithError = {
-  render: function Story(): JSX.Element {
+export const PlayerWithError: StoryObj = {
+  render: function Story() {
     return (
       <MockMessagePipelineProvider
         presence={PlayerPresence.ERROR}
@@ -273,4 +279,7 @@ export const PlayerWithError = {
   },
 };
 
-export const PlayerWithErrorChinese = { ...PlayerWithError, parameters: { forceLanguage: "zh" } };
+export const PlayerWithErrorChinese: StoryObj = {
+  ...PlayerWithError,
+  parameters: { forceLanguage: "zh" },
+};

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
@@ -88,168 +88,189 @@ const TOPICS: Topic[] = [
   },
 ];
 
-export const PlayerNotPresent = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
-      <Box height="100%" bgcolor="background.paper">
-        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
-      </Box>
-    </MockMessagePipelineProvider>
-  );
+export const PlayerNotPresent = {
+  render: function Story(): JSX.Element {
+    return (
+      <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
+        <Box height="100%" bgcolor="background.paper">
+          <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+        </Box>
+      </MockMessagePipelineProvider>
+    );
+  },
 };
+
 export const PlayerNotPresentChinese = { ...PlayerNotPresent, parameters: { forceLanguage: "zh" } };
 
-export const PlayerIntializing = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider
-      startTime={START_TIME}
-      endTime={END_TIME}
-      presence={PlayerPresence.INITIALIZING}
-    >
-      <Box height="100%" bgcolor="background.paper">
-        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
-      </Box>
-    </MockMessagePipelineProvider>
-  );
+export const PlayerIntializing = {
+  render: function Story(): JSX.Element {
+    return (
+      <MockMessagePipelineProvider
+        startTime={START_TIME}
+        endTime={END_TIME}
+        presence={PlayerPresence.INITIALIZING}
+      >
+        <Box height="100%" bgcolor="background.paper">
+          <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+        </Box>
+      </MockMessagePipelineProvider>
+    );
+  },
 };
+
 export const PlayerIntializingChinese = {
   ...PlayerIntializing,
   parameters: { forceLanguage: "zh" },
 };
 
-export const PlayerReconnecting = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider
-      startTime={START_TIME}
-      endTime={END_TIME}
-      topics={TOPICS}
-      presence={PlayerPresence.RECONNECTING}
-      problems={[
-        {
-          severity: "error",
-          message: "Connection lost",
-          tip: "A tip that we might want to show the user",
-          error: new Error("Original Error"),
-        },
-      ]}
-    >
-      <Box height="100%" bgcolor="background.paper">
-        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
-      </Box>
-    </MockMessagePipelineProvider>
-  );
+export const PlayerReconnecting = {
+  render: function Story(): JSX.Element {
+    return (
+      <MockMessagePipelineProvider
+        startTime={START_TIME}
+        endTime={END_TIME}
+        topics={TOPICS}
+        presence={PlayerPresence.RECONNECTING}
+        problems={[
+          {
+            severity: "error",
+            message: "Connection lost",
+            tip: "A tip that we might want to show the user",
+            error: new Error("Original Error"),
+          },
+        ]}
+      >
+        <Box height="100%" bgcolor="background.paper">
+          <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+        </Box>
+      </MockMessagePipelineProvider>
+    );
+  },
 };
+
 export const PlayerReconnectingChinese = {
   ...PlayerReconnecting,
   parameters: { forceLanguage: "zh" },
 };
 
-export const PlayerPresent = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider
-      startTime={START_TIME}
-      endTime={END_TIME}
-      topics={TOPICS}
-      presence={PlayerPresence.PRESENT}
-    >
-      <Box height="100%" bgcolor="background.paper">
-        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
-      </Box>
-    </MockMessagePipelineProvider>
-  );
-};
-export const PlayerPresentChinese = { ...PlayerPresent, parameters: { forceLanguage: "zh" } };
-
-export const PlayerPresentWithCustomTimezone = (): JSX.Element => {
-  const [_, setTimezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
-
-  useEffect(() => {
-    setTimezone("Pacific/Ponape").catch(console.error);
-  }, [setTimezone]);
-
-  return (
-    <MockMessagePipelineProvider
-      startTime={fromDate(new Date(2022, 1, 22, 21, 22, 11))}
-      endTime={fromDate(new Date(2022, 1, 22, 23, 22, 22))}
-      topics={TOPICS}
-      presence={PlayerPresence.PRESENT}
-    >
-      <Box height="100%" bgcolor="background.paper">
-        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
-      </Box>
-    </MockMessagePipelineProvider>
-  );
-};
-export const PlayerPresentWithCustomTimezoneChinese = Object.assign(
-  PlayerPresentWithCustomTimezone.bind(undefined),
-  { parameters: { forceLanguage: "zh" } },
-);
-
-export const WithEvents = (): JSX.Element => {
-  const userContextValue = {
-    currentUser: { id: "ok" } as User,
-    signIn: () => undefined,
-    signOut: async () => undefined,
-  };
-
-  const setEventsSupported = useEvents((store) => store.setEventsSupported);
-  useEffect(() => {
-    setEventsSupported(true);
-  }, [setEventsSupported]);
-
-  return (
-    <MockMessagePipelineProvider
-      startTime={START_TIME}
-      endTime={END_TIME}
-      topics={TOPICS}
-      presence={PlayerPresence.PRESENT}
-    >
-      <CurrentUserContext.Provider value={userContextValue}>
+export const PlayerPresent = {
+  render: function Story(): JSX.Element {
+    return (
+      <MockMessagePipelineProvider
+        startTime={START_TIME}
+        endTime={END_TIME}
+        topics={TOPICS}
+        presence={PlayerPresence.PRESENT}
+      >
         <Box height="100%" bgcolor="background.paper">
           <DataSourceSidebar onSelectDataSourceAction={() => {}} />
         </Box>
-      </CurrentUserContext.Provider>
-    </MockMessagePipelineProvider>
-  );
+      </MockMessagePipelineProvider>
+    );
+  },
 };
+
+export const PlayerPresentChinese = { ...PlayerPresent, parameters: { forceLanguage: "zh" } };
+
+export const PlayerPresentWithCustomTimezone = {
+  render: function Story(): JSX.Element {
+    const [_, setTimezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
+
+    useEffect(() => {
+      setTimezone("Pacific/Ponape").catch(console.error);
+    }, [setTimezone]);
+
+    return (
+      <MockMessagePipelineProvider
+        startTime={fromDate(new Date(2022, 1, 22, 21, 22, 11))}
+        endTime={fromDate(new Date(2022, 1, 22, 23, 22, 22))}
+        topics={TOPICS}
+        presence={PlayerPresence.PRESENT}
+      >
+        <Box height="100%" bgcolor="background.paper">
+          <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+        </Box>
+      </MockMessagePipelineProvider>
+    );
+  },
+};
+
+export const PlayerPresentWithCustomTimezoneChinese = {
+  ...PlayerPresentWithCustomTimezone,
+  parameters: { forceLanguage: "zh" },
+};
+
+export const WithEvents = {
+  render: function Story(): JSX.Element {
+    const userContextValue = {
+      currentUser: { id: "ok" } as User,
+      signIn: () => undefined,
+      signOut: async () => undefined,
+    };
+
+    const setEventsSupported = useEvents((store) => store.setEventsSupported);
+    useEffect(() => {
+      setEventsSupported(true);
+    }, [setEventsSupported]);
+
+    return (
+      <MockMessagePipelineProvider
+        startTime={START_TIME}
+        endTime={END_TIME}
+        topics={TOPICS}
+        presence={PlayerPresence.PRESENT}
+      >
+        <CurrentUserContext.Provider value={userContextValue}>
+          <Box height="100%" bgcolor="background.paper">
+            <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+          </Box>
+        </CurrentUserContext.Provider>
+      </MockMessagePipelineProvider>
+    );
+  },
+};
+
 export const WithEventsChinese = { ...WithEvents, parameters: { forceLanguage: "zh" } };
 
-export const PlayerWithError = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider
-      presence={PlayerPresence.ERROR}
-      startTime={START_TIME}
-      endTime={END_TIME}
-      problems={[
-        {
-          severity: "error",
-          message: "Some message",
-          tip: "A tip that we might want to show the user",
-          error: new Error("Original Error"),
-        },
-        {
-          severity: "error",
-          message:
-            "Error initializing player: Error: Cannot identify bag format. at _.verifyBagHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:9) at async _.readHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:69) at async m.open (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:1:677) at async Se.initialize (https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:15:1986) at async https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:17:4281",
-          error: new Error(
-            "Error initializing player: Error: Cannot identify bag format. at _.verifyBagHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:9) at async _.readHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:69) at async m.open (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:1:677) at async Se.initialize (https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:15:1986) at async https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:17:4281",
-          ),
-          tip: "Is this a bag file?",
-        },
-        {
-          severity: "warn",
-          message: "Some longer warning message about sadness",
-        },
-        {
-          severity: "info",
-          message: "Some longer info message",
-        },
-      ]}
-    >
-      <Box height="100%" bgcolor="background.paper">
-        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
-      </Box>
-    </MockMessagePipelineProvider>
-  );
+export const PlayerWithError = {
+  render: function Story(): JSX.Element {
+    return (
+      <MockMessagePipelineProvider
+        presence={PlayerPresence.ERROR}
+        startTime={START_TIME}
+        endTime={END_TIME}
+        problems={[
+          {
+            severity: "error",
+            message: "Some message",
+            tip: "A tip that we might want to show the user",
+            error: new Error("Original Error"),
+          },
+          {
+            severity: "error",
+            message:
+              "Error initializing player: Error: Cannot identify bag format. at _.verifyBagHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:9) at async _.readHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:69) at async m.open (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:1:677) at async Se.initialize (https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:15:1986) at async https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:17:4281",
+            error: new Error(
+              "Error initializing player: Error: Cannot identify bag format. at _.verifyBagHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:9) at async _.readHeader (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:2:69) at async m.open (https://studio.foxglove.dev/5562.c1166ea8644d0123e6d6.js:1:677) at async Se.initialize (https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:15:1986) at async https://studio.foxglove.dev/1324.f562ab30da8aea77f0c3.js:17:4281",
+            ),
+            tip: "Is this a bag file?",
+          },
+          {
+            severity: "warn",
+            message: "Some longer warning message about sadness",
+          },
+          {
+            severity: "info",
+            message: "Some longer info message",
+          },
+        ]}
+      >
+        <Box height="100%" bgcolor="background.paper">
+          <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+        </Box>
+      </MockMessagePipelineProvider>
+    );
+  },
 };
+
 export const PlayerWithErrorChinese = { ...PlayerWithError, parameters: { forceLanguage: "zh" } };

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { useEffect } from "react";
 
 import { fromDate } from "@foxglove/rostime";
@@ -17,10 +17,10 @@ import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 
 import DataSourceSidebar from "./DataSourceSidebar";
 
-function Wrapper(StoryFn: Story): JSX.Element {
+function Wrapper(Wrapped: StoryFn): JSX.Element {
   return (
     <EventsProvider>
-      <StoryFn />
+      <Wrapped />
     </EventsProvider>
   );
 }

--- a/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { useEffect } from "react";
 
@@ -38,24 +38,28 @@ export const Default: StoryFn = (): JSX.Element => {
   return <EventsList />;
 };
 
-export const Selected: StoryFn = (): JSX.Element => {
-  const setEvents = useEvents((store) => store.setEvents);
-  const selectEvent = useEvents((store) => store.selectEvent);
+export const Selected: StoryObj = {
+  render: function Story(): JSX.Element {
+    const setEvents = useEvents((store) => store.setEvents);
+    const selectEvent = useEvents((store) => store.selectEvent);
 
-  useEffect(() => {
-    const events = makeMockEvents(20);
+    useEffect(() => {
+      const events = makeMockEvents(20);
 
-    setEvents({ loading: false, value: events });
-  }, [selectEvent, setEvents]);
+      setEvents({ loading: false, value: events });
+    }, [selectEvent, setEvents]);
 
-  return <EventsList />;
-};
-Selected.play = async () => {
-  const events = await screen.findAllByTestId("sidebar-event");
-  userEvent.click(events[1]!);
-};
-Selected.parameters = {
-  colorScheme: "light",
+    return <EventsList />;
+  },
+
+  play: async () => {
+    const events = await screen.findAllByTestId("sidebar-event");
+    userEvent.click(events[1]!);
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
 };
 
 export const WithError: StoryFn = (): JSX.Element => {

--- a/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
@@ -29,17 +29,19 @@ export default {
   decorators: [Wrapper],
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  const setEvents = useEvents((store) => store.setEvents);
-  useEffect(() => {
-    setEvents({ loading: false, value: makeMockEvents(20) });
-  }, [setEvents]);
+export const Default: StoryObj = {
+  render: function Story() {
+    const setEvents = useEvents((store) => store.setEvents);
+    useEffect(() => {
+      setEvents({ loading: false, value: makeMockEvents(20) });
+    }, [setEvents]);
 
-  return <EventsList />;
+    return <EventsList />;
+  },
 };
 
 export const Selected: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const setEvents = useEvents((store) => store.setEvents);
     const selectEvent = useEvents((store) => store.selectEvent);
 
@@ -62,20 +64,24 @@ export const Selected: StoryObj = {
   },
 };
 
-export const WithError: StoryFn = (): JSX.Element => {
-  const setEvents = useEvents((store) => store.setEvents);
-  useEffect(() => {
-    setEvents({ loading: false, error: new Error("Error loading events") });
-  }, [setEvents]);
+export const WithError: StoryObj = {
+  render: function Story() {
+    const setEvents = useEvents((store) => store.setEvents);
+    useEffect(() => {
+      setEvents({ loading: false, error: new Error("Error loading events") });
+    }, [setEvents]);
 
-  return <EventsList />;
+    return <EventsList />;
+  },
 };
 
-export const Loading: StoryFn = (): JSX.Element => {
-  const setEvents = useEvents((store) => store.setEvents);
-  useEffect(() => {
-    setEvents({ loading: true });
-  }, [setEvents]);
+export const Loading: StoryObj = {
+  render: function Story() {
+    const setEvents = useEvents((store) => store.setEvents);
+    useEffect(() => {
+      setEvents({ loading: true });
+    }, [setEvents]);
 
-  return <EventsList />;
+    return <EventsList />;
+  },
 };

--- a/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
@@ -29,16 +29,16 @@ export default {
   decorators: [Wrapper],
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   const setEvents = useEvents((store) => store.setEvents);
   useEffect(() => {
     setEvents({ loading: false, value: makeMockEvents(20) });
   }, [setEvents]);
 
   return <EventsList />;
-}
+};
 
-export function Selected(): JSX.Element {
+export const Selected: StoryFn = (): JSX.Element => {
   const setEvents = useEvents((store) => store.setEvents);
   const selectEvent = useEvents((store) => store.selectEvent);
 
@@ -49,7 +49,7 @@ export function Selected(): JSX.Element {
   }, [selectEvent, setEvents]);
 
   return <EventsList />;
-}
+};
 Selected.play = async () => {
   const events = await screen.findAllByTestId("sidebar-event");
   userEvent.click(events[1]!);
@@ -58,20 +58,20 @@ Selected.parameters = {
   colorScheme: "light",
 };
 
-export function WithError(): JSX.Element {
+export const WithError: StoryFn = (): JSX.Element => {
   const setEvents = useEvents((store) => store.setEvents);
   useEffect(() => {
     setEvents({ loading: false, error: new Error("Error loading events") });
   }, [setEvents]);
 
   return <EventsList />;
-}
+};
 
-export function Loading(): JSX.Element {
+export const Loading: StoryFn = (): JSX.Element => {
   const setEvents = useEvents((store) => store.setEvents);
   useEffect(() => {
     setEvents({ loading: true });
   }, [setEvents]);
 
   return <EventsList />;
-}
+};

--- a/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/EventsList.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { useEffect } from "react";
 
@@ -13,7 +13,7 @@ import { makeMockEvents } from "@foxglove/studio-base/test/mocks/makeMockEvents"
 
 import { EventsList } from "./EventsList";
 
-function Wrapper(Child: Story): JSX.Element {
+function Wrapper(Child: StoryFn): JSX.Element {
   return (
     <MockMessagePipelineProvider>
       <EventsProvider>

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
@@ -55,6 +55,8 @@ export default {
   decorators: [Wrapper],
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return <TopicList />;
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return <TopicList />;
+  },
 };

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
@@ -56,7 +56,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <TopicList />;
   },
 };

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
@@ -55,6 +55,6 @@ export default {
   decorators: [Wrapper],
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return <TopicList />;
-}
+};

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
@@ -2,14 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
 
 import { TopicList } from "./TopicList";
 
-function Wrapper(StoryFn: Story): JSX.Element {
+function Wrapper(Wrapped: StoryFn): JSX.Element {
   return (
     <MockMessagePipelineProvider
       capabilities={[PlayerCapabilities.playbackControl]}
@@ -44,7 +44,7 @@ function Wrapper(StoryFn: Story): JSX.Element {
         ])
       }
     >
-      <StoryFn />
+      <Wrapped />
     </MockMessagePipelineProvider>
   );
 }

--- a/packages/studio-base/src/components/DropOverlay.stories.tsx
+++ b/packages/studio-base/src/components/DropOverlay.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
+
 import DropOverlay from "@foxglove/studio-base/components/DropOverlay";
 
 export default {
@@ -9,12 +11,12 @@ export default {
   component: DropOverlay,
 };
 
-export const Dark = {
-  render: (): JSX.Element => <DropOverlay open>Some DropOverlay</DropOverlay>,
+export const Dark: StoryObj = {
+  render: () => <DropOverlay open>Some DropOverlay</DropOverlay>,
   parameters: { colorScheme: "dark" },
 };
 
-export const Light = {
-  render: (): JSX.Element => <DropOverlay open>Some DropOverlay</DropOverlay>,
+export const Light: StoryObj = {
+  render: () => <DropOverlay open>Some DropOverlay</DropOverlay>,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/components/DropOverlay.stories.tsx
+++ b/packages/studio-base/src/components/DropOverlay.stories.tsx
@@ -9,8 +9,12 @@ export default {
   component: DropOverlay,
 };
 
-export const Dark = (): JSX.Element => <DropOverlay open>Some DropOverlay</DropOverlay>;
-Dark.parameters = { colorScheme: "dark" };
+export const Dark = {
+  render: (): JSX.Element => <DropOverlay open>Some DropOverlay</DropOverlay>,
+  parameters: { colorScheme: "dark" },
+};
 
-export const Light = (): JSX.Element => <DropOverlay open>Some DropOverlay</DropOverlay>;
-Light.parameters = { colorScheme: "light" };
+export const Light = {
+  render: (): JSX.Element => <DropOverlay open>Some DropOverlay</DropOverlay>,
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/components/ErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -35,22 +35,26 @@ export default {
   title: "components/ErrorBoundary",
 };
 
-export const Default: StoryFn = () => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <ErrorBoundary>
-        <Broken />
-      </ErrorBoundary>
-    </DndProvider>
-  );
+export const Default: StoryObj = {
+  render: () => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <ErrorBoundary>
+          <Broken />
+        </ErrorBoundary>
+      </DndProvider>
+    );
+  },
 };
 
-export const ShowingDetails: StoryFn = () => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <ErrorBoundary showErrorDetails hideErrorSourceLocations>
-        <Broken />
-      </ErrorBoundary>
-    </DndProvider>
-  );
+export const ShowingDetails: StoryObj = {
+  render: () => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <ErrorBoundary showErrorDetails hideErrorSourceLocations>
+          <Broken />
+        </ErrorBoundary>
+      </DndProvider>
+    );
+  },
 };

--- a/packages/studio-base/src/components/ErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -35,7 +35,7 @@ export default {
   title: "components/ErrorBoundary",
 };
 
-export const Default: Story = () => {
+export const Default: StoryFn = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <ErrorBoundary>
@@ -45,7 +45,7 @@ export const Default: Story = () => {
   );
 };
 
-export const ShowingDetails: Story = () => {
+export const ShowingDetails: StoryFn = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <ErrorBoundary showErrorDetails hideErrorSourceLocations>

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.stories.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.stories.tsx
@@ -11,8 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
-import { ReactElement, useState } from "react";
+import { StoryObj } from "@storybook/react";
+import { useState } from "react";
 
 import { ExperimentalFeatureSettings } from "@foxglove/studio-base/components/ExperimentalFeatureSettings";
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
@@ -23,12 +23,14 @@ export default {
   component: ExperimentalFeatureSettings,
 };
 
-export const Basic: StoryFn = (): ReactElement => {
-  const [config] = useState(() => makeMockAppConfiguration());
+export const Basic: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
 
-  return (
-    <AppConfigurationContext.Provider value={config}>
-      <ExperimentalFeatureSettings />
-    </AppConfigurationContext.Provider>
-  );
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExperimentalFeatureSettings />
+      </AppConfigurationContext.Provider>
+    );
+  },
 };

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.stories.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryFn } from "@storybook/react";
 import { ReactElement, useState } from "react";
 
 import { ExperimentalFeatureSettings } from "@foxglove/studio-base/components/ExperimentalFeatureSettings";
@@ -22,7 +23,7 @@ export default {
   component: ExperimentalFeatureSettings,
 };
 
-export function Basic(): ReactElement {
+export const Basic: StoryFn = (): ReactElement => {
   const [config] = useState(() => makeMockAppConfiguration());
 
   return (
@@ -30,4 +31,4 @@ export function Basic(): ReactElement {
       <ExperimentalFeatureSettings />
     </AppConfigurationContext.Provider>
   );
-}
+};

--- a/packages/studio-base/src/components/ExtensionDetails.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useState } from "react";
 
 import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
@@ -67,16 +67,18 @@ const extension: ExtensionMarketplaceDetail = {
   },
 };
 
-export const Details: StoryFn = (): JSX.Element => {
-  const [config] = useState(() => makeMockAppConfiguration());
+export const Details: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
 
-  return (
-    <AppConfigurationContext.Provider value={config}>
-      <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
-        <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
-          <ExtensionDetails extension={extension} onClose={() => {}} installed={false} />
-        </ExtensionMarketplaceContext.Provider>
-      </ExtensionCatalogProvider>
-    </AppConfigurationContext.Provider>
-  );
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+          <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
+            <ExtensionDetails extension={extension} onClose={() => {}} installed={false} />
+          </ExtensionMarketplaceContext.Provider>
+        </ExtensionCatalogProvider>
+      </AppConfigurationContext.Provider>
+    );
+  },
 };

--- a/packages/studio-base/src/components/ExtensionDetails.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryFn } from "@storybook/react";
 import { useState } from "react";
 
 import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
@@ -66,7 +67,7 @@ const extension: ExtensionMarketplaceDetail = {
   },
 };
 
-export function Details(): JSX.Element {
+export const Details: StoryFn = (): JSX.Element => {
   const [config] = useState(() => makeMockAppConfiguration());
 
   return (
@@ -78,4 +79,4 @@ export function Details(): JSX.Element {
       </ExtensionCatalogProvider>
     </AppConfigurationContext.Provider>
   );
-}
+};

--- a/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useState } from "react";
 
 import { ExtensionInfo, ExtensionLoader } from "@foxglove/studio-base";
@@ -88,16 +88,18 @@ const MockExtensionMarketplace: ExtensionMarketplace = {
 Mock markdown rendering for URL [${url}](${url}).`,
 };
 
-export const Sidebar: StoryFn = (): JSX.Element => {
-  const [config] = useState(() => makeMockAppConfiguration());
+export const Sidebar: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
 
-  return (
-    <AppConfigurationContext.Provider value={config}>
-      <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
-        <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
-          <ExtensionsSettings />
-        </ExtensionMarketplaceContext.Provider>
-      </ExtensionCatalogProvider>
-    </AppConfigurationContext.Provider>
-  );
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+          <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
+            <ExtensionsSettings />
+          </ExtensionMarketplaceContext.Provider>
+        </ExtensionCatalogProvider>
+      </AppConfigurationContext.Provider>
+    );
+  },
 };

--- a/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryFn } from "@storybook/react";
 import { useState } from "react";
 
 import { ExtensionInfo, ExtensionLoader } from "@foxglove/studio-base";
@@ -87,7 +88,7 @@ const MockExtensionMarketplace: ExtensionMarketplace = {
 Mock markdown rendering for URL [${url}](${url}).`,
 };
 
-export function Sidebar(): JSX.Element {
+export const Sidebar: StoryFn = (): JSX.Element => {
   const [config] = useState(() => makeMockAppConfiguration());
 
   return (
@@ -99,4 +100,4 @@ export function Sidebar(): JSX.Element {
       </ExtensionCatalogProvider>
     </AppConfigurationContext.Provider>
   );
-}
+};

--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { UnsavedChangesPrompt } from "@foxglove/studio-base/components/LayoutBrowser/UnsavedChangesPrompt";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
@@ -32,47 +32,62 @@ const dummyLayout: Layout = {
   syncInfo: undefined,
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return <UnsavedChangesPrompt isOnline layout={dummyLayout} onComplete={action("onComplete")} />;
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return <UnsavedChangesPrompt isOnline layout={dummyLayout} onComplete={action("onComplete")} />;
+  },
 };
+
 export const DefaultLight = { ...Default, parameters: { colorScheme: "light" } };
 
-export const Offline: StoryFn = (): JSX.Element => {
-  return (
-    <UnsavedChangesPrompt isOnline={false} layout={dummyLayout} onComplete={action("onComplete")} />
-  );
+export const Offline: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <UnsavedChangesPrompt
+        isOnline={false}
+        layout={dummyLayout}
+        onComplete={action("onComplete")}
+      />
+    );
+  },
 };
 
-export const Overwrite: StoryFn = (): JSX.Element => {
-  return (
-    <UnsavedChangesPrompt
-      isOnline
-      layout={dummyLayout}
-      onComplete={action("onComplete")}
-      defaultSelectedKey="overwrite"
-    />
-  );
+export const Overwrite: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <UnsavedChangesPrompt
+        isOnline
+        layout={dummyLayout}
+        onComplete={action("onComplete")}
+        defaultSelectedKey="overwrite"
+      />
+    );
+  },
 };
 
-export const MakePersonal: StoryFn = (): JSX.Element => {
-  return (
-    <UnsavedChangesPrompt
-      isOnline
-      layout={dummyLayout}
-      onComplete={action("onComplete")}
-      defaultSelectedKey="makePersonal"
-    />
-  );
+export const MakePersonal: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <UnsavedChangesPrompt
+        isOnline
+        layout={dummyLayout}
+        onComplete={action("onComplete")}
+        defaultSelectedKey="makePersonal"
+      />
+    );
+  },
 };
 
-export const MakePersonalWithEmptyField: StoryFn = (): JSX.Element => {
-  return (
-    <UnsavedChangesPrompt
-      isOnline
-      layout={dummyLayout}
-      onComplete={action("onComplete")}
-      defaultSelectedKey="makePersonal"
-      defaultPersonalCopyName=""
-    />
-  );
+export const MakePersonalWithEmptyField: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <UnsavedChangesPrompt
+        isOnline
+        layout={dummyLayout}
+        onComplete={action("onComplete")}
+        defaultSelectedKey="makePersonal"
+        defaultPersonalCopyName=""
+      />
+    );
+  },
 };

--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
+import { StoryFn } from "@storybook/react";
 
 import { UnsavedChangesPrompt } from "@foxglove/studio-base/components/LayoutBrowser/UnsavedChangesPrompt";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
@@ -31,20 +32,20 @@ const dummyLayout: Layout = {
   syncInfo: undefined,
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return <UnsavedChangesPrompt isOnline layout={dummyLayout} onComplete={action("onComplete")} />;
-}
+};
 export const DefaultLight = Object.assign(Default.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-export function Offline(): JSX.Element {
+export const Offline: StoryFn = (): JSX.Element => {
   return (
     <UnsavedChangesPrompt isOnline={false} layout={dummyLayout} onComplete={action("onComplete")} />
   );
-}
+};
 
-export function Overwrite(): JSX.Element {
+export const Overwrite: StoryFn = (): JSX.Element => {
   return (
     <UnsavedChangesPrompt
       isOnline
@@ -53,9 +54,9 @@ export function Overwrite(): JSX.Element {
       defaultSelectedKey="overwrite"
     />
   );
-}
+};
 
-export function MakePersonal(): JSX.Element {
+export const MakePersonal: StoryFn = (): JSX.Element => {
   return (
     <UnsavedChangesPrompt
       isOnline
@@ -64,9 +65,9 @@ export function MakePersonal(): JSX.Element {
       defaultSelectedKey="makePersonal"
     />
   );
-}
+};
 
-export function MakePersonalWithEmptyField(): JSX.Element {
+export const MakePersonalWithEmptyField: StoryFn = (): JSX.Element => {
   return (
     <UnsavedChangesPrompt
       isOnline
@@ -76,4 +77,4 @@ export function MakePersonalWithEmptyField(): JSX.Element {
       defaultPersonalCopyName=""
     />
   );
-}
+};

--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
@@ -33,15 +33,15 @@ const dummyLayout: Layout = {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <UnsavedChangesPrompt isOnline layout={dummyLayout} onComplete={action("onComplete")} />;
   },
 };
 
-export const DefaultLight = { ...Default, parameters: { colorScheme: "light" } };
+export const DefaultLight: StoryObj = { ...Default, parameters: { colorScheme: "light" } };
 
 export const Offline: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <UnsavedChangesPrompt
         isOnline={false}
@@ -53,7 +53,7 @@ export const Offline: StoryObj = {
 };
 
 export const Overwrite: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <UnsavedChangesPrompt
         isOnline
@@ -66,7 +66,7 @@ export const Overwrite: StoryObj = {
 };
 
 export const MakePersonal: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <UnsavedChangesPrompt
         isOnline
@@ -79,7 +79,7 @@ export const MakePersonal: StoryObj = {
 };
 
 export const MakePersonalWithEmptyField: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <UnsavedChangesPrompt
         isOnline

--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
@@ -35,9 +35,7 @@ const dummyLayout: Layout = {
 export const Default: StoryFn = (): JSX.Element => {
   return <UnsavedChangesPrompt isOnline layout={dummyLayout} onComplete={action("onComplete")} />;
 };
-export const DefaultLight = Object.assign(Default.bind(undefined), {
-  parameters: { colorScheme: "light" },
-});
+export const DefaultLight = { ...Default, parameters: { colorScheme: "light" } };
 
 export const Offline: StoryFn = (): JSX.Element => {
   return (

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -300,7 +300,7 @@ export const MenuOpen: StoryObj = {
 export const MenuOpenLight: StoryObj = {
   ...MenuOpen,
   parameters: { colorScheme: "light" },
-  play: async (): Promise<void> => {
+  play: async () => {
     const actions = await screen.findAllByTestId("layout-actions");
     if (actions[1]) {
       fireEvent.click(actions[1]);

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -146,14 +146,14 @@ export default {
   decorators: [WithSetup],
 };
 
-export function Empty(): JSX.Element {
+export const Empty: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 Empty.parameters = { mockLayouts: [] };
 
-export function LayoutList(): JSX.Element {
+export const LayoutList: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 
 export const MultiSelect: StoryObj = {
   render: (): JSX.Element => {
@@ -185,9 +185,9 @@ export const MultiSelect: StoryObj = {
   },
 };
 
-export function MultiDelete(): JSX.Element {
+export const MultiDelete: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 MultiDelete.parameters = { colorScheme: "dark" };
 MultiDelete.play = async () => {
   await doMultiAction("Delete");
@@ -196,9 +196,9 @@ MultiDelete.play = async () => {
   fireEvent.click(confirmButton);
 };
 
-export function MultiDuplicate(): JSX.Element {
+export const MultiDuplicate: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 MultiDuplicate.parameters = {
   colorScheme: "dark",
   mockLayouts: [exampleCurrentLayout, makeUnsavedLayout(1), shortLayout],
@@ -207,9 +207,9 @@ MultiDuplicate.play = async () => {
   await doMultiAction("Duplicate");
 };
 
-export function MultiRevert(): JSX.Element {
+export const MultiRevert: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 MultiRevert.parameters = {
   colorScheme: "dark",
   mockLayouts: [makeUnsavedLayout(1), makeUnsavedLayout(2), makeUnsavedLayout(3)],
@@ -221,9 +221,9 @@ MultiRevert.play = async () => {
   fireEvent.click(revertButton);
 };
 
-export function MultiSave(): JSX.Element {
+export const MultiSave: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 MultiSave.parameters = {
   colorScheme: "dark",
   mockLayouts: [makeUnsavedLayout(1), makeUnsavedLayout(2), makeUnsavedLayout(3)],
@@ -241,9 +241,9 @@ TruncatedLayoutName.parameters = {
     },
   ],
 };
-export function TruncatedLayoutName(): JSX.Element {
+export const TruncatedLayoutName: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 
 TruncatedLayoutNameSelected.parameters = {
   mockLayouts: [
@@ -254,26 +254,26 @@ TruncatedLayoutNameSelected.parameters = {
     },
   ],
 };
-export function TruncatedLayoutNameSelected(): JSX.Element {
+export const TruncatedLayoutNameSelected: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 
-export function AddLayout(_args: unknown): JSX.Element {
+export const AddLayout: StoryFn = (): JSX.Element => {
   return (
     <LayoutBrowser
       currentDateForStorybook={useMemo(() => new Date("2021-06-16T04:28:33.549Z"), [])}
     />
   );
-}
+};
 AddLayout.parameters = { colorScheme: "dark" };
 AddLayout.play = async () => {
   const button = await screen.findByTestId("add-layout");
   fireEvent.click(button);
 };
 
-export function MenuOpen(_args: unknown): JSX.Element {
+export const MenuOpen: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 MenuOpen.parameters = { colorScheme: "dark" };
 MenuOpen.play = async () => {
   const actions = await screen.findAllByTestId("layout-actions");
@@ -291,9 +291,9 @@ MenuOpenLight.play = async () => {
   }
 };
 
-export function EditingName(_args: unknown): JSX.Element {
+export const EditingName: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 EditingName.parameters = { colorScheme: "dark" };
 EditingName.play = async () => {
   const actions = await screen.findAllByTestId("layout-actions");
@@ -304,9 +304,9 @@ EditingName.play = async () => {
   fireEvent.click(button);
 };
 
-export function CancelRenameWithEscape(_args: unknown): JSX.Element {
+export const CancelRenameWithEscape: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 CancelRenameWithEscape.parameters = { colorScheme: "dark" };
 CancelRenameWithEscape.play = async () => {
   const actions = await screen.findAllByTestId("layout-actions");
@@ -318,9 +318,9 @@ CancelRenameWithEscape.play = async () => {
   fireEvent.keyDown(document.activeElement!, { key: "Escape" });
 };
 
-export function CommitRenameWithTab(_args: unknown): JSX.Element {
+export const CommitRenameWithTab: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 CommitRenameWithTab.parameters = { colorScheme: "dark" };
 CommitRenameWithTab.play = async () => {
   const actions = await screen.findAllByTestId("layout-actions");
@@ -333,9 +333,9 @@ CommitRenameWithTab.play = async () => {
   fireEvent.focusOut(document.activeElement!);
 };
 
-export function Duplicate(_args: unknown): JSX.Element {
+export const Duplicate: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 Duplicate.parameters = { colorScheme: "dark" };
 Duplicate.play = async () => {
   const actions = await screen.findAllByTestId("layout-actions");
@@ -346,15 +346,15 @@ Duplicate.play = async () => {
   fireEvent.click(button);
 };
 
-export function DeleteLayout(_args: unknown): JSX.Element {
+export const DeleteLayout: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 DeleteLayout.parameters = { colorScheme: "dark" };
 DeleteLayout.play = async () => await deleteLayoutInteraction(0);
 
-export function DeleteSelectedLayout(_args: unknown): JSX.Element {
+export const DeleteSelectedLayout: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 DeleteSelectedLayout.play = async () => {
   const layouts = await screen.findAllByTestId("layout-list-item");
   if (layouts[1]) {
@@ -367,16 +367,16 @@ DeleteSelectedLayout.play = async () => {
 };
 DeleteSelectedLayout.parameters = { colorScheme: "dark" };
 
-export function DeleteLastLayout(_args: unknown): JSX.Element {
+export const DeleteLastLayout: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
-}
+};
 DeleteLastLayout.parameters = {
   mockLayouts: [exampleCurrentLayout],
   colorScheme: "dark",
 };
 DeleteLastLayout.play = async () => await deleteLayoutInteraction(0);
 
-export function SignInPrompt(_args: unknown): JSX.Element {
+export const SignInPrompt: StoryFn = (): JSX.Element => {
   return (
     <CurrentUserContext.Provider
       value={{
@@ -390,7 +390,7 @@ export function SignInPrompt(_args: unknown): JSX.Element {
       </WorkspaceContextProvider>
     </CurrentUserContext.Provider>
   );
-}
+};
 SignInPrompt.parameters = {
   colorScheme: "light",
 };

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -291,13 +291,15 @@ export const MenuOpen: StoryObj = {
   },
 };
 
-export const MenuOpenLight = MenuOpen.bind(undefined);
-MenuOpenLight.parameters = { colorScheme: "light" };
-MenuOpenLight.play = async () => {
-  const actions = await screen.findAllByTestId("layout-actions");
-  if (actions[1]) {
-    fireEvent.click(actions[1]);
-  }
+export const MenuOpenLight = {
+  ...MenuOpen,
+  parameters: { colorScheme: "light" },
+  play: async (): Promise<void> => {
+    const actions = await screen.findAllByTestId("layout-actions");
+    if (actions[1]) {
+      fireEvent.click(actions[1]);
+    }
+  },
 };
 
 export const EditingName: StoryObj = {

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -146,17 +146,20 @@ export default {
   decorators: [WithSetup],
 };
 
-export const Empty: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
+export const Empty: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: { mockLayouts: [] },
 };
-Empty.parameters = { mockLayouts: [] };
 
 export const LayoutList: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
 };
 
 export const MultiSelect: StoryObj = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <LayoutBrowser />;
   },
 
@@ -185,101 +188,107 @@ export const MultiSelect: StoryObj = {
   },
 };
 
-export const MultiDelete: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-MultiDelete.parameters = { colorScheme: "dark" };
-MultiDelete.play = async () => {
-  await doMultiAction("Delete");
+export const MultiDelete: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
 
-  const confirmButton = await screen.findByText("Delete");
-  fireEvent.click(confirmButton);
-};
+  parameters: { colorScheme: "dark" },
 
-export const MultiDuplicate: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-MultiDuplicate.parameters = {
-  colorScheme: "dark",
-  mockLayouts: [exampleCurrentLayout, makeUnsavedLayout(1), shortLayout],
-};
-MultiDuplicate.play = async () => {
-  await doMultiAction("Duplicate");
+  play: async () => {
+    await doMultiAction("Delete");
+
+    const confirmButton = await screen.findByText("Delete");
+    fireEvent.click(confirmButton);
+  },
 };
 
-export const MultiRevert: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-MultiRevert.parameters = {
-  colorScheme: "dark",
-  mockLayouts: [makeUnsavedLayout(1), makeUnsavedLayout(2), makeUnsavedLayout(3)],
-};
-MultiRevert.play = async () => {
-  await doMultiAction("Revert");
+export const MultiDuplicate: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
 
-  const revertButton = await screen.findByText("Discard changes");
-  fireEvent.click(revertButton);
-};
+  parameters: {
+    colorScheme: "dark",
+    mockLayouts: [exampleCurrentLayout, makeUnsavedLayout(1), shortLayout],
+  },
 
-export const MultiSave: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-MultiSave.parameters = {
-  colorScheme: "dark",
-  mockLayouts: [makeUnsavedLayout(1), makeUnsavedLayout(2), makeUnsavedLayout(3)],
-};
-MultiSave.play = async () => {
-  await doMultiAction("Save changes");
+  play: async () => {
+    await doMultiAction("Duplicate");
+  },
 };
 
-TruncatedLayoutName.parameters = {
-  mockLayouts: [
-    {
-      id: "not-current",
-      name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-      baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
-    },
-  ],
+export const MultiRevert: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: {
+    colorScheme: "dark",
+    mockLayouts: [makeUnsavedLayout(1), makeUnsavedLayout(2), makeUnsavedLayout(3)],
+  },
+
+  play: async () => {
+    await doMultiAction("Revert");
+
+    const revertButton = await screen.findByText("Discard changes");
+    fireEvent.click(revertButton);
+  },
 };
+
+export const MultiSave: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: {
+    colorScheme: "dark",
+    mockLayouts: [makeUnsavedLayout(1), makeUnsavedLayout(2), makeUnsavedLayout(3)],
+  },
+
+  play: async () => {
+    await doMultiAction("Save changes");
+  },
+};
+
 export const TruncatedLayoutName: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
 };
 
-TruncatedLayoutNameSelected.parameters = {
-  mockLayouts: [
-    {
-      id: "test-id",
-      name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
-      baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
-    },
-  ],
-};
 export const TruncatedLayoutNameSelected: StoryFn = (): JSX.Element => {
   return <LayoutBrowser />;
 };
 
-export const AddLayout: StoryFn = (): JSX.Element => {
-  return (
-    <LayoutBrowser
-      currentDateForStorybook={useMemo(() => new Date("2021-06-16T04:28:33.549Z"), [])}
-    />
-  );
-};
-AddLayout.parameters = { colorScheme: "dark" };
-AddLayout.play = async () => {
-  const button = await screen.findByTestId("add-layout");
-  fireEvent.click(button);
+export const AddLayout: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <LayoutBrowser
+        currentDateForStorybook={useMemo(() => new Date("2021-06-16T04:28:33.549Z"), [])}
+      />
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const button = await screen.findByTestId("add-layout");
+    fireEvent.click(button);
+  },
 };
 
-export const MenuOpen: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-MenuOpen.parameters = { colorScheme: "dark" };
-MenuOpen.play = async () => {
-  const actions = await screen.findAllByTestId("layout-actions");
-  if (actions[1]) {
-    fireEvent.click(actions[1]);
-  }
+export const MenuOpen: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const actions = await screen.findAllByTestId("layout-actions");
+    if (actions[1]) {
+      fireEvent.click(actions[1]);
+    }
+  },
 };
 
 export const MenuOpenLight = MenuOpen.bind(undefined);
@@ -291,106 +300,136 @@ MenuOpenLight.play = async () => {
   }
 };
 
-export const EditingName: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-EditingName.parameters = { colorScheme: "dark" };
-EditingName.play = async () => {
-  const actions = await screen.findAllByTestId("layout-actions");
-  if (actions[1]) {
-    fireEvent.click(actions[1]);
-  }
-  const button = await screen.findByText("Rename");
-  fireEvent.click(button);
+export const EditingName: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const actions = await screen.findAllByTestId("layout-actions");
+    if (actions[1]) {
+      fireEvent.click(actions[1]);
+    }
+    const button = await screen.findByText("Rename");
+    fireEvent.click(button);
+  },
 };
 
-export const CancelRenameWithEscape: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-CancelRenameWithEscape.parameters = { colorScheme: "dark" };
-CancelRenameWithEscape.play = async () => {
-  const actions = await screen.findAllByTestId("layout-actions");
-  if (actions[1]) {
-    fireEvent.click(actions[1]);
-  }
-  const button = await screen.findByText("Rename");
-  fireEvent.click(button);
-  fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+export const CancelRenameWithEscape: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const actions = await screen.findAllByTestId("layout-actions");
+    if (actions[1]) {
+      fireEvent.click(actions[1]);
+    }
+    const button = await screen.findByText("Rename");
+    fireEvent.click(button);
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+  },
 };
 
-export const CommitRenameWithTab: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-CommitRenameWithTab.parameters = { colorScheme: "dark" };
-CommitRenameWithTab.play = async () => {
-  const actions = await screen.findAllByTestId("layout-actions");
-  if (actions[1]) {
-    fireEvent.click(actions[1]);
-  }
-  const button = await screen.findByText("Rename");
-  fireEvent.click(button);
-  fireEvent.change(document.activeElement!, { target: { value: "New name" } });
-  fireEvent.focusOut(document.activeElement!);
+export const CommitRenameWithTab: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const actions = await screen.findAllByTestId("layout-actions");
+    if (actions[1]) {
+      fireEvent.click(actions[1]);
+    }
+    const button = await screen.findByText("Rename");
+    fireEvent.click(button);
+    fireEvent.change(document.activeElement!, { target: { value: "New name" } });
+    fireEvent.focusOut(document.activeElement!);
+  },
 };
 
-export const Duplicate: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-Duplicate.parameters = { colorScheme: "dark" };
-Duplicate.play = async () => {
-  const actions = await screen.findAllByTestId("layout-actions");
-  if (actions[1]) {
-    fireEvent.click(actions[1]);
-  }
-  const button = await screen.findByText("Duplicate");
-  fireEvent.click(button);
+export const Duplicate: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const actions = await screen.findAllByTestId("layout-actions");
+    if (actions[1]) {
+      fireEvent.click(actions[1]);
+    }
+    const button = await screen.findByText("Duplicate");
+    fireEvent.click(button);
+  },
 };
 
-export const DeleteLayout: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-DeleteLayout.parameters = { colorScheme: "dark" };
-DeleteLayout.play = async () => await deleteLayoutInteraction(0);
+export const DeleteLayout: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
 
-export const DeleteSelectedLayout: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
+  parameters: { colorScheme: "dark" },
+  play: async () => await deleteLayoutInteraction(0),
 };
-DeleteSelectedLayout.play = async () => {
-  const layouts = await screen.findAllByTestId("layout-list-item");
-  if (layouts[1]) {
-    fireEvent.click(layouts[1]);
-  }
-  await deleteLayoutInteraction(1);
-  if (layouts[0]) {
-    fireEvent.click(layouts[0]);
-  }
-};
-DeleteSelectedLayout.parameters = { colorScheme: "dark" };
 
-export const DeleteLastLayout: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-DeleteLastLayout.parameters = {
-  mockLayouts: [exampleCurrentLayout],
-  colorScheme: "dark",
-};
-DeleteLastLayout.play = async () => await deleteLayoutInteraction(0);
+export const DeleteSelectedLayout: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
 
-export const SignInPrompt: StoryFn = (): JSX.Element => {
-  return (
-    <CurrentUserContext.Provider
-      value={{
-        currentUser: undefined,
-        signIn: () => undefined,
-        signOut: async () => undefined,
-      }}
-    >
-      <WorkspaceContextProvider>
-        <LayoutBrowser />
-      </WorkspaceContextProvider>
-    </CurrentUserContext.Provider>
-  );
+  play: async () => {
+    const layouts = await screen.findAllByTestId("layout-list-item");
+    if (layouts[1]) {
+      fireEvent.click(layouts[1]);
+    }
+    await deleteLayoutInteraction(1);
+    if (layouts[0]) {
+      fireEvent.click(layouts[0]);
+    }
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-SignInPrompt.parameters = {
-  colorScheme: "light",
+
+export const DeleteLastLayout: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <LayoutBrowser />;
+  },
+
+  parameters: {
+    mockLayouts: [exampleCurrentLayout],
+    colorScheme: "dark",
+  },
+
+  play: async () => await deleteLayoutInteraction(0),
+};
+
+export const SignInPrompt: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <CurrentUserContext.Provider
+        value={{
+          currentUser: undefined,
+          signIn: () => undefined,
+          signOut: async () => undefined,
+        }}
+      >
+        <WorkspaceContextProvider>
+          <LayoutBrowser />
+        </WorkspaceContextProvider>
+      </CurrentUserContext.Provider>
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
 };

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -154,8 +154,10 @@ export const Empty: StoryObj = {
   parameters: { mockLayouts: [] },
 };
 
-export const LayoutList: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
+export const LayoutList: StoryObj = {
+  render: (): JSX.Element => {
+    return <LayoutBrowser />;
+  },
 };
 
 export const MultiSelect: StoryObj = {
@@ -251,12 +253,16 @@ export const MultiSave: StoryObj = {
   },
 };
 
-export const TruncatedLayoutName: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
+export const TruncatedLayoutName: StoryObj = {
+  render: (): JSX.Element => {
+    return <LayoutBrowser />;
+  },
 };
 
-export const TruncatedLayoutNameSelected: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
+export const TruncatedLayoutNameSelected: StoryObj = {
+  render: (): JSX.Element => {
+    return <LayoutBrowser />;
+  },
 };
 
 export const AddLayout: StoryObj = {

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -257,11 +257,29 @@ export const TruncatedLayoutName: StoryObj = {
   render: () => {
     return <LayoutBrowser />;
   },
+  parameters: {
+    mockLayouts: [
+      {
+        id: "not-current",
+        name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+        baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
+      },
+    ],
+  },
 };
 
 export const TruncatedLayoutNameSelected: StoryObj = {
   render: () => {
     return <LayoutBrowser />;
+  },
+  parameters: {
+    mockLayouts: [
+      {
+        id: "test-id",
+        name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+        baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
+      },
+    ],
   },
 };
 

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -147,7 +147,7 @@ export default {
 };
 
 export const Empty: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -155,13 +155,13 @@ export const Empty: StoryObj = {
 };
 
 export const LayoutList: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <LayoutBrowser />;
   },
 };
 
 export const MultiSelect: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -191,7 +191,7 @@ export const MultiSelect: StoryObj = {
 };
 
 export const MultiDelete: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -206,7 +206,7 @@ export const MultiDelete: StoryObj = {
 };
 
 export const MultiDuplicate: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -221,7 +221,7 @@ export const MultiDuplicate: StoryObj = {
 };
 
 export const MultiRevert: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -239,7 +239,7 @@ export const MultiRevert: StoryObj = {
 };
 
 export const MultiSave: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -254,19 +254,19 @@ export const MultiSave: StoryObj = {
 };
 
 export const TruncatedLayoutName: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <LayoutBrowser />;
   },
 };
 
 export const TruncatedLayoutNameSelected: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <LayoutBrowser />;
   },
 };
 
 export const AddLayout: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <LayoutBrowser
         currentDateForStorybook={useMemo(() => new Date("2021-06-16T04:28:33.549Z"), [])}
@@ -283,7 +283,7 @@ export const AddLayout: StoryObj = {
 };
 
 export const MenuOpen: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -297,7 +297,7 @@ export const MenuOpen: StoryObj = {
   },
 };
 
-export const MenuOpenLight = {
+export const MenuOpenLight: StoryObj = {
   ...MenuOpen,
   parameters: { colorScheme: "light" },
   play: async (): Promise<void> => {
@@ -309,7 +309,7 @@ export const MenuOpenLight = {
 };
 
 export const EditingName: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -326,7 +326,7 @@ export const EditingName: StoryObj = {
 };
 
 export const CancelRenameWithEscape: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -344,7 +344,7 @@ export const CancelRenameWithEscape: StoryObj = {
 };
 
 export const CommitRenameWithTab: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -363,7 +363,7 @@ export const CommitRenameWithTab: StoryObj = {
 };
 
 export const Duplicate: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -380,7 +380,7 @@ export const Duplicate: StoryObj = {
 };
 
 export const DeleteLayout: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -389,7 +389,7 @@ export const DeleteLayout: StoryObj = {
 };
 
 export const DeleteSelectedLayout: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -408,7 +408,7 @@ export const DeleteSelectedLayout: StoryObj = {
 };
 
 export const DeleteLastLayout: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <LayoutBrowser />;
   },
 
@@ -421,7 +421,7 @@ export const DeleteLastLayout: StoryObj = {
 };
 
 export const SignInPrompt: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <CurrentUserContext.Provider
         value={{

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story, StoryContext, StoryFn } from "@storybook/react";
+import { StoryObj, StoryContext, StoryFn } from "@storybook/react";
 import { fireEvent, screen, userEvent, within } from "@storybook/testing-library";
 import { useMemo } from "react";
 
@@ -105,7 +105,7 @@ async function selectAllAction() {
   layouts.forEach((layout) => fireEvent.click(layout, { ctrlKey: true }));
 }
 
-function WithSetup(Child: Story, ctx: StoryContext): JSX.Element {
+function WithSetup(Child: StoryFn, ctx: StoryContext): JSX.Element {
   const storage = useMemo(
     () =>
       new MockLayoutStorage(
@@ -155,30 +155,34 @@ export function LayoutList(): JSX.Element {
   return <LayoutBrowser />;
 }
 
-export const MultiSelect: StoryFn = (): JSX.Element => {
-  return <LayoutBrowser />;
-};
-MultiSelect.parameters = {
-  colorScheme: "dark",
-  mockLayouts: Array(8)
-    .fill(undefined)
-    .map((_, idx) => ({
-      id: `layout-${idx + 1}`,
-      name: `Layout ${idx + 1}`,
-      baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
-    })),
-};
-MultiSelect.play = async ({ canvasElement }) => {
-  const layouts = await within(canvasElement).findAllByTestId("layout-list-item");
+export const MultiSelect: StoryObj = {
+  render: (): JSX.Element => {
+    return <LayoutBrowser />;
+  },
 
-  userEvent.click(layouts[0]!);
+  parameters: {
+    colorScheme: "dark",
+    mockLayouts: Array(8)
+      .fill(undefined)
+      .map((_, idx) => ({
+        id: `layout-${idx + 1}`,
+        name: `Layout ${idx + 1}`,
+        baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
+      })),
+  },
 
-  userEvent.click(layouts[1]!, { metaKey: true });
-  userEvent.click(layouts[3]!, { metaKey: true });
+  play: async ({ canvasElement }) => {
+    const layouts = await within(canvasElement).findAllByTestId("layout-list-item");
 
-  userEvent.click(layouts[6]!, { shiftKey: true });
+    userEvent.click(layouts[0]!);
 
-  userEvent.click(layouts[4]!, { metaKey: true });
+    userEvent.click(layouts[1]!, { metaKey: true });
+    userEvent.click(layouts[3]!, { metaKey: true });
+
+    userEvent.click(layouts[6]!, { shiftKey: true });
+
+    userEvent.click(layouts[4]!, { metaKey: true });
+  },
 };
 
 export function MultiDelete(): JSX.Element {

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -103,141 +103,206 @@ function makePathAndSelectionAction(path: undefined | string, item: number) {
   };
 }
 
-export const PathWithHeaderFields = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.header.stamp.sec" />;
+export const PathWithHeaderFields = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.header.stamp.sec" />;
+  },
+
+  name: "path with header fields",
 };
-PathWithHeaderFields.storyName = "path with header fields";
 
-export const AutocompleteTopics = (): JSX.Element => {
-  return <MessagePathInputStory path="/" />;
+export const AutocompleteTopics = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/" />;
+  },
+
+  name: "autocomplete topics",
 };
-AutocompleteTopics.storyName = "autocomplete topics";
 
-export const AutocompleteScalarFromTopicAndEmptyPath = (): JSX.Element => {
-  return <MessagePathInputStory path="" validTypes={["int32"]} />;
+export const AutocompleteScalarFromTopicAndEmptyPath = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="" validTypes={["int32"]} />;
+  },
+
+  play: makePathAndSelectionAction(undefined, 2),
+  name: "autocomplete scalar from topic and empty path",
 };
-AutocompleteScalarFromTopicAndEmptyPath.play = makePathAndSelectionAction(undefined, 2);
 
-AutocompleteScalarFromTopicAndEmptyPath.storyName = "autocomplete scalar from topic and empty path";
+export const AutocompleteScalarFromTopic = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="" validTypes={["int32"]} />;
+  },
 
-export const AutocompleteScalarFromTopic = (): JSX.Element => {
-  return <MessagePathInputStory path="" validTypes={["int32"]} />;
+  play: makePathAndSelectionAction("/some_logs_", 1),
+  name: "autocomplete scalar from topic",
 };
-AutocompleteScalarFromTopic.play = makePathAndSelectionAction("/some_logs_", 1);
-AutocompleteScalarFromTopic.storyName = "autocomplete scalar from topic";
 
-export const AutocompleteScalarFromFullTopic = (): JSX.Element => {
-  return <MessagePathInputStory path="" validTypes={["int32"]} />;
+export const AutocompleteScalarFromFullTopic = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="" validTypes={["int32"]} />;
+  },
+
+  play: makePathAndSelectionAction("/some_logs_topic", 0),
+  name: "autocomplete scalar from full topic",
 };
-AutocompleteScalarFromFullTopic.play = makePathAndSelectionAction("/some_logs_topic", 0);
-AutocompleteScalarFromFullTopic.storyName = "autocomplete scalar from full topic";
 
-export const AutocompleteMessagePath = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/location.po" />;
+export const AutocompleteMessagePath = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/location.po" />;
+  },
+
+  name: "autocomplete messagePath",
 };
-AutocompleteMessagePath.storyName = "autocomplete messagePath";
 
-export const AutocompleteMessagePathLight = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/location.po" />;
+export const AutocompleteMessagePathLight = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/location.po" />;
+  },
+
+  name: "autocomplete messagePath light",
+  parameters: { colorScheme: "light" },
 };
-AutocompleteMessagePathLight.storyName = "autocomplete messagePath light";
-AutocompleteMessagePathLight.parameters = { colorScheme: "light" };
 
-export const AutocompleteFilter = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:]{}" />;
+export const AutocompleteFilter = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:]{}" />;
+  },
+
+  name: "autocomplete filter",
 };
-AutocompleteFilter.storyName = "autocomplete filter";
 
-export const AutocompleteTopLevelFilter = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state{}" />;
+export const AutocompleteTopLevelFilter = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state{}" />;
+  },
+
+  name: "autocomplete top level filter",
 };
-AutocompleteTopLevelFilter.storyName = "autocomplete top level filter";
 
-export const AutocompleteForGlobalVariablesVariables = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state{foo_id==0}.items[:]{id==$}" />;
+export const AutocompleteForGlobalVariablesVariables = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state{foo_id==0}.items[:]{id==$}" />;
+  },
+
+  name: "autocomplete for globalVariables variables",
 };
-AutocompleteForGlobalVariablesVariables.storyName = "autocomplete for globalVariables variables";
 
-export const PathWithValidGlobalVariablesVariable = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}" />;
+export const PathWithValidGlobalVariablesVariable = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}" />;
+  },
+
+  name: "path with valid globalVariables variable",
 };
-PathWithValidGlobalVariablesVariable.storyName = "path with valid globalVariables variable";
 
-export const PathWithInvalidGlobalVariablesVariable = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_3}" />;
+export const PathWithInvalidGlobalVariablesVariable = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_3}" />;
+  },
+
+  name: "path with invalid globalVariables variable",
 };
-PathWithInvalidGlobalVariablesVariable.storyName = "path with invalid globalVariables variable";
 
-export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:]{id==global_var_2}" />;
+export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:]{id==global_var_2}" />;
+  },
+
+  name: "path with incorrectly prefixed globalVariables variable",
 };
-PathWithIncorrectlyPrefixedGlobalVariablesVariable.storyName =
-  "path with incorrectly prefixed globalVariables variable";
 
-export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[$]" />;
+export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[$]" />;
+  },
+
+  name: "autocomplete for path with globalVariables variable in slice (single idx)",
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx.storyName =
-  "autocomplete for path with globalVariables variable in slice (single idx)";
 
-export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[$:]" />;
+export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[$:]" />;
+  },
+
+  name: "autocomplete for path with globalVariables variable in slice (start idx)",
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx.storyName =
-  "autocomplete for path with globalVariables variable in slice (start idx)";
 
-export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:$]" />;
+export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:$]" />;
+  },
+
+  name: "autocomplete for path with globalVariables variable in slice (end idx)",
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx.storyName =
-  "autocomplete for path with globalVariables variable in slice (end idx)";
 
-export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx =
-  (): JSX.Element => {
+export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx = {
+  render: (): JSX.Element => {
     return <MessagePathInputStory path="/some_topic/state.items[$global_var_2:$]" />;
-  };
-AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx.storyName =
-  "autocomplete for path with globalVariables variables in slice (start and end idx)";
+  },
 
-export const PathWithInvalidMathModifier = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
+  name: "autocomplete for path with globalVariables variables in slice (start and end idx)",
 };
-PathWithInvalidMathModifier.storyName = "path with invalid math modifier";
 
-export const AutocompleteWhenPrioritizedDatatypeIsAvailable = (): JSX.Element => {
-  return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
-};
-AutocompleteWhenPrioritizedDatatypeIsAvailable.storyName =
-  "autocomplete when prioritized datatype is available";
+export const PathWithInvalidMathModifier = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
+  },
 
-export const AutocompleteForMessageWithJsonField = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_logs_topic." />;
+  name: "path with invalid math modifier",
 };
-AutocompleteForMessageWithJsonField.storyName = "autocomplete for message with json field";
 
-export const AutocompleteForPathWithExistingFilter = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:]{id==1}." />;
-};
-AutocompleteForPathWithExistingFilter.storyName = "autocomplete for path with existing filter";
+export const AutocompleteWhenPrioritizedDatatypeIsAvailable = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
+  },
 
-export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}." />;
+  name: "autocomplete when prioritized datatype is available",
 };
-AutocompleteForPathWithExistingFilterUsingAGlobalVariable.storyName =
-  "autocomplete for path with existing filter using a global variable";
 
-export const PathForFieldInsideJsonObject = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_logs_topic.myJson" />;
-};
-PathForFieldInsideJsonObject.storyName = "path for field inside json object";
+export const AutocompleteForMessageWithJsonField = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_logs_topic." />;
+  },
 
-export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = (): JSX.Element => {
-  return <MessagePathInputStory path="/some_logs_topic.myJson.a.b.c" />;
+  name: "autocomplete for message with json field",
 };
-PathForMultipleLevelsOfNestedFieldsInsideJsonObject.storyName =
-  "path for multiple levels of nested fields inside json object";
 
-export const PerformanceTesting = (): JSX.Element => {
-  return <MessagePathPerformanceStory path="." />;
+export const AutocompleteForPathWithExistingFilter = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:]{id==1}." />;
+  },
+
+  name: "autocomplete for path with existing filter",
 };
-PerformanceTesting.storyName = "performance testing";
+
+export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}." />;
+  },
+
+  name: "autocomplete for path with existing filter using a global variable",
+};
+
+export const PathForFieldInsideJsonObject = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_logs_topic.myJson" />;
+  },
+
+  name: "path for field inside json object",
+};
+
+export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = {
+  render: (): JSX.Element => {
+    return <MessagePathInputStory path="/some_logs_topic.myJson.a.b.c" />;
+  },
+
+  name: "path for multiple levels of nested fields inside json object",
+};
+
+export const PerformanceTesting = {
+  render: (): JSX.Element => {
+    return <MessagePathPerformanceStory path="." />;
+  },
+
+  name: "performance testing",
+};

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Stack } from "@mui/material";
+import { StoryObj } from "@storybook/react";
 import { screen, waitFor, userEvent } from "@storybook/testing-library";
 
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -103,24 +104,24 @@ function makePathAndSelectionAction(path: undefined | string, item: number) {
   };
 }
 
-export const PathWithHeaderFields = {
-  render: function Story(): JSX.Element {
+export const PathWithHeaderFields: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.header.stamp.sec" />;
   },
 
   name: "path with header fields",
 };
 
-export const AutocompleteTopics = {
-  render: function Story(): JSX.Element {
+export const AutocompleteTopics: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/" />;
   },
 
   name: "autocomplete topics",
 };
 
-export const AutocompleteScalarFromTopicAndEmptyPath = {
-  render: function Story(): JSX.Element {
+export const AutocompleteScalarFromTopicAndEmptyPath: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="" validTypes={["int32"]} />;
   },
 
@@ -128,8 +129,8 @@ export const AutocompleteScalarFromTopicAndEmptyPath = {
   name: "autocomplete scalar from topic and empty path",
 };
 
-export const AutocompleteScalarFromTopic = {
-  render: function Story(): JSX.Element {
+export const AutocompleteScalarFromTopic: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="" validTypes={["int32"]} />;
   },
 
@@ -137,8 +138,8 @@ export const AutocompleteScalarFromTopic = {
   name: "autocomplete scalar from topic",
 };
 
-export const AutocompleteScalarFromFullTopic = {
-  render: function Story(): JSX.Element {
+export const AutocompleteScalarFromFullTopic: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="" validTypes={["int32"]} />;
   },
 
@@ -146,16 +147,16 @@ export const AutocompleteScalarFromFullTopic = {
   name: "autocomplete scalar from full topic",
 };
 
-export const AutocompleteMessagePath = {
-  render: function Story(): JSX.Element {
+export const AutocompleteMessagePath: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/location.po" />;
   },
 
   name: "autocomplete messagePath",
 };
 
-export const AutocompleteMessagePathLight = {
-  render: function Story(): JSX.Element {
+export const AutocompleteMessagePathLight: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/location.po" />;
   },
 
@@ -163,144 +164,144 @@ export const AutocompleteMessagePathLight = {
   parameters: { colorScheme: "light" },
 };
 
-export const AutocompleteFilter = {
-  render: function Story(): JSX.Element {
+export const AutocompleteFilter: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:]{}" />;
   },
 
   name: "autocomplete filter",
 };
 
-export const AutocompleteTopLevelFilter = {
-  render: function Story(): JSX.Element {
+export const AutocompleteTopLevelFilter: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state{}" />;
   },
 
   name: "autocomplete top level filter",
 };
 
-export const AutocompleteForGlobalVariablesVariables = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForGlobalVariablesVariables: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state{foo_id==0}.items[:]{id==$}" />;
   },
 
   name: "autocomplete for globalVariables variables",
 };
 
-export const PathWithValidGlobalVariablesVariable = {
-  render: function Story(): JSX.Element {
+export const PathWithValidGlobalVariablesVariable: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}" />;
   },
 
   name: "path with valid globalVariables variable",
 };
 
-export const PathWithInvalidGlobalVariablesVariable = {
-  render: function Story(): JSX.Element {
+export const PathWithInvalidGlobalVariablesVariable: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_3}" />;
   },
 
   name: "path with invalid globalVariables variable",
 };
 
-export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = {
-  render: function Story(): JSX.Element {
+export const PathWithIncorrectlyPrefixedGlobalVariablesVariable: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==global_var_2}" />;
   },
 
   name: "path with incorrectly prefixed globalVariables variable",
 };
 
-export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[$]" />;
   },
 
   name: "autocomplete for path with globalVariables variable in slice (single idx)",
 };
 
-export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[$:]" />;
   },
 
   name: "autocomplete for path with globalVariables variable in slice (start idx)",
 };
 
-export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:$]" />;
   },
 
   name: "autocomplete for path with globalVariables variable in slice (end idx)",
 };
 
-export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[$global_var_2:$]" />;
   },
 
   name: "autocomplete for path with globalVariables variables in slice (start and end idx)",
 };
 
-export const PathWithInvalidMathModifier = {
-  render: function Story(): JSX.Element {
+export const PathWithInvalidMathModifier: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
   },
 
   name: "path with invalid math modifier",
 };
 
-export const AutocompleteWhenPrioritizedDatatypeIsAvailable = {
-  render: function Story(): JSX.Element {
+export const AutocompleteWhenPrioritizedDatatypeIsAvailable: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
   },
 
   name: "autocomplete when prioritized datatype is available",
 };
 
-export const AutocompleteForMessageWithJsonField = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForMessageWithJsonField: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_logs_topic." />;
   },
 
   name: "autocomplete for message with json field",
 };
 
-export const AutocompleteForPathWithExistingFilter = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForPathWithExistingFilter: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==1}." />;
   },
 
   name: "autocomplete for path with existing filter",
 };
 
-export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = {
-  render: function Story(): JSX.Element {
+export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}." />;
   },
 
   name: "autocomplete for path with existing filter using a global variable",
 };
 
-export const PathForFieldInsideJsonObject = {
-  render: function Story(): JSX.Element {
+export const PathForFieldInsideJsonObject: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_logs_topic.myJson" />;
   },
 
   name: "path for field inside json object",
 };
 
-export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = {
-  render: function Story(): JSX.Element {
+export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject: StoryObj = {
+  render: function Story() {
     return <MessagePathInputStory path="/some_logs_topic.myJson.a.b.c" />;
   },
 
   name: "path for multiple levels of nested fields inside json object",
 };
 
-export const PerformanceTesting = {
-  render: function Story(): JSX.Element {
+export const PerformanceTesting: StoryObj = {
+  render: function Story() {
     return <MessagePathPerformanceStory path="." />;
   },
 

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -104,7 +104,7 @@ function makePathAndSelectionAction(path: undefined | string, item: number) {
 }
 
 export const PathWithHeaderFields = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.header.stamp.sec" />;
   },
 
@@ -112,7 +112,7 @@ export const PathWithHeaderFields = {
 };
 
 export const AutocompleteTopics = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/" />;
   },
 
@@ -120,7 +120,7 @@ export const AutocompleteTopics = {
 };
 
 export const AutocompleteScalarFromTopicAndEmptyPath = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="" validTypes={["int32"]} />;
   },
 
@@ -129,7 +129,7 @@ export const AutocompleteScalarFromTopicAndEmptyPath = {
 };
 
 export const AutocompleteScalarFromTopic = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="" validTypes={["int32"]} />;
   },
 
@@ -138,7 +138,7 @@ export const AutocompleteScalarFromTopic = {
 };
 
 export const AutocompleteScalarFromFullTopic = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="" validTypes={["int32"]} />;
   },
 
@@ -147,7 +147,7 @@ export const AutocompleteScalarFromFullTopic = {
 };
 
 export const AutocompleteMessagePath = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/location.po" />;
   },
 
@@ -155,7 +155,7 @@ export const AutocompleteMessagePath = {
 };
 
 export const AutocompleteMessagePathLight = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/location.po" />;
   },
 
@@ -164,7 +164,7 @@ export const AutocompleteMessagePathLight = {
 };
 
 export const AutocompleteFilter = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:]{}" />;
   },
 
@@ -172,7 +172,7 @@ export const AutocompleteFilter = {
 };
 
 export const AutocompleteTopLevelFilter = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state{}" />;
   },
 
@@ -180,7 +180,7 @@ export const AutocompleteTopLevelFilter = {
 };
 
 export const AutocompleteForGlobalVariablesVariables = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state{foo_id==0}.items[:]{id==$}" />;
   },
 
@@ -188,7 +188,7 @@ export const AutocompleteForGlobalVariablesVariables = {
 };
 
 export const PathWithValidGlobalVariablesVariable = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}" />;
   },
 
@@ -196,7 +196,7 @@ export const PathWithValidGlobalVariablesVariable = {
 };
 
 export const PathWithInvalidGlobalVariablesVariable = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_3}" />;
   },
 
@@ -204,7 +204,7 @@ export const PathWithInvalidGlobalVariablesVariable = {
 };
 
 export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==global_var_2}" />;
   },
 
@@ -212,7 +212,7 @@ export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = {
 };
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[$]" />;
   },
 
@@ -220,7 +220,7 @@ export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = {
 };
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[$:]" />;
   },
 
@@ -228,7 +228,7 @@ export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = {
 };
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:$]" />;
   },
 
@@ -236,7 +236,7 @@ export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = {
 };
 
 export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[$global_var_2:$]" />;
   },
 
@@ -244,7 +244,7 @@ export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndId
 };
 
 export const PathWithInvalidMathModifier = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
   },
 
@@ -252,7 +252,7 @@ export const PathWithInvalidMathModifier = {
 };
 
 export const AutocompleteWhenPrioritizedDatatypeIsAvailable = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
   },
 
@@ -260,7 +260,7 @@ export const AutocompleteWhenPrioritizedDatatypeIsAvailable = {
 };
 
 export const AutocompleteForMessageWithJsonField = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_logs_topic." />;
   },
 
@@ -268,7 +268,7 @@ export const AutocompleteForMessageWithJsonField = {
 };
 
 export const AutocompleteForPathWithExistingFilter = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==1}." />;
   },
 
@@ -276,7 +276,7 @@ export const AutocompleteForPathWithExistingFilter = {
 };
 
 export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}." />;
   },
 
@@ -284,7 +284,7 @@ export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = {
 };
 
 export const PathForFieldInsideJsonObject = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_logs_topic.myJson" />;
   },
 
@@ -292,7 +292,7 @@ export const PathForFieldInsideJsonObject = {
 };
 
 export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathInputStory path="/some_logs_topic.myJson.a.b.c" />;
   },
 
@@ -300,7 +300,7 @@ export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = {
 };
 
 export const PerformanceTesting = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MessagePathPerformanceStory path="." />;
   },
 

--- a/packages/studio-base/src/components/NotificationModal.stories.tsx
+++ b/packages/studio-base/src/components/NotificationModal.stories.tsx
@@ -44,8 +44,10 @@ export const ErrorNoSubtextWithDetails = {
   parameters: { colorScheme: "light" },
 };
 
-export const ErrorNoSubtextWithDetailsDark = ErrorNoSubtextWithDetails.bind(undefined);
-ErrorNoSubtextWithDetailsDark.parameters = { colorScheme: "dark" };
+export const ErrorNoSubtextWithDetailsDark = {
+  ...ErrorNoSubtextWithDetails,
+  parameters: { colorScheme: "dark" },
+};
 
 export const ErrorWithSubtextAndDetails = {
   render: function Story(): JSX.Element {
@@ -148,8 +150,10 @@ export const ErrorWithJsxElementDetails = {
   parameters: { colorScheme: "light" },
 };
 
-export const ErrorWithJsxElementDetailsDark = ErrorWithJsxElementDetails.bind(undefined);
-ErrorWithJsxElementDetailsDark.parameters = { colorScheme: "dark" };
+export const ErrorWithJsxElementDetailsDark = {
+  ...ErrorWithJsxElementDetails,
+  parameters: { colorScheme: "dark" },
+};
 
 export const ErrorWithNewlineDetails = {
   render: function Story(): JSX.Element {

--- a/packages/studio-base/src/components/NotificationModal.stories.tsx
+++ b/packages/studio-base/src/components/NotificationModal.stories.tsx
@@ -25,124 +25,147 @@ export default {
   title: "components/NotificationModal",
 };
 
-export const ErrorNoSubtextWithDetails = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Error 1",
-        details: fakeError(),
-        created: new Date(),
-        severity: "error",
-      }}
-    />
-  );
+export const ErrorNoSubtextWithDetails = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Error 1",
+          details: fakeError(),
+          created: new Date(),
+          severity: "error",
+        }}
+      />
+    );
+  },
+
+  parameters: { colorScheme: "light" },
 };
-ErrorNoSubtextWithDetails.parameters = { colorScheme: "light" };
+
 export const ErrorNoSubtextWithDetailsDark = ErrorNoSubtextWithDetails.bind(undefined);
 ErrorNoSubtextWithDetailsDark.parameters = { colorScheme: "dark" };
 
-export const ErrorWithSubtextAndDetails = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Error 1",
-        details: fakeError(),
-        created: new Date(),
-        severity: "error",
-        subText: "This error has a subtext.",
-      }}
-    />
-  );
-};
-ErrorWithSubtextAndDetails.parameters = { colorScheme: "light" };
+export const ErrorWithSubtextAndDetails = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Error 1",
+          details: fakeError(),
+          created: new Date(),
+          severity: "error",
+          subText: "This error has a subtext.",
+        }}
+      />
+    );
+  },
 
-export const ErrorWithSubtextNoDetails = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Error 1",
-        details: undefined,
-        created: new Date(),
-        severity: "error",
-        subText: "This error has a subtext.",
-      }}
-    />
-  );
+  parameters: { colorScheme: "light" },
 };
-ErrorWithSubtextNoDetails.parameters = { colorScheme: "light" };
 
-export const Warning = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Warning 1",
-        details: "Some error details",
-        created: new Date(),
-        severity: "warn",
-      }}
-    />
-  );
-};
-Warning.parameters = { colorScheme: "dark" };
+export const ErrorWithSubtextNoDetails = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Error 1",
+          details: undefined,
+          created: new Date(),
+          severity: "error",
+          subText: "This error has a subtext.",
+        }}
+      />
+    );
+  },
 
-export const ErrorNoDetailsOrSubtext = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Error 1",
-        details: undefined,
-        created: new Date(),
-        severity: "error",
-      }}
-    />
-  );
+  parameters: { colorScheme: "light" },
 };
-ErrorNoDetailsOrSubtext.parameters = { colorScheme: "dark" };
 
-export const ErrorWithJsxElementDetails = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Error 1",
-        details: (
-          <p>
-            This is <b style={{ color: "red" }}>customized</b> error detail.
-          </p>
-        ),
-        created: new Date(),
-        severity: "error",
-      }}
-    />
-  );
+export const Warning = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Warning 1",
+          details: "Some error details",
+          created: new Date(),
+          severity: "warn",
+        }}
+      />
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-ErrorWithJsxElementDetails.parameters = { colorScheme: "light" };
+
+export const ErrorNoDetailsOrSubtext = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Error 1",
+          details: undefined,
+          created: new Date(),
+          severity: "error",
+        }}
+      />
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
+};
+
+export const ErrorWithJsxElementDetails = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Error 1",
+          details: (
+            <p>
+              This is <b style={{ color: "red" }}>customized</b> error detail.
+            </p>
+          ),
+          created: new Date(),
+          severity: "error",
+        }}
+      />
+    );
+  },
+
+  parameters: { colorScheme: "light" },
+};
+
 export const ErrorWithJsxElementDetailsDark = ErrorWithJsxElementDetails.bind(undefined);
 ErrorWithJsxElementDetailsDark.parameters = { colorScheme: "dark" };
 
-export const ErrorWithNewlineDetails = (): JSX.Element => {
-  return (
-    <NotificationModal
-      onRequestClose={() => {}}
-      notification={{
-        id: "1",
-        message: "Error 1",
-        details: "Some details.\n\nWith a newline.",
-        created: new Date(),
-        severity: "error",
-      }}
-    />
-  );
+export const ErrorWithNewlineDetails = {
+  render: (): JSX.Element => {
+    return (
+      <NotificationModal
+        onRequestClose={() => {}}
+        notification={{
+          id: "1",
+          message: "Error 1",
+          details: "Some details.\n\nWith a newline.",
+          created: new Date(),
+          severity: "error",
+        }}
+      />
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-ErrorWithNewlineDetails.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/NotificationModal.stories.tsx
+++ b/packages/studio-base/src/components/NotificationModal.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
+
 import NotificationModal from "@foxglove/studio-base/components/NotificationModal";
 
 const fakeError = () => {
@@ -25,8 +27,8 @@ export default {
   title: "components/NotificationModal",
 };
 
-export const ErrorNoSubtextWithDetails = {
-  render: function Story(): JSX.Element {
+export const ErrorNoSubtextWithDetails: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -44,13 +46,13 @@ export const ErrorNoSubtextWithDetails = {
   parameters: { colorScheme: "light" },
 };
 
-export const ErrorNoSubtextWithDetailsDark = {
+export const ErrorNoSubtextWithDetailsDark: StoryObj = {
   ...ErrorNoSubtextWithDetails,
   parameters: { colorScheme: "dark" },
 };
 
-export const ErrorWithSubtextAndDetails = {
-  render: function Story(): JSX.Element {
+export const ErrorWithSubtextAndDetails: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -69,8 +71,8 @@ export const ErrorWithSubtextAndDetails = {
   parameters: { colorScheme: "light" },
 };
 
-export const ErrorWithSubtextNoDetails = {
-  render: function Story(): JSX.Element {
+export const ErrorWithSubtextNoDetails: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -89,8 +91,8 @@ export const ErrorWithSubtextNoDetails = {
   parameters: { colorScheme: "light" },
 };
 
-export const Warning = {
-  render: function Story(): JSX.Element {
+export const Warning: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -108,8 +110,8 @@ export const Warning = {
   parameters: { colorScheme: "dark" },
 };
 
-export const ErrorNoDetailsOrSubtext = {
-  render: function Story(): JSX.Element {
+export const ErrorNoDetailsOrSubtext: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -127,8 +129,8 @@ export const ErrorNoDetailsOrSubtext = {
   parameters: { colorScheme: "dark" },
 };
 
-export const ErrorWithJsxElementDetails = {
-  render: function Story(): JSX.Element {
+export const ErrorWithJsxElementDetails: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -150,13 +152,13 @@ export const ErrorWithJsxElementDetails = {
   parameters: { colorScheme: "light" },
 };
 
-export const ErrorWithJsxElementDetailsDark = {
+export const ErrorWithJsxElementDetailsDark: StoryObj = {
   ...ErrorWithJsxElementDetails,
   parameters: { colorScheme: "dark" },
 };
 
-export const ErrorWithNewlineDetails = {
-  render: function Story(): JSX.Element {
+export const ErrorWithNewlineDetails: StoryObj = {
+  render: function Story() {
     return (
       <NotificationModal
         onRequestClose={() => {}}

--- a/packages/studio-base/src/components/NotificationModal.stories.tsx
+++ b/packages/studio-base/src/components/NotificationModal.stories.tsx
@@ -26,7 +26,7 @@ export default {
 };
 
 export const ErrorNoSubtextWithDetails = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -48,7 +48,7 @@ export const ErrorNoSubtextWithDetailsDark = ErrorNoSubtextWithDetails.bind(unde
 ErrorNoSubtextWithDetailsDark.parameters = { colorScheme: "dark" };
 
 export const ErrorWithSubtextAndDetails = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -68,7 +68,7 @@ export const ErrorWithSubtextAndDetails = {
 };
 
 export const ErrorWithSubtextNoDetails = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -88,7 +88,7 @@ export const ErrorWithSubtextNoDetails = {
 };
 
 export const Warning = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -107,7 +107,7 @@ export const Warning = {
 };
 
 export const ErrorNoDetailsOrSubtext = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -126,7 +126,7 @@ export const ErrorNoDetailsOrSubtext = {
 };
 
 export const ErrorWithJsxElementDetails = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}
@@ -152,7 +152,7 @@ export const ErrorWithJsxElementDetailsDark = ErrorWithJsxElementDetails.bind(un
 ErrorWithJsxElementDetailsDark.parameters = { colorScheme: "dark" };
 
 export const ErrorWithNewlineDetails = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <NotificationModal
         onRequestClose={() => {}}

--- a/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
@@ -61,23 +61,29 @@ const playerSelection: PlayerSelection = {
 
 const defaultProps: OpenDialogProps = { activeView: "connection", backdropAnimation: false };
 
-export const Light = (): JSX.Element => (
-  <PlayerSelectionContext.Provider value={playerSelection}>
-    <OpenDialog {...defaultProps} />
-  </PlayerSelectionContext.Provider>
-);
-Light.storyName = "Default (light)";
-Light.parameters = { colorScheme: "light" };
+export const Light = {
+  render: (): JSX.Element => (
+    <PlayerSelectionContext.Provider value={playerSelection}>
+      <OpenDialog {...defaultProps} />
+    </PlayerSelectionContext.Provider>
+  ),
+
+  name: "Default (light)",
+  parameters: { colorScheme: "light" },
+};
 
 export const LightChinese = Object.assign(Light.bind(undefined), {
   storyName: "Default Chinese",
   parameters: { forceLanguage: "zh" },
 });
 
-export const Dark = (): JSX.Element => (
-  <PlayerSelectionContext.Provider value={playerSelection}>
-    <OpenDialog {...defaultProps} />
-  </PlayerSelectionContext.Provider>
-);
-Dark.storyName = "Default (dark)";
-Dark.parameters = { colorScheme: "dark" };
+export const Dark = {
+  render: (): JSX.Element => (
+    <PlayerSelectionContext.Provider value={playerSelection}>
+      <OpenDialog {...defaultProps} />
+    </PlayerSelectionContext.Provider>
+  ),
+
+  name: "Default (dark)",
+  parameters: { colorScheme: "dark" },
+};

--- a/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
@@ -62,7 +62,7 @@ const playerSelection: PlayerSelection = {
 const defaultProps: OpenDialogProps = { activeView: "connection", backdropAnimation: false };
 
 export const Light = {
-  render: function Story(): JSX.Element (
+  render: (): JSX.Element => (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>
@@ -72,13 +72,14 @@ export const Light = {
   parameters: { colorScheme: "light" },
 };
 
-export const LightChinese = Object.assign(Light.bind(undefined), {
-  storyName: "Default Chinese",
+export const LightChinese = {
+  ...Light,
+  name: "Default Chinese",
   parameters: { forceLanguage: "zh" },
-});
+};
 
 export const Dark = {
-  render: function Story(): JSX.Element (
+  render: (): JSX.Element => (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>

--- a/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
@@ -62,7 +62,7 @@ const playerSelection: PlayerSelection = {
 const defaultProps: OpenDialogProps = { activeView: "connection", backdropAnimation: false };
 
 export const Light = {
-  render: (): JSX.Element => (
+  render: function Story(): JSX.Element (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>
@@ -78,7 +78,7 @@ export const LightChinese = Object.assign(Light.bind(undefined), {
 });
 
 export const Dark = {
-  render: (): JSX.Element => (
+  render: function Story(): JSX.Element (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>

--- a/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
+
 import PlayerSelectionContext, {
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
@@ -61,8 +63,8 @@ const playerSelection: PlayerSelection = {
 
 const defaultProps: OpenDialogProps = { activeView: "connection", backdropAnimation: false };
 
-export const Light = {
-  render: (): JSX.Element => (
+export const Light: StoryObj = {
+  render: () => (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>
@@ -72,14 +74,14 @@ export const Light = {
   parameters: { colorScheme: "light" },
 };
 
-export const LightChinese = {
+export const LightChinese: StoryObj = {
   ...Light,
   name: "Default Chinese",
   parameters: { forceLanguage: "zh" },
 };
 
-export const Dark = {
-  render: (): JSX.Element => (
+export const Dark: StoryObj = {
+  render: () => (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>

--- a/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
@@ -129,10 +129,11 @@ export const UserNoAuth: StoryObj = {
   name: "User not authenticated",
 };
 
-export const UserNoAuthChinese = Object.assign(UserNoAuth.bind(undefined), {
-  storyName: "User not authenticated Chinese",
+export const UserNoAuthChinese = {
+  ...UserNoAuth,
+  name: "User not authenticated Chinese",
   parameters: { forceLanguage: "zh" },
-});
+};
 
 export const UserPrivate: StoryObj = {
   render: function Story(): JSX.Element {
@@ -148,10 +149,11 @@ export const UserPrivate: StoryObj = {
   name: "User not authenticated (private)",
 };
 
-export const UserPrivateChinese = Object.assign(UserPrivate.bind(undefined), {
-  storyName: "User not authenticated (private) Chinese",
+export const UserPrivateChinese = {
+  ...UserPrivate,
+  name: "User not authenticated (private) Chinese",
   parameters: { forceLanguage: "zh" },
-});
+};
 
 export const UserAuthedFree: StoryObj = {
   render: function Story(): JSX.Element {
@@ -169,10 +171,11 @@ export const UserAuthedFree: StoryObj = {
   name: "User Authenticated with Free Account",
 };
 
-export const UserAuthedFreeChinese = Object.assign(UserAuthedFree.bind(undefined), {
-  storyName: "User Authenticated with Free Account Chinese",
+export const UserAuthedFreeChinese = {
+  ...UserAuthedFree,
+  name: "User Authenticated with Free Account Chinese",
   parameters: { forceLanguage: "zh" },
-});
+};
 
 export const UserAuthedPaid: StoryObj = {
   render: function Story(): JSX.Element {
@@ -190,7 +193,8 @@ export const UserAuthedPaid: StoryObj = {
   name: "User Authenticated with Paid Account",
 };
 
-export const UserAuthedPaidChinese = Object.assign(UserAuthedPaid.bind(undefined), {
-  storyName: "User Authenticated with Paid Account Chinese",
+export const UserAuthedPaidChinese = {
+  ...UserAuthedPaid,
+  name: "User Authenticated with Paid Account Chinese",
   parameters: { forceLanguage: "zh" },
-});
+};

--- a/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { ReactNode } from "react";
 
 import CurrentUserContext, {
@@ -116,13 +117,13 @@ export const DefaultDark = {
   name: "Default (dark)",
 };
 
-export function UserNoAuth(): JSX.Element {
+export const UserNoAuth: StoryFn = (): JSX.Element => {
   return (
     <PlayerSelectionContext.Provider value={playerSelection}>
       <OpenDialog {...defaultProps} />
     </PlayerSelectionContext.Provider>
   );
-}
+};
 UserNoAuth.storyName = "User not authenticated";
 
 export const UserNoAuthChinese = Object.assign(UserNoAuth.bind(undefined), {
@@ -130,7 +131,7 @@ export const UserNoAuthChinese = Object.assign(UserNoAuth.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
 
-export function UserPrivate(): JSX.Element {
+export const UserPrivate: StoryFn = (): JSX.Element => {
   return (
     <CurrentUserWrapper>
       <PlayerSelectionContext.Provider value={playerSelection}>
@@ -138,7 +139,7 @@ export function UserPrivate(): JSX.Element {
       </PlayerSelectionContext.Provider>
     </CurrentUserWrapper>
   );
-}
+};
 UserPrivate.storyName = "User not authenticated (private)";
 
 export const UserPrivateChinese = Object.assign(UserPrivate.bind(undefined), {
@@ -146,7 +147,7 @@ export const UserPrivateChinese = Object.assign(UserPrivate.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
 
-export function UserAuthedFree(): JSX.Element {
+export const UserAuthedFree: StoryFn = (): JSX.Element => {
   const freeUser = fakeUser("free");
 
   return (
@@ -156,7 +157,7 @@ export function UserAuthedFree(): JSX.Element {
       </PlayerSelectionContext.Provider>
     </CurrentUserWrapper>
   );
-}
+};
 UserAuthedFree.storyName = "User Authenticated with Free Account";
 
 export const UserAuthedFreeChinese = Object.assign(UserAuthedFree.bind(undefined), {
@@ -164,7 +165,7 @@ export const UserAuthedFreeChinese = Object.assign(UserAuthedFree.bind(undefined
   parameters: { forceLanguage: "zh" },
 });
 
-export function UserAuthedPaid(): JSX.Element {
+export const UserAuthedPaid: StoryFn = (): JSX.Element => {
   const freeUser = fakeUser("paid");
 
   return (
@@ -174,7 +175,7 @@ export function UserAuthedPaid(): JSX.Element {
       </PlayerSelectionContext.Provider>
     </CurrentUserWrapper>
   );
-}
+};
 UserAuthedPaid.storyName = "User Authenticated with Paid Account";
 
 export const UserAuthedPaidChinese = Object.assign(UserAuthedPaid.bind(undefined), {

--- a/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
@@ -106,19 +106,19 @@ function CurrentUserWrapper(props: { children: ReactNode; user?: User | undefine
 
 const defaultProps: OpenDialogProps = { backdropAnimation: false };
 
-export const DefaultLight = {
-  render: (): JSX.Element => <OpenDialog {...defaultProps} />,
+export const DefaultLight: StoryObj = {
+  render: () => <OpenDialog {...defaultProps} />,
   name: "Default (light)",
   parameters: { colorScheme: "light" },
 };
 
-export const DefaultDark = {
-  render: (): JSX.Element => <OpenDialog {...defaultProps} />,
+export const DefaultDark: StoryObj = {
+  render: () => <OpenDialog {...defaultProps} />,
   name: "Default (dark)",
 };
 
 export const UserNoAuth: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <PlayerSelectionContext.Provider value={playerSelection}>
         <OpenDialog {...defaultProps} />
@@ -129,14 +129,14 @@ export const UserNoAuth: StoryObj = {
   name: "User not authenticated",
 };
 
-export const UserNoAuthChinese = {
+export const UserNoAuthChinese: StoryObj = {
   ...UserNoAuth,
   name: "User not authenticated Chinese",
   parameters: { forceLanguage: "zh" },
 };
 
 export const UserPrivate: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <CurrentUserWrapper>
         <PlayerSelectionContext.Provider value={playerSelection}>
@@ -149,14 +149,14 @@ export const UserPrivate: StoryObj = {
   name: "User not authenticated (private)",
 };
 
-export const UserPrivateChinese = {
+export const UserPrivateChinese: StoryObj = {
   ...UserPrivate,
   name: "User not authenticated (private) Chinese",
   parameters: { forceLanguage: "zh" },
 };
 
 export const UserAuthedFree: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const freeUser = fakeUser("free");
 
     return (
@@ -171,14 +171,14 @@ export const UserAuthedFree: StoryObj = {
   name: "User Authenticated with Free Account",
 };
 
-export const UserAuthedFreeChinese = {
+export const UserAuthedFreeChinese: StoryObj = {
   ...UserAuthedFree,
   name: "User Authenticated with Free Account Chinese",
   parameters: { forceLanguage: "zh" },
 };
 
 export const UserAuthedPaid: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const freeUser = fakeUser("paid");
 
     return (
@@ -193,7 +193,7 @@ export const UserAuthedPaid: StoryObj = {
   name: "User Authenticated with Paid Account",
 };
 
-export const UserAuthedPaidChinese = {
+export const UserAuthedPaidChinese: StoryObj = {
   ...UserAuthedPaid,
   name: "User Authenticated with Paid Account Chinese",
   parameters: { forceLanguage: "zh" },

--- a/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { ReactNode } from "react";
 
 import CurrentUserContext, {
@@ -117,66 +117,78 @@ export const DefaultDark = {
   name: "Default (dark)",
 };
 
-export const UserNoAuth: StoryFn = (): JSX.Element => {
-  return (
-    <PlayerSelectionContext.Provider value={playerSelection}>
-      <OpenDialog {...defaultProps} />
-    </PlayerSelectionContext.Provider>
-  );
+export const UserNoAuth: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <PlayerSelectionContext.Provider value={playerSelection}>
+        <OpenDialog {...defaultProps} />
+      </PlayerSelectionContext.Provider>
+    );
+  },
+
+  name: "User not authenticated",
 };
-UserNoAuth.storyName = "User not authenticated";
 
 export const UserNoAuthChinese = Object.assign(UserNoAuth.bind(undefined), {
   storyName: "User not authenticated Chinese",
   parameters: { forceLanguage: "zh" },
 });
 
-export const UserPrivate: StoryFn = (): JSX.Element => {
-  return (
-    <CurrentUserWrapper>
-      <PlayerSelectionContext.Provider value={playerSelection}>
-        <OpenDialog {...defaultProps} />
-      </PlayerSelectionContext.Provider>
-    </CurrentUserWrapper>
-  );
+export const UserPrivate: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <CurrentUserWrapper>
+        <PlayerSelectionContext.Provider value={playerSelection}>
+          <OpenDialog {...defaultProps} />
+        </PlayerSelectionContext.Provider>
+      </CurrentUserWrapper>
+    );
+  },
+
+  name: "User not authenticated (private)",
 };
-UserPrivate.storyName = "User not authenticated (private)";
 
 export const UserPrivateChinese = Object.assign(UserPrivate.bind(undefined), {
   storyName: "User not authenticated (private) Chinese",
   parameters: { forceLanguage: "zh" },
 });
 
-export const UserAuthedFree: StoryFn = (): JSX.Element => {
-  const freeUser = fakeUser("free");
+export const UserAuthedFree: StoryObj = {
+  render: function Story(): JSX.Element {
+    const freeUser = fakeUser("free");
 
-  return (
-    <CurrentUserWrapper user={freeUser}>
-      <PlayerSelectionContext.Provider value={playerSelection}>
-        <OpenDialog {...defaultProps} />
-      </PlayerSelectionContext.Provider>
-    </CurrentUserWrapper>
-  );
+    return (
+      <CurrentUserWrapper user={freeUser}>
+        <PlayerSelectionContext.Provider value={playerSelection}>
+          <OpenDialog {...defaultProps} />
+        </PlayerSelectionContext.Provider>
+      </CurrentUserWrapper>
+    );
+  },
+
+  name: "User Authenticated with Free Account",
 };
-UserAuthedFree.storyName = "User Authenticated with Free Account";
 
 export const UserAuthedFreeChinese = Object.assign(UserAuthedFree.bind(undefined), {
   storyName: "User Authenticated with Free Account Chinese",
   parameters: { forceLanguage: "zh" },
 });
 
-export const UserAuthedPaid: StoryFn = (): JSX.Element => {
-  const freeUser = fakeUser("paid");
+export const UserAuthedPaid: StoryObj = {
+  render: function Story(): JSX.Element {
+    const freeUser = fakeUser("paid");
 
-  return (
-    <CurrentUserWrapper user={freeUser}>
-      <PlayerSelectionContext.Provider value={playerSelection}>
-        <OpenDialog {...defaultProps} />
-      </PlayerSelectionContext.Provider>
-    </CurrentUserWrapper>
-  );
+    return (
+      <CurrentUserWrapper user={freeUser}>
+        <PlayerSelectionContext.Provider value={playerSelection}>
+          <OpenDialog {...defaultProps} />
+        </PlayerSelectionContext.Provider>
+      </CurrentUserWrapper>
+    );
+  },
+
+  name: "User Authenticated with Paid Account",
 };
-UserAuthedPaid.storyName = "User Authenticated with Paid Account";
 
 export const UserAuthedPaidChinese = Object.assign(UserAuthedPaid.bind(undefined), {
   storyName: "User Authenticated with Paid Account Chinese",

--- a/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.stories.tsx
@@ -105,12 +105,16 @@ function CurrentUserWrapper(props: { children: ReactNode; user?: User | undefine
 
 const defaultProps: OpenDialogProps = { backdropAnimation: false };
 
-export const DefaultLight = (): JSX.Element => <OpenDialog {...defaultProps} />;
-DefaultLight.storyName = "Default (light)";
-DefaultLight.parameters = { colorScheme: "light" };
+export const DefaultLight = {
+  render: (): JSX.Element => <OpenDialog {...defaultProps} />,
+  name: "Default (light)",
+  parameters: { colorScheme: "light" },
+};
 
-export const DefaultDark = (): JSX.Element => <OpenDialog {...defaultProps} />;
-DefaultDark.storyName = "Default (dark)";
+export const DefaultDark = {
+  render: (): JSX.Element => <OpenDialog {...defaultProps} />,
+  name: "Default (dark)",
+};
 
 export function UserNoAuth(): JSX.Element {
   return (

--- a/packages/studio-base/src/components/PanelContextMenu.stories.tsx
+++ b/packages/studio-base/src/components/PanelContextMenu.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { fireEvent } from "@storybook/testing-library";
 import { v4 as uuid } from "uuid";
 
@@ -55,17 +55,19 @@ const Dummy = Panel(
   }),
 );
 
-export const Default: Story = () => {
-  return (
-    <PanelSetup>
-      <Dummy></Dummy>
-    </PanelSetup>
-  );
-};
+export const Default: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup>
+        <Dummy></Dummy>
+      </PanelSetup>
+    );
+  },
 
-Default.play = () => {
-  Array.from(document.getElementsByClassName(DUMMY_CLASS)).forEach((el) => {
-    const rect = el.getBoundingClientRect();
-    fireEvent.contextMenu(el, { clientX: rect.x + 100, clientY: rect.y + 100 });
-  });
+  play: () => {
+    Array.from(document.getElementsByClassName(DUMMY_CLASS)).forEach((el) => {
+      const rect = el.getBoundingClientRect();
+      fireEvent.contextMenu(el, { clientX: rect.x + 100, clientY: rect.y + 100 });
+    });
+  },
 };

--- a/packages/studio-base/src/components/PanelContextMenu.stories.tsx
+++ b/packages/studio-base/src/components/PanelContextMenu.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { fireEvent } from "@storybook/testing-library";
 import { v4 as uuid } from "uuid";
 

--- a/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -26,7 +26,7 @@ export default {
   title: "components/PanelErrorBoundary",
 };
 
-export const Default: Story = () => {
+export const Default: StoryFn = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <PanelErrorBoundary
@@ -39,7 +39,7 @@ export const Default: Story = () => {
   );
 };
 
-export const ShowingDetails: Story = () => {
+export const ShowingDetails: StoryFn = () => {
   return (
     <DndProvider backend={HTML5Backend}>
       <PanelErrorBoundary

--- a/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -26,30 +26,34 @@ export default {
   title: "components/PanelErrorBoundary",
 };
 
-export const Default: StoryFn = () => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelErrorBoundary
-        onRemovePanel={action("onRemovePanel")}
-        onResetPanel={action("onResetPanel")}
-      >
-        <Broken />
-      </PanelErrorBoundary>
-    </DndProvider>
-  );
+export const Default: StoryObj = {
+  render: () => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelErrorBoundary
+          onRemovePanel={action("onRemovePanel")}
+          onResetPanel={action("onResetPanel")}
+        >
+          <Broken />
+        </PanelErrorBoundary>
+      </DndProvider>
+    );
+  },
 };
 
-export const ShowingDetails: StoryFn = () => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelErrorBoundary
-        showErrorDetails
-        hideErrorSourceLocations
-        onRemovePanel={action("onRemovePanel")}
-        onResetPanel={action("onResetPanel")}
-      >
-        <Broken />
-      </PanelErrorBoundary>
-    </DndProvider>
-  );
+export const ShowingDetails: StoryObj = {
+  render: () => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelErrorBoundary
+          showErrorDetails
+          hideErrorSourceLocations
+          onRemovePanel={action("onRemovePanel")}
+          onResetPanel={action("onResetPanel")}
+        >
+          <Broken />
+        </PanelErrorBoundary>
+      </DndProvider>
+    );
+  },
 };

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { ReactElement, useLayoutEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
@@ -18,8 +19,8 @@ export default {
   component: PanelExtensionAdapter,
 };
 
-export const CatchRenderError = {
-  render: (): JSX.Element => {
+export const CatchRenderError: StoryObj = {
+  render: () => {
     const initPanel = (context: PanelExtensionContext) => {
       context.watch("topics");
 
@@ -84,7 +85,7 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
   );
 }
 
-export const SimplePanelRender = {
+export const SimplePanelRender: StoryObj = {
   render: (): ReactElement => {
     function initPanel(context: PanelExtensionContext) {
       ReactDOM.render(<SimplePanel context={context} />, context.panelElement);

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
@@ -18,41 +18,43 @@ export default {
   component: PanelExtensionAdapter,
 };
 
-export const CatchRenderError = (): JSX.Element => {
-  const initPanel = (context: PanelExtensionContext) => {
-    context.watch("topics");
+export const CatchRenderError = {
+  render: (): JSX.Element => {
+    const initPanel = (context: PanelExtensionContext) => {
+      context.watch("topics");
 
-    context.onRender = () => {
-      const err = new Error("sample render error");
-      // The default stacktrace contains paths from the webpack bundle. These paths have the bundle
-      // identifier/hash and change whenever the bundle changes. This makes the story change.
-      // To avoid the story changing we set the stacktrace explicitly.
-      err.stack = "sample stacktrace";
-      throw err;
+      context.onRender = () => {
+        const err = new Error("sample render error");
+        // The default stacktrace contains paths from the webpack bundle. These paths have the bundle
+        // identifier/hash and change whenever the bundle changes. This makes the story change.
+        // To avoid the story changing we set the stacktrace explicitly.
+        err.stack = "sample stacktrace";
+        throw err;
+      };
     };
-  };
 
-  return (
-    <PanelSetup
-      fixture={{
-        topics: [
-          {
-            name: "/topic",
-            schemaName: "test_msgs/Sample",
-          },
-        ],
-        datatypes: new Map(),
-        frame: {},
-        layout: "UnknownPanel!4co6n9d",
-      }}
-    >
-      <MockPanelContextProvider>
-        <ErrorBoundary>
-          <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
-        </ErrorBoundary>
-      </MockPanelContextProvider>
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup
+        fixture={{
+          topics: [
+            {
+              name: "/topic",
+              schemaName: "test_msgs/Sample",
+            },
+          ],
+          datatypes: new Map(),
+          frame: {},
+          layout: "UnknownPanel!4co6n9d",
+        }}
+      >
+        <MockPanelContextProvider>
+          <ErrorBoundary>
+            <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+          </ErrorBoundary>
+        </MockPanelContextProvider>
+      </PanelSetup>
+    );
+  },
 };
 
 function SimplePanel({ context }: { context: PanelExtensionContext }) {
@@ -82,29 +84,31 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
   );
 }
 
-export const SimplePanelRender = (): ReactElement => {
-  function initPanel(context: PanelExtensionContext) {
-    ReactDOM.render(<SimplePanel context={context} />, context.panelElement);
-  }
+export const SimplePanelRender = {
+  render: (): ReactElement => {
+    function initPanel(context: PanelExtensionContext) {
+      ReactDOM.render(<SimplePanel context={context} />, context.panelElement);
+    }
 
-  return (
-    <PanelSetup
-      fixture={{
-        datatypes: new Map(),
-        frame: {},
-        activeData: {
-          currentTime: { sec: 1, nsec: 2 },
-          parameters: new Map([
-            ["param1", "value1"],
-            ["param2", "value2"],
-          ]),
-        },
-        layout: "UnknownPanel!4co6n9d",
-      }}
-    >
-      <MockPanelContextProvider>
-        <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
-      </MockPanelContextProvider>
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup
+        fixture={{
+          datatypes: new Map(),
+          frame: {},
+          activeData: {
+            currentTime: { sec: 1, nsec: 2 },
+            parameters: new Map([
+              ["param1", "value1"],
+              ["param2", "value2"],
+            ]),
+          },
+          layout: "UnknownPanel!4co6n9d",
+        }}
+      >
+        <MockPanelContextProvider>
+          <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+        </MockPanelContextProvider>
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -105,7 +105,7 @@ export default {
 };
 
 export const PanelNotFound = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -143,7 +143,7 @@ export const PanelWithError = (): JSX.Element => {
 };
 
 export const RemoveUnknownPanel = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -173,7 +173,7 @@ export const EmptyLayout = (): JSX.Element => {
 };
 
 export const EmptyLayoutChinese = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <PanelSetup fixture={{ layout: undefined }}>
         <PanelLayout />
@@ -199,7 +199,7 @@ export const PanelLoading = (): JSX.Element => {
 };
 
 export const FullScreen = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -128,18 +128,20 @@ export const PanelNotFoundLight = {
   play: openPanelMenu,
 };
 
-export const PanelWithError = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelSetup
-        panelCatalog={new MockPanelCatalog()}
-        fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}
-        omitDragAndDrop
-      >
-        <PanelLayout />
-      </PanelSetup>
-    </DndProvider>
-  );
+export const PanelWithError = {
+  render: (): JSX.Element => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelSetup
+          panelCatalog={new MockPanelCatalog()}
+          fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}
+          omitDragAndDrop
+        >
+          <PanelLayout />
+        </PanelSetup>
+      </DndProvider>
+    );
+  },
 };
 
 export const RemoveUnknownPanel = {
@@ -164,12 +166,14 @@ export const RemoveUnknownPanel = {
   },
 };
 
-export const EmptyLayout = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={{ layout: undefined }}>
-      <PanelLayout />
-    </PanelSetup>
-  );
+export const EmptyLayout = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={{ layout: undefined }}>
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
 };
 
 export const EmptyLayoutChinese = {
@@ -184,18 +188,20 @@ export const EmptyLayoutChinese = {
   parameters: { forceLanguage: "zh" },
 };
 
-export const PanelLoading = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelSetup
-        panelCatalog={new MockPanelCatalog()}
-        fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!4co6n9d" }}
-        omitDragAndDrop
-      >
-        <PanelLayout />
-      </PanelSetup>
-    </DndProvider>
-  );
+export const PanelLoading = {
+  render: (): JSX.Element => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelSetup
+          panelCatalog={new MockPanelCatalog()}
+          fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!4co6n9d" }}
+          omitDragAndDrop
+        >
+          <PanelLayout />
+        </PanelSetup>
+      </DndProvider>
+    );
+  },
 };
 
 export const FullScreen = {

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -27,12 +27,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import PanelLayout from "./PanelLayout";
 
-async function openPanelMenu() {
+async function openPanelMenu(): Promise<void> {
   const buttons = await screen.findAllByTestId("panel-menu");
   fireEvent.click(buttons[0]!);
 }
 
-async function goFullScreen() {
+async function goFullScreen(): Promise<void> {
   await openPanelMenu();
   fireEvent.click(screen.getAllByTestId("panel-menu-fullscreen")[0]!);
 }
@@ -90,13 +90,13 @@ class MockPanelCatalog implements PanelCatalog {
 export default {
   title: "components/PanelLayout",
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       const storage = new MockLayoutStorage(LayoutManager.LOCAL_STORAGE_NAMESPACE, []);
 
       return (
         <LayoutStorageContext.Provider value={storage}>
           <LayoutManagerProvider>
-            <StoryFn />
+            <Wrapped />
           </LayoutManagerProvider>
         </LayoutStorageContext.Provider>
       );
@@ -104,25 +104,29 @@ export default {
   ],
 };
 
-export const PanelNotFound = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelSetup
-        fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
-        omitDragAndDrop
-      >
-        <PanelLayout />
-      </PanelSetup>
-    </DndProvider>
-  );
-};
-PanelNotFound.parameters = { colorScheme: "dark" };
-PanelNotFound.play = openPanelMenu;
+export const PanelNotFound = {
+  render: (): JSX.Element => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelSetup
+          fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
+          omitDragAndDrop
+        >
+          <PanelLayout />
+        </PanelSetup>
+      </DndProvider>
+    );
+  },
 
-export const PanelNotFoundLight = Object.assign(PanelNotFound.bind(undefined), {
+  parameters: { colorScheme: "dark" },
+  play: openPanelMenu,
+};
+
+export const PanelNotFoundLight = {
+  ...PanelNotFound,
   parameters: { colorScheme: "light" },
-});
-PanelNotFoundLight.play = openPanelMenu;
+  play: openPanelMenu,
+};
 
 export const PanelWithError = (): JSX.Element => {
   return (
@@ -138,21 +142,26 @@ export const PanelWithError = (): JSX.Element => {
   );
 };
 
-export const RemoveUnknownPanel = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelSetup
-        fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
-        omitDragAndDrop
-      >
-        <PanelLayout />
-      </PanelSetup>
-    </DndProvider>
-  );
-};
-RemoveUnknownPanel.play = async () => {
-  (await screen.findAllByTestId("panel-menu")).forEach((button) => fireEvent.click(button));
-  (await screen.findAllByTestId("panel-menu-remove")).forEach((button) => fireEvent.click(button));
+export const RemoveUnknownPanel = {
+  render: (): JSX.Element => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelSetup
+          fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
+          omitDragAndDrop
+        >
+          <PanelLayout />
+        </PanelSetup>
+      </DndProvider>
+    );
+  },
+
+  play: async (): Promise<void> => {
+    (await screen.findAllByTestId("panel-menu")).forEach((button) => fireEvent.click(button));
+    (await screen.findAllByTestId("panel-menu-remove")).forEach((button) =>
+      fireEvent.click(button),
+    );
+  },
 };
 
 export const EmptyLayout = (): JSX.Element => {
@@ -163,14 +172,17 @@ export const EmptyLayout = (): JSX.Element => {
   );
 };
 
-export const EmptyLayoutChinese = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={{ layout: undefined }}>
-      <PanelLayout />
-    </PanelSetup>
-  );
+export const EmptyLayoutChinese = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={{ layout: undefined }}>
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { forceLanguage: "zh" },
 };
-EmptyLayoutChinese.parameters = { forceLanguage: "zh" };
 
 export const PanelLoading = (): JSX.Element => {
   return (
@@ -186,32 +198,36 @@ export const PanelLoading = (): JSX.Element => {
   );
 };
 
-export const FullScreen = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelSetup
-        panelCatalog={new MockPanelCatalog()}
-        fixture={{
-          topics: [],
-          datatypes: new Map(),
-          frame: {},
-          layout: { first: "Sample3!a", second: "Sample3!b", direction: "row" },
-          savedProps: {
-            "Sample3!a": { x: 1 },
-            "Sample3!b": { x: 2 },
-          },
-        }}
-        omitDragAndDrop
-      >
-        <PanelLayout />
-      </PanelSetup>
-    </DndProvider>
-  );
-};
-FullScreen.parameters = { colorScheme: "dark" };
-FullScreen.play = goFullScreen;
+export const FullScreen = {
+  render: (): JSX.Element => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <PanelSetup
+          panelCatalog={new MockPanelCatalog()}
+          fixture={{
+            topics: [],
+            datatypes: new Map(),
+            frame: {},
+            layout: { first: "Sample3!a", second: "Sample3!b", direction: "row" },
+            savedProps: {
+              "Sample3!a": { x: 1 },
+              "Sample3!b": { x: 2 },
+            },
+          }}
+          omitDragAndDrop
+        >
+          <PanelLayout />
+        </PanelSetup>
+      </DndProvider>
+    );
+  },
 
-export const FullScreenLight = Object.assign(FullScreen.bind(undefined), {
+  parameters: { colorScheme: "dark" },
+  play: goFullScreen,
+};
+
+export const FullScreenLight = {
+  ...FullScreen,
   parameters: { colorScheme: "light" },
-});
-FullScreenLight.play = goFullScreen;
+  play: goFullScreen,
+};

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -104,8 +104,8 @@ export default {
   ],
 };
 
-export const PanelNotFound = {
-  render: function Story(): JSX.Element {
+export const PanelNotFound: StoryObj = {
+  render: function Story() {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -122,14 +122,14 @@ export const PanelNotFound = {
   play: openPanelMenu,
 };
 
-export const PanelNotFoundLight = {
+export const PanelNotFoundLight: StoryObj = {
   ...PanelNotFound,
   parameters: { colorScheme: "light" },
   play: openPanelMenu,
 };
 
-export const PanelWithError = {
-  render: (): JSX.Element => {
+export const PanelWithError: StoryObj = {
+  render: () => {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -144,8 +144,8 @@ export const PanelWithError = {
   },
 };
 
-export const RemoveUnknownPanel = {
-  render: function Story(): JSX.Element {
+export const RemoveUnknownPanel: StoryObj = {
+  render: function Story() {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -166,8 +166,8 @@ export const RemoveUnknownPanel = {
   },
 };
 
-export const EmptyLayout = {
-  render: (): JSX.Element => {
+export const EmptyLayout: StoryObj = {
+  render: () => {
     return (
       <PanelSetup fixture={{ layout: undefined }}>
         <PanelLayout />
@@ -176,8 +176,8 @@ export const EmptyLayout = {
   },
 };
 
-export const EmptyLayoutChinese = {
-  render: function Story(): JSX.Element {
+export const EmptyLayoutChinese: StoryObj = {
+  render: function Story() {
     return (
       <PanelSetup fixture={{ layout: undefined }}>
         <PanelLayout />
@@ -188,8 +188,8 @@ export const EmptyLayoutChinese = {
   parameters: { forceLanguage: "zh" },
 };
 
-export const PanelLoading = {
-  render: (): JSX.Element => {
+export const PanelLoading: StoryObj = {
+  render: () => {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -204,8 +204,8 @@ export const PanelLoading = {
   },
 };
 
-export const FullScreen = {
-  render: function Story(): JSX.Element {
+export const FullScreen: StoryObj = {
+  render: function Story() {
     return (
       <DndProvider backend={HTML5Backend}>
         <PanelSetup
@@ -232,7 +232,7 @@ export const FullScreen = {
   play: goFullScreen,
 };
 
-export const FullScreenLight = {
+export const FullScreenLight: StoryObj = {
   ...FullScreen,
   parameters: { colorScheme: "light" },
   play: goFullScreen,

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -158,7 +158,7 @@ export const RemoveUnknownPanel: StoryObj = {
     );
   },
 
-  play: async (): Promise<void> => {
+  play: async () => {
     (await screen.findAllByTestId("panel-menu")).forEach((button) => fireEvent.click(button));
     (await screen.findAllByTestId("panel-menu-remove")).forEach((button) =>
       fireEvent.click(button),

--- a/packages/studio-base/src/components/PanelList/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelList/index.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { useTheme } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { useEffect, useRef } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -141,8 +141,8 @@ export default {
   ],
 };
 
-export const PanelListStory = {
-  render: function Story(): JSX.Element {
+export const PanelListStory: StoryObj = {
+  render: function Story() {
     const theme = useTheme();
     return (
       <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
@@ -154,8 +154,8 @@ export const PanelListStory = {
   name: "panel list",
 };
 
-export const PanelGrid = {
-  render: function Story(): JSX.Element {
+export const PanelGrid: StoryObj = {
+  render: function Story() {
     const theme = useTheme();
     return (
       <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
@@ -167,25 +167,25 @@ export const PanelGrid = {
   name: "panel grid",
 };
 
-export const FilteredPanelList = {
-  render: (): JSX.Element => <PanelListWithInteractions inputValue="AAA" />,
+export const FilteredPanelList: StoryObj = {
+  render: () => <PanelListWithInteractions inputValue="AAA" />,
   name: "filtered panel list",
 };
 
-export const FilteredPanelGrid = {
-  render: (): JSX.Element => <PanelListWithInteractions mode="grid" inputValue="AAA" />,
+export const FilteredPanelGrid: StoryObj = {
+  render: () => <PanelListWithInteractions mode="grid" inputValue="AAA" />,
 
   name: "filtered panel grid",
 };
 
-export const FilteredPanelGridWithDescription = {
-  render: (): JSX.Element => <PanelListWithInteractions mode="grid" inputValue="description" />,
+export const FilteredPanelGridWithDescription: StoryObj = {
+  render: () => <PanelListWithInteractions mode="grid" inputValue="description" />,
 
   name: "filtered panel grid with description",
 };
 
-export const FilteredPanelListLight = {
-  render: (): JSX.Element => <PanelListWithInteractions inputValue="AAA" />,
+export const FilteredPanelListLight: StoryObj = {
+  render: () => <PanelListWithInteractions inputValue="AAA" />,
 
   name: "filtered panel list light",
 
@@ -194,48 +194,48 @@ export const FilteredPanelListLight = {
   },
 };
 
-export const NavigatingArrows = {
-  render: (): JSX.Element => <PanelListWithInteractions events={[arrowDown, arrowDown, arrowUp]} />,
+export const NavigatingArrows: StoryObj = {
+  render: () => <PanelListWithInteractions events={[arrowDown, arrowDown, arrowUp]} />,
 
   name: "navigating panel list with arrow keys",
 };
 
-export const NavigatingArrowsWrap = {
-  render: (): JSX.Element => <PanelListWithInteractions events={[arrowUp]} />,
+export const NavigatingArrowsWrap: StoryObj = {
+  render: () => <PanelListWithInteractions events={[arrowUp]} />,
 
   name: "navigating up from top of panel list will scroll to highlighted last item",
 };
 
-export const NoResultsFirst = {
-  render: (): JSX.Element => <PanelListWithInteractions inputValue="regular" />,
+export const NoResultsFirst: StoryObj = {
+  render: () => <PanelListWithInteractions inputValue="regular" />,
   name: "filtered panel list without results in 1st category",
 };
 
-export const NoResultsLast = {
-  render: (): JSX.Element => <PanelListWithInteractions inputValue="preconfigured" />,
+export const NoResultsLast: StoryObj = {
+  render: () => <PanelListWithInteractions inputValue="preconfigured" />,
 
   name: "filtered panel list without results in last category",
 };
 
-export const NoResultsAnyList = {
-  render: (): JSX.Element => <PanelListWithInteractions inputValue="WWW" />,
+export const NoResultsAnyList: StoryObj = {
+  render: () => <PanelListWithInteractions inputValue="WWW" />,
   name: "filtered panel list without results in any category",
 };
 
-export const NoResultsAnyGrid = {
-  render: (): JSX.Element => <PanelListWithInteractions mode="grid" inputValue="WWW" />,
+export const NoResultsAnyGrid: StoryObj = {
+  render: () => <PanelListWithInteractions mode="grid" inputValue="WWW" />,
 
   name: "filtered panel grid without results in any category",
 };
 
-export const CaseInsensitiveFilter = {
-  render: (): JSX.Element => <PanelListWithInteractions inputValue="pA" />,
+export const CaseInsensitiveFilter: StoryObj = {
+  render: () => <PanelListWithInteractions inputValue="pA" />,
 
   name: "case-insensitive filtering and highlight submenu",
 };
 
-export const PanelListChinese = {
-  render: function Story(): JSX.Element {
+export const PanelListChinese: StoryObj = {
+  render: function Story() {
     const theme = useTheme();
     return (
       <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
@@ -247,8 +247,8 @@ export const PanelListChinese = {
   parameters: { forceLanguage: "zh" },
 };
 
-export const NoResultsChinese = {
-  render: function Story(): JSX.Element {
+export const NoResultsChinese: StoryObj = {
+  render: function Story() {
     return <PanelListWithInteractions mode="grid" inputValue="WWW" />;
   },
 

--- a/packages/studio-base/src/components/PanelList/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelList/index.stories.tsx
@@ -248,7 +248,7 @@ export const PanelListChinese = {
 };
 
 export const NoResultsChinese = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <PanelListWithInteractions mode="grid" inputValue="WWW" />;
   },
 

--- a/packages/studio-base/src/components/PanelList/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelList/index.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { useTheme } from "@mui/material";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { useEffect, useRef } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -127,12 +127,12 @@ export default {
     colorScheme: "dark",
   },
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       return (
         <DndProvider backend={HTML5Backend}>
           <PanelCatalogContext.Provider value={new MockPanelCatalog()}>
             <MockCurrentLayoutProvider>
-              <StoryFn />
+              <Wrapped />
             </MockCurrentLayoutProvider>
           </PanelCatalogContext.Provider>
         </DndProvider>
@@ -141,90 +141,116 @@ export default {
   ],
 };
 
-export const PanelListStory = (): JSX.Element => {
-  const theme = useTheme();
-  return (
-    <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
-      <PanelList onPanelSelect={() => {}} />
-    </div>
-  );
-};
-PanelListStory.storyName = "panel list";
+export const PanelListStory = {
+  render: function Story(): JSX.Element {
+    const theme = useTheme();
+    return (
+      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
+        <PanelList onPanelSelect={() => {}} />
+      </div>
+    );
+  },
 
-export const PanelGrid = (): JSX.Element => {
-  const theme = useTheme();
-  return (
-    <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
-      <PanelList mode="grid" onPanelSelect={() => {}} />
-    </div>
-  );
-};
-PanelGrid.storyName = "panel grid";
-
-export const FilteredPanelList = (): JSX.Element => <PanelListWithInteractions inputValue="AAA" />;
-FilteredPanelList.storyName = "filtered panel list";
-
-export const FilteredPanelGrid = (): JSX.Element => (
-  <PanelListWithInteractions mode="grid" inputValue="AAA" />
-);
-FilteredPanelGrid.storyName = "filtered panel grid";
-
-export const FilteredPanelGridWithDescription = (): JSX.Element => (
-  <PanelListWithInteractions mode="grid" inputValue="description" />
-);
-FilteredPanelGridWithDescription.storyName = "filtered panel grid with description";
-
-export const FilteredPanelListLight = (): JSX.Element => (
-  <PanelListWithInteractions inputValue="AAA" />
-);
-FilteredPanelListLight.storyName = "filtered panel list light";
-FilteredPanelListLight.parameters = {
-  colorScheme: "light",
+  name: "panel list",
 };
 
-export const NavigatingArrows = (): JSX.Element => (
-  <PanelListWithInteractions events={[arrowDown, arrowDown, arrowUp]} />
-);
-NavigatingArrows.storyName = "navigating panel list with arrow keys";
+export const PanelGrid = {
+  render: function Story(): JSX.Element {
+    const theme = useTheme();
+    return (
+      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
+        <PanelList mode="grid" onPanelSelect={() => {}} />
+      </div>
+    );
+  },
 
-export const NavigatingArrowsWrap = (): JSX.Element => (
-  <PanelListWithInteractions events={[arrowUp]} />
-);
-NavigatingArrowsWrap.storyName =
-  "navigating up from top of panel list will scroll to highlighted last item";
-
-export const NoResultsFirst = (): JSX.Element => <PanelListWithInteractions inputValue="regular" />;
-NoResultsFirst.storyName = "filtered panel list without results in 1st category";
-
-export const NoResultsLast = (): JSX.Element => (
-  <PanelListWithInteractions inputValue="preconfigured" />
-);
-NoResultsLast.storyName = "filtered panel list without results in last category";
-
-export const NoResultsAnyList = (): JSX.Element => <PanelListWithInteractions inputValue="WWW" />;
-NoResultsAnyList.storyName = "filtered panel list without results in any category";
-
-export const NoResultsAnyGrid = (): JSX.Element => (
-  <PanelListWithInteractions mode="grid" inputValue="WWW" />
-);
-NoResultsAnyGrid.storyName = "filtered panel grid without results in any category";
-
-export const CaseInsensitiveFilter = (): JSX.Element => (
-  <PanelListWithInteractions inputValue="pA" />
-);
-CaseInsensitiveFilter.storyName = "case-insensitive filtering and highlight submenu";
-
-export const PanelListChinese = (): JSX.Element => {
-  const theme = useTheme();
-  return (
-    <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
-      <PanelList onPanelSelect={() => {}} />
-    </div>
-  );
+  name: "panel grid",
 };
-PanelListChinese.parameters = { forceLanguage: "zh" };
 
-export const NoResultsChinese = (): JSX.Element => {
-  return <PanelListWithInteractions mode="grid" inputValue="WWW" />;
+export const FilteredPanelList = {
+  render: (): JSX.Element => <PanelListWithInteractions inputValue="AAA" />,
+  name: "filtered panel list",
 };
-NoResultsChinese.parameters = { forceLanguage: "zh" };
+
+export const FilteredPanelGrid = {
+  render: (): JSX.Element => <PanelListWithInteractions mode="grid" inputValue="AAA" />,
+
+  name: "filtered panel grid",
+};
+
+export const FilteredPanelGridWithDescription = {
+  render: (): JSX.Element => <PanelListWithInteractions mode="grid" inputValue="description" />,
+
+  name: "filtered panel grid with description",
+};
+
+export const FilteredPanelListLight = {
+  render: (): JSX.Element => <PanelListWithInteractions inputValue="AAA" />,
+
+  name: "filtered panel list light",
+
+  parameters: {
+    colorScheme: "light",
+  },
+};
+
+export const NavigatingArrows = {
+  render: (): JSX.Element => <PanelListWithInteractions events={[arrowDown, arrowDown, arrowUp]} />,
+
+  name: "navigating panel list with arrow keys",
+};
+
+export const NavigatingArrowsWrap = {
+  render: (): JSX.Element => <PanelListWithInteractions events={[arrowUp]} />,
+
+  name: "navigating up from top of panel list will scroll to highlighted last item",
+};
+
+export const NoResultsFirst = {
+  render: (): JSX.Element => <PanelListWithInteractions inputValue="regular" />,
+  name: "filtered panel list without results in 1st category",
+};
+
+export const NoResultsLast = {
+  render: (): JSX.Element => <PanelListWithInteractions inputValue="preconfigured" />,
+
+  name: "filtered panel list without results in last category",
+};
+
+export const NoResultsAnyList = {
+  render: (): JSX.Element => <PanelListWithInteractions inputValue="WWW" />,
+  name: "filtered panel list without results in any category",
+};
+
+export const NoResultsAnyGrid = {
+  render: (): JSX.Element => <PanelListWithInteractions mode="grid" inputValue="WWW" />,
+
+  name: "filtered panel grid without results in any category",
+};
+
+export const CaseInsensitiveFilter = {
+  render: (): JSX.Element => <PanelListWithInteractions inputValue="pA" />,
+
+  name: "case-insensitive filtering and highlight submenu",
+};
+
+export const PanelListChinese = {
+  render: function Story(): JSX.Element {
+    const theme = useTheme();
+    return (
+      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
+        <PanelList onPanelSelect={() => {}} />
+      </div>
+    );
+  },
+
+  parameters: { forceLanguage: "zh" },
+};
+
+export const NoResultsChinese = {
+  render: (): JSX.Element => {
+    return <PanelListWithInteractions mode="grid" inputValue="WWW" />;
+  },
+
+  parameters: { forceLanguage: "zh" },
+};

--- a/packages/studio-base/src/components/PanelSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -42,48 +42,54 @@ class MockPanelCatalog implements PanelCatalog {
 const fixture = { topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!abc" };
 const selectedPanelIds: readonly string[] = ["Sample1!abc"];
 
-export const NoPanelSelected: StoryFn = (): JSX.Element => {
-  return (
-    <div style={{ margin: 30, height: 400 }}>
-      <DndProvider backend={HTML5Backend}>
-        <MockCurrentLayoutProvider>
-          <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture} omitDragAndDrop>
-            <PanelSettings />
-          </PanelSetup>
-        </MockCurrentLayoutProvider>
-      </DndProvider>
-    </div>
-  );
+export const NoPanelSelected: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <div style={{ margin: 30, height: 400 }}>
+        <DndProvider backend={HTML5Backend}>
+          <MockCurrentLayoutProvider>
+            <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture} omitDragAndDrop>
+              <PanelSettings />
+            </PanelSetup>
+          </MockCurrentLayoutProvider>
+        </DndProvider>
+      </div>
+    );
+  },
 };
 
-export const PanelSelected: StoryFn = (): JSX.Element => {
-  return (
-    <div style={{ margin: 30, height: 400 }}>
-      <DndProvider backend={HTML5Backend}>
-        <MockCurrentLayoutProvider>
-          <PanelSetup
-            panelCatalog={new MockPanelCatalog()}
-            fixture={{ ...fixture, savedProps: { "Sample1!abc": { someKey: "someVal" } } }}
-            omitDragAndDrop
-          >
-            <PanelSettings selectedPanelIdsForTests={selectedPanelIds} />
-          </PanelSetup>
-        </MockCurrentLayoutProvider>
-      </DndProvider>
-    </div>
-  );
+export const PanelSelected: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <div style={{ margin: 30, height: 400 }}>
+        <DndProvider backend={HTML5Backend}>
+          <MockCurrentLayoutProvider>
+            <PanelSetup
+              panelCatalog={new MockPanelCatalog()}
+              fixture={{ ...fixture, savedProps: { "Sample1!abc": { someKey: "someVal" } } }}
+              omitDragAndDrop
+            >
+              <PanelSettings selectedPanelIdsForTests={selectedPanelIds} />
+            </PanelSetup>
+          </MockCurrentLayoutProvider>
+        </DndProvider>
+      </div>
+    );
+  },
 };
 
-export const PanelLoading: StoryFn = (): JSX.Element => {
-  return (
-    <div style={{ margin: 30, height: 400 }}>
-      <DndProvider backend={HTML5Backend}>
-        <MockCurrentLayoutProvider>
-          <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture} omitDragAndDrop>
-            <PanelSettings selectedPanelIdsForTests={selectedPanelIds} />
-          </PanelSetup>
-        </MockCurrentLayoutProvider>
-      </DndProvider>
-    </div>
-  );
+export const PanelLoading: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <div style={{ margin: 30, height: 400 }}>
+        <DndProvider backend={HTML5Backend}>
+          <MockCurrentLayoutProvider>
+            <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture} omitDragAndDrop>
+              <PanelSettings selectedPanelIdsForTests={selectedPanelIds} />
+            </PanelSetup>
+          </MockCurrentLayoutProvider>
+        </DndProvider>
+      </div>
+    );
+  },
 };

--- a/packages/studio-base/src/components/PanelSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.stories.tsx
@@ -43,7 +43,7 @@ const fixture = { topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!
 const selectedPanelIds: readonly string[] = ["Sample1!abc"];
 
 export const NoPanelSelected: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <div style={{ margin: 30, height: 400 }}>
         <DndProvider backend={HTML5Backend}>
@@ -59,7 +59,7 @@ export const NoPanelSelected: StoryObj = {
 };
 
 export const PanelSelected: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <div style={{ margin: 30, height: 400 }}>
         <DndProvider backend={HTML5Backend}>
@@ -79,7 +79,7 @@ export const PanelSelected: StoryObj = {
 };
 
 export const PanelLoading: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <div style={{ margin: 30, height: 400 }}>
         <DndProvider backend={HTML5Backend}>

--- a/packages/studio-base/src/components/PanelSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryFn } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -41,7 +42,7 @@ class MockPanelCatalog implements PanelCatalog {
 const fixture = { topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!abc" };
 const selectedPanelIds: readonly string[] = ["Sample1!abc"];
 
-export function NoPanelSelected(): JSX.Element {
+export const NoPanelSelected: StoryFn = (): JSX.Element => {
   return (
     <div style={{ margin: 30, height: 400 }}>
       <DndProvider backend={HTML5Backend}>
@@ -53,9 +54,9 @@ export function NoPanelSelected(): JSX.Element {
       </DndProvider>
     </div>
   );
-}
+};
 
-export function PanelSelected(): JSX.Element {
+export const PanelSelected: StoryFn = (): JSX.Element => {
   return (
     <div style={{ margin: 30, height: 400 }}>
       <DndProvider backend={HTML5Backend}>
@@ -71,9 +72,9 @@ export function PanelSelected(): JSX.Element {
       </DndProvider>
     </div>
   );
-}
+};
 
-export function PanelLoading(): JSX.Element {
+export const PanelLoading: StoryFn = (): JSX.Element => {
   return (
     <div style={{ margin: 30, height: 400 }}>
       <DndProvider backend={HTML5Backend}>
@@ -85,4 +86,4 @@ export function PanelLoading(): JSX.Element {
       </DndProvider>
     </div>
   );
-}
+};

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -13,7 +13,7 @@
 
 import { Database20Filled } from "@fluentui/react-icons";
 import { Box } from "@mui/material";
-import { DecoratorFn, StoryFn } from "@storybook/react";
+import { StoryObj, DecoratorFn, StoryFn } from "@storybook/react";
 import { Mosaic, MosaicWindow } from "react-mosaic-component";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
@@ -106,123 +106,151 @@ export default {
   ],
 };
 
-export const NonFloatingNarrow: StoryFn = () => {
-  return (
-    <MosaicWrapper width={268}>
-      <PanelToolbar>
-        <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>Some controls here</div>
-      </PanelToolbar>
-    </MosaicWrapper>
-  );
+export const NonFloatingNarrow: StoryObj = {
+  render: () => {
+    return (
+      <MosaicWrapper width={268}>
+        <PanelToolbar>
+          <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
+            Some controls here
+          </div>
+        </PanelToolbar>
+      </MosaicWrapper>
+    );
+  },
+
+  name: "non-floating (narrow)",
 };
 
-NonFloatingNarrow.storyName = "non-floating (narrow)";
+export const NonFloatingWideWithPanelName: StoryObj = {
+  render: () => {
+    return (
+      <MosaicWrapper width={468}>
+        <PanelToolbar>
+          <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
+            Some controls here
+          </div>
+        </PanelToolbar>
+      </MosaicWrapper>
+    );
+  },
 
-export const NonFloatingWideWithPanelName: StoryFn = () => {
-  return (
-    <MosaicWrapper width={468}>
-      <PanelToolbar>
-        <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>Some controls here</div>
-      </PanelToolbar>
-    </MosaicWrapper>
-  );
+  name: "non-floating (wide with panel name)",
 };
 
-NonFloatingWideWithPanelName.storyName = "non-floating (wide with panel name)";
+export const OneAdditionalIcon: StoryObj = {
+  render: () => {
+    const additionalIcons = (
+      <ToolbarIconButton title="database icon">
+        <Database20Filled />
+      </ToolbarIconButton>
+    );
+    return (
+      <MosaicWrapper width={468}>
+        <PanelToolbar additionalIcons={additionalIcons}>
+          <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
+            Some controls here
+          </div>
+        </PanelToolbar>
+      </MosaicWrapper>
+    );
+  },
 
-export const OneAdditionalIcon: StoryFn = () => {
-  const additionalIcons = (
-    <ToolbarIconButton title="database icon">
-      <Database20Filled />
-    </ToolbarIconButton>
-  );
-  return (
-    <MosaicWrapper width={468}>
-      <PanelToolbar additionalIcons={additionalIcons}>
-        <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>Some controls here</div>
-      </PanelToolbar>
-    </MosaicWrapper>
-  );
+  name: "one additional icon",
 };
 
-OneAdditionalIcon.storyName = "one additional icon";
-
-export const MenuOnlyPanel: StoryFn = () => {
-  class Story extends React.Component {
-    public override render() {
-      return (
-        <MosaicWrapper width={268}>
-          <PanelToolbarWithOpenMenu />
-        </MosaicWrapper>
-      );
+export const MenuOnlyPanel: StoryObj = {
+  render: () => {
+    class Story extends React.Component {
+      public override render() {
+        return (
+          <MosaicWrapper width={268}>
+            <PanelToolbarWithOpenMenu />
+          </MosaicWrapper>
+        );
+      }
     }
-  }
-  return <Story />;
+    return <Story />;
+  },
+
+  name: "menu (only panel)",
+  parameters: { colorScheme: "dark" },
 };
 
-MenuOnlyPanel.storyName = "menu (only panel)";
-MenuOnlyPanel.parameters = { colorScheme: "dark" };
-
-export const MenuLight: StoryFn = () => {
-  class Story extends React.Component {
-    public override render() {
-      return (
-        <MosaicWrapper width={268}>
-          <PanelToolbarWithOpenMenu />
-        </MosaicWrapper>
-      );
+export const MenuLight: StoryObj = {
+  render: () => {
+    class Story extends React.Component {
+      public override render() {
+        return (
+          <MosaicWrapper width={268}>
+            <PanelToolbarWithOpenMenu />
+          </MosaicWrapper>
+        );
+      }
     }
-  }
-  return <Story />;
+    return <Story />;
+  },
+
+  name: "menu light",
+  parameters: { colorScheme: "light" },
 };
 
-MenuLight.storyName = "menu light";
-MenuLight.parameters = { colorScheme: "light" };
-
-export const MenuWithSiblingPanel: StoryFn = () => {
-  class Story extends React.Component {
-    public override render() {
-      return (
-        <MosaicWrapper width={268} layout={{ direction: "row", first: "dummy", second: "Sibling" }}>
-          <PanelToolbarWithOpenMenu />
-        </MosaicWrapper>
-      );
+export const MenuWithSiblingPanel: StoryObj = {
+  render: () => {
+    class Story extends React.Component {
+      public override render() {
+        return (
+          <MosaicWrapper
+            width={268}
+            layout={{ direction: "row", first: "dummy", second: "Sibling" }}
+          >
+            <PanelToolbarWithOpenMenu />
+          </MosaicWrapper>
+        );
+      }
     }
-  }
-  return <Story />;
+    return <Story />;
+  },
+
+  name: "menu (with sibling panel)",
+  parameters: { colorScheme: "dark" },
 };
 
-MenuWithSiblingPanel.storyName = "menu (with sibling panel)";
-MenuWithSiblingPanel.parameters = { colorScheme: "dark" };
-
-export const MenuForTabPanel: StoryFn = () => {
-  class Story extends React.Component {
-    public override render() {
-      return (
-        <MosaicWrapper width={268} layout={{ direction: "row", first: "Tab", second: "Sibling" }}>
-          <PanelToolbarWithOpenMenu />
-        </MosaicWrapper>
-      );
+export const MenuForTabPanel: StoryObj = {
+  render: () => {
+    class Story extends React.Component {
+      public override render() {
+        return (
+          <MosaicWrapper width={268} layout={{ direction: "row", first: "Tab", second: "Sibling" }}>
+            <PanelToolbarWithOpenMenu />
+          </MosaicWrapper>
+        );
+      }
     }
-  }
-  return <Story />;
+    return <Story />;
+  },
+
+  name: "menu for Tab panel",
+  parameters: { colorScheme: "dark" },
 };
 
-MenuForTabPanel.storyName = "menu for Tab panel";
-MenuForTabPanel.parameters = { colorScheme: "dark" };
-
-export const NoToolbars: StoryFn = () => {
-  class Story extends React.Component {
-    public override render() {
-      return (
-        <MosaicWrapper width={268} layout={{ direction: "row", first: "dummy", second: "Sibling" }}>
-          <PanelToolbarWithOpenMenu />
-        </MosaicWrapper>
-      );
+export const NoToolbars: StoryObj = {
+  render: () => {
+    class Story extends React.Component {
+      public override render() {
+        return (
+          <MosaicWrapper
+            width={268}
+            layout={{ direction: "row", first: "dummy", second: "Sibling" }}
+          >
+            <PanelToolbarWithOpenMenu />
+          </MosaicWrapper>
+        );
+      }
     }
-  }
-  return <Story />;
-};
+    return <Story />;
+  },
 
-NoToolbars.storyName = "no toolbars";
-NoToolbars.parameters = { colorScheme: "dark" };
+  name: "no toolbars",
+  parameters: { colorScheme: "dark" },
+};

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -13,7 +13,7 @@
 
 import { Database20Filled } from "@fluentui/react-icons";
 import { Box } from "@mui/material";
-import { StoryObj, DecoratorFn, StoryFn } from "@storybook/react";
+import { StoryObj, DecoratorFn } from "@storybook/react";
 import { Mosaic, MosaicWindow } from "react-mosaic-component";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
@@ -37,7 +37,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
   },
 };

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
@@ -36,11 +36,11 @@ export default {
   decorators: [Wrapper],
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
-}
+};
 
-export function WithEvents(): JSX.Element {
+export const WithEvents: StoryFn = (): JSX.Element => {
   const setEvents = useTimelineInteractionState((store) => store.setEventsAtHoverValue);
 
   useEffect(() => {
@@ -72,4 +72,4 @@ export function WithEvents(): JSX.Element {
   }, [setEvents]);
 
   return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
-}
+};

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useEffect } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
@@ -36,40 +36,44 @@ export default {
   decorators: [Wrapper],
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
+  },
 };
 
-export const WithEvents: StoryFn = (): JSX.Element => {
-  const setEvents = useTimelineInteractionState((store) => store.setEventsAtHoverValue);
+export const WithEvents: StoryObj = {
+  render: function Story() {
+    const setEvents = useTimelineInteractionState((store) => store.setEventsAtHoverValue);
 
-  useEffect(() => {
-    setEvents([
-      {
-        event: {
-          createdAt: "1",
-          id: "1",
-          deviceId: "dev1",
-          durationNanos: "1",
-          endTime: { sec: 1, nsec: 1 },
-          endTimeInSeconds: 1,
-          metadata: {
-            "meta 1": "value 1",
-            "meta 2": "value 2",
-            "long event metadata key that might overflow":
-              "long event metadata value that might also overflow",
+    useEffect(() => {
+      setEvents([
+        {
+          event: {
+            createdAt: "1",
+            id: "1",
+            deviceId: "dev1",
+            durationNanos: "1",
+            endTime: { sec: 1, nsec: 1 },
+            endTimeInSeconds: 1,
+            metadata: {
+              "meta 1": "value 1",
+              "meta 2": "value 2",
+              "long event metadata key that might overflow":
+                "long event metadata value that might also overflow",
+            },
+            startTime: { sec: 0, nsec: 0 },
+            startTimeInSeconds: 1,
+            timestampNanos: "1",
+            updatedAt: "1",
           },
-          startTime: { sec: 0, nsec: 0 },
-          startTimeInSeconds: 1,
-          timestampNanos: "1",
-          updatedAt: "1",
+          startPosition: 0,
+          endPosition: 0.1,
+          secondsSinceStart: 0,
         },
-        startPosition: 0,
-        endPosition: 0.1,
-        secondsSinceStart: 0,
-      },
-    ]);
-  }, [setEvents]);
+      ]);
+    }, [setEvents]);
 
-  return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
+    return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
+  },
 };

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { useEffect } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
@@ -11,7 +11,7 @@ import { PlaybackControlsTooltipContent } from "@foxglove/studio-base/components
 import { useTimelineInteractionState } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
 
-function Wrapper(StoryFn: Story): JSX.Element {
+function Wrapper(Wrapped: StoryFn): JSX.Element {
   const theme = useTheme();
   return (
     <TimelineInteractionStateProvider>
@@ -23,7 +23,7 @@ function Wrapper(StoryFn: Story): JSX.Element {
             backgroundColor: theme.palette.background.paper,
           }}
         >
-          <StoryFn />
+          <Wrapped />
         </div>
       </MockMessagePipelineProvider>
     </TimelineInteractionStateProvider>

--- a/packages/studio-base/src/components/PlaybackControls/ProgressPlot.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ProgressPlot.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import { ProgressPlot } from "./ProgressPlot";
 
@@ -12,38 +12,42 @@ export default {
   component: ProgressPlot,
 };
 
-export const DisjointRanges: Story = () => {
-  return (
-    <Box bgcolor="background.paper" width="100%" height="100%" padding={2}>
-      <Box bgcolor="action.focus" height={40}>
-        <ProgressPlot
-          loading={false}
-          availableRanges={[
-            { start: 0, end: 0.2 },
-            { start: 0.8, end: 1 },
-          ]}
-        />
+export const DisjointRanges: StoryObj = {
+  render: () => {
+    return (
+      <Box bgcolor="background.paper" width="100%" height="100%" padding={2}>
+        <Box bgcolor="action.focus" height={40}>
+          <ProgressPlot
+            loading={false}
+            availableRanges={[
+              { start: 0, end: 0.2 },
+              { start: 0.8, end: 1 },
+            ]}
+          />
+        </Box>
       </Box>
-    </Box>
-  );
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
 };
 
-DisjointRanges.parameters = { colorScheme: "both-column" };
-
-export const Loading: Story = () => {
-  return (
-    <Box bgcolor="background.paper" width="100%" height="100%" padding={2}>
-      <Box bgcolor="action.focus" height={40}>
-        <ProgressPlot
-          loading={true}
-          availableRanges={[
-            { start: 0, end: 0.2 },
-            { start: 0.8, end: 1 },
-          ]}
-        />
+export const Loading: StoryObj = {
+  render: () => {
+    return (
+      <Box bgcolor="background.paper" width="100%" height="100%" padding={2}>
+        <Box bgcolor="action.focus" height={40}>
+          <ProgressPlot
+            loading={true}
+            availableRanges={[
+              { start: 0, end: 0.2 },
+              { start: 0.8, end: 1 },
+            ]}
+          />
+        </Box>
       </Box>
-    </Box>
-  );
-};
+    );
+  },
 
-Loading.parameters = { colorScheme: "both-column" };
+  parameters: { colorScheme: "both-column" },
+};

--- a/packages/studio-base/src/components/PlaybackControls/ProgressPlot.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ProgressPlot.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { ProgressPlot } from "./ProgressPlot";
 

--- a/packages/studio-base/src/components/PlaybackControls/Slider.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Slider.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Box } from "@mui/material";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
@@ -41,7 +41,7 @@ export default {
   title: "components/PlaybackControls/Slider",
 };
 
-export const Examples: Story = () => {
+export const Examples: StoryFn = () => {
   const [value, setValue] = useState(0.5);
   const [draggableValue, setDraggableValue] = useState(0.25);
   return (
@@ -71,7 +71,7 @@ export const Examples: Story = () => {
   );
 };
 
-export const CustomRenderer: Story = () => {
+export const CustomRenderer: StoryFn = () => {
   const { classes } = useStyles();
   const [draggableValue, setDraggableValue] = useState(0.25);
 

--- a/packages/studio-base/src/components/PlaybackControls/Slider.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Slider.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Box } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
@@ -41,55 +41,59 @@ export default {
   title: "components/PlaybackControls/Slider",
 };
 
-export const Examples: StoryFn = () => {
-  const [value, setValue] = useState(0.5);
-  const [draggableValue, setDraggableValue] = useState(0.25);
-  return (
-    <Box padding={4}>
-      <p>standard (clickable)</p>
-      <Box bgcolor="error.light" height={30} width={300}>
-        <Slider onChange={(v) => setValue(v)} fraction={value} />
+export const Examples: StoryObj = {
+  render: function Story() {
+    const [value, setValue] = useState(0.5);
+    const [draggableValue, setDraggableValue] = useState(0.25);
+    return (
+      <Box padding={4}>
+        <p>standard (clickable)</p>
+        <Box bgcolor="error.light" height={30} width={300}>
+          <Slider onChange={(v) => setValue(v)} fraction={value} />
+        </Box>
+        <p>disabled (not clickable)</p>
+        <Box bgcolor="error.light" height={30} width={300}>
+          <Slider disabled onChange={(v) => setValue(v)} fraction={value} />
+        </Box>
+        <p>no value</p>
+        <Box bgcolor="error.light" height={30} width={300}>
+          <Slider
+            onChange={() => {
+              // no-op
+            }}
+            fraction={undefined}
+          />
+        </Box>
+        <p>draggable</p>
+        <Box bgcolor="info.main" height={20} width={500}>
+          <Slider onChange={(v) => setDraggableValue(v)} fraction={draggableValue} />
+        </Box>
       </Box>
-      <p>disabled (not clickable)</p>
-      <Box bgcolor="error.light" height={30} width={300}>
-        <Slider disabled onChange={(v) => setValue(v)} fraction={value} />
-      </Box>
-      <p>no value</p>
-      <Box bgcolor="error.light" height={30} width={300}>
-        <Slider
-          onChange={() => {
-            // no-op
-          }}
-          fraction={undefined}
-        />
-      </Box>
-      <p>draggable</p>
-      <Box bgcolor="info.main" height={20} width={500}>
-        <Slider onChange={(v) => setDraggableValue(v)} fraction={draggableValue} />
-      </Box>
-    </Box>
-  );
+    );
+  },
 };
 
-export const CustomRenderer: StoryFn = () => {
-  const { classes } = useStyles();
-  const [draggableValue, setDraggableValue] = useState(0.25);
+export const CustomRenderer: StoryObj = {
+  render: function Story() {
+    const { classes } = useStyles();
+    const [draggableValue, setDraggableValue] = useState(0.25);
 
-  return (
-    <Box padding={4}>
-      <p>Customize slider UI using renderSlider</p>
-      <Box bgcolor="info.main" height={20} width={500}>
-        <Slider
-          onChange={(v) => setDraggableValue(v)}
-          fraction={draggableValue}
-          renderSlider={(width) => (
-            <>
-              <div className={classes.customRange} style={{ width: `${(width ?? 0) * 100}%` }} />
-              <div className={classes.customMarker} style={{ left: `${(width ?? 0) * 100}%` }} />
-            </>
-          )}
-        />
+    return (
+      <Box padding={4}>
+        <p>Customize slider UI using renderSlider</p>
+        <Box bgcolor="info.main" height={20} width={500}>
+          <Slider
+            onChange={(v) => setDraggableValue(v)}
+            fraction={draggableValue}
+            renderSlider={(width) => (
+              <>
+                <div className={classes.customRange} style={{ width: `${(width ?? 0) * 100}%` }} />
+                <div className={classes.customMarker} style={{ left: `${(width ?? 0) * 100}%` }} />
+              </>
+            )}
+          />
+        </Box>
       </Box>
-    </Box>
-  );
+    );
+  },
 };

--- a/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
@@ -201,7 +201,7 @@ export const DownloadProgressByRanges: StoryObj = {
 };
 
 export const HoverTicks: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const player = getPlayerState();
     const setHoverValue = useSetHoverValue();
 
@@ -230,7 +230,7 @@ export const HoverTicks: StoryObj = {
 };
 
 export const WithEvents: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const player = getPlayerState();
     const setEvents = useEvents((store) => store.setEvents);
 

--- a/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { action } from "@storybook/addon-actions";
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useEffect, useLayoutEffect } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
@@ -107,11 +107,11 @@ function Wrapper({
 export default {
   title: "components/PlaybackControls",
   decorators: [
-    (StoryFn: Story): JSX.Element => (
+    (Wrapped: StoryFn): JSX.Element => (
       <AppConfigurationContext.Provider value={mockAppConfiguration}>
         <MockCurrentLayoutProvider>
           <EventsProvider>
-            <StoryFn />
+            <Wrapped />
           </EventsProvider>
         </MockCurrentLayoutProvider>
       </AppConfigurationContext.Provider>
@@ -119,119 +119,137 @@ export default {
   ],
 };
 
-export const Playing: Story = () => {
-  return (
-    <Wrapper isPlaying>
-      <PlaybackControls
-        isPlaying={true}
-        getTimeInfo={() => ({})}
-        play={action("play")}
-        pause={action("pause")}
-        seek={action("seek")}
-      />
-    </Wrapper>
-  );
+export const Playing: StoryObj = {
+  render: () => {
+    return (
+      <Wrapper isPlaying>
+        <PlaybackControls
+          isPlaying={true}
+          getTimeInfo={() => ({})}
+          play={action("play")}
+          pause={action("pause")}
+          seek={action("seek")}
+        />
+      </Wrapper>
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
 };
-Playing.parameters = { colorScheme: "both-column" };
 
-export const Paused: Story = () => {
-  return (
-    <Wrapper>
-      <PlaybackControls
-        isPlaying={false}
-        getTimeInfo={() => ({})}
-        play={action("play")}
-        pause={action("pause")}
-        seek={action("seek")}
-      />
-    </Wrapper>
-  );
+export const Paused: StoryObj = {
+  render: () => {
+    return (
+      <Wrapper>
+        <PlaybackControls
+          isPlaying={false}
+          getTimeInfo={() => ({})}
+          play={action("play")}
+          pause={action("pause")}
+          seek={action("seek")}
+        />
+      </Wrapper>
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
 };
-Paused.parameters = { colorScheme: "both-column" };
 
-export const Disabled: Story = () => {
-  return (
-    <Wrapper presence={PlayerPresence.ERROR} noActiveData>
-      <PlaybackControls
-        isPlaying={false}
-        getTimeInfo={() => ({})}
-        play={action("play")}
-        pause={action("pause")}
-        seek={action("seek")}
-      />
-    </Wrapper>
-  );
+export const Disabled: StoryObj = {
+  render: () => {
+    return (
+      <Wrapper presence={PlayerPresence.ERROR} noActiveData>
+        <PlaybackControls
+          isPlaying={false}
+          getTimeInfo={() => ({})}
+          play={action("play")}
+          pause={action("pause")}
+          seek={action("seek")}
+        />
+      </Wrapper>
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
 };
-Disabled.parameters = { colorScheme: "both-column" };
 
-export const DownloadProgressByRanges: Story = () => {
-  const player = getPlayerState();
-  player.progress = {
-    ...player.progress,
-    fullyLoadedFractionRanges: [
-      { start: -2, end: 0.1 },
-      { start: 0.23, end: 0.6 },
-      { start: 0.7, end: 1 },
-    ],
-  };
-  return (
-    <Wrapper progress={player.progress}>
-      <PlaybackControls
-        isPlaying
-        getTimeInfo={() => ({})}
-        play={action("play")}
-        pause={action("pause")}
-        seek={action("seek")}
-      />
-    </Wrapper>
-  );
+export const DownloadProgressByRanges: StoryObj = {
+  render: () => {
+    const player = getPlayerState();
+    player.progress = {
+      ...player.progress,
+      fullyLoadedFractionRanges: [
+        { start: -2, end: 0.1 },
+        { start: 0.23, end: 0.6 },
+        { start: 0.7, end: 1 },
+      ],
+    };
+    return (
+      <Wrapper progress={player.progress}>
+        <PlaybackControls
+          isPlaying
+          getTimeInfo={() => ({})}
+          play={action("play")}
+          pause={action("pause")}
+          seek={action("seek")}
+        />
+      </Wrapper>
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
 };
-DownloadProgressByRanges.parameters = { colorScheme: "both-column" };
 
-export const HoverTicks: Story = () => {
-  const player = getPlayerState();
-  const setHoverValue = useSetHoverValue();
+export const HoverTicks: StoryObj = {
+  render: function Story(): JSX.Element {
+    const player = getPlayerState();
+    const setHoverValue = useSetHoverValue();
 
-  useLayoutEffect(() => {
-    setHoverValue({
-      type: "PLAYBACK_SECONDS",
-      value: 0.5,
-      componentId: "story",
+    useLayoutEffect(() => {
+      setHoverValue({
+        type: "PLAYBACK_SECONDS",
+        value: 0.5,
+        componentId: "story",
+      });
+    }, [setHoverValue]);
+
+    return (
+      <Wrapper activeData={player.activeData}>
+        <PlaybackControls
+          isPlaying
+          getTimeInfo={() => ({})}
+          play={action("play")}
+          pause={action("pause")}
+          seek={action("seek")}
+        />
+      </Wrapper>
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
+};
+
+export const WithEvents: StoryObj = {
+  render: function Story(): JSX.Element {
+    const player = getPlayerState();
+    const setEvents = useEvents((store) => store.setEvents);
+
+    useEffect(() => {
+      setEvents({ loading: false, value: makeMockEvents(4, START_TIME + 1, 4) });
     });
-  }, [setHoverValue]);
 
-  return (
-    <Wrapper activeData={player.activeData}>
-      <PlaybackControls
-        isPlaying
-        getTimeInfo={() => ({})}
-        play={action("play")}
-        pause={action("pause")}
-        seek={action("seek")}
-      />
-    </Wrapper>
-  );
+    return (
+      <Wrapper activeData={player.activeData}>
+        <PlaybackControls
+          isPlaying
+          getTimeInfo={() => ({})}
+          play={action("play")}
+          pause={action("pause")}
+          seek={action("seek")}
+        />
+      </Wrapper>
+    );
+  },
+
+  parameters: { colorScheme: "both-column" },
 };
-HoverTicks.parameters = { colorScheme: "both-column" };
-
-export const WithEvents: Story = () => {
-  const player = getPlayerState();
-  const setEvents = useEvents((store) => store.setEvents);
-
-  useEffect(() => {
-    setEvents({ loading: false, value: makeMockEvents(4, START_TIME + 1, 4) });
-  });
-
-  return (
-    <Wrapper activeData={player.activeData}>
-      <PlaybackControls
-        isPlaying
-        getTimeInfo={() => ({})}
-        play={action("play")}
-        pause={action("pause")}
-        seek={action("seek")}
-      />
-    </Wrapper>
-  );
-};
-WithEvents.parameters = { colorScheme: "both-column" };

--- a/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";

--- a/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";
@@ -40,54 +40,62 @@ export default {
   title: "components/PlaybackSpeedControls",
 };
 
-export const WithoutSpeedCapability: StoryFn = () => {
-  return (
-    <MockCurrentLayoutProvider>
-      <MockMessagePipelineProvider>
-        <ControlsStory />
-      </MockMessagePipelineProvider>
-    </MockCurrentLayoutProvider>
-  );
+export const WithoutSpeedCapability: StoryObj = {
+  render: () => {
+    return (
+      <MockCurrentLayoutProvider>
+        <MockMessagePipelineProvider>
+          <ControlsStory />
+        </MockMessagePipelineProvider>
+      </MockCurrentLayoutProvider>
+    );
+  },
+
+  name: "without speed capability",
+  parameters: { colorScheme: "dark" },
 };
 
-WithoutSpeedCapability.storyName = "without speed capability";
-WithoutSpeedCapability.parameters = { colorScheme: "dark" };
+export const WithoutASpeedFromThePlayer: StoryObj = {
+  render: () => {
+    return (
+      <MockCurrentLayoutProvider>
+        <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: undefined }}>
+          <ControlsStory />
+        </MockMessagePipelineProvider>
+      </MockCurrentLayoutProvider>
+    );
+  },
 
-export const WithoutASpeedFromThePlayer: StoryFn = () => {
-  return (
-    <MockCurrentLayoutProvider>
-      <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: undefined }}>
-        <ControlsStory />
-      </MockMessagePipelineProvider>
-    </MockCurrentLayoutProvider>
-  );
+  name: "without a speed from the player",
+  parameters: { colorScheme: "dark" },
 };
 
-WithoutASpeedFromThePlayer.storyName = "without a speed from the player";
-WithoutASpeedFromThePlayer.parameters = { colorScheme: "dark" };
+export const WithASpeed: StoryObj = {
+  render: () => {
+    return (
+      <MockCurrentLayoutProvider>
+        <MockMessagePipelineProvider capabilities={CAPABILITIES}>
+          <ControlsStory />
+        </MockMessagePipelineProvider>
+      </MockCurrentLayoutProvider>
+    );
+  },
 
-export const WithASpeed: StoryFn = () => {
-  return (
-    <MockCurrentLayoutProvider>
-      <MockMessagePipelineProvider capabilities={CAPABILITIES}>
-        <ControlsStory />
-      </MockMessagePipelineProvider>
-    </MockCurrentLayoutProvider>
-  );
+  name: "with a speed",
+  parameters: { colorScheme: "dark" },
 };
 
-WithASpeed.storyName = "with a speed";
-WithASpeed.parameters = { colorScheme: "dark" };
+export const WithAVerySmallSpeed: StoryObj = {
+  render: () => {
+    return (
+      <MockCurrentLayoutProvider>
+        <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: 0.01 }}>
+          <ControlsStory />
+        </MockMessagePipelineProvider>
+      </MockCurrentLayoutProvider>
+    );
+  },
 
-export const WithAVerySmallSpeed: StoryFn = () => {
-  return (
-    <MockCurrentLayoutProvider>
-      <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: 0.01 }}>
-        <ControlsStory />
-      </MockMessagePipelineProvider>
-    </MockCurrentLayoutProvider>
-  );
+  name: "with a very small speed",
+  parameters: { colorScheme: "dark" },
 };
-
-WithAVerySmallSpeed.storyName = "with a very small speed";
-WithAVerySmallSpeed.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/SendNotificationToastAdapter.stories.tsx
+++ b/packages/studio-base/src/components/SendNotificationToastAdapter.stories.tsx
@@ -57,55 +57,65 @@ export default {
   ],
 };
 
-export const OneError = (): JSX.Element => {
-  useEffect(() => {
-    sendNotification("Something bad happened", fakeError(), "app", "error");
-  }, []);
+export const OneError = {
+  render: function Story(): JSX.Element {
+    useEffect(() => {
+      sendNotification("Something bad happened", fakeError(), "app", "error");
+    }, []);
 
-  return <SendNotificationToastAdapter />;
+    return <SendNotificationToastAdapter />;
+  },
 };
 
-export const OneWarning = (): JSX.Element => {
-  useEffect(() => {
-    sendNotification(
-      "This is the final countdown",
-      "This warning is on purpose - it comes from the story",
-      "app",
-      "warn",
-    );
-  }, []);
+export const OneWarning = {
+  render: function Story(): JSX.Element {
+    useEffect(() => {
+      sendNotification(
+        "This is the final countdown",
+        "This warning is on purpose - it comes from the story",
+        "app",
+        "warn",
+      );
+    }, []);
 
-  return <SendNotificationToastAdapter />;
+    return <SendNotificationToastAdapter />;
+  },
 };
 
-export const OneInfo = (): JSX.Element => {
-  useEffect(() => {
-    sendNotification(
-      "Here's a helpful tip",
-      "These are the details of the message",
-      "user",
-      "info",
-    );
-  }, []);
+export const OneInfo = {
+  render: function Story(): JSX.Element {
+    useEffect(() => {
+      sendNotification(
+        "Here's a helpful tip",
+        "These are the details of the message",
+        "user",
+        "info",
+      );
+    }, []);
 
-  return <SendNotificationToastAdapter />;
+    return <SendNotificationToastAdapter />;
+  },
 };
 
-export const MultipleMessages = (): JSX.Element => {
-  useEffect(() => {
-    sendNotification("Something bad happened 1", fakeError(), "app", "error");
-    sendNotification("Here's a helpful tip", fakeError(), "user", "info");
-    sendNotification(
-      "Just a warning",
-      "This warning is on purpose - it comes from the story",
-      "app",
-      "warn",
-    );
-    sendNotification("Something bad happened 2", fakeError(), "app", "error");
-  }, []);
+export const MultipleMessages = {
+  render: function Story(): JSX.Element {
+    useEffect(() => {
+      sendNotification("Something bad happened 1", fakeError(), "app", "error");
+      sendNotification("Here's a helpful tip", fakeError(), "user", "info");
+      sendNotification(
+        "Just a warning",
+        "This warning is on purpose - it comes from the story",
+        "app",
+        "warn",
+      );
+      sendNotification("Something bad happened 2", fakeError(), "app", "error");
+    }, []);
 
-  return <SendNotificationToastAdapter />;
+    return <SendNotificationToastAdapter />;
+  },
 };
 
-export const MultipleMessagesLightTheme = MultipleMessages.bind(undefined);
-(MultipleMessagesLightTheme as any).parameters = { colorScheme: "light" };
+export const MultipleMessagesLightTheme = {
+  ...MultipleMessages,
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/components/SendNotificationToastAdapter.stories.tsx
+++ b/packages/studio-base/src/components/SendNotificationToastAdapter.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { useEffect } from "react";
 
 import SendNotificationToastAdapter from "@foxglove/studio-base/components/SendNotificationToastAdapter";
@@ -45,11 +45,11 @@ export default {
     colorScheme: "dark",
   },
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       return (
         <div style={{ padding: 10, height: "300px" }}>
           <StudioToastProvider>
-            <StoryFn />
+            <Wrapped />
           </StudioToastProvider>
         </div>
       );

--- a/packages/studio-base/src/components/SendNotificationToastAdapter.stories.tsx
+++ b/packages/studio-base/src/components/SendNotificationToastAdapter.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 
 import SendNotificationToastAdapter from "@foxglove/studio-base/components/SendNotificationToastAdapter";
@@ -57,8 +57,8 @@ export default {
   ],
 };
 
-export const OneError = {
-  render: function Story(): JSX.Element {
+export const OneError: StoryObj = {
+  render: function Story() {
     useEffect(() => {
       sendNotification("Something bad happened", fakeError(), "app", "error");
     }, []);
@@ -67,8 +67,8 @@ export const OneError = {
   },
 };
 
-export const OneWarning = {
-  render: function Story(): JSX.Element {
+export const OneWarning: StoryObj = {
+  render: function Story() {
     useEffect(() => {
       sendNotification(
         "This is the final countdown",
@@ -82,8 +82,8 @@ export const OneWarning = {
   },
 };
 
-export const OneInfo = {
-  render: function Story(): JSX.Element {
+export const OneInfo: StoryObj = {
+  render: function Story() {
     useEffect(() => {
       sendNotification(
         "Here's a helpful tip",
@@ -97,8 +97,8 @@ export const OneInfo = {
   },
 };
 
-export const MultipleMessages = {
-  render: function Story(): JSX.Element {
+export const MultipleMessages: StoryObj = {
+  render: function Story() {
     useEffect(() => {
       sendNotification("Something bad happened 1", fakeError(), "app", "error");
       sendNotification("Here's a helpful tip", fakeError(), "user", "info");
@@ -115,7 +115,7 @@ export const MultipleMessages = {
   },
 };
 
-export const MultipleMessagesLightTheme = {
+export const MultipleMessagesLightTheme: StoryObj = {
   ...MultipleMessages,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { fireEvent, userEvent } from "@storybook/testing-library";
 import produce from "immer";
 import { last } from "lodash";
@@ -874,14 +874,16 @@ function Wrapper({ nodes }: { nodes: SettingsTreeNodes }): JSX.Element {
   );
 }
 
-export const Basics: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={BasicSettings} />;
-};
+export const Basics: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={BasicSettings} />;
+  },
 
-Basics.play = () => {
-  Array.from(document.querySelectorAll("[data-testid=node-actions-menu-button]"))
-    .slice(0, 1)
-    .forEach((node) => fireEvent.click(node));
+  play: () => {
+    Array.from(document.querySelectorAll("[data-testid=node-actions-menu-button]"))
+      .slice(0, 1)
+      .forEach((node) => fireEvent.click(node));
+  },
 };
 
 export const BasicsChinese = Object.assign(Basics.bind(undefined), {
@@ -897,18 +899,20 @@ export const ReadonlyFields: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={ReadonlySettings} />;
 };
 
-export const PanelExamples: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={PanelExamplesSettings} />;
-};
+export const PanelExamples: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={PanelExamplesSettings} />;
+  },
 
-PanelExamples.play = () => {
-  Array.from(document.querySelectorAll("[data-node-function=edit-label]"))
-    .slice(0, 1)
-    .forEach((node) => {
-      fireEvent.click(node);
-      fireEvent.change(document.activeElement!, { target: { value: "Renamed Node" } });
-      fireEvent.keyDown(document.activeElement!, { key: "Enter" });
-    });
+  play: () => {
+    Array.from(document.querySelectorAll("[data-node-function=edit-label]"))
+      .slice(0, 1)
+      .forEach((node) => {
+        fireEvent.click(node);
+        fireEvent.change(document.activeElement!, { target: { value: "Renamed Node" } });
+        fireEvent.keyDown(document.activeElement!, { key: "Enter" });
+      });
+  },
 };
 
 export const IconExamples: StoryFn = (): JSX.Element => {
@@ -919,15 +923,18 @@ export const Topics: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={TopicSettings} />;
 };
 
-export const Filter: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={FilterSettings} />;
-};
-Filter.play = () => {
-  const node = document.querySelector("[data-testid=settings-filter-field] input");
-  if (node) {
-    fireEvent.click(node);
-    fireEvent.change(node, { target: { value: "matcha" } });
-  }
+export const Filter: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={FilterSettings} />;
+  },
+
+  play: () => {
+    const node = document.querySelector("[data-testid=settings-filter-field] input");
+    if (node) {
+      fireEvent.click(node);
+      fireEvent.change(node, { target: { value: "matcha" } });
+    }
+  },
 };
 
 export const Colors: StoryFn = (): JSX.Element => {
@@ -1014,36 +1021,54 @@ export const Vec3: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={settings} />;
 };
 
-async function clickSelect() {
+async function clickSelect(): Promise<void> {
   userEvent.click(document.querySelector(".MuiSelect-select")!);
 }
 
-export const SelectInvalidWithUndefined: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={SelectInvalidWithUndefinedSettings} />;
-};
-SelectInvalidWithUndefined.play = clickSelect;
+export const SelectInvalidWithUndefined: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={SelectInvalidWithUndefinedSettings} />;
+  },
 
-export const SelectInvalidWithoutUndefined: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={SelectInvalidWithoutUndefinedSettings} />;
+  play: clickSelect,
 };
-SelectInvalidWithoutUndefined.play = clickSelect;
 
-export const SelectValidWithUndefined: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={SelectValidWithUndefinedSettings} />;
-};
-SelectValidWithUndefined.play = clickSelect;
+export const SelectInvalidWithoutUndefined: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={SelectInvalidWithoutUndefinedSettings} />;
+  },
 
-export const SelectValidWithEmptyString: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={SelectValidWithEmptyStringSettings} />;
+  play: clickSelect,
 };
-SelectValidWithEmptyString.play = clickSelect;
 
-export const SelectEmpty: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={SelectEmptySettings} />;
-};
-SelectEmpty.play = clickSelect;
+export const SelectValidWithUndefined: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={SelectValidWithUndefinedSettings} />;
+  },
 
-export const SelectEmptyInvalid: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={SelectEmptyInvalidSettings} />;
+  play: clickSelect,
 };
-SelectEmptyInvalid.play = clickSelect;
+
+export const SelectValidWithEmptyString: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={SelectValidWithEmptyStringSettings} />;
+  },
+
+  play: clickSelect,
+};
+
+export const SelectEmpty: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={SelectEmptySettings} />;
+  },
+
+  play: clickSelect,
+};
+
+export const SelectEmptyInvalid: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <Wrapper nodes={SelectEmptyInvalidSettings} />;
+  },
+
+  play: clickSelect,
+};

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { fireEvent, userEvent } from "@storybook/testing-library";
 import produce from "immer";
 import { last } from "lodash";
@@ -888,12 +888,16 @@ export const Basics: StoryObj = {
 
 export const BasicsChinese = { ...Basics, play: Basics.play, parameters: { forceLanguage: "zh" } };
 
-export const DisabledFields: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={DisabledSettings} />;
+export const DisabledFields: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={DisabledSettings} />;
+  },
 };
 
-export const ReadonlyFields: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={ReadonlySettings} />;
+export const ReadonlyFields: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={ReadonlySettings} />;
+  },
 };
 
 export const PanelExamples: StoryObj = {
@@ -912,12 +916,16 @@ export const PanelExamples: StoryObj = {
   },
 };
 
-export const IconExamples: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={IconExamplesSettings} />;
+export const IconExamples: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={IconExamplesSettings} />;
+  },
 };
 
-export const Topics: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={TopicSettings} />;
+export const Topics: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={TopicSettings} />;
+  },
 };
 
 export const Filter: StoryObj = {
@@ -934,88 +942,98 @@ export const Filter: StoryObj = {
   },
 };
 
-export const Colors: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={ColorSettings} />;
+export const Colors: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={ColorSettings} />;
+  },
 };
 
-export const EmptyValue: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={ColorSettings} />;
+export const EmptyValue: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={ColorSettings} />;
+  },
 };
 
-export const SetHiddenValueToTrue: StoryFn = (): JSX.Element => {
-  return <Wrapper nodes={ColorSettings} />;
+export const SetHiddenValueToTrue: StoryObj = {
+  render: (): JSX.Element => {
+    return <Wrapper nodes={ColorSettings} />;
+  },
 };
 
-export const Vec2: StoryFn = (): JSX.Element => {
-  const settings: SettingsTreeNodes = {
-    fields: {
+export const Vec2: StoryObj = {
+  render: (): JSX.Element => {
+    const settings: SettingsTreeNodes = {
       fields: {
-        basic: {
-          label: "Basic",
-          input: "vec2",
-        },
-        labels: {
-          label: "Custom Labels",
-          input: "vec2",
-          labels: ["A", "B"],
-        },
-        values: {
-          label: "Values",
-          input: "vec2",
-          value: [1.1111, 2.2222],
-        },
-        someValues: {
-          label: "Some values",
-          input: "vec2",
-          value: [1.1111, undefined],
-        },
-        placeholder: {
-          label: "Placeholder",
-          input: "vec2",
-          placeholder: ["foo", "bar"],
-          value: [1.1111, undefined],
+        fields: {
+          basic: {
+            label: "Basic",
+            input: "vec2",
+          },
+          labels: {
+            label: "Custom Labels",
+            input: "vec2",
+            labels: ["A", "B"],
+          },
+          values: {
+            label: "Values",
+            input: "vec2",
+            value: [1.1111, 2.2222],
+          },
+          someValues: {
+            label: "Some values",
+            input: "vec2",
+            value: [1.1111, undefined],
+          },
+          placeholder: {
+            label: "Placeholder",
+            input: "vec2",
+            placeholder: ["foo", "bar"],
+            value: [1.1111, undefined],
+          },
         },
       },
-    },
-  };
+    };
 
-  return <Wrapper nodes={settings} />;
+    return <Wrapper nodes={settings} />;
+  },
 };
 
-export const Vec3: StoryFn = (): JSX.Element => {
-  const settings: SettingsTreeNodes = {
-    fields: {
+export const Vec3: StoryObj = {
+  render: (): JSX.Element => {
+    const settings: SettingsTreeNodes = {
       fields: {
-        basic: {
-          label: "Basic",
-          input: "vec3",
-        },
-        labels: {
-          label: "Custom Labels",
-          input: "vec3",
-          labels: ["A", "B", "C"],
-        },
-        values: {
-          label: "Values",
-          input: "vec3",
-          value: [1.1111, 2.2222, 3.333],
-        },
-        someValues: {
-          label: "Some values",
-          input: "vec3",
-          value: [1.1111, undefined, 2.222],
-        },
-        placeholder: {
-          label: "Placeholder",
-          input: "vec3",
-          placeholder: ["foo", "bar", "baz"],
-          value: [1.1111, undefined, undefined],
+        fields: {
+          basic: {
+            label: "Basic",
+            input: "vec3",
+          },
+          labels: {
+            label: "Custom Labels",
+            input: "vec3",
+            labels: ["A", "B", "C"],
+          },
+          values: {
+            label: "Values",
+            input: "vec3",
+            value: [1.1111, 2.2222, 3.333],
+          },
+          someValues: {
+            label: "Some values",
+            input: "vec3",
+            value: [1.1111, undefined, 2.222],
+          },
+          placeholder: {
+            label: "Placeholder",
+            input: "vec3",
+            placeholder: ["foo", "bar", "baz"],
+            value: [1.1111, undefined, undefined],
+          },
         },
       },
-    },
-  };
+    };
 
-  return <Wrapper nodes={settings} />;
+    return <Wrapper nodes={settings} />;
+  },
 };
 
 async function clickSelect(): Promise<void> {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 import { fireEvent, userEvent } from "@storybook/testing-library";
 import produce from "immer";
 import { last } from "lodash";
@@ -873,9 +874,9 @@ function Wrapper({ nodes }: { nodes: SettingsTreeNodes }): JSX.Element {
   );
 }
 
-export function Basics(): JSX.Element {
+export const Basics: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={BasicSettings} />;
-}
+};
 
 Basics.play = () => {
   Array.from(document.querySelectorAll("[data-testid=node-actions-menu-button]"))
@@ -888,17 +889,17 @@ export const BasicsChinese = Object.assign(Basics.bind(undefined), {
   parameters: { forceLanguage: "zh" },
 });
 
-export function DisabledFields(): JSX.Element {
+export const DisabledFields: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={DisabledSettings} />;
-}
+};
 
-export function ReadonlyFields(): JSX.Element {
+export const ReadonlyFields: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={ReadonlySettings} />;
-}
+};
 
-export function PanelExamples(): JSX.Element {
+export const PanelExamples: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={PanelExamplesSettings} />;
-}
+};
 
 PanelExamples.play = () => {
   Array.from(document.querySelectorAll("[data-node-function=edit-label]"))
@@ -910,17 +911,17 @@ PanelExamples.play = () => {
     });
 };
 
-export function IconExamples(): JSX.Element {
+export const IconExamples: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={IconExamplesSettings} />;
-}
+};
 
-export function Topics(): JSX.Element {
+export const Topics: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={TopicSettings} />;
-}
+};
 
-export function Filter(): JSX.Element {
+export const Filter: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={FilterSettings} />;
-}
+};
 Filter.play = () => {
   const node = document.querySelector("[data-testid=settings-filter-field] input");
   if (node) {
@@ -929,19 +930,19 @@ Filter.play = () => {
   }
 };
 
-export function Colors(): JSX.Element {
+export const Colors: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={ColorSettings} />;
-}
+};
 
-export function EmptyValue(): JSX.Element {
+export const EmptyValue: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={ColorSettings} />;
-}
+};
 
-export function SetHiddenValueToTrue(): JSX.Element {
+export const SetHiddenValueToTrue: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={ColorSettings} />;
-}
+};
 
-export function Vec2(): JSX.Element {
+export const Vec2: StoryFn = (): JSX.Element => {
   const settings: SettingsTreeNodes = {
     fields: {
       fields: {
@@ -975,9 +976,9 @@ export function Vec2(): JSX.Element {
   };
 
   return <Wrapper nodes={settings} />;
-}
+};
 
-export function Vec3(): JSX.Element {
+export const Vec3: StoryFn = (): JSX.Element => {
   const settings: SettingsTreeNodes = {
     fields: {
       fields: {
@@ -1011,38 +1012,38 @@ export function Vec3(): JSX.Element {
   };
 
   return <Wrapper nodes={settings} />;
-}
+};
 
 async function clickSelect() {
   userEvent.click(document.querySelector(".MuiSelect-select")!);
 }
 
-export function SelectInvalidWithUndefined(): JSX.Element {
+export const SelectInvalidWithUndefined: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={SelectInvalidWithUndefinedSettings} />;
-}
+};
 SelectInvalidWithUndefined.play = clickSelect;
 
-export function SelectInvalidWithoutUndefined(): JSX.Element {
+export const SelectInvalidWithoutUndefined: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={SelectInvalidWithoutUndefinedSettings} />;
-}
+};
 SelectInvalidWithoutUndefined.play = clickSelect;
 
-export function SelectValidWithUndefined(): JSX.Element {
+export const SelectValidWithUndefined: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={SelectValidWithUndefinedSettings} />;
-}
+};
 SelectValidWithUndefined.play = clickSelect;
 
-export function SelectValidWithEmptyString(): JSX.Element {
+export const SelectValidWithEmptyString: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={SelectValidWithEmptyStringSettings} />;
-}
+};
 SelectValidWithEmptyString.play = clickSelect;
 
-export function SelectEmpty(): JSX.Element {
+export const SelectEmpty: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={SelectEmptySettings} />;
-}
+};
 SelectEmpty.play = clickSelect;
 
-export function SelectEmptyInvalid(): JSX.Element {
+export const SelectEmptyInvalid: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={SelectEmptyInvalidSettings} />;
-}
+};
 SelectEmptyInvalid.play = clickSelect;

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -886,10 +886,7 @@ export const Basics: StoryObj = {
   },
 };
 
-export const BasicsChinese = Object.assign(Basics.bind(undefined), {
-  play: Basics.play,
-  parameters: { forceLanguage: "zh" },
-});
+export const BasicsChinese = { ...Basics, play: Basics.play, parameters: { forceLanguage: "zh" } };
 
 export const DisabledFields: StoryFn = (): JSX.Element => {
   return <Wrapper nodes={DisabledSettings} />;

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -875,7 +875,7 @@ function Wrapper({ nodes }: { nodes: SettingsTreeNodes }): JSX.Element {
 }
 
 export const Basics: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={BasicSettings} />;
   },
 
@@ -886,22 +886,26 @@ export const Basics: StoryObj = {
   },
 };
 
-export const BasicsChinese = { ...Basics, play: Basics.play, parameters: { forceLanguage: "zh" } };
+export const BasicsChinese: StoryObj = {
+  ...Basics,
+  play: Basics.play,
+  parameters: { forceLanguage: "zh" },
+};
 
 export const DisabledFields: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={DisabledSettings} />;
   },
 };
 
 export const ReadonlyFields: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={ReadonlySettings} />;
   },
 };
 
 export const PanelExamples: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={PanelExamplesSettings} />;
   },
 
@@ -917,19 +921,19 @@ export const PanelExamples: StoryObj = {
 };
 
 export const IconExamples: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={IconExamplesSettings} />;
   },
 };
 
 export const Topics: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={TopicSettings} />;
   },
 };
 
 export const Filter: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={FilterSettings} />;
   },
 
@@ -943,25 +947,25 @@ export const Filter: StoryObj = {
 };
 
 export const Colors: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={ColorSettings} />;
   },
 };
 
 export const EmptyValue: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={ColorSettings} />;
   },
 };
 
 export const SetHiddenValueToTrue: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <Wrapper nodes={ColorSettings} />;
   },
 };
 
 export const Vec2: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     const settings: SettingsTreeNodes = {
       fields: {
         fields: {
@@ -999,7 +1003,7 @@ export const Vec2: StoryObj = {
 };
 
 export const Vec3: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     const settings: SettingsTreeNodes = {
       fields: {
         fields: {
@@ -1041,7 +1045,7 @@ async function clickSelect(): Promise<void> {
 }
 
 export const SelectInvalidWithUndefined: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={SelectInvalidWithUndefinedSettings} />;
   },
 
@@ -1049,7 +1053,7 @@ export const SelectInvalidWithUndefined: StoryObj = {
 };
 
 export const SelectInvalidWithoutUndefined: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={SelectInvalidWithoutUndefinedSettings} />;
   },
 
@@ -1057,7 +1061,7 @@ export const SelectInvalidWithoutUndefined: StoryObj = {
 };
 
 export const SelectValidWithUndefined: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={SelectValidWithUndefinedSettings} />;
   },
 
@@ -1065,7 +1069,7 @@ export const SelectValidWithUndefined: StoryObj = {
 };
 
 export const SelectValidWithEmptyString: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={SelectValidWithEmptyStringSettings} />;
   },
 
@@ -1073,7 +1077,7 @@ export const SelectValidWithEmptyString: StoryObj = {
 };
 
 export const SelectEmpty: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={SelectEmptySettings} />;
   },
 
@@ -1081,7 +1085,7 @@ export const SelectEmpty: StoryObj = {
 };
 
 export const SelectEmptyInvalid: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <Wrapper nodes={SelectEmptyInvalidSettings} />;
   },
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useState } from "react";
 
 import { ColorGradientInput } from "./ColorGradientInput";
@@ -12,26 +12,34 @@ export default {
   component: ColorGradientInput,
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
+export const Default: StoryObj = {
+  render: function Story() {
+    const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
 
-  return <ColorGradientInput colors={colors} onChange={setColors} />;
+    return <ColorGradientInput colors={colors} onChange={setColors} />;
+  },
 };
 
-export const Disabled: StoryFn = (): JSX.Element => {
-  const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
+export const Disabled: StoryObj = {
+  render: function Story() {
+    const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
 
-  return <ColorGradientInput disabled colors={colors} onChange={setColors} />;
+    return <ColorGradientInput disabled colors={colors} onChange={setColors} />;
+  },
 };
 
-export const ReadOnly: StoryFn = (): JSX.Element => {
-  const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
+export const ReadOnly: StoryObj = {
+  render: function Story() {
+    const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
 
-  return <ColorGradientInput readOnly colors={colors} onChange={setColors} />;
+    return <ColorGradientInput readOnly colors={colors} onChange={setColors} />;
+  },
 };
 
-export const WithAlpha: StoryFn = (): JSX.Element => {
-  const [colors, setColors] = useState<[string, string]>(["#ffaa0088", "#0026ffcc"]);
+export const WithAlpha: StoryObj = {
+  render: function Story() {
+    const [colors, setColors] = useState<[string, string]>(["#ffaa0088", "#0026ffcc"]);
 
-  return <ColorGradientInput colors={colors} onChange={setColors} />;
+    return <ColorGradientInput colors={colors} onChange={setColors} />;
+  },
 };

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { useState } from "react";
 
 import { ColorGradientInput } from "./ColorGradientInput";
@@ -11,26 +12,26 @@ export default {
   component: ColorGradientInput,
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
 
   return <ColorGradientInput colors={colors} onChange={setColors} />;
-}
+};
 
-export function Disabled(): JSX.Element {
+export const Disabled: StoryFn = (): JSX.Element => {
   const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
 
   return <ColorGradientInput disabled colors={colors} onChange={setColors} />;
-}
+};
 
-export function ReadOnly(): JSX.Element {
+export const ReadOnly: StoryFn = (): JSX.Element => {
   const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
 
   return <ColorGradientInput readOnly colors={colors} onChange={setColors} />;
-}
+};
 
-export function WithAlpha(): JSX.Element {
+export const WithAlpha: StoryFn = (): JSX.Element => {
   const [colors, setColors] = useState<[string, string]>(["#ffaa0088", "#0026ffcc"]);
 
   return <ColorGradientInput colors={colors} onChange={setColors} />;
-}
+};

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { useState } from "react";
 
@@ -12,23 +13,23 @@ export default {
   component: ColorPickerControl,
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   const [color, setColor] = useState("#ffaa00");
 
   return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;
-}
+};
 
-export function WithAlpha(): JSX.Element {
+export const WithAlpha: StoryFn = (): JSX.Element => {
   const [color, setColor] = useState("#ffaa0088");
 
   return <ColorPickerControl alphaType="alpha" value={color} onChange={setColor} />;
-}
+};
 
-export function TextEntry(): JSX.Element {
+export const TextEntry: StoryFn = (): JSX.Element => {
   const [color, setColor] = useState("");
 
   return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;
-}
+};
 TextEntry.play = async () => {
   const inputs = await screen.findAllByPlaceholderText("RRGGBB");
   for (const input of inputs) {

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { useState } from "react";
 
@@ -13,20 +13,24 @@ export default {
   component: ColorPickerControl,
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  const [color, setColor] = useState("#ffaa00");
+export const Default: StoryObj = {
+  render: function Story() {
+    const [color, setColor] = useState("#ffaa00");
 
-  return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;
+    return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;
+  },
 };
 
-export const WithAlpha: StoryFn = (): JSX.Element => {
-  const [color, setColor] = useState("#ffaa0088");
+export const WithAlpha: StoryObj = {
+  render: function Story() {
+    const [color, setColor] = useState("#ffaa0088");
 
-  return <ColorPickerControl alphaType="alpha" value={color} onChange={setColor} />;
+    return <ColorPickerControl alphaType="alpha" value={color} onChange={setColor} />;
+  },
 };
 
 export const TextEntry: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const [color, setColor] = useState("");
 
     return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { useState } from "react";
 
@@ -25,15 +25,18 @@ export const WithAlpha: StoryFn = (): JSX.Element => {
   return <ColorPickerControl alphaType="alpha" value={color} onChange={setColor} />;
 };
 
-export const TextEntry: StoryFn = (): JSX.Element => {
-  const [color, setColor] = useState("");
+export const TextEntry: StoryObj = {
+  render: function Story(): JSX.Element {
+    const [color, setColor] = useState("");
 
-  return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;
-};
-TextEntry.play = async () => {
-  const inputs = await screen.findAllByPlaceholderText("RRGGBB");
-  for (const input of inputs) {
-    userEvent.click(input);
-    userEvent.type(input, "aabbcc");
-  }
+    return <ColorPickerControl alphaType="none" value={color} onChange={setColor} />;
+  },
+
+  play: async () => {
+    const inputs = await screen.findAllByPlaceholderText("RRGGBB");
+    for (const input of inputs) {
+      userEvent.click(input);
+      userEvent.type(input, "aabbcc");
+    }
+  },
 };

--- a/packages/studio-base/src/components/ShareJsonModal.stories.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -54,7 +54,7 @@ export const Json: StoryObj = {
 };
 
 export const SubmittingInvalidLayout: StoryObj = {
-  render: () => {
+  render: function Story() {
     useEffect(() => {
       setTimeout(() => {
         const textarea = document.querySelector("textarea")!;

--- a/packages/studio-base/src/components/ShareJsonModal.stories.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -21,46 +21,54 @@ export default {
   title: "components/ShareJsonModal",
 };
 
-export const Standard: StoryFn = () => (
-  <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
-);
+export const Standard: StoryObj = {
+  render: () => (
+    <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
+  ),
 
-Standard.storyName = "standard";
-Standard.parameters = { colorScheme: "dark" };
-
-export const StandardLight: StoryFn = () => (
-  <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
-);
-
-StandardLight.storyName = "standard light";
-StandardLight.parameters = { colorScheme: "light" };
-
-export const Json: StoryFn = () => (
-  <ShareJsonModal
-    title="Foo"
-    onRequestClose={() => {}}
-    initialValue={{ foo: "bar", baz: "qux" }}
-    onChange={() => {}}
-  />
-);
-
-Json.storyName = "JSON";
-Json.parameters = { colorScheme: "dark" };
-
-export const SubmittingInvalidLayout: StoryFn = () => {
-  useEffect(() => {
-    setTimeout(() => {
-      const textarea = document.querySelector("textarea")!;
-      textarea.value = "{";
-      TestUtils.Simulate.change(textarea);
-    }, 10);
-  }, []);
-  return (
-    <div data-modalcontainer="true">
-      <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
-    </div>
-  );
+  name: "standard",
+  parameters: { colorScheme: "dark" },
 };
 
-SubmittingInvalidLayout.storyName = "submitting invalid layout";
-SubmittingInvalidLayout.parameters = { colorScheme: "dark" };
+export const StandardLight: StoryObj = {
+  render: () => (
+    <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
+  ),
+
+  name: "standard light",
+  parameters: { colorScheme: "light" },
+};
+
+export const Json: StoryObj = {
+  render: () => (
+    <ShareJsonModal
+      title="Foo"
+      onRequestClose={() => {}}
+      initialValue={{ foo: "bar", baz: "qux" }}
+      onChange={() => {}}
+    />
+  ),
+
+  name: "JSON",
+  parameters: { colorScheme: "dark" },
+};
+
+export const SubmittingInvalidLayout: StoryObj = {
+  render: () => {
+    useEffect(() => {
+      setTimeout(() => {
+        const textarea = document.querySelector("textarea")!;
+        textarea.value = "{";
+        TestUtils.Simulate.change(textarea);
+      }, 10);
+    }, []);
+    return (
+      <div data-modalcontainer="true">
+        <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
+      </div>
+    );
+  },
+
+  name: "submitting invalid layout",
+  parameters: { colorScheme: "dark" },
+};

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -122,7 +122,7 @@ export const LeftClicked: StoryObj = {
   name: "Left (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async (): Promise<void> => {
+  play: async () => {
     const leftTab = await screen.findByTestId("b-left");
     userEvent.click(leftTab);
   },
@@ -136,7 +136,7 @@ export const LeftClosed: StoryObj = {
   name: "Left (closed by interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async (): Promise<void> => {
+  play: async () => {
     const leftClose = await screen.findByTestId("sidebar-close-left");
     userEvent.click(leftClose);
   },
@@ -157,7 +157,7 @@ export const RightClicked: StoryObj = {
   name: "Right (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async (): Promise<void> => {
+  play: async () => {
     const rightTab = await screen.findByTestId("y-right");
     userEvent.click(rightTab);
   },
@@ -171,7 +171,7 @@ export const RightClosed: StoryObj = {
   name: "Right (closed by interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async (): Promise<void> => {
+  play: async () => {
     const rightClose = await screen.findByTestId("sidebar-close-right");
     userEvent.click(rightClose);
   },
@@ -191,7 +191,7 @@ export const BothClicked: StoryObj = {
   name: "Both (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async (): Promise<void> => {
+  play: async () => {
     const leftTab = await screen.findByTestId("b-left");
     userEvent.click(leftTab);
 

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -121,21 +121,21 @@ export const LeftClicked = {
   name: "Left (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async () => {
+  play: async (): Promise<void> => {
     const leftTab = await screen.findByTestId("b-left");
     userEvent.click(leftTab);
   },
 };
 
 export const LeftClosed = {
-  render: function Story(): JSX.Element (
+  render: (): JSX.Element => (
     <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
   ),
 
   name: "Left (closed by interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async () => {
+  play: async (): Promise<void> => {
     const leftClose = await screen.findByTestId("sidebar-close-left");
     userEvent.click(leftClose);
   },
@@ -156,21 +156,21 @@ export const RightClicked = {
   name: "Right (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async () => {
+  play: async (): Promise<void> => {
     const rightTab = await screen.findByTestId("y-right");
     userEvent.click(rightTab);
   },
 };
 
 export const RightClosed = {
-  render: function Story(): JSX.Element (
+  render: (): JSX.Element => (
     <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
   ),
 
   name: "Right (closed by interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async () => {
+  play: async (): Promise<void> => {
     const rightClose = await screen.findByTestId("sidebar-close-right");
     userEvent.click(rightClose);
   },
@@ -188,7 +188,7 @@ export const BothClicked = {
   name: "Both (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
-  play: async () => {
+  play: async (): Promise<void> => {
     const leftTab = await screen.findByTestId("b-left");
     userEvent.click(leftTab);
 

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -128,7 +128,7 @@ export const LeftClicked = {
 };
 
 export const LeftClosed = {
-  render: (): JSX.Element => (
+  render: function Story(): JSX.Element (
     <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
   ),
 
@@ -163,7 +163,7 @@ export const RightClicked = {
 };
 
 export const RightClosed = {
-  render: (): JSX.Element => (
+  render: function Story(): JSX.Element (
     <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
   ),
 

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -106,66 +106,93 @@ function Story({
   );
 }
 
-// Left
-export const LeftOpen = (): JSX.Element => <Story defaultLeftKey="a" />;
-LeftOpen.storyName = "Left";
-
-export const LeftLongText = (): JSX.Element => <Story defaultLeftKey="c" />;
-LeftLongText.storyName = "Left (with text overflow)";
-
-export const LeftClicked = (): JSX.Element => <Story defaultLeftKey="a" />;
-LeftClicked.storyName = "Left (tab click interaction)";
-LeftClicked.parameters = { colorScheme: "dark" };
-LeftClicked.play = async () => {
-  const leftTab = await screen.findByTestId("b-left");
-  userEvent.click(leftTab);
-};
-export const LeftClosed = (): JSX.Element => (
-  <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
-);
-LeftClosed.storyName = "Left (closed by interaction)";
-LeftClosed.parameters = { colorScheme: "dark" };
-LeftClosed.play = async () => {
-  const leftClose = await screen.findByTestId("sidebar-close-left");
-  userEvent.click(leftClose);
+export const LeftOpen = {
+  render: (): JSX.Element => <Story defaultLeftKey="a" />,
+  name: "Left",
 };
 
-// Right
-export const RightOpen = (): JSX.Element => <Story defaultRightKey="x" />;
-RightOpen.storyName = "Right";
-
-export const RightLongText = (): JSX.Element => <Story defaultRightKey="z" />;
-RightLongText.storyName = "Right (with text overflow)";
-
-export const RightClicked = (): JSX.Element => <Story defaultRightKey="x" />;
-RightClicked.storyName = "Right (tab click interaction)";
-RightClicked.parameters = { colorScheme: "dark" };
-RightClicked.play = async () => {
-  const rightTab = await screen.findByTestId("y-right");
-  userEvent.click(rightTab);
-};
-export const RightClosed = (): JSX.Element => (
-  <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
-);
-RightClosed.storyName = "Right (closed by interaction)";
-RightClosed.parameters = { colorScheme: "dark" };
-RightClosed.play = async () => {
-  const rightClose = await screen.findByTestId("sidebar-close-right");
-  userEvent.click(rightClose);
+export const LeftLongText = {
+  render: (): JSX.Element => <Story defaultLeftKey="c" />,
+  name: "Left (with text overflow)",
 };
 
-// Both
+export const LeftClicked = {
+  render: (): JSX.Element => <Story defaultLeftKey="a" />,
+  name: "Left (tab click interaction)",
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const leftTab = await screen.findByTestId("b-left");
+    userEvent.click(leftTab);
+  },
+};
+
+export const LeftClosed = {
+  render: (): JSX.Element => (
+    <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
+  ),
+
+  name: "Left (closed by interaction)",
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const leftClose = await screen.findByTestId("sidebar-close-left");
+    userEvent.click(leftClose);
+  },
+};
+
+export const RightOpen = {
+  render: (): JSX.Element => <Story defaultRightKey="x" />,
+  name: "Right",
+};
+
+export const RightLongText = {
+  render: (): JSX.Element => <Story defaultRightKey="z" />,
+  name: "Right (with text overflow)",
+};
+
+export const RightClicked = {
+  render: (): JSX.Element => <Story defaultRightKey="x" />,
+  name: "Right (tab click interaction)",
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const rightTab = await screen.findByTestId("y-right");
+    userEvent.click(rightTab);
+  },
+};
+
+export const RightClosed = {
+  render: (): JSX.Element => (
+    <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
+  ),
+
+  name: "Right (closed by interaction)",
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const rightClose = await screen.findByTestId("sidebar-close-right");
+    userEvent.click(rightClose);
+  },
+};
+
 export const Default = (): JSX.Element => <Story label="Both sidebars should be closed" />;
-export const BothOpen = (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />;
-BothOpen.storyName = "Both (opened)";
 
-export const BothClicked = (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />;
-BothClicked.storyName = "Both (tab click interaction)";
-BothClicked.parameters = { colorScheme: "dark" };
-BothClicked.play = async () => {
-  const leftTab = await screen.findByTestId("b-left");
-  userEvent.click(leftTab);
+export const BothOpen = {
+  render: (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />,
+  name: "Both (opened)",
+};
 
-  const rightTab = await screen.findByTestId("y-right");
-  userEvent.click(rightTab);
+export const BothClicked = {
+  render: (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />,
+  name: "Both (tab click interaction)",
+  parameters: { colorScheme: "dark" },
+
+  play: async () => {
+    const leftTab = await screen.findByTestId("b-left");
+    userEvent.click(leftTab);
+
+    const rightTab = await screen.findByTestId("y-right");
+    userEvent.click(rightTab);
+  },
 };

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { PropsWithChildren, useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
@@ -106,18 +107,18 @@ function Story({
   );
 }
 
-export const LeftOpen = {
-  render: (): JSX.Element => <Story defaultLeftKey="a" />,
+export const LeftOpen: StoryObj = {
+  render: () => <Story defaultLeftKey="a" />,
   name: "Left",
 };
 
-export const LeftLongText = {
-  render: (): JSX.Element => <Story defaultLeftKey="c" />,
+export const LeftLongText: StoryObj = {
+  render: () => <Story defaultLeftKey="c" />,
   name: "Left (with text overflow)",
 };
 
-export const LeftClicked = {
-  render: (): JSX.Element => <Story defaultLeftKey="a" />,
+export const LeftClicked: StoryObj = {
+  render: () => <Story defaultLeftKey="a" />,
   name: "Left (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
@@ -127,8 +128,8 @@ export const LeftClicked = {
   },
 };
 
-export const LeftClosed = {
-  render: (): JSX.Element => (
+export const LeftClosed: StoryObj = {
+  render: () => (
     <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
   ),
 
@@ -141,18 +142,18 @@ export const LeftClosed = {
   },
 };
 
-export const RightOpen = {
-  render: (): JSX.Element => <Story defaultRightKey="x" />,
+export const RightOpen: StoryObj = {
+  render: () => <Story defaultRightKey="x" />,
   name: "Right",
 };
 
-export const RightLongText = {
-  render: (): JSX.Element => <Story defaultRightKey="z" />,
+export const RightLongText: StoryObj = {
+  render: () => <Story defaultRightKey="z" />,
   name: "Right (with text overflow)",
 };
 
-export const RightClicked = {
-  render: (): JSX.Element => <Story defaultRightKey="x" />,
+export const RightClicked: StoryObj = {
+  render: () => <Story defaultRightKey="x" />,
   name: "Right (tab click interaction)",
   parameters: { colorScheme: "dark" },
 
@@ -162,8 +163,8 @@ export const RightClicked = {
   },
 };
 
-export const RightClosed = {
-  render: (): JSX.Element => (
+export const RightClosed: StoryObj = {
+  render: () => (
     <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
   ),
 
@@ -176,17 +177,17 @@ export const RightClosed = {
   },
 };
 
-export const Default = {
-  render: (): JSX.Element => <Story label="Both sidebars should be closed" />,
+export const Default: StoryObj = {
+  render: () => <Story label="Both sidebars should be closed" />,
 };
 
-export const BothOpen = {
-  render: (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />,
+export const BothOpen: StoryObj = {
+  render: () => <Story defaultLeftKey="a" defaultRightKey="x" />,
   name: "Both (opened)",
 };
 
-export const BothClicked = {
-  render: (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />,
+export const BothClicked: StoryObj = {
+  render: () => <Story defaultLeftKey="a" defaultRightKey="x" />,
   name: "Both (tab click interaction)",
   parameters: { colorScheme: "dark" },
 

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -176,7 +176,9 @@ export const RightClosed = {
   },
 };
 
-export const Default = (): JSX.Element => <Story label="Both sidebars should be closed" />;
+export const Default = {
+  render: (): JSX.Element => <Story label="Both sidebars should be closed" />,
+};
 
 export const BothOpen = {
   render: (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />,

--- a/packages/studio-base/src/components/Sidebars/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.stories.tsx
@@ -100,10 +100,15 @@ export const Unselected = (): JSX.Element => <Story />;
 export const ASelected = (): JSX.Element => <Story defaultSelectedKey="a" />;
 export const BSelected = (): JSX.Element => <Story defaultSelectedKey="b" />;
 
-export const ClickToSelect = (): JSX.Element => <Story clickKey="a" />;
-ClickToSelect.parameters = { colorScheme: "dark" };
-export const ClickToDeselect = (): JSX.Element => <Story defaultSelectedKey="a" clickKey="a" />;
-ClickToDeselect.parameters = { colorScheme: "dark" };
+export const ClickToSelect = {
+  render: (): JSX.Element => <Story clickKey="a" />,
+  parameters: { colorScheme: "dark" },
+};
+
+export const ClickToDeselect = {
+  render: (): JSX.Element => <Story defaultSelectedKey="a" clickKey="a" />,
+  parameters: { colorScheme: "dark" },
+};
 
 export const OverflowUnselected = (): JSX.Element => <Story height={200} />;
 export const OverflowCSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="c" />;

--- a/packages/studio-base/src/components/Sidebars/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -96,27 +97,27 @@ function Story({
   );
 }
 
-export const Unselected = {
-  render: (): JSX.Element => <Story />,
+export const Unselected: StoryObj = {
+  render: () => <Story />,
 };
 
-export const ASelected = { render: (): JSX.Element => <Story defaultSelectedKey="a" /> };
-export const BSelected = { render: (): JSX.Element => <Story defaultSelectedKey="b" /> };
+export const ASelected: StoryObj = { render: () => <Story defaultSelectedKey="a" /> };
+export const BSelected: StoryObj = { render: () => <Story defaultSelectedKey="b" /> };
 
-export const ClickToSelect = {
-  render: (): JSX.Element => <Story clickKey="a" />,
+export const ClickToSelect: StoryObj = {
+  render: () => <Story clickKey="a" />,
   parameters: { colorScheme: "dark" },
 };
 
-export const ClickToDeselect = {
-  render: (): JSX.Element => <Story defaultSelectedKey="a" clickKey="a" />,
+export const ClickToDeselect: StoryObj = {
+  render: () => <Story defaultSelectedKey="a" clickKey="a" />,
   parameters: { colorScheme: "dark" },
 };
 
-export const OverflowUnselected = { render: (): JSX.Element => <Story height={200} /> };
-export const OverflowCSelected = {
-  render: (): JSX.Element => <Story height={200} defaultSelectedKey="c" />,
+export const OverflowUnselected: StoryObj = { render: () => <Story height={200} /> };
+export const OverflowCSelected: StoryObj = {
+  render: () => <Story height={200} defaultSelectedKey="c" />,
 };
-export const OverflowBSelected = {
-  render: (): JSX.Element => <Story height={200} defaultSelectedKey="b" />,
+export const OverflowBSelected: StoryObj = {
+  render: () => <Story height={200} defaultSelectedKey="b" />,
 };

--- a/packages/studio-base/src/components/Sidebars/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.stories.tsx
@@ -96,9 +96,12 @@ function Story({
   );
 }
 
-export const Unselected = (): JSX.Element => <Story />;
-export const ASelected = (): JSX.Element => <Story defaultSelectedKey="a" />;
-export const BSelected = (): JSX.Element => <Story defaultSelectedKey="b" />;
+export const Unselected = {
+  render: (): JSX.Element => <Story />,
+};
+
+export const ASelected = { render: (): JSX.Element => <Story defaultSelectedKey="a" /> };
+export const BSelected = { render: (): JSX.Element => <Story defaultSelectedKey="b" /> };
 
 export const ClickToSelect = {
   render: (): JSX.Element => <Story clickKey="a" />,
@@ -110,6 +113,10 @@ export const ClickToDeselect = {
   parameters: { colorScheme: "dark" },
 };
 
-export const OverflowUnselected = (): JSX.Element => <Story height={200} />;
-export const OverflowCSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="c" />;
-export const OverflowBSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="b" />;
+export const OverflowUnselected = { render: (): JSX.Element => <Story height={200} /> };
+export const OverflowCSelected = {
+  render: (): JSX.Element => <Story height={200} defaultSelectedKey="c" />,
+};
+export const OverflowBSelected = {
+  render: (): JSX.Element => <Story height={200} defaultSelectedKey="b" />,
+};

--- a/packages/studio-base/src/components/Sparkline.stories.tsx
+++ b/packages/studio-base/src/components/Sparkline.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { Sparkline, SparklinePoint } from "@foxglove/studio-base/components/Sparkline";
 

--- a/packages/studio-base/src/components/Sparkline.stories.tsx
+++ b/packages/studio-base/src/components/Sparkline.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import { Sparkline, SparklinePoint } from "@foxglove/studio-base/components/Sparkline";
 
@@ -34,22 +34,26 @@ export default {
   title: "components/Sparkline",
 };
 
-export const Standard: StoryFn = () => {
-  return (
-    <div style={{ padding: 8 }}>
-      <Sparkline {...props} />
-    </div>
-  );
+export const Standard: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ padding: 8 }}>
+        <Sparkline {...props} />
+      </div>
+    );
+  },
+
+  name: "standard",
 };
 
-Standard.storyName = "standard";
+export const WithExplicitMaximumOf200: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ padding: 8 }}>
+        <Sparkline {...props} maximum={200} />
+      </div>
+    );
+  },
 
-export const WithExplicitMaximumOf200: StoryFn = () => {
-  return (
-    <div style={{ padding: 8 }}>
-      <Sparkline {...props} maximum={200} />
-    </div>
-  );
+  name: "with explicit maximum of 200",
 };
-
-WithExplicitMaximumOf200.storyName = "with explicit maximum of 200";

--- a/packages/studio-base/src/components/Stack.stories.tsx
+++ b/packages/studio-base/src/components/Stack.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { PropsWithChildren } from "react";
 
 import Stack, { StackProps } from "./Stack";
@@ -35,57 +35,59 @@ function Box({ children }: PropsWithChildren<StackProps>): JSX.Element {
   );
 }
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <Stack data-testid padding={2} gap={2} fullHeight>
-      <Stack direction="row" gap={2}>
-        {ITEMS.map((_, index) => (
-          <Stack flex="auto" key={index}>
-            <Box>{`Row item ${index + 1}`}</Box>
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <Stack data-testid padding={2} gap={2} fullHeight>
+        <Stack direction="row" gap={2}>
+          {ITEMS.map((_, index) => (
+            <Stack flex="auto" key={index}>
+              <Box>{`Row item ${index + 1}`}</Box>
+            </Stack>
+          ))}
+        </Stack>
+        <Stack flexGrow={2} justifyContent="space-between" gap={2}>
+          <Stack direction="row" gap={2} justifyContent="flex-start">
+            {ITEMS.map((_, index) => (
+              <Box key={index}>{`Row item ${index + 1}`}</Box>
+            ))}
           </Stack>
-        ))}
-      </Stack>
-      <Stack flexGrow={2} justifyContent="space-between" gap={2}>
-        <Stack direction="row" gap={2} justifyContent="flex-start">
-          {ITEMS.map((_, index) => (
-            <Box key={index}>{`Row item ${index + 1}`}</Box>
-          ))}
-        </Stack>
-        <Stack direction="row" justifyContent="center" gap={2} alignSelf="center">
-          {ITEMS.map((_, index) => (
-            <Box key={index}>{`Row item ${index + 1}`}</Box>
-          ))}
-        </Stack>
-        <Stack direction="row" justifyContent="flex-end" gap={2} alignSelf="flex-end">
-          {ITEMS.map((_, index) => (
-            <Box key={index}>{`Row item ${index + 1}`}</Box>
-          ))}
-        </Stack>
-      </Stack>
-      <Stack gap={2} justifyContent="space-between">
-        {ITEMS.map((_, index) => (
-          <Stack flex="auto" key={index}>
-            <Box>{`Col item ${index + 1}`}</Box>
+          <Stack direction="row" justifyContent="center" gap={2} alignSelf="center">
+            {ITEMS.map((_, index) => (
+              <Box key={index}>{`Row item ${index + 1}`}</Box>
+            ))}
           </Stack>
-        ))}
+          <Stack direction="row" justifyContent="flex-end" gap={2} alignSelf="flex-end">
+            {ITEMS.map((_, index) => (
+              <Box key={index}>{`Row item ${index + 1}`}</Box>
+            ))}
+          </Stack>
+        </Stack>
+        <Stack gap={2} justifyContent="space-between">
+          {ITEMS.map((_, index) => (
+            <Stack flex="auto" key={index}>
+              <Box>{`Col item ${index + 1}`}</Box>
+            </Stack>
+          ))}
+        </Stack>
+        <Stack flex="auto" gap={2} justifyContent="space-between">
+          <Stack gap={2} alignSelf="flex-start">
+            {ITEMS.map((_, index) => (
+              <Box key={index}>{`Col item ${index + 1}`}</Box>
+            ))}
+          </Stack>
+          <Stack gap={2} alignSelf="center">
+            {ITEMS.map((_, index) => (
+              <Box key={index}>{`Col item ${index + 1}`}</Box>
+            ))}
+          </Stack>
+          <Stack gap={2} alignSelf="flex-end">
+            {ITEMS.map((_, index) => (
+              <Box key={index}>{`Col item ${index + 1}`}</Box>
+            ))}
+          </Stack>
+        </Stack>
       </Stack>
-      <Stack flex="auto" gap={2} justifyContent="space-between">
-        <Stack gap={2} alignSelf="flex-start">
-          {ITEMS.map((_, index) => (
-            <Box key={index}>{`Col item ${index + 1}`}</Box>
-          ))}
-        </Stack>
-        <Stack gap={2} alignSelf="center">
-          {ITEMS.map((_, index) => (
-            <Box key={index}>{`Col item ${index + 1}`}</Box>
-          ))}
-        </Stack>
-        <Stack gap={2} alignSelf="flex-end">
-          {ITEMS.map((_, index) => (
-            <Box key={index}>{`Col item ${index + 1}`}</Box>
-          ))}
-        </Stack>
-      </Stack>
-    </Stack>
-  );
+    );
+  },
 };

--- a/packages/studio-base/src/components/Stack.stories.tsx
+++ b/packages/studio-base/src/components/Stack.stories.tsx
@@ -36,7 +36,7 @@ function Box({ children }: PropsWithChildren<StackProps>): JSX.Element {
 }
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <Stack data-testid padding={2} gap={2} fullHeight>
         <Stack direction="row" gap={2}>

--- a/packages/studio-base/src/components/Stack.stories.tsx
+++ b/packages/studio-base/src/components/Stack.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 import { PropsWithChildren } from "react";
 
 import Stack, { StackProps } from "./Stack";
@@ -34,7 +35,7 @@ function Box({ children }: PropsWithChildren<StackProps>): JSX.Element {
   );
 }
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <Stack data-testid padding={2} gap={2} fullHeight>
       <Stack direction="row" gap={2}>
@@ -87,4 +88,4 @@ export function Default(): JSX.Element {
       </Stack>
     </Stack>
   );
-}
+};

--- a/packages/studio-base/src/components/StudioToastProvider.stories.tsx
+++ b/packages/studio-base/src/components/StudioToastProvider.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { useSnackbar } from "notistack";
 import { useEffect } from "react";
 
@@ -28,49 +28,59 @@ export default {
   ],
 };
 
-export const OneError = (): JSX.Element => {
-  const { enqueueSnackbar } = useSnackbar();
+export const OneError: StoryObj = {
+  render: function Story() {
+    const { enqueueSnackbar } = useSnackbar();
 
-  useEffect(() => {
-    enqueueSnackbar("Something bad happened", { variant: "error", persist: true });
-  }, [enqueueSnackbar]);
+    useEffect(() => {
+      enqueueSnackbar("Something bad happened", { variant: "error", persist: true });
+    }, [enqueueSnackbar]);
 
-  return <StudioToastProvider />;
+    return <StudioToastProvider />;
+  },
 };
 
-export const OneWarning = (): JSX.Element => {
-  const { enqueueSnackbar } = useSnackbar();
+export const OneWarning: StoryObj = {
+  render: function Story() {
+    const { enqueueSnackbar } = useSnackbar();
 
-  useEffect(() => {
-    enqueueSnackbar("This is the final countdown", { variant: "warning", persist: true });
-  }, [enqueueSnackbar]);
+    useEffect(() => {
+      enqueueSnackbar("This is the final countdown", { variant: "warning", persist: true });
+    }, [enqueueSnackbar]);
 
-  return <StudioToastProvider />;
+    return <StudioToastProvider />;
+  },
 };
 
-export const OneInfo = (): JSX.Element => {
-  const { enqueueSnackbar } = useSnackbar();
+export const OneInfo = {
+  render: function Story(): JSX.Element {
+    const { enqueueSnackbar } = useSnackbar();
 
-  useEffect(() => {
-    enqueueSnackbar("This is the final countdown", { variant: "info", persist: true });
-  }, [enqueueSnackbar]);
+    useEffect(() => {
+      enqueueSnackbar("This is the final countdown", { variant: "info", persist: true });
+    }, [enqueueSnackbar]);
 
-  return <StudioToastProvider />;
+    return <StudioToastProvider />;
+  },
 };
 
-export const MultipleMessages = (): JSX.Element => {
-  const { enqueueSnackbar } = useSnackbar();
+export const MultipleMessages = {
+  render: function Story(): JSX.Element {
+    const { enqueueSnackbar } = useSnackbar();
 
-  useEffect(() => {
-    enqueueSnackbar("Something bad happened 1", { variant: "error", persist: true });
-    enqueueSnackbar("Here's a helpful tip", { variant: "default", persist: true });
-    enqueueSnackbar("Just a warning", { variant: "warning", persist: true });
-    enqueueSnackbar("Great job!", { variant: "success", persist: true });
-    enqueueSnackbar("Something happened 2", { variant: "info", persist: true });
-  }, [enqueueSnackbar]);
+    useEffect(() => {
+      enqueueSnackbar("Something bad happened 1", { variant: "error", persist: true });
+      enqueueSnackbar("Here's a helpful tip", { variant: "default", persist: true });
+      enqueueSnackbar("Just a warning", { variant: "warning", persist: true });
+      enqueueSnackbar("Great job!", { variant: "success", persist: true });
+      enqueueSnackbar("Something happened 2", { variant: "info", persist: true });
+    }, [enqueueSnackbar]);
 
-  return <StudioToastProvider />;
+    return <StudioToastProvider />;
+  },
 };
 
-export const MultipleMessagesLightTheme = MultipleMessages.bind(undefined);
-(MultipleMessagesLightTheme as any).parameters = { colorScheme: "light" };
+export const MultipleMessagesLightTheme = {
+  ...MultipleMessages,
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/components/StudioToastProvider.stories.tsx
+++ b/packages/studio-base/src/components/StudioToastProvider.stories.tsx
@@ -52,8 +52,8 @@ export const OneWarning: StoryObj = {
   },
 };
 
-export const OneInfo = {
-  render: function Story(): JSX.Element {
+export const OneInfo: StoryObj = {
+  render: function Story() {
     const { enqueueSnackbar } = useSnackbar();
 
     useEffect(() => {
@@ -64,8 +64,8 @@ export const OneInfo = {
   },
 };
 
-export const MultipleMessages = {
-  render: function Story(): JSX.Element {
+export const MultipleMessages: StoryObj = {
+  render: function Story() {
     const { enqueueSnackbar } = useSnackbar();
 
     useEffect(() => {
@@ -80,7 +80,7 @@ export const MultipleMessages = {
   },
 };
 
-export const MultipleMessagesLightTheme = {
+export const MultipleMessagesLightTheme: StoryObj = {
   ...MultipleMessages,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/components/StudioToastProvider.stories.tsx
+++ b/packages/studio-base/src/components/StudioToastProvider.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { useSnackbar } from "notistack";
 import { useEffect } from "react";
 
@@ -18,10 +18,10 @@ export default {
     colorScheme: "dark",
   },
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       return (
         <StudioToastProvider>
-          <StoryFn />
+          <Wrapped />
         </StudioToastProvider>
       );
     },

--- a/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 
 import TextMiddleTruncate from "./TextMiddleTruncate";
@@ -24,44 +24,48 @@ export default {
   component: TextMiddleTruncate,
 };
 
-async function hoverText() {
+async function hoverText(): Promise<void> {
   const allText = await screen.findAllByTestId("text-middle-truncate");
   fireEvent.pointerOver(allText[3]!);
 }
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <div
-      style={{
-        display: "grid",
-        gridAutoRows: 84,
-        gridTemplateColumns: "300px 240px",
-        gap: 16,
-        padding: 16,
-      }}
-    >
-      <div>Short text:</div>
-      <TextMiddleTruncate text="Some short text" />
 
-      <div>Long text:</div>
-      <TextMiddleTruncate text="Some long text Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptate laborum amet velit eius cum modi qui. Sapiente natus unde assumenda." />
+export const Default: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <div
+        style={{
+          display: "grid",
+          gridAutoRows: 84,
+          gridTemplateColumns: "300px 240px",
+          gap: 16,
+          padding: 16,
+        }}
+      >
+        <div>Short text:</div>
+        <TextMiddleTruncate text="Some short text" />
 
-      <div>Specifify endTextLength as 20:</div>
-      <TextMiddleTruncate
-        endTextLength={20}
-        text="Some long text Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptate laborum amet velit eius cum modi qui. Sapiente natus unde assumenda."
-      />
+        <div>Long text:</div>
+        <TextMiddleTruncate text="Some long text Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptate laborum amet velit eius cum modi qui. Sapiente natus unde assumenda." />
 
-      <div>Show the last part of topic name with visibile text:</div>
-      <TextMiddleTruncate
-        endTextLength={LONG_TOPIC_NAME.split("/").pop()!.length + 1}
-        text={LONG_TOPIC_NAME}
-      />
+        <div>Specifify endTextLength as 20:</div>
+        <TextMiddleTruncate
+          endTextLength={20}
+          text="Some long text Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptate laborum amet velit eius cum modi qui. Sapiente natus unde assumenda."
+        />
 
-      <div>Whitespace handling</div>
-      <div style={{ width: "12em" }}>
-        <TextMiddleTruncate text="Open a new connection..." endTextLength={18} />
+        <div>Show the last part of topic name with visibile text:</div>
+        <TextMiddleTruncate
+          endTextLength={LONG_TOPIC_NAME.split("/").pop()!.length + 1}
+          text={LONG_TOPIC_NAME}
+        />
+
+        <div>Whitespace handling</div>
+        <div style={{ width: "12em" }}>
+          <TextMiddleTruncate text="Open a new connection..." endTextLength={18} />
+        </div>
       </div>
-    </div>
-  );
+    );
+  },
+
+  play: hoverText,
 };
-Default.play = hoverText;

--- a/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryFn } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 
 import TextMiddleTruncate from "./TextMiddleTruncate";
@@ -27,7 +28,7 @@ async function hoverText() {
   const allText = await screen.findAllByTestId("text-middle-truncate");
   fireEvent.pointerOver(allText[3]!);
 }
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <div
       style={{
@@ -62,5 +63,5 @@ export function Default(): JSX.Element {
       </div>
     </div>
   );
-}
+};
 Default.play = hoverText;

--- a/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
@@ -30,7 +30,7 @@ async function hoverText(): Promise<void> {
 }
 
 export const Default: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <div
         style={{

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Tooltip } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { TimeBasedChartTooltipData } from "@foxglove/studio-base/components/TimeBasedChart";
 
@@ -23,148 +23,160 @@ export default {
   component: TimeBasedChartTooltipContent,
 };
 
-export const SingleItemSingleDataset: StoryFn = (): JSX.Element => {
-  const data: TimeBasedChartTooltipData = {
-    x: 0,
-    y: 0,
-    path: "/some/topic.path",
-    value: 3,
-    constantName: "ACTIVE",
-  };
-  return (
-    <Tooltip
-      open
-      title={<TimeBasedChartTooltipContent multiDataset={false} content={[data]} />}
-      placement="top"
-      arrow
-      PopperProps={{
-        anchorEl: {
-          getBoundingClientRect: () => {
-            return new DOMRect(200, 100, 0, 0);
+export const SingleItemSingleDataset: StoryObj = {
+  render: function Story(): JSX.Element {
+    const data: TimeBasedChartTooltipData = {
+      x: 0,
+      y: 0,
+      path: "/some/topic.path",
+      value: 3,
+      constantName: "ACTIVE",
+    };
+    return (
+      <Tooltip
+        open
+        title={<TimeBasedChartTooltipContent multiDataset={false} content={[data]} />}
+        placement="top"
+        arrow
+        PopperProps={{
+          anchorEl: {
+            getBoundingClientRect: () => {
+              return new DOMRect(200, 100, 0, 0);
+            },
           },
-        },
-      }}
-    >
-      <div style={{ width: "100%", height: "100%" }} />
-    </Tooltip>
-  );
+        }}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </Tooltip>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-SingleItemSingleDataset.parameters = { colorScheme: "dark" };
 
 export const SingleItemSingleDatasetLight = Object.assign(SingleItemSingleDataset.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-export const SingleItemMultiDataset: StoryFn = (): JSX.Element => {
-  const data: TimeBasedChartTooltipData = {
-    x: 0,
-    y: 0,
-    path: "/some/topic.path",
-    value: 3,
-    constantName: "ACTIVE",
-  };
-  return (
-    <Tooltip
-      open
-      title={<TimeBasedChartTooltipContent multiDataset={true} content={[data]} />}
-      placement="top"
-      arrow
-      PopperProps={{
-        anchorEl: {
-          getBoundingClientRect: () => {
-            return new DOMRect(200, 100, 0, 0);
+export const SingleItemMultiDataset: StoryObj = {
+  render: function Story(): JSX.Element {
+    const data: TimeBasedChartTooltipData = {
+      x: 0,
+      y: 0,
+      path: "/some/topic.path",
+      value: 3,
+      constantName: "ACTIVE",
+    };
+    return (
+      <Tooltip
+        open
+        title={<TimeBasedChartTooltipContent multiDataset={true} content={[data]} />}
+        placement="top"
+        arrow
+        PopperProps={{
+          anchorEl: {
+            getBoundingClientRect: () => {
+              return new DOMRect(200, 100, 0, 0);
+            },
           },
-        },
-      }}
-    >
-      <div style={{ width: "100%", height: "100%" }} />
-    </Tooltip>
-  );
+        }}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </Tooltip>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-SingleItemMultiDataset.parameters = { colorScheme: "dark" };
 
 export const SingleItemMultiDatasetLight = Object.assign(SingleItemMultiDataset.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-export const MultipleItemsSingleDataset: StoryFn = (): JSX.Element => {
-  const data: TimeBasedChartTooltipData = {
-    x: 0,
-    y: 0,
-    path: "/some/topic.path",
-    value: 3,
-    constantName: "ACTIVE",
-  };
-  return (
-    <Tooltip
-      open
-      title={<TimeBasedChartTooltipContent multiDataset={false} content={[data, data]} />}
-      placement="top"
-      arrow
-      PopperProps={{
-        anchorEl: {
-          getBoundingClientRect: () => {
-            return new DOMRect(200, 100, 0, 0);
+export const MultipleItemsSingleDataset: StoryObj = {
+  render: function Story(): JSX.Element {
+    const data: TimeBasedChartTooltipData = {
+      x: 0,
+      y: 0,
+      path: "/some/topic.path",
+      value: 3,
+      constantName: "ACTIVE",
+    };
+    return (
+      <Tooltip
+        open
+        title={<TimeBasedChartTooltipContent multiDataset={false} content={[data, data]} />}
+        placement="top"
+        arrow
+        PopperProps={{
+          anchorEl: {
+            getBoundingClientRect: () => {
+              return new DOMRect(200, 100, 0, 0);
+            },
           },
-        },
-      }}
-    >
-      <div style={{ width: "100%", height: "100%" }} />
-    </Tooltip>
-  );
+        }}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </Tooltip>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-MultipleItemsSingleDataset.parameters = { colorScheme: "dark" };
 
 export const MultipleItemsSingleDatasetLight = Object.assign(
   MultipleItemsSingleDataset.bind(undefined),
   { parameters: { colorScheme: "light" } },
 );
 
-export const MultipleItemsMultipleDataset: StoryFn = (): JSX.Element => {
-  const data: TimeBasedChartTooltipData[] = [
-    {
-      datasetIndex: 0,
-      x: 0,
-      y: 0,
-      path: "/some/topic.path",
-      value: 3,
-      constantName: "ACTIVE",
-    },
-    {
-      datasetIndex: 1,
-      x: 0,
-      y: 0,
-      path: "/other/topic.path",
-      value: 4,
-      constantName: "ACTIVE",
-    },
-  ];
-  return (
-    <Tooltip
-      open
-      title={
-        <TimeBasedChartTooltipContent
-          multiDataset={true}
-          content={data}
-          colorsByDatasetIndex={{ "0": "chartreuse", "1": "yellow" }}
-          labelsByDatasetIndex={{ "1": "-*- Custom Label -*-" }}
-        />
-      }
-      placement="top"
-      arrow
-      PopperProps={{
-        anchorEl: {
-          getBoundingClientRect: () => {
-            return new DOMRect(200, 100, 0, 0);
+export const MultipleItemsMultipleDataset: StoryObj = {
+  render: function Story(): JSX.Element {
+    const data: TimeBasedChartTooltipData[] = [
+      {
+        datasetIndex: 0,
+        x: 0,
+        y: 0,
+        path: "/some/topic.path",
+        value: 3,
+        constantName: "ACTIVE",
+      },
+      {
+        datasetIndex: 1,
+        x: 0,
+        y: 0,
+        path: "/other/topic.path",
+        value: 4,
+        constantName: "ACTIVE",
+      },
+    ];
+    return (
+      <Tooltip
+        open
+        title={
+          <TimeBasedChartTooltipContent
+            multiDataset={true}
+            content={data}
+            colorsByDatasetIndex={{ "0": "chartreuse", "1": "yellow" }}
+            labelsByDatasetIndex={{ "1": "-*- Custom Label -*-" }}
+          />
+        }
+        placement="top"
+        arrow
+        PopperProps={{
+          anchorEl: {
+            getBoundingClientRect: () => {
+              return new DOMRect(200, 100, 0, 0);
+            },
           },
-        },
-      }}
-    >
-      <div style={{ width: "100%", height: "100%" }} />
-    </Tooltip>
-  );
+        }}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </Tooltip>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-MultipleItemsMultipleDataset.parameters = { colorScheme: "dark" };
 
 export const MultipleItemsMultiDatasetLight = Object.assign(
   MultipleItemsMultipleDataset.bind(undefined),

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Tooltip } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 
 import { TimeBasedChartTooltipData } from "@foxglove/studio-base/components/TimeBasedChart";
 
@@ -22,7 +23,7 @@ export default {
   component: TimeBasedChartTooltipContent,
 };
 
-export function SingleItemSingleDataset(): JSX.Element {
+export const SingleItemSingleDataset: StoryFn = (): JSX.Element => {
   const data: TimeBasedChartTooltipData = {
     x: 0,
     y: 0,
@@ -47,14 +48,14 @@ export function SingleItemSingleDataset(): JSX.Element {
       <div style={{ width: "100%", height: "100%" }} />
     </Tooltip>
   );
-}
+};
 SingleItemSingleDataset.parameters = { colorScheme: "dark" };
 
 export const SingleItemSingleDatasetLight = Object.assign(SingleItemSingleDataset.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-export function SingleItemMultiDataset(): JSX.Element {
+export const SingleItemMultiDataset: StoryFn = (): JSX.Element => {
   const data: TimeBasedChartTooltipData = {
     x: 0,
     y: 0,
@@ -79,14 +80,14 @@ export function SingleItemMultiDataset(): JSX.Element {
       <div style={{ width: "100%", height: "100%" }} />
     </Tooltip>
   );
-}
+};
 SingleItemMultiDataset.parameters = { colorScheme: "dark" };
 
 export const SingleItemMultiDatasetLight = Object.assign(SingleItemMultiDataset.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-export function MultipleItemsSingleDataset(): JSX.Element {
+export const MultipleItemsSingleDataset: StoryFn = (): JSX.Element => {
   const data: TimeBasedChartTooltipData = {
     x: 0,
     y: 0,
@@ -111,7 +112,7 @@ export function MultipleItemsSingleDataset(): JSX.Element {
       <div style={{ width: "100%", height: "100%" }} />
     </Tooltip>
   );
-}
+};
 MultipleItemsSingleDataset.parameters = { colorScheme: "dark" };
 
 export const MultipleItemsSingleDatasetLight = Object.assign(
@@ -119,7 +120,7 @@ export const MultipleItemsSingleDatasetLight = Object.assign(
   { parameters: { colorScheme: "light" } },
 );
 
-export function MultipleItemsMultipleDataset(): JSX.Element {
+export const MultipleItemsMultipleDataset: StoryFn = (): JSX.Element => {
   const data: TimeBasedChartTooltipData[] = [
     {
       datasetIndex: 0,
@@ -162,7 +163,7 @@ export function MultipleItemsMultipleDataset(): JSX.Element {
       <div style={{ width: "100%", height: "100%" }} />
     </Tooltip>
   );
-}
+};
 MultipleItemsMultipleDataset.parameters = { colorScheme: "dark" };
 
 export const MultipleItemsMultiDatasetLight = Object.assign(

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -24,7 +24,7 @@ export default {
 };
 
 export const SingleItemSingleDataset: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const data: TimeBasedChartTooltipData = {
       x: 0,
       y: 0,
@@ -54,13 +54,13 @@ export const SingleItemSingleDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const SingleItemSingleDatasetLight = {
+export const SingleItemSingleDatasetLight: StoryObj = {
   ...SingleItemSingleDataset,
   parameters: { colorScheme: "light" },
 };
 
 export const SingleItemMultiDataset: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const data: TimeBasedChartTooltipData = {
       x: 0,
       y: 0,
@@ -90,13 +90,13 @@ export const SingleItemMultiDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const SingleItemMultiDatasetLight = {
+export const SingleItemMultiDatasetLight: StoryObj = {
   ...SingleItemMultiDataset,
   parameters: { colorScheme: "light" },
 };
 
 export const MultipleItemsSingleDataset: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const data: TimeBasedChartTooltipData = {
       x: 0,
       y: 0,
@@ -126,13 +126,13 @@ export const MultipleItemsSingleDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const MultipleItemsSingleDatasetLight = {
+export const MultipleItemsSingleDatasetLight: StoryObj = {
   ...MultipleItemsSingleDataset,
   parameters: { colorScheme: "light" },
 };
 
 export const MultipleItemsMultipleDataset: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const data: TimeBasedChartTooltipData[] = [
       {
         datasetIndex: 0,
@@ -180,7 +180,7 @@ export const MultipleItemsMultipleDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const MultipleItemsMultiDatasetLight = {
+export const MultipleItemsMultiDatasetLight: StoryObj = {
   ...MultipleItemsMultipleDataset,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -54,9 +54,10 @@ export const SingleItemSingleDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const SingleItemSingleDatasetLight = Object.assign(SingleItemSingleDataset.bind(undefined), {
+export const SingleItemSingleDatasetLight = {
+  ...SingleItemSingleDataset,
   parameters: { colorScheme: "light" },
-});
+};
 
 export const SingleItemMultiDataset: StoryObj = {
   render: function Story(): JSX.Element {
@@ -89,9 +90,10 @@ export const SingleItemMultiDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const SingleItemMultiDatasetLight = Object.assign(SingleItemMultiDataset.bind(undefined), {
+export const SingleItemMultiDatasetLight = {
+  ...SingleItemMultiDataset,
   parameters: { colorScheme: "light" },
-});
+};
 
 export const MultipleItemsSingleDataset: StoryObj = {
   render: function Story(): JSX.Element {
@@ -124,10 +126,10 @@ export const MultipleItemsSingleDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const MultipleItemsSingleDatasetLight = Object.assign(
-  MultipleItemsSingleDataset.bind(undefined),
-  { parameters: { colorScheme: "light" } },
-);
+export const MultipleItemsSingleDatasetLight = {
+  ...MultipleItemsSingleDataset,
+  parameters: { colorScheme: "light" },
+};
 
 export const MultipleItemsMultipleDataset: StoryObj = {
   render: function Story(): JSX.Element {
@@ -178,7 +180,7 @@ export const MultipleItemsMultipleDataset: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const MultipleItemsMultiDatasetLight = Object.assign(
-  MultipleItemsMultipleDataset.bind(undefined),
-  { parameters: { colorScheme: "light" } },
-);
+export const MultipleItemsMultiDatasetLight = {
+  ...MultipleItemsMultipleDataset,
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -101,7 +101,7 @@ export default {
   },
 };
 
-export function Simple(): JSX.Element {
+export const Simple: StoryFn = (): JSX.Element => {
   return (
     <div style={{ width: "100%", height: "100%" }}>
       <MockMessagePipelineProvider>
@@ -109,13 +109,13 @@ export function Simple(): JSX.Element {
       </MockMessagePipelineProvider>
     </div>
   );
-}
+};
 export const SimpleLight = Object.assign(Simple.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
 // zoom and update without resetting zoom
-export function CanZoomAndUpdate(): JSX.Element {
+export const CanZoomAndUpdate: StoryFn = (): JSX.Element => {
   const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
   const callCountRef = useRef(0);
 
@@ -159,7 +159,7 @@ export function CanZoomAndUpdate(): JSX.Element {
       </MockMessagePipelineProvider>
     </div>
   );
-}
+};
 
 CanZoomAndUpdate.parameters = {
   chromatic: {
@@ -224,7 +224,7 @@ export const CleansUpTooltipOnUnmount: StoryObj = {
   parameters: { useReadySignal: true },
 };
 
-export function CallPauseOnInitialMount(): JSX.Element {
+export const CallPauseOnInitialMount: StoryFn = (): JSX.Element => {
   const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);
   const pauseFrame = useCallback(() => {
     return () => {
@@ -242,7 +242,7 @@ export function CallPauseOnInitialMount(): JSX.Element {
       </MockMessagePipelineProvider>
     </div>
   );
-}
+};
 
 // We should still call resumeFrame exactly once when removed in the middle of an update.
 // The way this test works:
@@ -253,7 +253,7 @@ export function CallPauseOnInitialMount(): JSX.Element {
 // (`resumeFrame`) fires.
 // - `resumeFrame` should then fire exactly once.
 // shows `SUCCESS` message with no chart visible
-export function ResumeFrameOnUnmount(): JSX.Element {
+export const ResumeFrameOnUnmount: StoryFn = (): JSX.Element => {
   const [showChart, setShowChart] = useState(true);
   const [statusMessage, setStatusMessage] = useState("FAILURE - START");
   const pauseFrame = useCallback(() => {
@@ -277,4 +277,4 @@ export function ResumeFrameOnUnmount(): JSX.Element {
       </MockMessagePipelineProvider>
     </div>
   );
-}
+};

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -10,7 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback, useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -167,57 +167,62 @@ CanZoomAndUpdate.parameters = {
   },
 };
 
-export const CleansUpTooltipOnUnmount: Story = (_args: unknown) => {
-  const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
-  const { error } = useAsync(async () => {
-    const [canvas] = document.getElementsByTagName("canvas");
-    const { top, left } = canvas!.getBoundingClientRect();
-    // wait for chart to render before triggering tooltip
-    let tooltip: Element | undefined;
+export const CleansUpTooltipOnUnmount: StoryObj = {
+  render: (_args: unknown) => {
+    const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
+    const { error } = useAsync(async () => {
+      const [canvas] = document.getElementsByTagName("canvas");
+      const { top, left } = canvas!.getBoundingClientRect();
+      // wait for chart to render before triggering tooltip
+      let tooltip: Element | undefined;
 
-    TestUtils.Simulate.mouseEnter(canvas!.parentElement!);
-    for (let i = 0; !tooltip && i < 20; i++) {
-      TestUtils.Simulate.mouseMove(canvas!.parentElement!, {
-        clientX: 70 + left,
-        clientY: 296 + top,
-      });
-      await delay(100);
-      tooltip = document.querySelector("[data-testid~=TimeBasedChartTooltipContent]") ?? undefined;
+      TestUtils.Simulate.mouseEnter(canvas!.parentElement!);
+      for (let i = 0; !tooltip && i < 20; i++) {
+        TestUtils.Simulate.mouseMove(canvas!.parentElement!, {
+          clientX: 70 + left,
+          clientY: 296 + top,
+        });
+        await delay(100);
+        tooltip =
+          document.querySelector("[data-testid~=TimeBasedChartTooltipContent]") ?? undefined;
+      }
+      if (tooltip == undefined) {
+        throw new Error("could not find tooltip");
+      }
+      setHasRenderedOnce(true);
+    }, []);
+
+    const readySignal = useReadySignal();
+
+    useEffect(() => {
+      if (hasRenderedOnce) {
+        readySignal();
+      }
+    }, [hasRenderedOnce, readySignal]);
+
+    if (error) {
+      throw error;
     }
-    if (tooltip == undefined) {
-      throw new Error("could not find tooltip");
-    }
-    setHasRenderedOnce(true);
-  }, []);
 
-  const readySignal = useReadySignal();
-
-  useEffect(() => {
     if (hasRenderedOnce) {
-      readySignal();
+      return <></>;
     }
-  }, [hasRenderedOnce, readySignal]);
 
-  if (error) {
-    throw error;
-  }
+    return (
+      <div style={{ width: "100%", height: "100%", background: "black" }}>
+        <MockMessagePipelineProvider>
+          <TimeBasedChart {...commonProps} />
+        </MockMessagePipelineProvider>
+      </div>
+    );
+  },
 
-  if (hasRenderedOnce) {
-    return <></>;
-  }
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 
-  return (
-    <div style={{ width: "100%", height: "100%", background: "black" }}>
-      <MockMessagePipelineProvider>
-        <TimeBasedChart {...commonProps} />
-      </MockMessagePipelineProvider>
-    </div>
-  );
+  parameters: { useReadySignal: true },
 };
-CleansUpTooltipOnUnmount.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-CleansUpTooltipOnUnmount.parameters = { useReadySignal: true };
 
 export function CallPauseOnInitialMount(): JSX.Element {
   const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -10,7 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback, useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -101,14 +101,16 @@ export default {
   },
 };
 
-export const Simple: StoryFn = (): JSX.Element => {
-  return (
-    <div style={{ width: "100%", height: "100%" }}>
-      <MockMessagePipelineProvider>
-        <TimeBasedChart {...commonProps} />
-      </MockMessagePipelineProvider>
-    </div>
-  );
+export const Simple: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <div style={{ width: "100%", height: "100%" }}>
+        <MockMessagePipelineProvider>
+          <TimeBasedChart {...commonProps} />
+        </MockMessagePipelineProvider>
+      </div>
+    );
+  },
 };
 
 export const SimpleLight = { ...Simple, parameters: { colorScheme: "light" } };
@@ -224,48 +226,52 @@ export const CleansUpTooltipOnUnmount: StoryObj = {
   parameters: { useReadySignal: true },
 };
 
-export const CallPauseOnInitialMount: StoryFn = (): JSX.Element => {
-  const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);
-  const pauseFrame = useCallback(() => {
-    return () => {
-      setUnpauseFrameCount((old) => old + 1);
-    };
-  }, []);
+export const CallPauseOnInitialMount: StoryObj = {
+  render: function Story(): JSX.Element {
+    const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);
+    const pauseFrame = useCallback(() => {
+      return () => {
+        setUnpauseFrameCount((old) => old + 1);
+      };
+    }, []);
 
-  return (
-    <div style={{ width: "100%", height: "100%", background: "black" }}>
-      <div style={{ fontSize: 20, padding: 6 }}>
-        Finished pause frame count: {unpauseFrameCount}
+    return (
+      <div style={{ width: "100%", height: "100%", background: "black" }}>
+        <div style={{ fontSize: 20, padding: 6 }}>
+          Finished pause frame count: {unpauseFrameCount}
+        </div>
+        <MockMessagePipelineProvider pauseFrame={pauseFrame}>
+          <TimeBasedChart {...commonProps} />
+        </MockMessagePipelineProvider>
       </div>
-      <MockMessagePipelineProvider pauseFrame={pauseFrame}>
-        <TimeBasedChart {...commonProps} />
-      </MockMessagePipelineProvider>
-    </div>
-  );
+    );
+  },
 };
 
-export const ResumeFrameOnUnmount: StoryFn = (): JSX.Element => {
-  const [showChart, setShowChart] = useState(true);
-  const [statusMessage, setStatusMessage] = useState("FAILURE - START");
-  const pauseFrame = useCallback(() => {
-    setShowChart(() => false);
-    return () => {
-      setStatusMessage((old) => {
-        if (old === "FAILURE - START") {
-          return "SUCCESS";
-        } else {
-          return "FAILURE - CANNOT CALL RESUME FRAME TWICE";
-        }
-      });
-    };
-  }, [setStatusMessage]);
+export const ResumeFrameOnUnmount: StoryObj = {
+  render: function Story(): JSX.Element {
+    const [showChart, setShowChart] = useState(true);
+    const [statusMessage, setStatusMessage] = useState("FAILURE - START");
+    const pauseFrame = useCallback(() => {
+      setShowChart(() => false);
+      return () => {
+        setStatusMessage((old) => {
+          if (old === "FAILURE - START") {
+            return "SUCCESS";
+          } else {
+            return "FAILURE - CANNOT CALL RESUME FRAME TWICE";
+          }
+        });
+      };
+    }, [setStatusMessage]);
 
-  return (
-    <div style={{ width: "100%", height: "100%", background: "black" }}>
-      <MockMessagePipelineProvider pauseFrame={pauseFrame}>
-        <div style={{ fontSize: 48, padding: 50 }}>{statusMessage}</div>
-        {showChart && <TimeBasedChart {...commonProps} />}
-      </MockMessagePipelineProvider>
-    </div>
-  );
+    return (
+      <div style={{ width: "100%", height: "100%", background: "black" }}>
+        <MockMessagePipelineProvider pauseFrame={pauseFrame}>
+          <div style={{ fontSize: 48, padding: 50 }}>{statusMessage}</div>
+          {showChart && <TimeBasedChart {...commonProps} />}
+        </MockMessagePipelineProvider>
+      </div>
+    );
+  },
 };

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -111,9 +111,7 @@ export const Simple: StoryFn = (): JSX.Element => {
   );
 };
 
-export const SimpleLight = Object.assign(Simple.bind(undefined), {
-  parameters: { colorScheme: "light" },
-});
+export const SimpleLight = { ...Simple, parameters: { colorScheme: "light" } };
 
 export const CanZoomAndUpdate: StoryObj = {
   render: function Story(): JSX.Element {
@@ -170,7 +168,7 @@ export const CanZoomAndUpdate: StoryObj = {
 };
 
 export const CleansUpTooltipOnUnmount: StoryObj = {
-  render: (_args: unknown) => {
+  render: function Story(): JSX.Element {
     const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
     const { error } = useAsync(async () => {
       const [canvas] = document.getElementsByTagName("canvas");

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -102,7 +102,7 @@ export default {
 };
 
 export const Simple: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <div style={{ width: "100%", height: "100%" }}>
         <MockMessagePipelineProvider>
@@ -113,10 +113,10 @@ export const Simple: StoryObj = {
   },
 };
 
-export const SimpleLight = { ...Simple, parameters: { colorScheme: "light" } };
+export const SimpleLight: StoryObj = { ...Simple, parameters: { colorScheme: "light" } };
 
 export const CanZoomAndUpdate: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
     const callCountRef = useRef(0);
 
@@ -170,7 +170,7 @@ export const CanZoomAndUpdate: StoryObj = {
 };
 
 export const CleansUpTooltipOnUnmount: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
     const { error } = useAsync(async () => {
       const [canvas] = document.getElementsByTagName("canvas");
@@ -227,7 +227,7 @@ export const CleansUpTooltipOnUnmount: StoryObj = {
 };
 
 export const CallPauseOnInitialMount: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);
     const pauseFrame = useCallback(() => {
       return () => {
@@ -249,7 +249,7 @@ export const CallPauseOnInitialMount: StoryObj = {
 };
 
 export const ResumeFrameOnUnmount: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const [showChart, setShowChart] = useState(true);
     const [statusMessage, setStatusMessage] = useState("FAILURE - START");
     const pauseFrame = useCallback(() => {

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -110,60 +110,62 @@ export const Simple: StoryFn = (): JSX.Element => {
     </div>
   );
 };
+
 export const SimpleLight = Object.assign(Simple.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-// zoom and update without resetting zoom
-export const CanZoomAndUpdate: StoryFn = (): JSX.Element => {
-  const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
-  const callCountRef = useRef(0);
+export const CanZoomAndUpdate: StoryObj = {
+  render: function Story(): JSX.Element {
+    const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
+    const callCountRef = useRef(0);
 
-  const doScroll = useCallback(async () => {
-    const canvasEl = document.querySelector("canvas");
-    if (!canvasEl) {
-      return;
-    }
-
-    // Zoom is a continuous event, so we need to simulate wheel multiple times
-    for (let i = 0; i < 5; i++) {
-      triggerWheel(canvasEl.parentElement!, 2);
-      await delay(10);
-    }
-
-    await delay(100);
-    setChartProps((oldProps) => {
-      const newProps = cloneDeep(oldProps);
-      const newDataPoint = cloneDeep(newProps.data.datasets[0]!.data[0]!);
-      newDataPoint.x = 20;
-      newProps.data.datasets[0]!.data[1] = newDataPoint;
-      return newProps;
-    });
-  }, []);
-
-  const pauseFrame = useCallback(() => {
-    return () => {
-      // first render of the chart triggers scrolling
-      if (callCountRef.current === 0) {
-        void doScroll();
+    const doScroll = useCallback(async () => {
+      const canvasEl = document.querySelector("canvas");
+      if (!canvasEl) {
+        return;
       }
 
-      ++callCountRef.current;
-    };
-  }, [doScroll]);
+      // Zoom is a continuous event, so we need to simulate wheel multiple times
+      for (let i = 0; i < 5; i++) {
+        triggerWheel(canvasEl.parentElement!, 2);
+        await delay(10);
+      }
 
-  return (
-    <div style={{ width: 800, height: 800, background: "black" }}>
-      <MockMessagePipelineProvider pauseFrame={pauseFrame}>
-        <TimeBasedChart {...chartProps} width={800} height={800} />
-      </MockMessagePipelineProvider>
-    </div>
-  );
-};
+      await delay(100);
+      setChartProps((oldProps) => {
+        const newProps = cloneDeep(oldProps);
+        const newDataPoint = cloneDeep(newProps.data.datasets[0]!.data[0]!);
+        newDataPoint.x = 20;
+        newProps.data.datasets[0]!.data[1] = newDataPoint;
+        return newProps;
+      });
+    }, []);
 
-CanZoomAndUpdate.parameters = {
-  chromatic: {
-    delay: 500,
+    const pauseFrame = useCallback(() => {
+      return () => {
+        // first render of the chart triggers scrolling
+        if (callCountRef.current === 0) {
+          void doScroll();
+        }
+
+        ++callCountRef.current;
+      };
+    }, [doScroll]);
+
+    return (
+      <div style={{ width: 800, height: 800, background: "black" }}>
+        <MockMessagePipelineProvider pauseFrame={pauseFrame}>
+          <TimeBasedChart {...chartProps} width={800} height={800} />
+        </MockMessagePipelineProvider>
+      </div>
+    );
+  },
+
+  parameters: {
+    chromatic: {
+      delay: 500,
+    },
   },
 };
 
@@ -244,15 +246,6 @@ export const CallPauseOnInitialMount: StoryFn = (): JSX.Element => {
   );
 };
 
-// We should still call resumeFrame exactly once when removed in the middle of an update.
-// The way this test works:
-// - start by rendering the chart normally
-// - after the timeout (chart should be rendered), force a re-render of the chart.
-// - This rerender updates the chart, which calls `pauseFrame` until the chart has finished updating
-// - in `pauseFrame`, trigger an update that removes the chart. This happens before the returned function
-// (`resumeFrame`) fires.
-// - `resumeFrame` should then fire exactly once.
-// shows `SUCCESS` message with no chart visible
 export const ResumeFrameOnUnmount: StoryFn = (): JSX.Element => {
   const [showChart, setShowChart] = useState(true);
   const [statusMessage, setStatusMessage] = useState("FAILURE - START");

--- a/packages/studio-base/src/components/Timestamp.stories.tsx
+++ b/packages/studio-base/src/components/Timestamp.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Stack } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { PropsWithChildren, useState } from "react";
 
 import { Time } from "@foxglove/rostime";
@@ -40,42 +40,50 @@ function TimestampStory(props: PropsWithChildren<Props>): JSX.Element {
   );
 }
 
-export const Default: StoryFn = (): JSX.Element => {
-  return <TimestampStory config={[[AppSetting.TIMEZONE, "UTC"]]} time={ABSOLUTE_TIME} />;
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return <TimestampStory config={[[AppSetting.TIMEZONE, "UTC"]]} time={ABSOLUTE_TIME} />;
+  },
 };
 
-export const TimeFormatSeconds: StoryFn = (): JSX.Element => {
-  return (
-    <TimestampStory
-      config={[
-        [AppSetting.TIME_FORMAT, "SEC"],
-        [AppSetting.TIMEZONE, "UTC"],
-      ]}
-      time={ABSOLUTE_TIME}
-    />
-  );
+export const TimeFormatSeconds: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <TimestampStory
+        config={[
+          [AppSetting.TIME_FORMAT, "SEC"],
+          [AppSetting.TIMEZONE, "UTC"],
+        ]}
+        time={ABSOLUTE_TIME}
+      />
+    );
+  },
 };
 
-export const TimeFormatTOD: StoryFn = (): JSX.Element => {
-  return (
-    <TimestampStory
-      config={[
-        [AppSetting.TIME_FORMAT, "TOD"],
-        [AppSetting.TIMEZONE, "UTC"],
-      ]}
-      time={ABSOLUTE_TIME}
-    />
-  );
+export const TimeFormatTOD: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <TimestampStory
+        config={[
+          [AppSetting.TIME_FORMAT, "TOD"],
+          [AppSetting.TIMEZONE, "UTC"],
+        ]}
+        time={ABSOLUTE_TIME}
+      />
+    );
+  },
 };
 
-export const TimeFormatRelative: StoryFn = (): JSX.Element => {
-  return (
-    <TimestampStory
-      config={[
-        [AppSetting.TIME_FORMAT, "TOD"],
-        [AppSetting.TIMEZONE, "UTC"],
-      ]}
-      time={RELATIVE_TIME}
-    />
-  );
+export const TimeFormatRelative: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <TimestampStory
+        config={[
+          [AppSetting.TIME_FORMAT, "TOD"],
+          [AppSetting.TIMEZONE, "UTC"],
+        ]}
+        time={RELATIVE_TIME}
+      />
+    );
+  },
 };

--- a/packages/studio-base/src/components/Timestamp.stories.tsx
+++ b/packages/studio-base/src/components/Timestamp.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Stack } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 import { PropsWithChildren, useState } from "react";
 
 import { Time } from "@foxglove/rostime";
@@ -39,11 +40,11 @@ function TimestampStory(props: PropsWithChildren<Props>): JSX.Element {
   );
 }
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return <TimestampStory config={[[AppSetting.TIMEZONE, "UTC"]]} time={ABSOLUTE_TIME} />;
-}
+};
 
-export function TimeFormatSeconds(): JSX.Element {
+export const TimeFormatSeconds: StoryFn = (): JSX.Element => {
   return (
     <TimestampStory
       config={[
@@ -53,9 +54,9 @@ export function TimeFormatSeconds(): JSX.Element {
       time={ABSOLUTE_TIME}
     />
   );
-}
+};
 
-export function TimeFormatTOD(): JSX.Element {
+export const TimeFormatTOD: StoryFn = (): JSX.Element => {
   return (
     <TimestampStory
       config={[
@@ -65,9 +66,9 @@ export function TimeFormatTOD(): JSX.Element {
       time={ABSOLUTE_TIME}
     />
   );
-}
+};
 
-export function TimeFormatRelative(): JSX.Element {
+export const TimeFormatRelative: StoryFn = (): JSX.Element => {
   return (
     <TimestampStory
       config={[
@@ -77,4 +78,4 @@ export function TimeFormatRelative(): JSX.Element {
       time={RELATIVE_TIME}
     />
   );
-}
+};

--- a/packages/studio-base/src/components/Timestamp.stories.tsx
+++ b/packages/studio-base/src/components/Timestamp.stories.tsx
@@ -41,13 +41,13 @@ function TimestampStory(props: PropsWithChildren<Props>): JSX.Element {
 }
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <TimestampStory config={[[AppSetting.TIMEZONE, "UTC"]]} time={ABSOLUTE_TIME} />;
   },
 };
 
 export const TimeFormatSeconds: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <TimestampStory
         config={[
@@ -61,7 +61,7 @@ export const TimeFormatSeconds: StoryObj = {
 };
 
 export const TimeFormatTOD: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <TimestampStory
         config={[
@@ -75,7 +75,7 @@ export const TimeFormatTOD: StoryObj = {
 };
 
 export const TimeFormatRelative: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <TimestampStory
         config={[

--- a/packages/studio-base/src/components/VariablesList/index.stories.tsx
+++ b/packages/studio-base/src/components/VariablesList/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -22,14 +22,16 @@ const initialState = {
   },
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <MockCurrentLayoutProvider>
-        <VariablesList />
-      </MockCurrentLayoutProvider>
-    </DndProvider>
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <VariablesList />
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    );
+  },
 };
 
 export const Interactive: StoryObj = {

--- a/packages/studio-base/src/components/VariablesList/index.stories.tsx
+++ b/packages/studio-base/src/components/VariablesList/index.stories.tsx
@@ -23,7 +23,7 @@ const initialState = {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <DndProvider backend={HTML5Backend}>
         <MockCurrentLayoutProvider>
@@ -35,7 +35,7 @@ export const Default: StoryObj = {
 };
 
 export const Interactive: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <DndProvider backend={HTML5Backend}>
         <MockCurrentLayoutProvider>
@@ -71,7 +71,7 @@ export const Interactive: StoryObj = {
 };
 
 export const WithVariablesLight: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <DndProvider backend={HTML5Backend}>
         <MockCurrentLayoutProvider initialState={initialState}>
@@ -85,7 +85,7 @@ export const WithVariablesLight: StoryObj = {
 };
 
 export const WithVariablesDark: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <DndProvider backend={HTML5Backend}>
         <MockCurrentLayoutProvider initialState={initialState}>

--- a/packages/studio-base/src/components/VariablesList/index.stories.tsx
+++ b/packages/studio-base/src/components/VariablesList/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -32,59 +32,66 @@ export const Default: StoryFn = (): JSX.Element => {
   );
 };
 
-export const Interactive: StoryFn = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <MockCurrentLayoutProvider>
-        <VariablesList />
-      </MockCurrentLayoutProvider>
-    </DndProvider>
-  );
-};
-Interactive.play = async () => {
-  const addButton = await screen.findByTestId("add-variable-button");
-  fireEvent.click(addButton);
+export const Interactive: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <VariablesList />
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    );
+  },
 
-  const input = await screen.findByPlaceholderText("variable_name");
-  fireEvent.change(input, { target: { value: "new_variable_name" } });
+  play: async () => {
+    const addButton = await screen.findByTestId("add-variable-button");
+    fireEvent.click(addButton);
 
-  const valueInput = await screen.findByDisplayValue('""');
-  fireEvent.change(valueInput, { target: { value: '"edited value"' } });
+    const input = await screen.findByPlaceholderText("variable_name");
+    fireEvent.change(input, { target: { value: "new_variable_name" } });
 
-  const menuButton = await screen.findByTestId("variable-action-button");
-  fireEvent.click(menuButton);
+    const valueInput = await screen.findByDisplayValue('""');
+    fireEvent.change(valueInput, { target: { value: '"edited value"' } });
 
-  await screen.findByTestId("global-variable-key-input-new_variable_name");
+    const menuButton = await screen.findByTestId("variable-action-button");
+    fireEvent.click(menuButton);
 
-  const menuButton2 = await screen.findByTestId("variable-action-button");
-  fireEvent.click(menuButton2);
+    await screen.findByTestId("global-variable-key-input-new_variable_name");
 
-  const deleteButton = await screen.findByText("Delete variable");
-  fireEvent.click(deleteButton);
-};
+    const menuButton2 = await screen.findByTestId("variable-action-button");
+    fireEvent.click(menuButton2);
 
-Interactive.parameters = { colorScheme: "light" };
+    const deleteButton = await screen.findByText("Delete variable");
+    fireEvent.click(deleteButton);
+  },
 
-export const WithVariablesLight: StoryFn = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <MockCurrentLayoutProvider initialState={initialState}>
-        <VariablesList />
-      </MockCurrentLayoutProvider>
-    </DndProvider>
-  );
+  parameters: { colorScheme: "light" },
 };
 
-WithVariablesLight.parameters = { colorScheme: "light" };
+export const WithVariablesLight: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider initialState={initialState}>
+          <VariablesList />
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    );
+  },
 
-export const WithVariablesDark: StoryFn = (): JSX.Element => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <MockCurrentLayoutProvider initialState={initialState}>
-        <VariablesList />
-      </MockCurrentLayoutProvider>
-    </DndProvider>
-  );
+  parameters: { colorScheme: "light" },
 };
 
-WithVariablesDark.parameters = { colorScheme: "dark" };
+export const WithVariablesDark: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider initialState={initialState}>
+          <VariablesList />
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
+};

--- a/packages/studio-base/src/components/VariablesList/index.stories.tsx
+++ b/packages/studio-base/src/components/VariablesList/index.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { fireEvent, screen } from "@storybook/testing-library";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -21,7 +22,7 @@ const initialState = {
   },
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <MockCurrentLayoutProvider>
@@ -29,9 +30,9 @@ export function Default(): JSX.Element {
       </MockCurrentLayoutProvider>
     </DndProvider>
   );
-}
+};
 
-export function Interactive(): JSX.Element {
+export const Interactive: StoryFn = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <MockCurrentLayoutProvider>
@@ -39,7 +40,7 @@ export function Interactive(): JSX.Element {
       </MockCurrentLayoutProvider>
     </DndProvider>
   );
-}
+};
 Interactive.play = async () => {
   const addButton = await screen.findByTestId("add-variable-button");
   fireEvent.click(addButton);
@@ -64,7 +65,7 @@ Interactive.play = async () => {
 
 Interactive.parameters = { colorScheme: "light" };
 
-export function WithVariablesLight(): JSX.Element {
+export const WithVariablesLight: StoryFn = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <MockCurrentLayoutProvider initialState={initialState}>
@@ -72,11 +73,11 @@ export function WithVariablesLight(): JSX.Element {
       </MockCurrentLayoutProvider>
     </DndProvider>
   );
-}
+};
 
 WithVariablesLight.parameters = { colorScheme: "light" };
 
-export function WithVariablesDark(): JSX.Element {
+export const WithVariablesDark: StoryFn = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <MockCurrentLayoutProvider initialState={initialState}>
@@ -84,6 +85,6 @@ export function WithVariablesDark(): JSX.Element {
       </MockCurrentLayoutProvider>
     </DndProvider>
   );
-}
+};
 
 WithVariablesDark.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/WssErrorModal.stories.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import WssErrorModal from "./WssErrorModal";
 
@@ -14,10 +14,12 @@ export default {
   },
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <WssErrorModal
-      playerProblems={[{ severity: "error", message: "Insecure WebSocket connection" }]}
-    />
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <WssErrorModal
+        playerProblems={[{ severity: "error", message: "Insecure WebSocket connection" }]}
+      />
+    );
+  },
 };

--- a/packages/studio-base/src/components/WssErrorModal.stories.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import WssErrorModal from "./WssErrorModal";
 
 export default {
@@ -12,10 +14,10 @@ export default {
   },
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <WssErrorModal
       playerProblems={[{ severity: "error", message: "Insecure WebSocket connection" }]}
     />
   );
-}
+};

--- a/packages/studio-base/src/components/WssErrorModal.stories.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.stories.tsx
@@ -15,7 +15,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <WssErrorModal
         playerProblems={[{ severity: "error", message: "Insecure WebSocket connection" }]}

--- a/packages/studio-base/src/hooks/useConfirm.stories.tsx
+++ b/packages/studio-base/src/hooks/useConfirm.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryObj } from "@storybook/react";
 import { useLayoutEffect } from "react";
 
 import { useConfirm } from "./useConfirm";
@@ -20,49 +21,55 @@ export default {
   parameters: { colorScheme: "dark" },
 };
 
-export const Defaults = (): unknown => {
-  const [confirm, confirmModal] = useConfirm();
+export const Defaults: StoryObj = {
+  render: function Story() {
+    const [confirm, confirmModal] = useConfirm();
 
-  useLayoutEffect(() => {
-    void confirm({
-      title: "Example title",
-    });
-  }, [confirm]);
+    useLayoutEffect(() => {
+      void confirm({
+        title: "Example title",
+      });
+    }, [confirm]);
 
-  return <>{confirmModal}</>;
+    return <>{confirmModal}</>;
+  },
 };
 
-export const Primary = (): unknown => {
-  const [confirm, confirmModal] = useConfirm();
+export const Primary: StoryObj = {
+  render: function Story() {
+    const [confirm, confirmModal] = useConfirm();
 
-  useLayoutEffect(() => {
-    void confirm({
-      title: "Example title",
-      prompt: "Example prompt",
-      variant: "primary",
-      ok: "Custom OK",
-      cancel: "Continue anyway",
-    });
-  }, [confirm]);
+    useLayoutEffect(() => {
+      void confirm({
+        title: "Example title",
+        prompt: "Example prompt",
+        variant: "primary",
+        ok: "Custom OK",
+        cancel: "Continue anyway",
+      });
+    }, [confirm]);
 
-  return <>{confirmModal}</>;
+    return <>{confirmModal}</>;
+  },
 };
-export const PrimaryLight = Primary.bind(undefined);
-(PrimaryLight as any).parameters = { colorScheme: "light" };
 
-export const Danger = (): unknown => {
-  const [confirm, confirmModal] = useConfirm();
+export const PrimaryLight: StoryObj = { ...Primary, parameters: { colorScheme: "light" } };
 
-  useLayoutEffect(() => {
-    void confirm({
-      title: "Example title",
-      prompt: "Example prompt",
-      variant: "danger",
-      ok: "Destroy",
-    });
-  }, [confirm]);
+export const Danger: StoryObj = {
+  render: function Story() {
+    const [confirm, confirmModal] = useConfirm();
 
-  return <>{confirmModal}</>;
+    useLayoutEffect(() => {
+      void confirm({
+        title: "Example title",
+        prompt: "Example prompt",
+        variant: "danger",
+        ok: "Destroy",
+      });
+    }, [confirm]);
+
+    return <>{confirmModal}</>;
+  },
 };
-export const DangerLight = Danger.bind(undefined);
-(DangerLight as any).parameters = { colorScheme: "light" };
+
+export const DangerLight: StoryObj = { ...Danger, parameters: { colorScheme: "light" } };

--- a/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
@@ -36,7 +36,7 @@ const TOPICS: Topic[] = [
 ];
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <MockMessagePipelineProvider
         startTime={START_TIME}
@@ -53,7 +53,7 @@ export const Default: StoryObj = {
 };
 
 export const Empty: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
         <PanelSetup>

--- a/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { fromDate } from "@foxglove/rostime";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
@@ -35,27 +35,31 @@ const TOPICS: Topic[] = [
   { schemaName: "nav_msgs/Odometry", name: "/odom" },
 ];
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider
-      startTime={START_TIME}
-      endTime={END_TIME}
-      topics={TOPICS}
-      presence={PlayerPresence.PRESENT}
-    >
-      <PanelSetup fixture={{ topics: TOPICS }}>
-        <DataSourceInfoPanel />
-      </PanelSetup>
-    </MockMessagePipelineProvider>
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <MockMessagePipelineProvider
+        startTime={START_TIME}
+        endTime={END_TIME}
+        topics={TOPICS}
+        presence={PlayerPresence.PRESENT}
+      >
+        <PanelSetup fixture={{ topics: TOPICS }}>
+          <DataSourceInfoPanel />
+        </PanelSetup>
+      </MockMessagePipelineProvider>
+    );
+  },
 };
 
-export const Empty: StoryFn = (): JSX.Element => {
-  return (
-    <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
-      <PanelSetup>
-        <DataSourceInfoPanel />
-      </PanelSetup>
-    </MockMessagePipelineProvider>
-  );
+export const Empty: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
+        <PanelSetup>
+          <DataSourceInfoPanel />
+        </PanelSetup>
+      </MockMessagePipelineProvider>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { fromDate } from "@foxglove/rostime";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import DataSourceInfoPanel from "@foxglove/studio-base/panels/DataSourceInfo";
@@ -33,7 +35,7 @@ const TOPICS: Topic[] = [
   { schemaName: "nav_msgs/Odometry", name: "/odom" },
 ];
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <MockMessagePipelineProvider
       startTime={START_TIME}
@@ -46,9 +48,9 @@ export function Default(): JSX.Element {
       </PanelSetup>
     </MockMessagePipelineProvider>
   );
-}
+};
 
-export function Empty(): JSX.Element {
+export const Empty: StoryFn = (): JSX.Element => {
   return (
     <MockMessagePipelineProvider noActiveData presence={PlayerPresence.NOT_PRESENT}>
       <PanelSetup>
@@ -56,4 +58,4 @@ export function Empty(): JSX.Element {
       </PanelSetup>
     </MockMessagePipelineProvider>
   );
-}
+};

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -40,8 +40,10 @@ function makeFixture(value: number) {
   };
 }
 
-export const EmptyState = (): JSX.Element => {
-  return <GaugePanel />;
+export const EmptyState = {
+  render: (): JSX.Element => {
+    return <GaugePanel />;
+  },
 };
 
 export const InvalidValue = {

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -45,7 +45,7 @@ export const EmptyState = (): JSX.Element => {
 };
 
 export const InvalidValue = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
@@ -53,7 +53,7 @@ export const InvalidValue = {
 };
 
 export const Rainbow = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <GaugePanel
         overrideConfig={{
@@ -71,7 +71,7 @@ export const Rainbow = {
 };
 
 export const Turbo = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <GaugePanel
         overrideConfig={{
@@ -89,7 +89,7 @@ export const Turbo = {
 };
 
 export const TurboReverse = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <GaugePanel
         overrideConfig={{
@@ -108,7 +108,7 @@ export const TurboReverse = {
 };
 
 export const CustomGradient = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <GaugePanel
         overrideConfig={{
@@ -126,7 +126,7 @@ export const CustomGradient = {
 };
 
 export const CustomGradientReverse = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <GaugePanel
         overrideConfig={{
@@ -145,7 +145,7 @@ export const CustomGradientReverse = {
 };
 
 export const MinValue = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
@@ -153,7 +153,7 @@ export const MinValue = {
 };
 
 export const MaxValue = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
@@ -161,7 +161,7 @@ export const MaxValue = {
 };
 
 export const TooLow = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
@@ -169,7 +169,7 @@ export const TooLow = {
 };
 
 export const TooHigh = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
@@ -177,7 +177,7 @@ export const TooHigh = {
 };
 
 export const CustomRange = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 5, maxValue: 7 }} />;
   },
 
@@ -185,7 +185,7 @@ export const CustomRange = {
 };
 
 export const MessagePathWithFilter = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <GaugePanel overrideConfig={{ path: `/data{id=="b"}.value`, minValue: 0, maxValue: 4 }} />
     );
@@ -220,7 +220,7 @@ export const MessagePathWithFilter = {
 };
 
 export const StringValue = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <GaugePanel overrideConfig={{ path: `/data.value`, minValue: 0, maxValue: 1 }} />;
   },
 

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -12,7 +12,7 @@ export default {
   title: "panels/Gauge",
   component: GaugePanel,
   decorators: [
-    (StoryComponent: Story, { parameters }: StoryContext): JSX.Element => {
+    (StoryComponent: StoryFn, { parameters }: StoryContext): JSX.Element => {
       return (
         <PanelSetup fixture={parameters.panelSetup?.fixture}>
           <StoryComponent />
@@ -44,157 +44,199 @@ export const EmptyState = (): JSX.Element => {
   return <GaugePanel />;
 };
 
-export const InvalidValue = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
-};
-InvalidValue.parameters = { panelSetup: { fixture: makeFixture(NaN) } };
+export const InvalidValue = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+  },
 
-export const Rainbow = (): JSX.Element => {
-  return (
-    <GaugePanel
-      overrideConfig={{
-        path: "/data.value",
-        minValue: 0,
-        maxValue: 1,
-        colorMode: "colormap",
-        colorMap: "rainbow",
-      }}
-    />
-  );
+  parameters: { panelSetup: { fixture: makeFixture(NaN) } },
 };
-Rainbow.parameters = { panelSetup: { fixture: makeFixture(0.3) } };
 
-export const Turbo = (): JSX.Element => {
-  return (
-    <GaugePanel
-      overrideConfig={{
-        path: "/data.value",
-        minValue: 0,
-        maxValue: 1,
-        colorMode: "colormap",
-        colorMap: "turbo",
-      }}
-    />
-  );
-};
-Turbo.parameters = { panelSetup: { fixture: makeFixture(0.3) } };
+export const Rainbow = {
+  render: (): JSX.Element => {
+    return (
+      <GaugePanel
+        overrideConfig={{
+          path: "/data.value",
+          minValue: 0,
+          maxValue: 1,
+          colorMode: "colormap",
+          colorMap: "rainbow",
+        }}
+      />
+    );
+  },
 
-export const TurboReverse = (): JSX.Element => {
-  return (
-    <GaugePanel
-      overrideConfig={{
-        path: "/data.value",
-        minValue: 0,
-        maxValue: 1,
-        colorMode: "colormap",
-        colorMap: "turbo",
-        reverse: true,
-      }}
-    />
-  );
+  parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
-TurboReverse.parameters = { panelSetup: { fixture: makeFixture(0.3) } };
 
-export const CustomGradient = (): JSX.Element => {
-  return (
-    <GaugePanel
-      overrideConfig={{
-        path: "/data.value",
-        minValue: 0,
-        maxValue: 1,
-        colorMode: "gradient",
-        gradient: ["#ec9a57", "#65c6ff"],
-      }}
-    />
-  );
-};
-CustomGradient.parameters = { panelSetup: { fixture: makeFixture(0.3) } };
+export const Turbo = {
+  render: (): JSX.Element => {
+    return (
+      <GaugePanel
+        overrideConfig={{
+          path: "/data.value",
+          minValue: 0,
+          maxValue: 1,
+          colorMode: "colormap",
+          colorMap: "turbo",
+        }}
+      />
+    );
+  },
 
-export const CustomGradientReverse = (): JSX.Element => {
-  return (
-    <GaugePanel
-      overrideConfig={{
-        path: "/data.value",
-        minValue: 0,
-        maxValue: 1,
-        colorMode: "gradient",
-        gradient: ["#ec9a57", "#65c6ff"],
-        reverse: true,
-      }}
-    />
-  );
+  parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
-CustomGradientReverse.parameters = { panelSetup: { fixture: makeFixture(0.3) } };
 
-export const MinValue = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
-};
-MinValue.parameters = { panelSetup: { fixture: makeFixture(0) } };
+export const TurboReverse = {
+  render: (): JSX.Element => {
+    return (
+      <GaugePanel
+        overrideConfig={{
+          path: "/data.value",
+          minValue: 0,
+          maxValue: 1,
+          colorMode: "colormap",
+          colorMap: "turbo",
+          reverse: true,
+        }}
+      />
+    );
+  },
 
-export const MaxValue = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+  parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
-MaxValue.parameters = { panelSetup: { fixture: makeFixture(1) } };
 
-export const TooLow = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
-};
-TooLow.parameters = { panelSetup: { fixture: makeFixture(-1) } };
-export const TooHigh = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
-};
-TooHigh.parameters = { panelSetup: { fixture: makeFixture(2) } };
+export const CustomGradient = {
+  render: (): JSX.Element => {
+    return (
+      <GaugePanel
+        overrideConfig={{
+          path: "/data.value",
+          minValue: 0,
+          maxValue: 1,
+          colorMode: "gradient",
+          gradient: ["#ec9a57", "#65c6ff"],
+        }}
+      />
+    );
+  },
 
-export const CustomRange = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 5, maxValue: 7 }} />;
+  parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
-CustomRange.parameters = { panelSetup: { fixture: makeFixture(6.5) } };
 
-export const MessagePathWithFilter = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: `/data{id=="b"}.value`, minValue: 0, maxValue: 4 }} />;
+export const CustomGradientReverse = {
+  render: (): JSX.Element => {
+    return (
+      <GaugePanel
+        overrideConfig={{
+          path: "/data.value",
+          minValue: 0,
+          maxValue: 1,
+          colorMode: "gradient",
+          gradient: ["#ec9a57", "#65c6ff"],
+          reverse: true,
+        }}
+      />
+    );
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
-MessagePathWithFilter.parameters = {
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
-      frame: {
-        "/data": [
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { id: "a", value: 1 },
-          },
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { id: "b", value: 2 },
-          },
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { id: "c", value: 3 },
-          },
-        ],
+
+export const MinValue = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture(0) } },
+};
+
+export const MaxValue = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture(1) } },
+};
+
+export const TooLow = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture(-1) } },
+};
+
+export const TooHigh = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture(2) } },
+};
+
+export const CustomRange = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 5, maxValue: 7 }} />;
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture(6.5) } },
+};
+
+export const MessagePathWithFilter = {
+  render: (): JSX.Element => {
+    return (
+      <GaugePanel overrideConfig={{ path: `/data{id=="b"}.value`, minValue: 0, maxValue: 4 }} />
+    );
+  },
+
+  parameters: {
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+        frame: {
+          "/data": [
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { id: "a", value: 1 },
+            },
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { id: "b", value: 2 },
+            },
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { id: "c", value: 3 },
+            },
+          ],
+        },
       },
     },
   },
 };
 
-export const StringValue = (): JSX.Element => {
-  return <GaugePanel overrideConfig={{ path: `/data.value`, minValue: 0, maxValue: 1 }} />;
-};
-StringValue.parameters = {
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
-      frame: {
-        "/data": [
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { value: "0.2" },
-          },
-        ],
+export const StringValue = {
+  render: (): JSX.Element => {
+    return <GaugePanel overrideConfig={{ path: `/data.value`, minValue: 0, maxValue: 1 }} />;
+  },
+
+  parameters: {
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+        frame: {
+          "/data": [
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { value: "0.2" },
+            },
+          ],
+        },
       },
     },
   },

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext, StoryObj } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -40,22 +40,22 @@ function makeFixture(value: number) {
   };
 }
 
-export const EmptyState = {
-  render: (): JSX.Element => {
+export const EmptyState: StoryObj = {
+  render: () => {
     return <GaugePanel />;
   },
 };
 
-export const InvalidValue = {
-  render: function Story(): JSX.Element {
+export const InvalidValue: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
   parameters: { panelSetup: { fixture: makeFixture(NaN) } },
 };
 
-export const Rainbow = {
-  render: function Story(): JSX.Element {
+export const Rainbow: StoryObj = {
+  render: function Story() {
     return (
       <GaugePanel
         overrideConfig={{
@@ -72,8 +72,8 @@ export const Rainbow = {
   parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
 
-export const Turbo = {
-  render: function Story(): JSX.Element {
+export const Turbo: StoryObj = {
+  render: function Story() {
     return (
       <GaugePanel
         overrideConfig={{
@@ -90,8 +90,8 @@ export const Turbo = {
   parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
 
-export const TurboReverse = {
-  render: function Story(): JSX.Element {
+export const TurboReverse: StoryObj = {
+  render: function Story() {
     return (
       <GaugePanel
         overrideConfig={{
@@ -109,8 +109,8 @@ export const TurboReverse = {
   parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
 
-export const CustomGradient = {
-  render: function Story(): JSX.Element {
+export const CustomGradient: StoryObj = {
+  render: function Story() {
     return (
       <GaugePanel
         overrideConfig={{
@@ -127,8 +127,8 @@ export const CustomGradient = {
   parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
 
-export const CustomGradientReverse = {
-  render: function Story(): JSX.Element {
+export const CustomGradientReverse: StoryObj = {
+  render: function Story() {
     return (
       <GaugePanel
         overrideConfig={{
@@ -146,48 +146,48 @@ export const CustomGradientReverse = {
   parameters: { panelSetup: { fixture: makeFixture(0.3) } },
 };
 
-export const MinValue = {
-  render: function Story(): JSX.Element {
+export const MinValue: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
   parameters: { panelSetup: { fixture: makeFixture(0) } },
 };
 
-export const MaxValue = {
-  render: function Story(): JSX.Element {
+export const MaxValue: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
   parameters: { panelSetup: { fixture: makeFixture(1) } },
 };
 
-export const TooLow = {
-  render: function Story(): JSX.Element {
+export const TooLow: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
   parameters: { panelSetup: { fixture: makeFixture(-1) } },
 };
 
-export const TooHigh = {
-  render: function Story(): JSX.Element {
+export const TooHigh: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
   },
 
   parameters: { panelSetup: { fixture: makeFixture(2) } },
 };
 
-export const CustomRange = {
-  render: function Story(): JSX.Element {
+export const CustomRange: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 5, maxValue: 7 }} />;
   },
 
   parameters: { panelSetup: { fixture: makeFixture(6.5) } },
 };
 
-export const MessagePathWithFilter = {
-  render: function Story(): JSX.Element {
+export const MessagePathWithFilter: StoryObj = {
+  render: function Story() {
     return (
       <GaugePanel overrideConfig={{ path: `/data{id=="b"}.value`, minValue: 0, maxValue: 4 }} />
     );
@@ -221,8 +221,8 @@ export const MessagePathWithFilter = {
   },
 };
 
-export const StringValue = {
-  render: function Story(): JSX.Element {
+export const StringValue: StoryObj = {
+  render: function Story() {
     return <GaugePanel overrideConfig={{ path: `/data.value`, minValue: 0, maxValue: 1 }} />;
   },
 

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { noop } from "lodash";
 
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -224,7 +224,7 @@ export default {
 };
 
 export const MarkersOriginal: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const image = useCompressedImage();
     const readySignal = useReadySignal();
 
@@ -257,7 +257,7 @@ export const MarkersOriginal: StoryObj = {
 };
 
 export const MarkersTransformed: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const image = useCompressedImage();
     const readySignal = useReadySignal();
 
@@ -290,7 +290,7 @@ export const MarkersTransformed: StoryObj = {
 };
 
 export const MarkersImageSize: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const image = useCompressedImage();
     const readySignal = useReadySignal();
 

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
@@ -322,92 +322,15 @@ export const MarkersImageSize: StoryObj = {
   },
 };
 
-export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => {
-  const image = useCompressedImage();
+export const MarkersWithFallbackRenderingUsingMainThread = {
+  render: function Story(): JSX.Element {
+    const image = useCompressedImage();
 
-  return (
-    <div>
-      <div>original markers</div>
-      <ImageCanvas
-        topic={topics[1]}
-        image={image}
-        rawMarkerData={{
-          markers: annotations,
-          cameraInfo: undefined,
-          transformMarkers: false,
-        }}
-        config={config}
-        saveConfig={noop}
-        setActivePixelData={noop}
-        renderInMainThread
-        onStartRenderImage={() => () => undefined}
-      />
-      <br />
-      <div>transformed markers</div>
-      <ImageCanvas
-        topic={topics[1]}
-        image={image}
-        rawMarkerData={{
-          markers: annotations,
-          cameraInfo,
-          transformMarkers: true,
-        }}
-        config={config}
-        saveConfig={noop}
-        setActivePixelData={noop}
-        renderInMainThread
-        onStartRenderImage={() => () => undefined}
-      />
-      <div>markers with different original image size</div>
-      <ImageCanvas
-        topic={topics[1]}
-        image={image}
-        rawMarkerData={{
-          markers: annotations,
-          cameraInfo: { ...cameraInfo, width: 200, height: 150 },
-          transformMarkers: true,
-        }}
-        config={config}
-        saveConfig={noop}
-        setActivePixelData={noop}
-        renderInMainThread
-        onStartRenderImage={() => () => undefined}
-      />
-    </div>
-  );
-};
-
-export const ErrorState = (): JSX.Element => {
-  return (
-    <ImageCanvas
-      topic={topics[0]}
-      image={{
-        type: "raw",
-        stamp: { sec: 0, nsec: 0 },
-        data: new Uint8Array([]),
-        width: 100,
-        height: 50,
-        encoding: "Foo",
-        is_bigendian: false,
-        step: 10,
-      }}
-      rawMarkerData={noMarkersMarkerData}
-      config={config}
-      saveConfig={noop}
-      setActivePixelData={noop}
-      onStartRenderImage={() => () => undefined}
-    />
-  );
-};
-
-export const CallsOnRenderFrameWhenRenderingSucceeds = (): JSX.Element => {
-  const image = useCompressedImage();
-
-  return (
-    <ShouldCallOnRenderImage>
-      {(onStartRenderImage) => (
+    return (
+      <div>
+        <div>original markers</div>
         <ImageCanvas
-          topic={topics[0]}
+          topic={topics[1]}
           image={image}
           rawMarkerData={{
             markers: annotations,
@@ -417,44 +340,132 @@ export const CallsOnRenderFrameWhenRenderingSucceeds = (): JSX.Element => {
           config={config}
           saveConfig={noop}
           setActivePixelData={noop}
-          onStartRenderImage={onStartRenderImage}
+          renderInMainThread
+          onStartRenderImage={() => () => undefined}
         />
-      )}
-    </ShouldCallOnRenderImage>
-  );
-};
-
-export const CallsOnRenderFrameWhenRenderingFails = (): JSX.Element => {
-  return (
-    <ShouldCallOnRenderImage>
-      {(onStartRenderImage) => (
+        <br />
+        <div>transformed markers</div>
         <ImageCanvas
-          topic={topics[0]}
-          image={{
-            type: "raw",
-            stamp: { sec: 0, nsec: 0 },
-            data: new Uint8Array([]),
-            width: 100,
-            height: 50,
-            encoding: "Foo",
-            is_bigendian: false,
-            step: 10,
+          topic={topics[1]}
+          image={image}
+          rawMarkerData={{
+            markers: annotations,
+            cameraInfo,
+            transformMarkers: true,
           }}
-          rawMarkerData={noMarkersMarkerData}
           config={config}
           saveConfig={noop}
           setActivePixelData={noop}
-          onStartRenderImage={onStartRenderImage}
+          renderInMainThread
+          onStartRenderImage={() => () => undefined}
         />
-      )}
-    </ShouldCallOnRenderImage>
-  );
+        <div>markers with different original image size</div>
+        <ImageCanvas
+          topic={topics[1]}
+          image={image}
+          rawMarkerData={{
+            markers: annotations,
+            cameraInfo: { ...cameraInfo, width: 200, height: 150 },
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          setActivePixelData={noop}
+          renderInMainThread
+          onStartRenderImage={() => () => undefined}
+        />
+      </div>
+    );
+  },
 };
 
-export const RGB8 = (): JSX.Element => <RGBStory encoding="rgb8" />;
-export const BGR8 = (): JSX.Element => <RGBStory encoding="bgr8" />;
-export const Mono16BigEndian = (): JSX.Element => <Mono16Story bigEndian={true} />;
-export const Mono16LittleEndian = (): JSX.Element => <Mono16Story bigEndian={false} />;
+export const ErrorState = {
+  render: (): JSX.Element => {
+    return (
+      <ImageCanvas
+        topic={topics[0]}
+        image={{
+          type: "raw",
+          stamp: { sec: 0, nsec: 0 },
+          data: new Uint8Array([]),
+          width: 100,
+          height: 50,
+          encoding: "Foo",
+          is_bigendian: false,
+          step: 10,
+        }}
+        rawMarkerData={noMarkersMarkerData}
+        config={config}
+        saveConfig={noop}
+        setActivePixelData={noop}
+        onStartRenderImage={() => () => undefined}
+      />
+    );
+  },
+};
+
+export const CallsOnRenderFrameWhenRenderingSucceeds = {
+  render: function Story(): JSX.Element {
+    const image = useCompressedImage();
+
+    return (
+      <ShouldCallOnRenderImage>
+        {(onStartRenderImage) => (
+          <ImageCanvas
+            topic={topics[0]}
+            image={image}
+            rawMarkerData={{
+              markers: annotations,
+              cameraInfo: undefined,
+              transformMarkers: false,
+            }}
+            config={config}
+            saveConfig={noop}
+            setActivePixelData={noop}
+            onStartRenderImage={onStartRenderImage}
+          />
+        )}
+      </ShouldCallOnRenderImage>
+    );
+  },
+};
+
+export const CallsOnRenderFrameWhenRenderingFails = {
+  render: (): JSX.Element => {
+    return (
+      <ShouldCallOnRenderImage>
+        {(onStartRenderImage) => (
+          <ImageCanvas
+            topic={topics[0]}
+            image={{
+              type: "raw",
+              stamp: { sec: 0, nsec: 0 },
+              data: new Uint8Array([]),
+              width: 100,
+              height: 50,
+              encoding: "Foo",
+              is_bigendian: false,
+              step: 10,
+            }}
+            rawMarkerData={noMarkersMarkerData}
+            config={config}
+            saveConfig={noop}
+            setActivePixelData={noop}
+            onStartRenderImage={onStartRenderImage}
+          />
+        )}
+      </ShouldCallOnRenderImage>
+    );
+  },
+};
+
+export const RGB8 = {
+  render: (): JSX.Element => <RGBStory encoding="rgb8" />,
+};
+
+export const BGR8 = { render: (): JSX.Element => <RGBStory encoding="bgr8" /> };
+export const Mono16BigEndian = { render: (): JSX.Element => <Mono16Story bigEndian={true} /> };
+export const Mono16LittleEndian = { render: (): JSX.Element => <Mono16Story bigEndian={false} /> };
 
 const mono16Args = { minValue: 5000, maxValue: 20000 };
 
@@ -463,8 +474,7 @@ export const Mono16CustomMinMax = {
 
   args: mono16Args,
 };
-
-export const BayerRGGB8 = (): JSX.Element => <BayerStory encoding="bayer_rggb8" />;
-export const BayerBGGR8 = (): JSX.Element => <BayerStory encoding="bayer_bggr8" />;
-export const BayerGBRG8 = (): JSX.Element => <BayerStory encoding="bayer_gbrg8" />;
-export const BayerGRBG8 = (): JSX.Element => <BayerStory encoding="bayer_grbg8" />;
+export const BayerRGGB8 = { render: (): JSX.Element => <BayerStory encoding="bayer_rggb8" /> };
+export const BayerBGGR8 = { render: (): JSX.Element => <BayerStory encoding="bayer_bggr8" /> };
+export const BayerGBRG8 = { render: (): JSX.Element => <BayerStory encoding="bayer_gbrg8" /> };
+export const BayerGRBG8 = { render: (): JSX.Element => <BayerStory encoding="bayer_grbg8" /> };

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
@@ -322,8 +322,8 @@ export const MarkersImageSize: StoryObj = {
   },
 };
 
-export const MarkersWithFallbackRenderingUsingMainThread = {
-  render: function Story(): JSX.Element {
+export const MarkersWithFallbackRenderingUsingMainThread: StoryObj = {
+  render: function Story() {
     const image = useCompressedImage();
 
     return (
@@ -379,8 +379,8 @@ export const MarkersWithFallbackRenderingUsingMainThread = {
   },
 };
 
-export const ErrorState = {
-  render: (): JSX.Element => {
+export const ErrorState: StoryObj = {
+  render: () => {
     return (
       <ImageCanvas
         topic={topics[0]}
@@ -404,8 +404,8 @@ export const ErrorState = {
   },
 };
 
-export const CallsOnRenderFrameWhenRenderingSucceeds = {
-  render: function Story(): JSX.Element {
+export const CallsOnRenderFrameWhenRenderingSucceeds: StoryObj = {
+  render: function Story() {
     const image = useCompressedImage();
 
     return (
@@ -430,8 +430,8 @@ export const CallsOnRenderFrameWhenRenderingSucceeds = {
   },
 };
 
-export const CallsOnRenderFrameWhenRenderingFails = {
-  render: (): JSX.Element => {
+export const CallsOnRenderFrameWhenRenderingFails: StoryObj = {
+  render: () => {
     return (
       <ShouldCallOnRenderImage>
         {(onStartRenderImage) => (
@@ -459,22 +459,34 @@ export const CallsOnRenderFrameWhenRenderingFails = {
   },
 };
 
-export const RGB8 = {
-  render: (): JSX.Element => <RGBStory encoding="rgb8" />,
+export const RGB8: StoryObj = {
+  render: () => <RGBStory encoding="rgb8" />,
 };
 
-export const BGR8 = { render: (): JSX.Element => <RGBStory encoding="bgr8" /> };
-export const Mono16BigEndian = { render: (): JSX.Element => <Mono16Story bigEndian={true} /> };
-export const Mono16LittleEndian = { render: (): JSX.Element => <Mono16Story bigEndian={false} /> };
+export const BGR8: StoryObj = { render: () => <RGBStory encoding="bgr8" /> };
+export const Mono16BigEndian: StoryObj = {
+  render: () => <Mono16Story bigEndian={true} />,
+};
+export const Mono16LittleEndian: StoryObj = {
+  render: () => <Mono16Story bigEndian={false} />,
+};
 
 const mono16Args = { minValue: 5000, maxValue: 20000 };
 
-export const Mono16CustomMinMax = {
-  render: (args: typeof mono16Args): JSX.Element => <Mono16Story bigEndian {...args} />,
+export const Mono16CustomMinMax: StoryObj<typeof mono16Args> = {
+  render: (args: typeof mono16Args) => <Mono16Story bigEndian {...args} />,
 
   args: mono16Args,
 };
-export const BayerRGGB8 = { render: (): JSX.Element => <BayerStory encoding="bayer_rggb8" /> };
-export const BayerBGGR8 = { render: (): JSX.Element => <BayerStory encoding="bayer_bggr8" /> };
-export const BayerGBRG8 = { render: (): JSX.Element => <BayerStory encoding="bayer_gbrg8" /> };
-export const BayerGRBG8 = { render: (): JSX.Element => <BayerStory encoding="bayer_grbg8" /> };
+export const BayerRGGB8: StoryObj = {
+  render: () => <BayerStory encoding="bayer_rggb8" />,
+};
+export const BayerBGGR8: StoryObj = {
+  render: () => <BayerStory encoding="bayer_bggr8" />,
+};
+export const BayerGBRG8: StoryObj = {
+  render: () => <BayerStory encoding="bayer_gbrg8" />,
+};
+export const BayerGRBG8: StoryObj = {
+  render: () => <BayerStory encoding="bayer_grbg8" />,
+};

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { noop } from "lodash";
 
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -223,92 +223,103 @@ export default {
   },
 };
 
-export const MarkersOriginal: Story = (_args) => {
-  const image = useCompressedImage();
-  const readySignal = useReadySignal();
+export const MarkersOriginal: StoryObj = {
+  render: (_args) => {
+    const image = useCompressedImage();
+    const readySignal = useReadySignal();
 
-  return (
-    <div style={{ height: "400px" }}>
-      <ImageCanvas
-        topic={topics[1]}
-        image={image}
-        rawMarkerData={{
-          markers: annotations,
-          cameraInfo: undefined,
-          transformMarkers: false,
-        }}
-        config={config}
-        saveConfig={noop}
-        setActivePixelData={noop}
-        onStartRenderImage={() => readySignal}
-      />
-    </div>
-  );
-};
-MarkersOriginal.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-MarkersOriginal.parameters = {
-  useReadySignal: true,
-};
+    return (
+      <div style={{ height: "400px" }}>
+        <ImageCanvas
+          topic={topics[1]}
+          image={image}
+          rawMarkerData={{
+            markers: annotations,
+            cameraInfo: undefined,
+            transformMarkers: false,
+          }}
+          config={config}
+          saveConfig={noop}
+          setActivePixelData={noop}
+          onStartRenderImage={() => readySignal}
+        />
+      </div>
+    );
+  },
 
-export const MarkersTransformed: Story = (_args) => {
-  const image = useCompressedImage();
-  const readySignal = useReadySignal();
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 
-  return (
-    <div style={{ height: "400px" }}>
-      <ImageCanvas
-        topic={topics[1]}
-        image={image}
-        rawMarkerData={{
-          markers: annotations,
-          cameraInfo,
-          transformMarkers: true,
-        }}
-        config={config}
-        saveConfig={noop}
-        setActivePixelData={noop}
-        onStartRenderImage={() => readySignal}
-      />
-    </div>
-  );
-};
-MarkersTransformed.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-MarkersTransformed.parameters = {
-  useReadySignal: true,
+  parameters: {
+    useReadySignal: true,
+  },
 };
 
-// markers with different original image size
-export const MarkersImageSize: Story = (_args) => {
-  const image = useCompressedImage();
-  const readySignal = useReadySignal();
+export const MarkersTransformed: StoryObj = {
+  render: (_args) => {
+    const image = useCompressedImage();
+    const readySignal = useReadySignal();
 
-  return (
-    <div style={{ height: "400px" }}>
-      <ImageCanvas
-        topic={topics[1]}
-        image={image}
-        rawMarkerData={{
-          markers: annotations,
-          cameraInfo: { ...cameraInfo, width: 200, height: 150 },
-          transformMarkers: true,
-        }}
-        config={config}
-        saveConfig={noop}
-        setActivePixelData={noop}
-        onStartRenderImage={() => readySignal}
-      />
-    </div>
-  );
+    return (
+      <div style={{ height: "400px" }}>
+        <ImageCanvas
+          topic={topics[1]}
+          image={image}
+          rawMarkerData={{
+            markers: annotations,
+            cameraInfo,
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          setActivePixelData={noop}
+          onStartRenderImage={() => readySignal}
+        />
+      </div>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
-MarkersImageSize.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-MarkersImageSize.parameters = {
-  useReadySignal: true,
+
+export const MarkersImageSize: StoryObj = {
+  render: (_args) => {
+    const image = useCompressedImage();
+    const readySignal = useReadySignal();
+
+    return (
+      <div style={{ height: "400px" }}>
+        <ImageCanvas
+          topic={topics[1]}
+          image={image}
+          rawMarkerData={{
+            markers: annotations,
+            cameraInfo: { ...cameraInfo, width: 200, height: 150 },
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          setActivePixelData={noop}
+          onStartRenderImage={() => readySignal}
+        />
+      </div>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
 
 export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => {
@@ -442,15 +453,16 @@ export const CallsOnRenderFrameWhenRenderingFails = (): JSX.Element => {
 
 export const RGB8 = (): JSX.Element => <RGBStory encoding="rgb8" />;
 export const BGR8 = (): JSX.Element => <RGBStory encoding="bgr8" />;
-
 export const Mono16BigEndian = (): JSX.Element => <Mono16Story bigEndian={true} />;
 export const Mono16LittleEndian = (): JSX.Element => <Mono16Story bigEndian={false} />;
 
 const mono16Args = { minValue: 5000, maxValue: 20000 };
-export const Mono16CustomMinMax = (args: typeof mono16Args): JSX.Element => (
-  <Mono16Story bigEndian {...args} />
-);
-Mono16CustomMinMax.args = mono16Args;
+
+export const Mono16CustomMinMax = {
+  render: (args: typeof mono16Args): JSX.Element => <Mono16Story bigEndian {...args} />,
+
+  args: mono16Args,
+};
 
 export const BayerRGGB8 = (): JSX.Element => <BayerStory encoding="bayer_rggb8" />;
 export const BayerBGGR8 = (): JSX.Element => <BayerStory encoding="bayer_bggr8" />;

--- a/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import ZoomMenu from "./ZoomMenu";
 
@@ -11,22 +11,26 @@ export default {
   component: ZoomMenu,
 };
 
-export const Dark: Story = () => {
-  return (
-    <div style={{ height: 250, margin: 10, position: "relative" }}>
-      <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} resetPanZoom={() => {}} />
-    </div>
-  );
+export const Dark: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ height: 250, margin: 10, position: "relative" }}>
+        <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} resetPanZoom={() => {}} />
+      </div>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
 
-Dark.parameters = { colorScheme: "dark" };
+export const Light: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ height: 250, margin: 10, position: "relative" }}>
+        <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} resetPanZoom={() => {}} />
+      </div>
+    );
+  },
 
-export const Light: Story = () => {
-  return (
-    <div style={{ height: 250, margin: 10, position: "relative" }}>
-      <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} resetPanZoom={() => {}} />
-    </div>
-  );
+  parameters: { colorScheme: "light" },
 };
-
-Light.parameters = { colorScheme: "light" };

--- a/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import ZoomMenu from "./ZoomMenu";
 

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -46,15 +46,18 @@ export const NoTopic: StoryFn = (): React.ReactElement => {
   );
 };
 
-export const WithSettings: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup includeSettings>
-      <ImageView />
-    </PanelSetup>
-  );
-};
-WithSettings.parameters = {
-  colorScheme: "light",
+export const WithSettings: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <PanelSetup includeSettings>
+        <ImageView />
+      </PanelSetup>
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
 };
 
 export const TopicButNoDataSource: StoryFn = (): React.ReactElement => {
@@ -65,15 +68,19 @@ export const TopicButNoDataSource: StoryFn = (): React.ReactElement => {
   );
 };
 
-export const TopicButNoDataSourceHovered: StoryFn = (): React.ReactElement => {
-  const onMount = useHoverOnPanel();
-  return (
-    <PanelSetup onMount={onMount}>
-      <ImageView overrideConfig={{ ...ImageView.defaultConfig, cameraTopic: "a_topic" }} />
-    </PanelSetup>
-  );
+export const TopicButNoDataSourceHovered: StoryObj = {
+  render: function Story(): JSX.Element {
+    const onMount = useHoverOnPanel();
+    return (
+      <PanelSetup onMount={onMount}>
+        <ImageView overrideConfig={{ ...ImageView.defaultConfig, cameraTopic: "a_topic" }} />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-TopicButNoDataSourceHovered.parameters = { colorScheme: "dark" };
+
 export const TopicButNoDataSourceHoveredLight = Object.assign(
   TopicButNoDataSourceHovered.bind(undefined),
   { parameters: { colorScheme: "light" } },

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -49,7 +49,7 @@ export const NoTopic: StoryObj = {
 };
 
 export const WithSettings: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <PanelSetup includeSettings>
         <ImageView />
@@ -73,7 +73,7 @@ export const TopicButNoDataSource: StoryObj = {
 };
 
 export const TopicButNoDataSourceHovered: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const onMount = useHoverOnPanel();
     return (
       <PanelSetup onMount={onMount}>
@@ -85,7 +85,7 @@ export const TopicButNoDataSourceHovered: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const TopicButNoDataSourceHoveredLight = {
+export const TopicButNoDataSourceHoveredLight: StoryObj = {
   ...TopicButNoDataSourceHovered,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -37,41 +38,41 @@ function useHoverOnPanel(andThen?: () => void) {
   };
 }
 
-export function NoTopic(): React.ReactElement {
+export const NoTopic: StoryFn = (): React.ReactElement => {
   return (
     <PanelSetup>
       <ImageView />
     </PanelSetup>
   );
-}
+};
 
-export function WithSettings(): JSX.Element {
+export const WithSettings: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup includeSettings>
       <ImageView />
     </PanelSetup>
   );
-}
+};
 WithSettings.parameters = {
   colorScheme: "light",
 };
 
-export function TopicButNoDataSource(): React.ReactElement {
+export const TopicButNoDataSource: StoryFn = (): React.ReactElement => {
   return (
     <PanelSetup>
       <ImageView overrideConfig={{ ...ImageView.defaultConfig, cameraTopic: "a_topic" }} />
     </PanelSetup>
   );
-}
+};
 
-export function TopicButNoDataSourceHovered(): React.ReactElement {
+export const TopicButNoDataSourceHovered: StoryFn = (): React.ReactElement => {
   const onMount = useHoverOnPanel();
   return (
     <PanelSetup onMount={onMount}>
       <ImageView overrideConfig={{ ...ImageView.defaultConfig, cameraTopic: "a_topic" }} />
     </PanelSetup>
   );
-}
+};
 TopicButNoDataSourceHovered.parameters = { colorScheme: "dark" };
 export const TopicButNoDataSourceHoveredLight = Object.assign(
   TopicButNoDataSourceHovered.bind(undefined),

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -38,12 +38,14 @@ function useHoverOnPanel(andThen?: () => void) {
   };
 }
 
-export const NoTopic: StoryFn = (): React.ReactElement => {
-  return (
-    <PanelSetup>
-      <ImageView />
-    </PanelSetup>
-  );
+export const NoTopic: StoryObj = {
+  render: (): React.ReactElement => {
+    return (
+      <PanelSetup>
+        <ImageView />
+      </PanelSetup>
+    );
+  },
 };
 
 export const WithSettings: StoryObj = {
@@ -60,12 +62,14 @@ export const WithSettings: StoryObj = {
   },
 };
 
-export const TopicButNoDataSource: StoryFn = (): React.ReactElement => {
-  return (
-    <PanelSetup>
-      <ImageView overrideConfig={{ ...ImageView.defaultConfig, cameraTopic: "a_topic" }} />
-    </PanelSetup>
-  );
+export const TopicButNoDataSource: StoryObj = {
+  render: (): React.ReactElement => {
+    return (
+      <PanelSetup>
+        <ImageView overrideConfig={{ ...ImageView.defaultConfig, cameraTopic: "a_topic" }} />
+      </PanelSetup>
+    );
+  },
 };
 
 export const TopicButNoDataSourceHovered: StoryObj = {

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -81,7 +81,7 @@ export const TopicButNoDataSourceHovered: StoryObj = {
   parameters: { colorScheme: "dark" },
 };
 
-export const TopicButNoDataSourceHoveredLight = Object.assign(
-  TopicButNoDataSourceHovered.bind(undefined),
-  { parameters: { colorScheme: "light" } },
-);
+export const TopicButNoDataSourceHoveredLight = {
+  ...TopicButNoDataSourceHovered,
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -130,7 +130,7 @@ export const MarkersWithRotations: StoryObj = {
   },
 };
 
-export function FoxgloveAnnotations(): JSX.Element {
+export const FoxgloveAnnotations: StoryFn = (): JSX.Element => {
   const imageMessage = useCompressedImage();
   const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
 
@@ -170,4 +170,4 @@ export function FoxgloveAnnotations(): JSX.Element {
       <canvas ref={canvasRef} style={{ width, height }} />
     </div>
   );
-}
+};

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { normalizeAnnotations } from "./normalizeAnnotations";
@@ -19,81 +19,28 @@ export default {
   },
 };
 
-export const MarkersWithHitmap: Story = (_args) => {
-  const imageMessage = useCompressedImage();
-  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
-  const hitmapRef = useRef<HTMLCanvasElement>(ReactNull);
+export const MarkersWithHitmap: StoryObj = {
+  render: (_args) => {
+    const imageMessage = useCompressedImage();
+    const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+    const hitmapRef = useRef<HTMLCanvasElement>(ReactNull);
 
-  const width = 400;
-  const height = 300;
+    const width = 400;
+    const height = 300;
 
-  useEffect(() => {
-    if (!canvasRef.current || !hitmapRef.current) {
-      return;
-    }
-
-    canvasRef.current.width = 2 * width;
-    canvasRef.current.height = 2 * height;
-    hitmapRef.current.width = 2 * width;
-    hitmapRef.current.height = 2 * height;
-
-    void renderImage({
-      canvas: canvasRef.current,
-      hitmapCanvas: hitmapRef.current,
-      geometry: {
-        flipHorizontal: false,
-        flipVertical: false,
-        panZoom: { x: 0, y: 0, scale: 1 },
-        rotation: 0,
-        viewport: { width, height },
-        zoomMode: "fill",
-      },
-      imageMessage,
-      rawMarkerData: {
-        markers: annotations,
-        cameraInfo,
-        transformMarkers: true,
-      },
-    });
-  }, [imageMessage]);
-
-  return (
-    <div style={{ backgroundColor: "white", padding: "1rem" }}>
-      <canvas ref={canvasRef} style={{ width, height }} />
-      <canvas ref={hitmapRef} style={{ width, height }} />
-    </div>
-  );
-};
-
-export const MarkersWithRotations: Story = (_args) => {
-  const width = 300;
-  const height = 200;
-  const imageMessage = useCompressedImage();
-  const canvasRefs = useRef<Array<HTMLCanvasElement | ReactNull>>([]);
-  const geometries = useMemo(
-    () => [
-      { rotation: 0 },
-      { rotation: 90 },
-      { rotation: 180 },
-      { rotation: 270 },
-      { flipHorizontal: true },
-      { flipVertical: true },
-    ],
-    [],
-  );
-
-  useEffect(() => {
-    canvasRefs.current.forEach((canvas, i) => {
-      if (!canvas) {
+    useEffect(() => {
+      if (!canvasRef.current || !hitmapRef.current) {
         return;
       }
 
-      canvas.width = 2 * width;
-      canvas.height = 2 * height;
+      canvasRef.current.width = 2 * width;
+      canvasRef.current.height = 2 * height;
+      hitmapRef.current.width = 2 * width;
+      hitmapRef.current.height = 2 * height;
 
       void renderImage({
-        canvas,
-        hitmapCanvas: undefined,
+        canvas: canvasRef.current,
+        hitmapCanvas: hitmapRef.current,
         geometry: {
           flipHorizontal: false,
           flipVertical: false,
@@ -101,7 +48,6 @@ export const MarkersWithRotations: Story = (_args) => {
           rotation: 0,
           viewport: { width, height },
           zoomMode: "fill",
-          ...geometries[i],
         },
         imageMessage,
         rawMarkerData: {
@@ -110,20 +56,78 @@ export const MarkersWithRotations: Story = (_args) => {
           transformMarkers: true,
         },
       });
-    });
-  }, [geometries, imageMessage]);
+    }, [imageMessage]);
 
-  return (
-    <div>
-      {geometries.map((r, i) => (
-        <canvas
-          key={JSON.stringify(r)}
-          ref={(ref) => (canvasRefs.current[i] = ref)}
-          style={{ width, height }}
-        />
-      ))}
-    </div>
-  );
+    return (
+      <div style={{ backgroundColor: "white", padding: "1rem" }}>
+        <canvas ref={canvasRef} style={{ width, height }} />
+        <canvas ref={hitmapRef} style={{ width, height }} />
+      </div>
+    );
+  },
+};
+
+export const MarkersWithRotations: StoryObj = {
+  render: (_args) => {
+    const width = 300;
+    const height = 200;
+    const imageMessage = useCompressedImage();
+    const canvasRefs = useRef<Array<HTMLCanvasElement | ReactNull>>([]);
+    const geometries = useMemo(
+      () => [
+        { rotation: 0 },
+        { rotation: 90 },
+        { rotation: 180 },
+        { rotation: 270 },
+        { flipHorizontal: true },
+        { flipVertical: true },
+      ],
+      [],
+    );
+
+    useEffect(() => {
+      canvasRefs.current.forEach((canvas, i) => {
+        if (!canvas) {
+          return;
+        }
+
+        canvas.width = 2 * width;
+        canvas.height = 2 * height;
+
+        void renderImage({
+          canvas,
+          hitmapCanvas: undefined,
+          geometry: {
+            flipHorizontal: false,
+            flipVertical: false,
+            panZoom: { x: 0, y: 0, scale: 1 },
+            rotation: 0,
+            viewport: { width, height },
+            zoomMode: "fill",
+            ...geometries[i],
+          },
+          imageMessage,
+          rawMarkerData: {
+            markers: annotations,
+            cameraInfo,
+            transformMarkers: true,
+          },
+        });
+      });
+    }, [geometries, imageMessage]);
+
+    return (
+      <div>
+        {geometries.map((r, i) => (
+          <canvas
+            key={JSON.stringify(r)}
+            ref={(ref) => (canvasRefs.current[i] = ref)}
+            style={{ width, height }}
+          />
+        ))}
+      </div>
+    );
+  },
 };
 
 export function FoxgloveAnnotations(): JSX.Element {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { normalizeAnnotations } from "./normalizeAnnotations";
@@ -20,7 +20,7 @@ export default {
 };
 
 export const MarkersWithHitmap: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const imageMessage = useCompressedImage();
     const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
     const hitmapRef = useRef<HTMLCanvasElement>(ReactNull);
@@ -68,7 +68,7 @@ export const MarkersWithHitmap: StoryObj = {
 };
 
 export const MarkersWithRotations: StoryObj = {
-  render: (_args) => {
+  render: function Story() {
     const width = 300;
     const height = 200;
     const imageMessage = useCompressedImage();
@@ -130,44 +130,46 @@ export const MarkersWithRotations: StoryObj = {
   },
 };
 
-export const FoxgloveAnnotations: StoryFn = (): JSX.Element => {
-  const imageMessage = useCompressedImage();
-  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+export const FoxgloveAnnotations: StoryObj = {
+  render: function Story() {
+    const imageMessage = useCompressedImage();
+    const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
 
-  const width = 400;
-  const height = 300;
+    const width = 400;
+    const height = 300;
 
-  useEffect(() => {
-    if (!canvasRef.current) {
-      return;
-    }
+    useEffect(() => {
+      if (!canvasRef.current) {
+        return;
+      }
 
-    canvasRef.current.width = 2 * width;
-    canvasRef.current.height = 2 * height;
+      canvasRef.current.width = 2 * width;
+      canvasRef.current.height = 2 * height;
 
-    void renderImage({
-      canvas: canvasRef.current,
-      hitmapCanvas: undefined,
-      geometry: {
-        flipHorizontal: false,
-        flipVertical: false,
-        panZoom: { x: 0, y: 0, scale: 1 },
-        rotation: 0,
-        viewport: { width, height },
-        zoomMode: "fill",
-      },
-      imageMessage,
-      rawMarkerData: {
-        markers: normalizeAnnotations(foxgloveAnnotations, "foxglove.ImageAnnotations")!,
-        cameraInfo,
-        transformMarkers: false,
-      },
-    });
-  }, [imageMessage]);
+      void renderImage({
+        canvas: canvasRef.current,
+        hitmapCanvas: undefined,
+        geometry: {
+          flipHorizontal: false,
+          flipVertical: false,
+          panZoom: { x: 0, y: 0, scale: 1 },
+          rotation: 0,
+          viewport: { width, height },
+          zoomMode: "fill",
+        },
+        imageMessage,
+        rawMarkerData: {
+          markers: normalizeAnnotations(foxgloveAnnotations, "foxglove.ImageAnnotations")!,
+          cameraInfo,
+          transformMarkers: false,
+        },
+      });
+    }, [imageMessage]);
 
-  return (
-    <div style={{ backgroundColor: "white", padding: "1rem" }}>
-      <canvas ref={canvasRef} style={{ width, height }} />
-    </div>
-  );
+    return (
+      <div style={{ backgroundColor: "white", padding: "1rem" }}>
+        <canvas ref={canvasRef} style={{ width, height }} />
+      </div>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/Indicator/index.stories.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext, StoryObj } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -37,14 +37,14 @@ function makeFixture(value: boolean | number | bigint | string) {
   };
 }
 
-export const EmptyState = {
-  render: (): JSX.Element => {
+export const EmptyState: StoryObj = {
+  render: () => {
     return <Indicator />;
   },
 };
 
-export const MissingValue = {
-  render: (): JSX.Element => {
+export const MissingValue: StoryObj = {
+  render: () => {
     return (
       <Indicator
         overrideConfig={{
@@ -62,8 +62,8 @@ export const MissingValue = {
   },
 };
 
-export const BackgroundStyle = {
-  render: (): JSX.Element => {
+export const BackgroundStyle: StoryObj = {
+  render: () => {
     return (
       <Indicator
         overrideConfig={{
@@ -98,18 +98,18 @@ const BooleanStory = (): JSX.Element => {
   );
 };
 
-export const BooleanTrue = {
-  render: (): JSX.Element => <BooleanStory />,
+export const BooleanTrue: StoryObj = {
+  render: () => <BooleanStory />,
   parameters: { panelSetup: { fixture: makeFixture(true) } },
 };
 
-export const BooleanFalse = {
-  render: (): JSX.Element => <BooleanStory />,
+export const BooleanFalse: StoryObj = {
+  render: () => <BooleanStory />,
   parameters: { panelSetup: { fixture: makeFixture(false) } },
 };
 
-export const String = {
-  render: function Story(): JSX.Element {
+export const String: StoryObj = {
+  render: function Story() {
     return (
       <Indicator
         overrideConfig={{
@@ -144,23 +144,23 @@ const NumberStory = (): JSX.Element => {
   );
 };
 
-export const NumberNegative = {
-  render: (): JSX.Element => <NumberStory />,
+export const NumberNegative: StoryObj = {
+  render: () => <NumberStory />,
   parameters: { panelSetup: { fixture: makeFixture(-1) } },
 };
 
-export const NumberZero = {
-  render: (): JSX.Element => <NumberStory />,
+export const NumberZero: StoryObj = {
+  render: () => <NumberStory />,
   parameters: { panelSetup: { fixture: makeFixture(0) } },
 };
 
-export const NumberPositive = {
-  render: (): JSX.Element => <NumberStory />,
+export const NumberPositive: StoryObj = {
+  render: () => <NumberStory />,
   parameters: { panelSetup: { fixture: makeFixture(1) } },
 };
 
-export const MessagePathWithFilter = {
-  render: function Story(): JSX.Element {
+export const MessagePathWithFilter: StoryObj = {
+  render: function Story() {
     return (
       <Indicator
         overrideConfig={{

--- a/packages/studio-base/src/panels/Indicator/index.stories.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.stories.tsx
@@ -103,7 +103,7 @@ export const BooleanFalse = {
 };
 
 export const String = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <Indicator
         overrideConfig={{
@@ -154,7 +154,7 @@ export const NumberPositive = {
 };
 
 export const MessagePathWithFilter = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <Indicator
         overrideConfig={{

--- a/packages/studio-base/src/panels/Indicator/index.stories.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.stories.tsx
@@ -37,42 +37,48 @@ function makeFixture(value: boolean | number | bigint | string) {
   };
 }
 
-export const EmptyState = (): JSX.Element => {
-  return <Indicator />;
+export const EmptyState = {
+  render: (): JSX.Element => {
+    return <Indicator />;
+  },
 };
 
-export const MissingValue = (): JSX.Element => {
-  return (
-    <Indicator
-      overrideConfig={{
-        path: "/data.value",
-        style: "bulb",
-        rules: [
-          { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
-          { operator: "=", rawValue: "true", color: "#dd00dd", label: "False" },
-        ],
-        fallbackColor: "#dddd00",
-        fallbackLabel: "Fallback",
-      }}
-    />
-  );
+export const MissingValue = {
+  render: (): JSX.Element => {
+    return (
+      <Indicator
+        overrideConfig={{
+          path: "/data.value",
+          style: "bulb",
+          rules: [
+            { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
+            { operator: "=", rawValue: "true", color: "#dd00dd", label: "False" },
+          ],
+          fallbackColor: "#dddd00",
+          fallbackLabel: "Fallback",
+        }}
+      />
+    );
+  },
 };
 
-export const BackgroundStyle = (): JSX.Element => {
-  return (
-    <Indicator
-      overrideConfig={{
-        path: "/data.value",
-        style: "background",
-        rules: [
-          { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
-          { operator: "=", rawValue: "true", color: "#dd00dd", label: "False" },
-        ],
-        fallbackColor: "#dddd00",
-        fallbackLabel: "Fallback",
-      }}
-    />
-  );
+export const BackgroundStyle = {
+  render: (): JSX.Element => {
+    return (
+      <Indicator
+        overrideConfig={{
+          path: "/data.value",
+          style: "background",
+          rules: [
+            { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
+            { operator: "=", rawValue: "true", color: "#dd00dd", label: "False" },
+          ],
+          fallbackColor: "#dddd00",
+          fallbackLabel: "Fallback",
+        }}
+      />
+    );
+  },
 };
 
 const BooleanStory = (): JSX.Element => {

--- a/packages/studio-base/src/panels/Indicator/index.stories.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -12,7 +12,7 @@ export default {
   title: "panels/IndicatorLight",
   component: Indicator,
   decorators: [
-    (StoryComponent: Story, { parameters }: StoryContext): JSX.Element => {
+    (StoryComponent: StoryFn, { parameters }: StoryContext): JSX.Element => {
       return (
         <PanelSetup fixture={parameters.panelSetup?.fixture}>
           <StoryComponent />
@@ -91,25 +91,34 @@ const BooleanStory = (): JSX.Element => {
     />
   );
 };
-export const BooleanTrue = (): JSX.Element => <BooleanStory />;
-BooleanTrue.parameters = { panelSetup: { fixture: makeFixture(true) } };
-export const BooleanFalse = (): JSX.Element => <BooleanStory />;
-BooleanFalse.parameters = { panelSetup: { fixture: makeFixture(false) } };
 
-export const String = (): JSX.Element => {
-  return (
-    <Indicator
-      overrideConfig={{
-        path: "/data.value",
-        style: "bulb",
-        rules: [{ operator: "=", rawValue: "hello", color: "#00dd00", label: "Hello" }],
-        fallbackColor: "#dddd00",
-        fallbackLabel: "Fallback",
-      }}
-    />
-  );
+export const BooleanTrue = {
+  render: (): JSX.Element => <BooleanStory />,
+  parameters: { panelSetup: { fixture: makeFixture(true) } },
 };
-String.parameters = { panelSetup: { fixture: makeFixture("hello") } };
+
+export const BooleanFalse = {
+  render: (): JSX.Element => <BooleanStory />,
+  parameters: { panelSetup: { fixture: makeFixture(false) } },
+};
+
+export const String = {
+  render: (): JSX.Element => {
+    return (
+      <Indicator
+        overrideConfig={{
+          path: "/data.value",
+          style: "bulb",
+          rules: [{ operator: "=", rawValue: "hello", color: "#00dd00", label: "Hello" }],
+          fallbackColor: "#dddd00",
+          fallbackLabel: "Fallback",
+        }}
+      />
+    );
+  },
+
+  parameters: { panelSetup: { fixture: makeFixture("hello") } },
+};
 
 const NumberStory = (): JSX.Element => {
   return (
@@ -128,51 +137,63 @@ const NumberStory = (): JSX.Element => {
     />
   );
 };
-export const NumberNegative = (): JSX.Element => <NumberStory />;
-NumberNegative.parameters = { panelSetup: { fixture: makeFixture(-1) } };
-export const NumberZero = (): JSX.Element => <NumberStory />;
-NumberZero.parameters = { panelSetup: { fixture: makeFixture(0) } };
-export const NumberPositive = (): JSX.Element => <NumberStory />;
-NumberPositive.parameters = { panelSetup: { fixture: makeFixture(1) } };
 
-export const MessagePathWithFilter = (): JSX.Element => {
-  return (
-    <Indicator
-      overrideConfig={{
-        path: `/data{id=="b"}.value`,
-        style: "bulb",
-        rules: [
-          { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
-          { operator: "=", rawValue: "false", color: "#dd00dd", label: "False" },
-        ],
-        fallbackColor: "#dddd00",
-        fallbackLabel: "Fallback",
-      }}
-    />
-  );
+export const NumberNegative = {
+  render: (): JSX.Element => <NumberStory />,
+  parameters: { panelSetup: { fixture: makeFixture(-1) } },
 };
-MessagePathWithFilter.parameters = {
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
-      frame: {
-        "/data": [
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { id: "a", value: false },
-          },
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { id: "b", value: true },
-          },
-          {
-            topic: "/data",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: { id: "c", value: false },
-          },
-        ],
+
+export const NumberZero = {
+  render: (): JSX.Element => <NumberStory />,
+  parameters: { panelSetup: { fixture: makeFixture(0) } },
+};
+
+export const NumberPositive = {
+  render: (): JSX.Element => <NumberStory />,
+  parameters: { panelSetup: { fixture: makeFixture(1) } },
+};
+
+export const MessagePathWithFilter = {
+  render: (): JSX.Element => {
+    return (
+      <Indicator
+        overrideConfig={{
+          path: `/data{id=="b"}.value`,
+          style: "bulb",
+          rules: [
+            { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
+            { operator: "=", rawValue: "false", color: "#dd00dd", label: "False" },
+          ],
+          fallbackColor: "#dddd00",
+          fallbackLabel: "Fallback",
+        }}
+      />
+    );
+  },
+
+  parameters: {
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+        frame: {
+          "/data": [
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { id: "a", value: false },
+            },
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { id: "b", value: true },
+            },
+            {
+              topic: "/data",
+              receiveTime: { sec: 123, nsec: 456 },
+              message: { id: "c", value: false },
+            },
+          ],
+        },
       },
     },
   },

--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryFn, StoryObj } from "@storybook/react";
 import { useCallback, useRef, useEffect } from "react";
 
 import PanelSetup, { Fixture, triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
@@ -134,61 +134,73 @@ export default {
   },
 };
 
-export const Basic: Story = () => {
-  const readySignal = useReadySignal();
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot
-        overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onFinishRender={readySignal}
-      />
-    </PanelSetup>
-  );
-};
-Basic.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-Basic.parameters = { useReadySignal: true };
+export const Basic: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal();
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot
+          overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
+          onFinishRender={readySignal}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const CustomMinMaxWindow: Story = () => {
-  const readySignal = useReadySignal();
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot
-        overrideConfig={{
-          path: { value: "/plot_a.versions[0]" },
-          minXVal: "0.5",
-          maxXVal: "6.5",
-          minYVal: "0.5",
-          maxYVal: "4.5",
-        }}
-        onFinishRender={readySignal}
-      />
-    </PanelSetup>
-  );
-};
-CustomMinMaxWindow.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-CustomMinMaxWindow.parameters = { useReadySignal: true };
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 
-export const CustomMinMaxVal: Story = () => {
-  const readySignal = useReadySignal();
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot
-        overrideConfig={{ path: { value: "/plot_a.versions[0]" }, maxYVal: "10" }}
-        onFinishRender={readySignal}
-      />
-    </PanelSetup>
-  );
+  parameters: { useReadySignal: true },
 };
-CustomMinMaxVal.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-CustomMinMaxVal.parameters = { useReadySignal: true };
 
-export const EmptyTopic: Story = () => {
+export const CustomMinMaxWindow: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal();
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot
+          overrideConfig={{
+            path: { value: "/plot_a.versions[0]" },
+            minXVal: "0.5",
+            maxXVal: "6.5",
+            minYVal: "0.5",
+            maxYVal: "4.5",
+          }}
+          onFinishRender={readySignal}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
+};
+
+export const CustomMinMaxVal: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal();
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot
+          overrideConfig={{ path: { value: "/plot_a.versions[0]" }, maxYVal: "10" }}
+          onFinishRender={readySignal}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
+};
+
+export const EmptyTopic: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <TwoDimensionalPlot overrideConfig={{ path: { value: "/plot_b" } }} />
@@ -196,50 +208,54 @@ export const EmptyTopic: Story = () => {
   );
 };
 
-export const WithTooltip: Story = () => {
-  const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const readySignal = useReadySignal();
+export const WithTooltip: StoryObj = {
+  render: () => {
+    const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const readySignal = useReadySignal();
 
-  useEffect(() => {
-    return () => {
-      if (timeOutID.current != undefined) {
-        clearTimeout(timeOutID.current);
-      }
-    };
-  }, []);
+    useEffect(() => {
+      return () => {
+        if (timeOutID.current != undefined) {
+          clearTimeout(timeOutID.current);
+        }
+      };
+    }, []);
 
-  return (
-    <div
-      style={{ width: 300, height: 300 }}
-      ref={() => {
-        timeOutID.current = setTimeout(() => {
-          const [canvas] = document.getElementsByTagName("canvas");
-          const x = 105;
-          const y = 190;
-          canvas?.dispatchEvent(
-            new MouseEvent("mousemove", {
-              pageX: x,
-              pageY: y,
-              clientX: x,
-              clientY: y,
-            } as MouseEventInit),
-          );
-        }, 100);
-      }}
-    >
-      <PanelSetup fixture={fixture}>
-        <TwoDimensionalPlot
-          overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-          onFinishRender={readySignal}
-        />
-      </PanelSetup>
-    </div>
-  );
+    return (
+      <div
+        style={{ width: 300, height: 300 }}
+        ref={() => {
+          timeOutID.current = setTimeout(() => {
+            const [canvas] = document.getElementsByTagName("canvas");
+            const x = 105;
+            const y = 190;
+            canvas?.dispatchEvent(
+              new MouseEvent("mousemove", {
+                pageX: x,
+                pageY: y,
+                clientX: x,
+                clientY: y,
+              } as MouseEventInit),
+            );
+          }, 100);
+        }}
+      >
+        <PanelSetup fixture={fixture}>
+          <TwoDimensionalPlot
+            overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
+            onFinishRender={readySignal}
+          />
+        </PanelSetup>
+      </div>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "dark" },
 };
-WithTooltip.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-WithTooltip.parameters = { useReadySignal: true, colorScheme: "dark" };
 
 type StepFn = () => void;
 function useStepSequence(...steps: StepFn[]): () => void {
@@ -254,100 +270,118 @@ function useStepSequence(...steps: StepFn[]): () => void {
   }, []);
 }
 
-export const ShowResetAfterHorizontalZoom: Story = () => {
-  const readySignal = useReadySignal();
+export const ShowResetAfterHorizontalZoom: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal();
 
-  const step = useStepSequence(zoomOut, readySignal);
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot
-        overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onFinishRender={step}
-      />
-    </PanelSetup>
-  );
+    const step = useStepSequence(zoomOut, readySignal);
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot
+          overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
+          onFinishRender={step}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "dark" },
 };
-ShowResetAfterHorizontalZoom.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+
+export const ShowResetAfterVerticalZoom: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 2 });
+    const step = useStepSequence(
+      useCallback(() => {
+        zoomOut({ key: "v", code: "KeyV", keyCode: 86, ctrlKey: false, metaKey: false });
+      }, []),
+      readySignal,
+      readySignal,
+    );
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot
+          overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
+          onFinishRender={step}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "dark" },
 };
-ShowResetAfterHorizontalZoom.parameters = { useReadySignal: true, colorScheme: "dark" };
 
-export const ShowResetAfterVerticalZoom: Story = () => {
-  const readySignal = useReadySignal({ count: 2 });
-  const step = useStepSequence(
-    useCallback(() => {
-      zoomOut({ key: "v", code: "KeyV", keyCode: 86, ctrlKey: false, metaKey: false });
-    }, []),
-    readySignal,
-    readySignal,
-  );
+export const ShowResetZoom: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 2 });
+    const step = useStepSequence(
+      useCallback(() => {
+        zoomOut({ key: "b", code: "KeyB", keyCode: 66, ctrlKey: false, metaKey: false });
+      }, []),
+      readySignal,
+      readySignal,
+    );
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot
-        overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onFinishRender={step}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot
+          overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
+          onFinishRender={step}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "dark" },
 };
-ShowResetAfterVerticalZoom.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+
+export const ResetZoom: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal();
+
+    const elRef = useRef<HTMLDivElement | ReactNull>();
+
+    const step = useStepSequence(
+      zoomOut,
+      useCallback(() => {
+        elRef.current
+          ?.querySelector<HTMLButtonElement>("button[data-testid='reset-zoom']")
+          ?.click();
+      }, []),
+      readySignal,
+    );
+
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={(el) => {
+          elRef.current = el;
+        }}
+      >
+        <TwoDimensionalPlot
+          overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
+          onFinishRender={step}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "dark" },
 };
-ShowResetAfterVerticalZoom.parameters = { useReadySignal: true, colorScheme: "dark" };
-
-export const ShowResetZoom: Story = () => {
-  const readySignal = useReadySignal({ count: 2 });
-  const step = useStepSequence(
-    useCallback(() => {
-      zoomOut({ key: "b", code: "KeyB", keyCode: 66, ctrlKey: false, metaKey: false });
-    }, []),
-    readySignal,
-    readySignal,
-  );
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot
-        overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onFinishRender={step}
-      />
-    </PanelSetup>
-  );
-};
-ShowResetZoom.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-ShowResetZoom.parameters = { useReadySignal: true, colorScheme: "dark" };
-
-export const ResetZoom: Story = () => {
-  const readySignal = useReadySignal();
-
-  const elRef = useRef<HTMLDivElement | ReactNull>();
-
-  const step = useStepSequence(
-    zoomOut,
-    useCallback(() => {
-      elRef.current?.querySelector<HTMLButtonElement>("button[data-testid='reset-zoom']")?.click();
-    }, []),
-    readySignal,
-  );
-
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={(el) => {
-        elRef.current = el;
-      }}
-    >
-      <TwoDimensionalPlot
-        overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onFinishRender={step}
-      />
-    </PanelSetup>
-  );
-};
-ResetZoom.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-ResetZoom.parameters = { useReadySignal: true, colorScheme: "dark" };

--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn, StoryObj } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useCallback, useRef, useEffect } from "react";
 
 import PanelSetup, { Fixture, triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
@@ -135,7 +135,7 @@ export default {
 };
 
 export const Basic: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal();
     return (
       <PanelSetup fixture={fixture}>
@@ -155,7 +155,7 @@ export const Basic: StoryObj = {
 };
 
 export const CustomMinMaxWindow: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal();
     return (
       <PanelSetup fixture={fixture}>
@@ -181,7 +181,7 @@ export const CustomMinMaxWindow: StoryObj = {
 };
 
 export const CustomMinMaxVal: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal();
     return (
       <PanelSetup fixture={fixture}>
@@ -200,16 +200,18 @@ export const CustomMinMaxVal: StoryObj = {
   parameters: { useReadySignal: true },
 };
 
-export const EmptyTopic: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <TwoDimensionalPlot overrideConfig={{ path: { value: "/plot_b" } }} />
-    </PanelSetup>
-  );
+export const EmptyTopic: StoryObj = {
+  render: function Story() {
+    return (
+      <PanelSetup fixture={fixture}>
+        <TwoDimensionalPlot overrideConfig={{ path: { value: "/plot_b" } }} />
+      </PanelSetup>
+    );
+  },
 };
 
 export const WithTooltip: StoryObj = {
-  render: () => {
+  render: function Story() {
     const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
     const readySignal = useReadySignal();
 
@@ -271,7 +273,7 @@ function useStepSequence(...steps: StepFn[]): () => void {
 }
 
 export const ShowResetAfterHorizontalZoom: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal();
 
     const step = useStepSequence(zoomOut, readySignal);
@@ -293,7 +295,7 @@ export const ShowResetAfterHorizontalZoom: StoryObj = {
 };
 
 export const ShowResetAfterVerticalZoom: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 2 });
     const step = useStepSequence(
       useCallback(() => {
@@ -321,7 +323,7 @@ export const ShowResetAfterVerticalZoom: StoryObj = {
 };
 
 export const ShowResetZoom: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 2 });
     const step = useStepSequence(
       useCallback(() => {
@@ -349,7 +351,7 @@ export const ShowResetZoom: StoryObj = {
 };
 
 export const ResetZoom: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal();
 
     const elRef = useRef<HTMLDivElement | ReactNull>();

--- a/packages/studio-base/src/panels/Log/index.stories.tsx
+++ b/packages/studio-base/src/panels/Log/index.stories.tsx
@@ -134,28 +134,34 @@ export default {
   component: Log,
 };
 
-export const Simple = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Log />
-    </PanelSetup>
-  );
+export const Simple = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Log />
+      </PanelSetup>
+    );
+  },
 };
 
-export const Scrolled = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={makeLongFixture()}>
-      <Log />
-    </PanelSetup>
-  );
+export const Scrolled = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={makeLongFixture()}>
+        <Log />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithSettings = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture} includeSettings>
-      <Log />
-    </PanelSetup>
-  );
+export const WithSettings = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <Log />
+      </PanelSetup>
+    );
+  },
 };
 
 export const TopicToRender = {
@@ -255,86 +261,88 @@ export const AutoCompleteItems: StoryObj = {
   },
 };
 
-export const FoxgloveLog = (): JSX.Element => {
-  const foxgloveLogFixture: Fixture = {
-    topics: [{ name: "/log", schemaName: "foxglove.Log" }],
-    frame: {
-      "/log": [
-        {
-          topic: "/log",
-          receiveTime: { sec: 123, nsec: 456 },
-          message: {
-            file: "some_topic_utils/src/foo.cpp",
-            timestamp: 123000000000n,
-            level: 1,
-            line: 242,
-            message: "Couldn't find int 83757.",
+export const FoxgloveLog = {
+  render: (): JSX.Element => {
+    const foxgloveLogFixture: Fixture = {
+      topics: [{ name: "/log", schemaName: "foxglove.Log" }],
+      frame: {
+        "/log": [
+          {
+            topic: "/log",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: {
+              file: "some_topic_utils/src/foo.cpp",
+              timestamp: 123000000000n,
+              level: 1,
+              line: 242,
+              message: "Couldn't find int 83757.",
+            },
+            schemaName: "foxglove.Log",
+            sizeInBytes: 0,
           },
-          schemaName: "foxglove.Log",
-          sizeInBytes: 0,
-        },
-        {
-          topic: "/log",
-          receiveTime: { sec: 123, nsec: 456 },
-          message: {
-            file: "other_topic_utils/src/foo.cpp",
-            function: "vector<int> other_node::findInt",
-            timestamp: 123000000000n,
-            level: 2,
-            line: 242,
-            message: "Couldn't find int 2121.",
+          {
+            topic: "/log",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: {
+              file: "other_topic_utils/src/foo.cpp",
+              function: "vector<int> other_node::findInt",
+              timestamp: 123000000000n,
+              level: 2,
+              line: 242,
+              message: "Couldn't find int 2121.",
+            },
+            schemaName: "foxglove.Log",
+            sizeInBytes: 0,
           },
-          schemaName: "foxglove.Log",
-          sizeInBytes: 0,
-        },
-        {
-          topic: "/log",
-          receiveTime: { sec: 123, nsec: 456 },
-          message: {
-            file: "other_topic_utils/src/foo.cpp",
-            function: "vector<int> other_node::findInt",
-            timestamp: 123000000000n,
-            level: 3,
-            line: 242,
-            message: "Lorem ipsum blah blah. This message should\nshow up as multiple lines",
+          {
+            topic: "/log",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: {
+              file: "other_topic_utils/src/foo.cpp",
+              function: "vector<int> other_node::findInt",
+              timestamp: 123000000000n,
+              level: 3,
+              line: 242,
+              message: "Lorem ipsum blah blah. This message should\nshow up as multiple lines",
+            },
+            schemaName: "foxglove.Log",
+            sizeInBytes: 0,
           },
-          schemaName: "foxglove.Log",
-          sizeInBytes: 0,
-        },
-        {
-          topic: "/log",
-          receiveTime: { sec: 0, nsec: 0 },
-          message: {
-            timestamp: 1529678605521518001n,
-            level: 4,
-            message:
-              "26826:\nheader: \n  seq: 0\n  stamp: 1529678605.349576000\n  Adipisicing minim veniam sint occaecat anim laborum irure velit ut non do labore.\n",
-            file: "somefile.cpp",
-            line: 491,
+          {
+            topic: "/log",
+            receiveTime: { sec: 0, nsec: 0 },
+            message: {
+              timestamp: 1529678605521518001n,
+              level: 4,
+              message:
+                "26826:\nheader: \n  seq: 0\n  stamp: 1529678605.349576000\n  Adipisicing minim veniam sint occaecat anim laborum irure velit ut non do labore.\n",
+              file: "somefile.cpp",
+              line: 491,
+            },
+            schemaName: "foxglove.Log",
+            sizeInBytes: 0,
           },
-          schemaName: "foxglove.Log",
-          sizeInBytes: 0,
-        },
-        {
-          topic: "/log",
-          receiveTime: { sec: 0, nsec: 0 },
-          message: {
-            timestamp: 1529678605521518001n,
-            level: 5,
-            message: "fatal message",
-            file: "somefile.cpp",
-            line: 491,
+          {
+            topic: "/log",
+            receiveTime: { sec: 0, nsec: 0 },
+            message: {
+              timestamp: 1529678605521518001n,
+              level: 5,
+              message: "fatal message",
+              file: "somefile.cpp",
+              line: 491,
+            },
+            schemaName: "foxglove.Log",
+            sizeInBytes: 0,
           },
-          schemaName: "foxglove.Log",
-          sizeInBytes: 0,
-        },
-      ],
-    },
-  };
+        ],
+      },
+    };
 
-  return (
-    <PanelSetup fixture={foxgloveLogFixture}>
-      <Log />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={foxgloveLogFixture}>
+        <Log />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/Log/index.stories.tsx
+++ b/packages/studio-base/src/panels/Log/index.stories.tsx
@@ -134,8 +134,8 @@ export default {
   component: Log,
 };
 
-export const Simple = {
-  render: (): JSX.Element => {
+export const Simple: StoryObj = {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <Log />
@@ -144,8 +144,8 @@ export const Simple = {
   },
 };
 
-export const Scrolled = {
-  render: (): JSX.Element => {
+export const Scrolled: StoryObj = {
+  render: () => {
     return (
       <PanelSetup fixture={makeLongFixture()}>
         <Log />
@@ -154,8 +154,8 @@ export const Scrolled = {
   },
 };
 
-export const WithSettings = {
-  render: (): JSX.Element => {
+export const WithSettings: StoryObj = {
+  render: () => {
     return (
       <PanelSetup fixture={fixture} includeSettings>
         <Log />
@@ -164,8 +164,8 @@ export const WithSettings = {
   },
 };
 
-export const TopicToRender = {
-  render: function Story(): JSX.Element {
+export const TopicToRender: StoryObj = {
+  render: function Story() {
     function makeMessages(topic: any) {
       return fixture.frame!["/rosout"]!.map((msg: any) => ({
         ...msg,
@@ -204,8 +204,8 @@ export const TopicToRender = {
   parameters: { colorScheme: "dark" },
 };
 
-export const FilteredTerms = {
-  render: function Story(): JSX.Element {
+export const FilteredTerms: StoryObj = {
+  render: function Story() {
     return (
       <PanelSetup fixture={fixture}>
         <Log
@@ -219,11 +219,11 @@ export const FilteredTerms = {
     );
   },
 
-  title: `filtered terms: "multiple", "/some_topic"`,
+  name: `filtered terms: "multiple", "/some_topic"`,
 };
 
-export const CaseInsensitiveFilter = {
-  render: function Story(): JSX.Element {
+export const CaseInsensitiveFilter: StoryObj = {
+  render: function Story() {
     return (
       <PanelSetup fixture={fixture}>
         <Log
@@ -237,11 +237,11 @@ export const CaseInsensitiveFilter = {
     );
   },
 
-  title: `case insensitive message filtering: "could", "Ipsum"`,
+  name: `case insensitive message filtering: "could", "Ipsum"`,
 };
 
 export const AutoCompleteItems: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <PanelSetup fixture={fixture}>
         <Log
@@ -261,8 +261,8 @@ export const AutoCompleteItems: StoryObj = {
   },
 };
 
-export const FoxgloveLog = {
-  render: (): JSX.Element => {
+export const FoxgloveLog: StoryObj = {
+  render: () => {
     const foxgloveLogFixture: Fixture = {
       topics: [{ name: "/log", schemaName: "foxglove.Log" }],
       frame: {

--- a/packages/studio-base/src/panels/Log/index.stories.tsx
+++ b/packages/studio-base/src/panels/Log/index.stories.tsx
@@ -158,7 +158,7 @@ export const WithSettings = (): JSX.Element => {
 };
 
 export const TopicToRender = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     function makeMessages(topic: any) {
       return fixture.frame!["/rosout"]!.map((msg: any) => ({
         ...msg,
@@ -198,7 +198,7 @@ export const TopicToRender = {
 };
 
 export const FilteredTerms = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <PanelSetup fixture={fixture}>
         <Log
@@ -216,7 +216,7 @@ export const FilteredTerms = {
 };
 
 export const CaseInsensitiveFilter = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <PanelSetup fixture={fixture}>
         <Log
@@ -234,7 +234,7 @@ export const CaseInsensitiveFilter = {
 };
 
 export const AutoCompleteItems = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <PanelSetup fixture={fixture}>
         <Log

--- a/packages/studio-base/src/panels/Log/index.stories.tsx
+++ b/packages/studio-base/src/panels/Log/index.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { range } from "lodash";
 import TestUtils from "react-dom/test-utils";
@@ -233,7 +234,7 @@ export const CaseInsensitiveFilter = {
   title: `case insensitive message filtering: "could", "Ipsum"`,
 };
 
-export const AutoCompleteItems = {
+export const AutoCompleteItems: StoryObj = {
   render: function Story(): JSX.Element {
     return (
       <PanelSetup fixture={fixture}>

--- a/packages/studio-base/src/panels/Log/index.stories.tsx
+++ b/packages/studio-base/src/panels/Log/index.stories.tsx
@@ -157,91 +157,101 @@ export const WithSettings = (): JSX.Element => {
   );
 };
 
-export const TopicToRender = (): JSX.Element => {
-  function makeMessages(topic: any) {
-    return fixture.frame!["/rosout"]!.map((msg: any) => ({
-      ...msg,
-      topic,
-      message: { ...msg.message, name: `${topic}${msg.message.name}` },
-    }));
-  }
-  return (
-    <PanelSetup
-      fixture={{
-        topics: [
-          { name: "/rosout", schemaName: "rosgraph_msgs/Log" },
-          { name: "/foo/rosout", schemaName: "rosgraph_msgs/Log" },
-          { name: "/studio_source_2/rosout", schemaName: "rosgraph_msgs/Log" },
-        ],
-        frame: {
-          "/rosout": makeMessages("/rosout"),
-          "/foo/rosout": makeMessages("/foo/rosout"),
-          "/studio_source_2/rosout": makeMessages("/studio_source_2/rosout"),
-        },
-      }}
-      onMount={() => {
-        TestUtils.Simulate.mouseEnter(
-          document.querySelectorAll("[data-testid~=panel-mouseenter-container]")[0]!,
-        );
-        setTimeout(() => {
-          TestUtils.Simulate.click(document.querySelectorAll("[data-testid=topic-set]")[0]!);
-        }, 0);
-      }}
-    >
-      <Log overrideConfig={{ searchTerms: [], minLogLevel: 1, topicToRender: "/foo/rosout" }} />
-    </PanelSetup>
-  );
-};
-TopicToRender.parameters = { colorScheme: "dark" };
-
-export const FilteredTerms = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Log
-        overrideConfig={{
-          searchTerms: ["multiple", "/some_topic"],
-          minLogLevel: 1,
-          topicToRender: "/rosout",
+export const TopicToRender = {
+  render: (): JSX.Element => {
+    function makeMessages(topic: any) {
+      return fixture.frame!["/rosout"]!.map((msg: any) => ({
+        ...msg,
+        topic,
+        message: { ...msg.message, name: `${topic}${msg.message.name}` },
+      }));
+    }
+    return (
+      <PanelSetup
+        fixture={{
+          topics: [
+            { name: "/rosout", schemaName: "rosgraph_msgs/Log" },
+            { name: "/foo/rosout", schemaName: "rosgraph_msgs/Log" },
+            { name: "/studio_source_2/rosout", schemaName: "rosgraph_msgs/Log" },
+          ],
+          frame: {
+            "/rosout": makeMessages("/rosout"),
+            "/foo/rosout": makeMessages("/foo/rosout"),
+            "/studio_source_2/rosout": makeMessages("/studio_source_2/rosout"),
+          },
         }}
-      />
-    </PanelSetup>
-  );
-};
-
-FilteredTerms.title = `filtered terms: "multiple", "/some_topic"`;
-
-export const CaseInsensitiveFilter = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Log
-        overrideConfig={{
-          searchTerms: ["could", "Ipsum"],
-          minLogLevel: 1,
-          topicToRender: "/rosout",
+        onMount={() => {
+          TestUtils.Simulate.mouseEnter(
+            document.querySelectorAll("[data-testid~=panel-mouseenter-container]")[0]!,
+          );
+          setTimeout(() => {
+            TestUtils.Simulate.click(document.querySelectorAll("[data-testid=topic-set]")[0]!);
+          }, 0);
         }}
-      />
-    </PanelSetup>
-  );
+      >
+        <Log overrideConfig={{ searchTerms: [], minLogLevel: 1, topicToRender: "/foo/rosout" }} />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
 
-CaseInsensitiveFilter.title = `case insensitive message filtering: "could", "Ipsum"`;
+export const FilteredTerms = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Log
+          overrideConfig={{
+            searchTerms: ["multiple", "/some_topic"],
+            minLogLevel: 1,
+            topicToRender: "/rosout",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const AutoCompleteItems = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Log
-        overrideConfig={{
-          searchTerms: ["could", "Ipsum"],
-          minLogLevel: 1,
-          topicToRender: "/rosout",
-        }}
-      />
-    </PanelSetup>
-  );
+  title: `filtered terms: "multiple", "/some_topic"`,
 };
-AutoCompleteItems.play = async () => {
-  const input = (await screen.findAllByPlaceholderText("Search filter"))[0]!;
-  userEvent.click(input);
+
+export const CaseInsensitiveFilter = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Log
+          overrideConfig={{
+            searchTerms: ["could", "Ipsum"],
+            minLogLevel: 1,
+            topicToRender: "/rosout",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  title: `case insensitive message filtering: "could", "Ipsum"`,
+};
+
+export const AutoCompleteItems = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Log
+          overrideConfig={{
+            searchTerms: ["could", "Ipsum"],
+            minLogLevel: 1,
+            topicToRender: "/rosout",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async () => {
+    const input = (await screen.findAllByPlaceholderText("Search filter"))[0]!;
+    userEvent.click(input);
+  },
 };
 
 export const FoxgloveLog = (): JSX.Element => {

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -96,16 +96,16 @@ export default {
   component: MapPanel,
 };
 
-export const EmptyState = {
-  render: function Story(): JSX.Element {
+export const EmptyState: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
   decorators: [Wrapper],
 };
 
-export const SinglePoint = {
-  render: function Story(): JSX.Element {
+export const SinglePoint: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
@@ -134,8 +134,8 @@ export const SinglePoint = {
   },
 };
 
-export const SinglePointWithMissingValues = {
-  render: function Story(): JSX.Element {
+export const SinglePointWithMissingValues: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
@@ -168,8 +168,8 @@ export const SinglePointWithMissingValues = {
   },
 };
 
-export const SinglePointWithNoFix = {
-  render: function Story(): JSX.Element {
+export const SinglePointWithNoFix: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
@@ -204,8 +204,8 @@ export const SinglePointWithNoFix = {
   },
 };
 
-export const SinglePointWithSettings = {
-  render: function Story(): JSX.Element {
+export const SinglePointWithSettings: StoryObj = {
+  render: function Story() {
     return <MapPanel overrideConfig={{ layer: "custom" }} />;
   },
 
@@ -217,8 +217,8 @@ export const SinglePointWithSettings = {
   },
 };
 
-export const SinglePointWithSettingsOverride = {
-  render: function Story(): JSX.Element {
+export const SinglePointWithSettingsOverride: StoryObj = {
+  render: function Story() {
     return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "#ffc0cb" } }} />;
   },
 
@@ -230,8 +230,8 @@ export const SinglePointWithSettingsOverride = {
   },
 };
 
-export const MultipleTopics = {
-  render: function Story(): JSX.Element {
+export const MultipleTopics: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
@@ -273,8 +273,8 @@ export const MultipleTopics = {
   },
 };
 
-export const SinglePointNoFix = {
-  render: function Story(): JSX.Element {
+export const SinglePointNoFix: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
@@ -314,8 +314,8 @@ export const SinglePointNoFix = {
   },
 };
 
-export const SinglePointDiagonalCovariance = {
-  render: function Story(): JSX.Element {
+export const SinglePointDiagonalCovariance: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 
@@ -356,8 +356,8 @@ export const SinglePointDiagonalCovariance = {
   },
 };
 
-export const SinglePointFullCovariance = {
-  render: function Story(): JSX.Element {
+export const SinglePointFullCovariance: StoryObj = {
+  render: function Story() {
     return <MapPanel />;
   },
 

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext, StoryObj } from "@storybook/react";
 import { userEvent } from "@storybook/testing-library";
 import { cloneDeep, tap } from "lodash";
 import { useState } from "react";
@@ -399,8 +399,8 @@ export const SinglePointFullCovariance = {
 
 const GeoCenter = { lat: 0.25, lon: 0.25 };
 
-export const GeoJSON = {
-  render: function Story(): JSX.Element {
+export const GeoJSON: StoryObj = {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/geo", schemaName: "foxglove.GeoJSON" },
       { name: "/geo2", schemaName: "foxglove.GeoJSON" },

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -97,7 +97,7 @@ export default {
 };
 
 export const EmptyState = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -105,7 +105,7 @@ export const EmptyState = {
 };
 
 export const SinglePoint = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -135,7 +135,7 @@ export const SinglePoint = {
 };
 
 export const SinglePointWithMissingValues = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -169,7 +169,7 @@ export const SinglePointWithMissingValues = {
 };
 
 export const SinglePointWithNoFix = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -205,7 +205,7 @@ export const SinglePointWithNoFix = {
 };
 
 export const SinglePointWithSettings = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel overrideConfig={{ layer: "custom" }} />;
   },
 
@@ -218,7 +218,7 @@ export const SinglePointWithSettings = {
 };
 
 export const SinglePointWithSettingsOverride = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "#ffc0cb" } }} />;
   },
 
@@ -231,7 +231,7 @@ export const SinglePointWithSettingsOverride = {
 };
 
 export const MultipleTopics = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -274,7 +274,7 @@ export const MultipleTopics = {
 };
 
 export const SinglePointNoFix = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -315,7 +315,7 @@ export const SinglePointNoFix = {
 };
 
 export const SinglePointDiagonalCovariance = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -357,7 +357,7 @@ export const SinglePointDiagonalCovariance = {
 };
 
 export const SinglePointFullCovariance = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <MapPanel />;
   },
 
@@ -400,7 +400,7 @@ export const SinglePointFullCovariance = {
 const GeoCenter = { lat: 0.25, lon: 0.25 };
 
 export const GeoJSON = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     const topics: Topic[] = [
       { name: "/geo", schemaName: "foxglove.GeoJSON" },
       { name: "/geo2", schemaName: "foxglove.GeoJSON" },

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext } from "@storybook/react";
 import { userEvent } from "@storybook/testing-library";
 import { cloneDeep, tap } from "lodash";
 import { useState } from "react";
@@ -80,7 +80,7 @@ function makeGeoJsonMessage(center: { lat: number; lon: number }) {
   };
 }
 
-const Wrapper = (StoryComponent: Story, { parameters }: StoryContext): JSX.Element => {
+const Wrapper = (StoryComponent: StoryFn, { parameters }: StoryContext): JSX.Element => {
   return (
     <PanelSetup
       fixture={parameters.panelSetup?.fixture}
@@ -96,329 +96,350 @@ export default {
   component: MapPanel,
 };
 
-export const EmptyState = (): JSX.Element => {
-  return <MapPanel />;
-};
-EmptyState.decorators = [Wrapper];
+export const EmptyState = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
+  },
 
-export const SinglePoint = (): JSX.Element => {
-  return <MapPanel />;
-};
-SinglePoint.decorators = [Wrapper];
-SinglePoint.parameters = {
-  chromatic: {
-    delay: 1000,
-  },
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: EMPTY_MESSAGE,
-          },
-        ],
-      },
-    } as Fixture,
-  },
+  decorators: [Wrapper],
 };
 
-export const SinglePointWithMissingValues = (): JSX.Element => {
-  return <MapPanel />;
-};
-SinglePointWithMissingValues.decorators = [Wrapper];
-SinglePointWithMissingValues.parameters = {
-  chromatic: {
-    delay: 1000,
+export const SinglePoint = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
   },
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: {
-              ...EMPTY_MESSAGE,
-              latitude: undefined,
-              longitude: undefined,
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: EMPTY_MESSAGE,
             },
-          },
-        ],
-      },
-    } as Fixture,
+          ],
+        },
+      } as Fixture,
+    },
   },
 };
 
-export const SinglePointWithNoFix = (): JSX.Element => {
-  return <MapPanel />;
-};
-SinglePointWithNoFix.decorators = [Wrapper];
-SinglePointWithNoFix.parameters = {
-  chromatic: {
-    delay: 1000,
+export const SinglePointWithMissingValues = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
   },
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: {
-              ...EMPTY_MESSAGE,
-              status: {
-                status: NavSatFixStatus.STATUS_NO_FIX,
-                service: NavSatFixService.SERVICE_GPS,
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: {
+                ...EMPTY_MESSAGE,
+                latitude: undefined,
+                longitude: undefined,
               },
             },
-          },
-        ],
-      },
-    } as Fixture,
+          ],
+        },
+      } as Fixture,
+    },
   },
 };
 
-export const SinglePointWithSettings = (): JSX.Element => {
-  return <MapPanel overrideConfig={{ layer: "custom" }} />;
-};
-SinglePointWithSettings.decorators = [Wrapper];
-SinglePointWithSettings.parameters = {
-  ...SinglePoint.parameters,
-  includeSettings: true,
-};
-
-export const SinglePointWithSettingsOverride = (): JSX.Element => {
-  return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "#ffc0cb" } }} />;
-};
-SinglePointWithSettingsOverride.decorators = [Wrapper];
-SinglePointWithSettingsOverride.parameters = {
-  ...SinglePoint.parameters,
-  includeSettings: true,
-};
-
-export const MultipleTopics = (): JSX.Element => {
-  return <MapPanel />;
-};
-MultipleTopics.decorators = [Wrapper];
-MultipleTopics.parameters = {
-  chromatic: {
-    delay: 1000,
+export const SinglePointWithNoFix = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
   },
+
   decorators: [Wrapper],
-  panelSetup: {
-    fixture: {
-      topics: [
-        { name: "/gps", schemaName: "sensor_msgs/NavSatFix" },
-        { name: "/another-gps-topic", schemaName: "sensor_msgs/NavSatFix" },
-      ],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: EMPTY_MESSAGE,
-          },
-        ],
-        "/another-gps-topic": [
-          {
-            topic: "/another-gps-topic",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: OFFSET_MESSAGE,
-          },
-        ],
-      },
-    } as Fixture,
-  },
-};
 
-export const SinglePointNoFix = (): JSX.Element => {
-  return <MapPanel />;
-};
-SinglePointNoFix.decorators = [Wrapper];
-SinglePointNoFix.parameters = {
-  chromatic: {
-    delay: 1000,
-  },
-  decorators: [Wrapper],
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: {
-              latitude: 0,
-              longitude: 0,
-              altitude: 0,
-              status: {
-                status: NavSatFixStatus.STATUS_NO_FIX,
-                service: NavSatFixService.SERVICE_GPS,
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: {
+                ...EMPTY_MESSAGE,
+                status: {
+                  status: NavSatFixStatus.STATUS_NO_FIX,
+                  service: NavSatFixService.SERVICE_GPS,
+                },
               },
-              position_covariance: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-              position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_UNKNOWN,
             },
-          },
-        ],
-      },
-    } as Fixture,
+          ],
+        },
+      } as Fixture,
+    },
   },
 };
 
-export const SinglePointDiagonalCovariance = (): JSX.Element => {
-  return <MapPanel />;
-};
-SinglePointDiagonalCovariance.decorators = [Wrapper];
-SinglePointDiagonalCovariance.parameters = {
-  chromatic: {
-    delay: 1000,
+export const SinglePointWithSettings = {
+  render: (): JSX.Element => {
+    return <MapPanel overrideConfig={{ layer: "custom" }} />;
   },
+
   decorators: [Wrapper],
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            schemaName: "sensor_msgs/NavSatFix",
-            sizeInBytes: 0,
-            receiveTime: { sec: 123, nsec: 456 },
-            message: {
-              latitude: 1,
-              longitude: 2,
-              altitude: 0,
-              status: { status: NavSatFixStatus.STATUS_FIX, service: NavSatFixService.SERVICE_GPS },
-              position_covariance: [1, 0, 0, 0, 5000000, 0, 0, 0, 1000000000],
-              position_covariance_type:
-                NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN,
-            },
-          },
-        ],
-      },
-    } as Fixture,
+
+  parameters: {
+    ...SinglePoint.parameters,
+    includeSettings: true,
   },
 };
 
-export const SinglePointFullCovariance = (): JSX.Element => {
-  return <MapPanel />;
-};
-SinglePointFullCovariance.decorators = [Wrapper];
-SinglePointFullCovariance.parameters = {
-  chromatic: {
-    delay: 1000,
+export const SinglePointWithSettingsOverride = {
+  render: (): JSX.Element => {
+    return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "#ffc0cb" } }} />;
   },
+
   decorators: [Wrapper],
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            receiveTime: { sec: 123, nsec: 456 },
-            sizeInBytes: 0,
-            schemaName: "sensor_msgs/NavSatFix",
-            message: {
-              latitude: 1,
-              longitude: 2,
-              altitude: 0,
-              status: {
-                status: NavSatFixStatus.STATUS_GBAS_FIX,
-                service: NavSatFixService.SERVICE_GPS,
+
+  parameters: {
+    ...SinglePoint.parameters,
+    includeSettings: true,
+  },
+};
+
+export const MultipleTopics = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
+  },
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    decorators: [Wrapper],
+    panelSetup: {
+      fixture: {
+        topics: [
+          { name: "/gps", schemaName: "sensor_msgs/NavSatFix" },
+          { name: "/another-gps-topic", schemaName: "sensor_msgs/NavSatFix" },
+        ],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: EMPTY_MESSAGE,
+            },
+          ],
+          "/another-gps-topic": [
+            {
+              topic: "/another-gps-topic",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: OFFSET_MESSAGE,
+            },
+          ],
+        },
+      } as Fixture,
+    },
+  },
+};
+
+export const SinglePointNoFix = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
+  },
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    decorators: [Wrapper],
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: {
+                latitude: 0,
+                longitude: 0,
+                altitude: 0,
+                status: {
+                  status: NavSatFixStatus.STATUS_NO_FIX,
+                  service: NavSatFixService.SERVICE_GPS,
+                },
+                position_covariance: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+                position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_UNKNOWN,
               },
-              position_covariance: [1, 2, 3, 2, 5000000, 6, 3, 6, 1000000000],
-              position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
             },
-          },
-        ],
-      },
-    } as Fixture,
+          ],
+        },
+      } as Fixture,
+    },
+  },
+};
+
+export const SinglePointDiagonalCovariance = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
+  },
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    decorators: [Wrapper],
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: {
+                latitude: 1,
+                longitude: 2,
+                altitude: 0,
+                status: {
+                  status: NavSatFixStatus.STATUS_FIX,
+                  service: NavSatFixService.SERVICE_GPS,
+                },
+                position_covariance: [1, 0, 0, 0, 5000000, 0, 0, 0, 1000000000],
+                position_covariance_type:
+                  NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN,
+              },
+            },
+          ],
+        },
+      } as Fixture,
+    },
+  },
+};
+
+export const SinglePointFullCovariance = {
+  render: (): JSX.Element => {
+    return <MapPanel />;
+  },
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    decorators: [Wrapper],
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              receiveTime: { sec: 123, nsec: 456 },
+              sizeInBytes: 0,
+              schemaName: "sensor_msgs/NavSatFix",
+              message: {
+                latitude: 1,
+                longitude: 2,
+                altitude: 0,
+                status: {
+                  status: NavSatFixStatus.STATUS_GBAS_FIX,
+                  service: NavSatFixService.SERVICE_GPS,
+                },
+                position_covariance: [1, 2, 3, 2, 5000000, 6, 3, 6, 1000000000],
+                position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
+              },
+            },
+          ],
+        },
+      } as Fixture,
+    },
   },
 };
 
 const GeoCenter = { lat: 0.25, lon: 0.25 };
 
-export const GeoJSON = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/geo", schemaName: "foxglove.GeoJSON" },
-    { name: "/geo2", schemaName: "foxglove.GeoJSON" },
-    { name: "/gps", schemaName: "sensor_msgs/NavSatFix" },
-  ];
+export const GeoJSON = {
+  render: (): JSX.Element => {
+    const topics: Topic[] = [
+      { name: "/geo", schemaName: "foxglove.GeoJSON" },
+      { name: "/geo2", schemaName: "foxglove.GeoJSON" },
+      { name: "/gps", schemaName: "sensor_msgs/NavSatFix" },
+    ];
 
-  const [fixture, setFixture] = useState<Fixture>({
-    topics,
-    frame: {
-      "/gps": [
-        {
-          topic: "/gps",
-          receiveTime: { sec: 123, nsec: 456 },
-          schemaName: "sensor_msgs/NavSatFix",
-          message: EMPTY_MESSAGE,
-          sizeInBytes: 10,
-        },
-      ],
-      "/geo": [
-        {
-          topic: "/geo",
-          receiveTime: { sec: 123, nsec: 0 },
-          schemaName: "foxglove.GeoJSON",
-          message: {
-            geojson: JSON.stringify(
-              makeGeoJsonMessage({ lat: GeoCenter.lat - 0.2, lon: GeoCenter.lon - 0.2 }),
-            ),
-          },
-          sizeInBytes: 10,
-        },
-      ],
-      "/geo2": [
-        {
-          topic: "/geo2",
-          receiveTime: { sec: 123, nsec: 0 },
-          schemaName: "foxglove.GeoJSON",
-          message: {
-            geojson: JSON.stringify(
-              makeGeoJsonMessage({ lat: GeoCenter.lat - 0.1, lon: GeoCenter.lon - 0.1 }),
-            ),
-          },
-          sizeInBytes: 10,
-        },
-      ],
-    },
-  });
-
-  // Send a second messaqge on /geo topic. This should replace the previous message but not
-  // the /geo2 message.
-  useTimeoutFn(() => {
-    setFixture({
+    const [fixture, setFixture] = useState<Fixture>({
       topics,
       frame: {
+        "/gps": [
+          {
+            topic: "/gps",
+            receiveTime: { sec: 123, nsec: 456 },
+            schemaName: "sensor_msgs/NavSatFix",
+            message: EMPTY_MESSAGE,
+            sizeInBytes: 10,
+          },
+        ],
         "/geo": [
           {
             topic: "/geo",
-            receiveTime: { sec: 130, nsec: 0 },
+            receiveTime: { sec: 123, nsec: 0 },
             schemaName: "foxglove.GeoJSON",
             message: {
               geojson: JSON.stringify(
-                makeGeoJsonMessage({ lat: GeoCenter.lat + 0.2, lon: GeoCenter.lon + 0.1 }),
+                makeGeoJsonMessage({ lat: GeoCenter.lat - 0.2, lon: GeoCenter.lon - 0.2 }),
+              ),
+            },
+            sizeInBytes: 10,
+          },
+        ],
+        "/geo2": [
+          {
+            topic: "/geo2",
+            receiveTime: { sec: 123, nsec: 0 },
+            schemaName: "foxglove.GeoJSON",
+            message: {
+              geojson: JSON.stringify(
+                makeGeoJsonMessage({ lat: GeoCenter.lat - 0.1, lon: GeoCenter.lon - 0.1 }),
               ),
             },
             sizeInBytes: 10,
@@ -426,28 +447,53 @@ export const GeoJSON = (): JSX.Element => {
         ],
       },
     });
-  }, 1000);
 
-  return (
-    <PanelSetup fixture={fixture} includeSettings>
-      <MapPanel
-        overrideConfig={{
-          topicColors: { "/geo": "#00ffaa", "/geo2": "#aa00ff" },
-          center: GeoCenter,
-        }}
-      />
-    </PanelSetup>
-  );
-};
-GeoJSON.parameters = {
-  chromatic: {
-    delay: 2000,
+    // Send a second messaqge on /geo topic. This should replace the previous message but not
+    // the /geo2 message.
+    useTimeoutFn(() => {
+      setFixture({
+        topics,
+        frame: {
+          "/geo": [
+            {
+              topic: "/geo",
+              receiveTime: { sec: 130, nsec: 0 },
+              schemaName: "foxglove.GeoJSON",
+              message: {
+                geojson: JSON.stringify(
+                  makeGeoJsonMessage({ lat: GeoCenter.lat + 0.2, lon: GeoCenter.lon + 0.1 }),
+                ),
+              },
+              sizeInBytes: 10,
+            },
+          ],
+        },
+      });
+    }, 1000);
+
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <MapPanel
+          overrideConfig={{
+            topicColors: { "/geo": "#00ffaa", "/geo2": "#aa00ff" },
+            center: GeoCenter,
+          }}
+        />
+      </PanelSetup>
+    );
   },
-  colorScheme: "light",
-};
-GeoJSON.play = async () => {
-  const followSelect = document.querySelectorAll("div[role=button][aria-haspopup=listbox]")[1];
-  if (followSelect) {
-    userEvent.click(followSelect);
-  }
+
+  parameters: {
+    chromatic: {
+      delay: 2000,
+    },
+    colorScheme: "light",
+  },
+
+  play: async () => {
+    const followSelect = document.querySelectorAll("div[role=button][aria-haspopup=listbox]")[1];
+    if (followSelect) {
+      userEvent.click(followSelect);
+    }
+  },
 };

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -65,8 +65,8 @@ const fixture = {
 const sourceCodeWithLogs = `
   import { Messages } from "ros";
 
-  export const inputs: StoryObj = ["/my_topic"];
-  export const output: StoryObj = "${DEFAULT_STUDIO_NODE_PREFIX}";
+  export const inputs = ["/my_topic"];
+  export const output = "${DEFAULT_STUDIO_NODE_PREFIX}";
 
   const publisher = (): Messages.std_msgs__ColorRGBA => {
     log({ "someKey": { "nestedKey": "nestedValue" } });
@@ -92,8 +92,8 @@ const sourceCodeWithUtils = `
   import { Input } from "ros";
   import { norm } from "./pointClouds";
 
-  export const inputs: StoryObj = ["/my_topic"];
-  export const output: StoryObj = "${DEFAULT_STUDIO_NODE_PREFIX}/1";
+  export const inputs = ["/my_topic"];
+  export const output = "${DEFAULT_STUDIO_NODE_PREFIX}/1";
 
   const publisher = (message: Input<"/my_topic">): { val: number } => {
     const val = norm({x:1, y:2, z:3});

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import NodePlayground from "@foxglove/studio-base/panels/NodePlayground";
 import rawUserUtils from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils";

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -65,8 +65,8 @@ const fixture = {
 const sourceCodeWithLogs = `
   import { Messages } from "ros";
 
-  export const inputs = ["/my_topic"];
-  export const output = "${DEFAULT_STUDIO_NODE_PREFIX}";
+  export const inputs: StoryObj = ["/my_topic"];
+  export const output: StoryObj = "${DEFAULT_STUDIO_NODE_PREFIX}";
 
   const publisher = (): Messages.std_msgs__ColorRGBA => {
     log({ "someKey": { "nestedKey": "nestedValue" } });
@@ -92,8 +92,8 @@ const sourceCodeWithUtils = `
   import { Input } from "ros";
   import { norm } from "./pointClouds";
 
-  export const inputs = ["/my_topic"];
-  export const output = "${DEFAULT_STUDIO_NODE_PREFIX}/1";
+  export const inputs: StoryObj = ["/my_topic"];
+  export const output: StoryObj = "${DEFAULT_STUDIO_NODE_PREFIX}/1";
 
   const publisher = (message: Input<"/my_topic">): { val: number } => {
     const val = norm({x:1, y:2, z:3});

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import NodePlayground from "@foxglove/studio-base/panels/NodePlayground";
 import rawUserUtils from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils";
@@ -124,469 +124,506 @@ export default {
   },
 };
 
-export const WelcomeScreen: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <NodePlayground />
-    </PanelSetup>
-  );
+export const WelcomeScreen: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <NodePlayground />
+      </PanelSetup>
+    );
+  },
+
+  name: "welcome screen",
 };
 
-WelcomeScreen.storyName = "welcome screen";
+export const RawUserUtils: StoryObj = {
+  render: () => {
+    return (
+      <div style={{ margin: 12 }}>
+        <p style={{ color: "lightgreen" }}>
+          This should be original TypeScript source code. This is a story rather than a unit test
+          because it’s effectively a test of our webpack config.
+        </p>
+        <pre>{rawUserUtils[0]?.sourceCode}</pre>;
+      </div>
+    );
+  },
 
-export const RawUserUtils: StoryFn = () => {
-  return (
-    <div style={{ margin: 12 }}>
-      <p style={{ color: "lightgreen" }}>
-        This should be original TypeScript source code. This is a story rather than a unit test
-        because it’s effectively a test of our webpack config.
-      </p>
-      <pre>{rawUserUtils[0]?.sourceCode}</pre>;
-    </div>
-  );
+  name: "rawUserUtils",
 };
 
-RawUserUtils.storyName = "rawUserUtils";
-
-export const UtilsUsageInNode: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: {
-        nodeId1: {
-          name: "/studio_script/script",
-          sourceCode: sourceCodeWithUtils,
-        },
-      },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: [] },
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
-
-UtilsUsageInNode.storyName = "utils usage in node";
-
-export const EditorShowsNewCodeWhenUserNodesChange: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: {
-        nodeId1: {
-          name: "/studio_script/script",
-          sourceCode: sourceCodeWithUtils,
-        },
-      },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: [] },
-    }}
-    onMount={(el, actions) => {
-      setTimeout(() => {
-        // Change the userNodes to confirm the code in the Editor updates
-        actions.setUserNodes({
+export const UtilsUsageInNode: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: {
           nodeId1: {
             name: "/studio_script/script",
-            sourceCode: utilsSourceCode,
+            sourceCode: sourceCodeWithUtils,
           },
-        });
-        el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]?.click();
-      }, 500);
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    <SExpectedResult style={{ left: "375px", top: "150px" }}>
-      Should show function norm() code
-    </SExpectedResult>
-  </PanelSetup>
-);
-
-EditorShowsNewCodeWhenUserNodesChange.storyName = "Editor shows new code when userNodes change";
-
-export const EditorGotoDefinition: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: {
-        nodeId1: {
-          name: "/studio_script/script",
-          sourceCode: sourceCodeWithUtils,
         },
-      },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: [] },
-    }}
-  >
-    <NodePlayground
-      overrideConfig={{
-        selectedNodeId: "nodeId1",
-        additionalBackStackItems: [
-          {
-            filePath: "/studio_script/pointClouds",
-            code: utilsSourceCode,
-            readOnly: true,
-          },
-        ],
-      }}
-    />
-  </PanelSetup>
-);
-
-EditorGotoDefinition.storyName = "editor goto definition";
-
-export const GoBackFromGotoDefinition: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: {
-        nodeId1: {
-          name: "/studio_script/script",
-          sourceCode: sourceCodeWithUtils,
-        },
-      },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: [] },
-    }}
-    onMount={(el) => {
-      setTimeout(() => {
-        el.querySelectorAll<HTMLElement>("[data-testid=go-back]")[0]!.click();
-      }, 500);
-    }}
-  >
-    <NodePlayground
-      overrideConfig={{
-        selectedNodeId: "nodeId1",
-        additionalBackStackItems: [
-          {
-            filePath: "/studio_script/pointClouds",
-            code: utilsSourceCode,
-            readOnly: true,
-          },
-        ],
-      }}
-    />
-  </PanelSetup>
-);
-
-GoBackFromGotoDefinition.storyName = "go back from goto definition";
-
-export const SidebarOpenNodeExplorer: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={{ ...fixture, userNodes }}
-      onMount={(el) => {
-        setTimeout(() => {
-          el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
-        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
-      }}
-    >
-      <NodePlayground />
-    </PanelSetup>
-  );
-};
-
-SidebarOpenNodeExplorer.storyName = "sidebar open - node explorer";
-
-export const SidebarOpenNodeExplorerSelectedNode: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={{ ...fixture, userNodes }}
-      onMount={(el) => {
-        setTimeout(() => {
-          el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
-        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: [] },
       }}
     >
       <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
     </PanelSetup>
-  );
+  ),
+
+  name: "utils usage in node",
 };
 
-SidebarOpenNodeExplorerSelectedNode.storyName = "sidebar open - node explorer - selected node";
-
-export const SidebarOpenUtilsExplorerSelectedUtility: StoryFn = () => {
-  return (
+export const EditorShowsNewCodeWhenUserNodesChange: StoryObj = {
+  render: () => (
     <PanelSetup
-      fixture={{ ...fixture, userNodes }}
-      onMount={(el) => {
+      fixture={{
+        ...fixture,
+        userNodes: {
+          nodeId1: {
+            name: "/studio_script/script",
+            sourceCode: sourceCodeWithUtils,
+          },
+        },
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: [] },
+      }}
+      onMount={(el, actions) => {
         setTimeout(() => {
-          el.querySelectorAll<HTMLElement>("[data-testid=utils-explorer]")[0]!.click();
-        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+          // Change the userNodes to confirm the code in the Editor updates
+          actions.setUserNodes({
+            nodeId1: {
+              name: "/studio_script/script",
+              sourceCode: utilsSourceCode,
+            },
+          });
+          el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]?.click();
+        }, 500);
       }}
     >
       <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+      <SExpectedResult style={{ left: "375px", top: "150px" }}>
+        Should show function norm() code
+      </SExpectedResult>
     </PanelSetup>
-  );
+  ),
+
+  name: "Editor shows new code when userNodes change",
 };
 
-SidebarOpenUtilsExplorerSelectedUtility.storyName =
-  "sidebar open - utils explorer - selected utility";
-
-export const SidebarOpenTemplatesExplorer: StoryFn = () => {
-  return (
+export const EditorGotoDefinition: StoryObj = {
+  render: () => (
     <PanelSetup
-      fixture={{ ...fixture, userNodes }}
-      onMount={(el) => {
-        setTimeout(() => {
-          el.querySelectorAll<HTMLElement>("[data-testid=templates-explorer]")[0]!.click();
-        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+      fixture={{
+        ...fixture,
+        userNodes: {
+          nodeId1: {
+            name: "/studio_script/script",
+            sourceCode: sourceCodeWithUtils,
+          },
+        },
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: [] },
       }}
     >
-      <NodePlayground />
-    </PanelSetup>
-  );
-};
-
-SidebarOpenTemplatesExplorer.storyName = "sidebar open - templates explorer";
-
-export const EditorLoadingState: StoryFn = () => {
-  const NeverLoad = () => {
-    throw new Promise(() => {
-      // no-op
-    });
-  };
-  return (
-    <PanelSetup fixture={{ ...fixture, userNodes }}>
       <NodePlayground
-        overrideConfig={{ selectedNodeId: "nodeId1", editorForStorybook: <NeverLoad /> }}
+        overrideConfig={{
+          selectedNodeId: "nodeId1",
+          additionalBackStackItems: [
+            {
+              filePath: "/studio_script/pointClouds",
+              code: utilsSourceCode,
+              readOnly: true,
+            },
+          ],
+        }}
       />
     </PanelSetup>
-  );
+  ),
+
+  name: "editor goto definition",
 };
 
-EditorLoadingState.storyName = "editor loading state";
-
-export const BottomBarNoErrorsOrLogsClosed: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-      userNodeDiagnostics: { nodeId1: [] },
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
-
-BottomBarNoErrorsOrLogsClosed.storyName = "BottomBar - no errors or logs - closed";
-
-export const BottomBarNoErrorsOpen: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-      userNodeDiagnostics: { nodeId1: [] },
-    }}
-    onMount={(el) => {
-      setTimeout(() => {
-        const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
-        if (diagnosticsErrorsLabel) {
-          diagnosticsErrorsLabel.click();
-        }
-      }, OPEN_BOTTOM_BAR_TIMEOUT);
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
-
-BottomBarNoErrorsOpen.storyName = "BottomBar - no errors - open";
-
-export const BottomBarNoLogsOpen: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-      userNodeDiagnostics: { nodeId1: [] },
-    }}
-    onMount={(el) => {
-      setTimeout(() => {
-        const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
-        if (logsLabel) {
-          logsLabel.click();
-        }
-      }, OPEN_BOTTOM_BAR_TIMEOUT);
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
-
-BottomBarNoLogsOpen.storyName = "BottomBar - no logs - open";
-
-export const BottomBarErrorsClosed: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-      userNodeDiagnostics: {
-        nodeId1: [
-          {
-            message: `Type '"bad number"' is not assignable to type 'number[]'.`,
-            severity: 8,
-            source: "Typescript",
-            startLineNumber: 0,
-            startColumn: 6,
-            endLineNumber: 72,
-            endColumn: 20,
-            code: 2304,
+export const GoBackFromGotoDefinition: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: {
+          nodeId1: {
+            name: "/studio_script/script",
+            sourceCode: sourceCodeWithUtils,
           },
-          {
-            message: "This is a warning message (without line or column numbers).",
-            severity: 4,
-            source: "Source A",
-            endLineNumber: 72,
-            endColumn: 20,
-            code: 2304,
-          },
-          {
-            message: "This is an info message (without line or column numbers).",
-            severity: 2,
-            source: "Source B",
-            code: 2304,
-          },
-          {
-            message: "This is a hint message (without line or column numbers).",
-            severity: 1,
-            source: "Source C",
-            code: 2304,
-          },
-        ],
-      },
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
-
-BottomBarErrorsClosed.storyName = "BottomBar - errors - closed";
-
-export const BottomBarErrorsOpen: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-      userNodeDiagnostics: {
-        nodeId1: [
-          {
-            message: `Type '"bad number"' is not assignable to type 'number[]'.`,
-            severity: 8,
-            source: "Typescript",
-            startLineNumber: 0,
-            startColumn: 6,
-            endLineNumber: 72,
-            endColumn: 20,
-            code: 2304,
-          },
-          {
-            message: "This is a warning message (without line or column numbers).",
-            severity: 4,
-            source: "Source A",
-            endLineNumber: 72,
-            endColumn: 20,
-            code: 2304,
-          },
-          {
-            message: "This is an info message (without line or column numbers).",
-            severity: 2,
-            source: "Source B",
-            code: 2304,
-          },
-          {
-            message: "This is a hint message (without line or column numbers).",
-            severity: 1,
-            source: "Source C",
-            code: 2304,
-          },
-        ],
-      },
-    }}
-    onMount={(el) => {
-      setTimeout(() => {
-        const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
-        if (diagnosticsErrorsLabel) {
-          diagnosticsErrorsLabel.click();
-        }
-      }, OPEN_BOTTOM_BAR_TIMEOUT);
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
-
-BottomBarErrorsOpen.storyName = "BottomBar - errors - open";
-
-export const BottomBarLogsClosed: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: {
-        nodeId1: {
-          name: "/studio_script/script",
-          sourceCode: sourceCodeWithLogs,
         },
-      },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: logs },
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: [] },
+      }}
+      onMount={(el) => {
+        setTimeout(() => {
+          el.querySelectorAll<HTMLElement>("[data-testid=go-back]")[0]!.click();
+        }, 500);
+      }}
+    >
+      <NodePlayground
+        overrideConfig={{
+          selectedNodeId: "nodeId1",
+          additionalBackStackItems: [
+            {
+              filePath: "/studio_script/pointClouds",
+              code: utilsSourceCode,
+              readOnly: true,
+            },
+          ],
+        }}
+      />
+    </PanelSetup>
+  ),
 
-BottomBarLogsClosed.storyName = "BottomBar - logs - closed";
+  name: "go back from goto definition",
+};
 
-export const BottomBarLogsOpen: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: {
-        nodeId1: {
-          name: "/studio_script/script",
-          sourceCode: sourceCodeWithLogs,
-        },
-      },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: logs },
-    }}
-    onMount={(el) => {
-      setTimeout(() => {
-        const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
-        if (logsLabel) {
-          logsLabel.click();
-        }
-      }, OPEN_BOTTOM_BAR_TIMEOUT);
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
+export const SidebarOpenNodeExplorer: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={{ ...fixture, userNodes }}
+        onMount={(el) => {
+          setTimeout(() => {
+            el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
+          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+        }}
+      >
+        <NodePlayground />
+      </PanelSetup>
+    );
+  },
 
-BottomBarLogsOpen.storyName = "BottomBar - logs - open";
+  name: "sidebar open - node explorer",
+};
 
-export const BottomBarClearedLogs: StoryFn = () => (
-  <PanelSetup
-    fixture={{
-      ...fixture,
-      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-      userNodeDiagnostics: { nodeId1: [] },
-      userNodeLogs: { nodeId1: logs },
-    }}
-    onFirstMount={(el) => {
-      setTimeout(() => {
-        const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
-        if (logsLabel) {
-          logsLabel.click();
-          const clearBtn = el.querySelector<HTMLElement>("button[data-testid=np-logs-clear]");
-          if (clearBtn) {
-            clearBtn.click();
+export const SidebarOpenNodeExplorerSelectedNode: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={{ ...fixture, userNodes }}
+        onMount={(el) => {
+          setTimeout(() => {
+            el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
+          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+        }}
+      >
+        <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+      </PanelSetup>
+    );
+  },
+
+  name: "sidebar open - node explorer - selected node",
+};
+
+export const SidebarOpenUtilsExplorerSelectedUtility: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={{ ...fixture, userNodes }}
+        onMount={(el) => {
+          setTimeout(() => {
+            el.querySelectorAll<HTMLElement>("[data-testid=utils-explorer]")[0]!.click();
+          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+        }}
+      >
+        <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+      </PanelSetup>
+    );
+  },
+
+  name: "sidebar open - utils explorer - selected utility",
+};
+
+export const SidebarOpenTemplatesExplorer: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={{ ...fixture, userNodes }}
+        onMount={(el) => {
+          setTimeout(() => {
+            el.querySelectorAll<HTMLElement>("[data-testid=templates-explorer]")[0]!.click();
+          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+        }}
+      >
+        <NodePlayground />
+      </PanelSetup>
+    );
+  },
+
+  name: "sidebar open - templates explorer",
+};
+
+export const EditorLoadingState: StoryObj = {
+  render: () => {
+    const NeverLoad = () => {
+      throw new Promise(() => {
+        // no-op
+      });
+    };
+    return (
+      <PanelSetup fixture={{ ...fixture, userNodes }}>
+        <NodePlayground
+          overrideConfig={{ selectedNodeId: "nodeId1", editorForStorybook: <NeverLoad /> }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  name: "editor loading state",
+};
+
+export const BottomBarNoErrorsOrLogsClosed: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+        userNodeDiagnostics: { nodeId1: [] },
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - no errors or logs - closed",
+};
+
+export const BottomBarNoErrorsOpen: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+        userNodeDiagnostics: { nodeId1: [] },
+      }}
+      onMount={(el) => {
+        setTimeout(() => {
+          const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
+          if (diagnosticsErrorsLabel) {
+            diagnosticsErrorsLabel.click();
           }
-        }
-      }, OPEN_BOTTOM_BAR_TIMEOUT);
-    }}
-  >
-    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-  </PanelSetup>
-);
+        }, OPEN_BOTTOM_BAR_TIMEOUT);
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
 
-BottomBarClearedLogs.storyName = "BottomBar - cleared logs";
+  name: "BottomBar - no errors - open",
+};
+
+export const BottomBarNoLogsOpen: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+        userNodeDiagnostics: { nodeId1: [] },
+      }}
+      onMount={(el) => {
+        setTimeout(() => {
+          const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
+          if (logsLabel) {
+            logsLabel.click();
+          }
+        }, OPEN_BOTTOM_BAR_TIMEOUT);
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - no logs - open",
+};
+
+export const BottomBarErrorsClosed: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+        userNodeDiagnostics: {
+          nodeId1: [
+            {
+              message: `Type '"bad number"' is not assignable to type 'number[]'.`,
+              severity: 8,
+              source: "Typescript",
+              startLineNumber: 0,
+              startColumn: 6,
+              endLineNumber: 72,
+              endColumn: 20,
+              code: 2304,
+            },
+            {
+              message: "This is a warning message (without line or column numbers).",
+              severity: 4,
+              source: "Source A",
+              endLineNumber: 72,
+              endColumn: 20,
+              code: 2304,
+            },
+            {
+              message: "This is an info message (without line or column numbers).",
+              severity: 2,
+              source: "Source B",
+              code: 2304,
+            },
+            {
+              message: "This is a hint message (without line or column numbers).",
+              severity: 1,
+              source: "Source C",
+              code: 2304,
+            },
+          ],
+        },
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - errors - closed",
+};
+
+export const BottomBarErrorsOpen: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+        userNodeDiagnostics: {
+          nodeId1: [
+            {
+              message: `Type '"bad number"' is not assignable to type 'number[]'.`,
+              severity: 8,
+              source: "Typescript",
+              startLineNumber: 0,
+              startColumn: 6,
+              endLineNumber: 72,
+              endColumn: 20,
+              code: 2304,
+            },
+            {
+              message: "This is a warning message (without line or column numbers).",
+              severity: 4,
+              source: "Source A",
+              endLineNumber: 72,
+              endColumn: 20,
+              code: 2304,
+            },
+            {
+              message: "This is an info message (without line or column numbers).",
+              severity: 2,
+              source: "Source B",
+              code: 2304,
+            },
+            {
+              message: "This is a hint message (without line or column numbers).",
+              severity: 1,
+              source: "Source C",
+              code: 2304,
+            },
+          ],
+        },
+      }}
+      onMount={(el) => {
+        setTimeout(() => {
+          const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
+          if (diagnosticsErrorsLabel) {
+            diagnosticsErrorsLabel.click();
+          }
+        }, OPEN_BOTTOM_BAR_TIMEOUT);
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - errors - open",
+};
+
+export const BottomBarLogsClosed: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: {
+          nodeId1: {
+            name: "/studio_script/script",
+            sourceCode: sourceCodeWithLogs,
+          },
+        },
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: logs },
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - logs - closed",
+};
+
+export const BottomBarLogsOpen: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: {
+          nodeId1: {
+            name: "/studio_script/script",
+            sourceCode: sourceCodeWithLogs,
+          },
+        },
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: logs },
+      }}
+      onMount={(el) => {
+        setTimeout(() => {
+          const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
+          if (logsLabel) {
+            logsLabel.click();
+          }
+        }, OPEN_BOTTOM_BAR_TIMEOUT);
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - logs - open",
+};
+
+export const BottomBarClearedLogs: StoryObj = {
+  render: () => (
+    <PanelSetup
+      fixture={{
+        ...fixture,
+        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+        userNodeDiagnostics: { nodeId1: [] },
+        userNodeLogs: { nodeId1: logs },
+      }}
+      onFirstMount={(el) => {
+        setTimeout(() => {
+          const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
+          if (logsLabel) {
+            logsLabel.click();
+            const clearBtn = el.querySelector<HTMLElement>("button[data-testid=np-logs-clear]");
+            if (clearBtn) {
+              clearBtn.click();
+            }
+          }
+        }, OPEN_BOTTOM_BAR_TIMEOUT);
+      }}
+    >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  ),
+
+  name: "BottomBar - cleared logs",
+};

--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { ParameterValue } from "@foxglove/studio";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
@@ -52,26 +52,32 @@ export default {
   component: Parameters,
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={getFixture({ getParameters: false, setParameters: false })}>
-      <Parameters />
-    </PanelSetup>
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={getFixture({ getParameters: false, setParameters: false })}>
+        <Parameters />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithParameters: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={getFixture({ getParameters: true, setParameters: false })}>
-      <Parameters />
-    </PanelSetup>
-  );
+export const WithParameters: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={getFixture({ getParameters: true, setParameters: false })}>
+        <Parameters />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithEditableParameters: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={getFixture({ getParameters: true, setParameters: true })}>
-      <Parameters />
-    </PanelSetup>
-  );
+export const WithEditableParameters: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={getFixture({ getParameters: true, setParameters: true })}>
+        <Parameters />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { ParameterValue } from "@foxglove/studio";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -50,26 +52,26 @@ export default {
   component: Parameters,
 };
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={getFixture({ getParameters: false, setParameters: false })}>
       <Parameters />
     </PanelSetup>
   );
-}
+};
 
-export function WithParameters(): JSX.Element {
+export const WithParameters: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={getFixture({ getParameters: true, setParameters: false })}>
       <Parameters />
     </PanelSetup>
   );
-}
+};
 
-export function WithEditableParameters(): JSX.Element {
+export const WithEditableParameters: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={getFixture({ getParameters: true, setParameters: true })}>
       <Parameters />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -53,7 +53,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={getFixture({ getParameters: false, setParameters: false })}>
         <Parameters />
@@ -63,7 +63,7 @@ export const Default: StoryObj = {
 };
 
 export const WithParameters: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={getFixture({ getParameters: true, setParameters: false })}>
         <Parameters />
@@ -73,7 +73,7 @@ export const WithParameters: StoryObj = {
 };
 
 export const WithEditableParameters: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={getFixture({ getParameters: true, setParameters: true })}>
         <Parameters />

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -21,10 +21,12 @@ export default {
   title: "panels/PlaybackPerformance",
 };
 
-export const SimpleExample: StoryFn = () => {
-  return (
-    <PanelSetup>
-      <PlaybackPerformance />
-    </PanelSetup>
-  );
+export const SimpleExample: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup>
+        <PlaybackPerformance />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -21,7 +21,7 @@ export default {
   title: "panels/PlaybackPerformance",
 };
 
-export const SimpleExample: Story = () => {
+export const SimpleExample: StoryFn = () => {
   return (
     <PanelSetup>
       <PlaybackPerformance />

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useCallback } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -44,13 +44,13 @@ const exampleConfig: PlotConfig = {
   maxXValue: 3,
 };
 
-function Wrapper(StoryFn: Story): JSX.Element {
+function Wrapper(Wrapped: StoryFn): JSX.Element {
   const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-      <StoryFn />
+      <Wrapped />
     </PanelSetup>
   );
 }
@@ -108,23 +108,33 @@ function Default() {
   );
 }
 
-export const Light: Story = () => {
-  return <Default />;
-};
-Light.storyName = "Plot Legend (Light)";
-Light.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-Light.parameters = { useReadySignal: true, colorScheme: "light" };
+export const Light: StoryObj = {
+  render: () => {
+    return <Default />;
+  },
 
-export const Dark: Story = () => {
-  return <Default />;
+  name: "Plot Legend (Light)",
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
-Dark.storyName = "Plot Legend (Dark)";
-Dark.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+
+export const Dark: StoryObj = {
+  render: () => {
+    return <Default />;
+  },
+
+  name: "Plot Legend (Dark)",
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "dark" },
 };
-Dark.parameters = { useReadySignal: true, colorScheme: "dark" };
 
 export function LimitWidth(): JSX.Element {
   return (

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -137,7 +137,7 @@ export const Dark: StoryObj = {
 };
 
 export const LimitWidth: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <div
         style={{

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -136,7 +136,7 @@ export const Dark: StoryObj = {
   parameters: { useReadySignal: true, colorScheme: "dark" },
 };
 
-export function LimitWidth(): JSX.Element {
+export const LimitWidth: StoryFn = (): JSX.Element => {
   return (
     <div
       style={{
@@ -147,5 +147,5 @@ export function LimitWidth(): JSX.Element {
       <Plot overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }} />
     </div>
   );
-}
+};
 LimitWidth.parameters = { useReadySignal: true, colorScheme: "light" };

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -136,16 +136,21 @@ export const Dark: StoryObj = {
   parameters: { useReadySignal: true, colorScheme: "dark" },
 };
 
-export const LimitWidth: StoryFn = (): JSX.Element => {
-  return (
-    <div
-      style={{
-        height: "100%",
-        width: "100%",
-      }}
-    >
-      <Plot overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }} />
-    </div>
-  );
+export const LimitWidth: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+        }}
+      >
+        <Plot
+          overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
+        />
+      </div>
+    );
+  },
+
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
-LimitWidth.parameters = { useReadySignal: true, colorScheme: "light" };

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { shuffle } from "lodash";
 import { useCallback, useRef } from "react";
@@ -373,91 +373,116 @@ export default {
   excludeStories: ["paths", "fixture"],
 };
 
-export const LineGraph: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
-};
-LineGraph.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-LineGraph.storyName = "line graph";
-LineGraph.parameters = {
-  useReadySignal: true,
+export const LineGraph: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  name: "line graph",
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
 
-export const LineGraphWithXMinMax: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{ ...exampleConfig, minXValue: 1, maxXValue: 2 }}
-    />
-  );
-};
-LineGraphWithXMinMax.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-LineGraphWithXMinMax.storyName = "line graph with x min & max";
-LineGraphWithXMinMax.parameters = {
-  colorScheme: "light",
-  useReadySignal: true,
+export const LineGraphWithXMinMax: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{ ...exampleConfig, minXValue: 1, maxXValue: 2 }}
+      />
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  name: "line graph with x min & max",
+
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
 };
 
-export const LineGraphWithXRange: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{ ...exampleConfig, followingViewWidth: 3 }}
-      includeSettings
-    />
-  );
-};
-LineGraphWithXRange.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-LineGraphWithXRange.parameters = {
-  colorScheme: "light",
-  useReadySignal: true,
-};
-LineGraphWithXRange.storyName = "line graph with x range";
+export const LineGraphWithXRange: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{ ...exampleConfig, followingViewWidth: 3 }}
+        includeSettings
+      />
+    );
+  },
 
-export const LineGraphWithNoTitle: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, title: undefined }} />;
-};
-LineGraphWithNoTitle.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-LineGraphWithNoTitle.storyName = "line graph with no title";
-LineGraphWithNoTitle.parameters = {
-  useReadySignal: true,
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
+
+  name: "line graph with x range",
 };
 
-export const LineGraphWithSettings: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{ ...exampleConfig, minYValue: -1, maxYValue: 1, minXValue: 0, maxXValue: 3 }}
-      includeSettings
-    />
-  );
+export const LineGraphWithNoTitle: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, title: undefined }} />;
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  name: "line graph with no title",
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
-LineGraphWithSettings.parameters = {
-  colorScheme: "light",
-  useReadySignal: true,
-};
-LineGraphWithSettings.storyName = "line graph with settings";
-LineGraphWithSettings.play = async (ctx) => {
-  const label = await screen.findByTestId("settings__nodeHeaderToggle__yAxis");
-  userEvent.click(label);
-  await ctx.parameters.storyReady;
+
+export const LineGraphWithSettings: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{ ...exampleConfig, minYValue: -1, maxYValue: 1, minXValue: 0, maxXValue: 3 }}
+        includeSettings
+      />
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
+
+  name: "line graph with settings",
+
+  play: async (ctx) => {
+    const label = await screen.findByTestId("settings__nodeHeaderToggle__yAxis");
+    userEvent.click(label);
+    await ctx.parameters.storyReady;
+  },
 };
 
 export const LineGraphWithSettingsChinese = Object.assign(LineGraphWithSettings.bind(undefined), {
@@ -468,17 +493,22 @@ export const LineGraphWithSettingsChinese = Object.assign(LineGraphWithSettings.
   },
 });
 
-export const LineGraphWithLegendsHidden: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, showLegend: false }} />;
-};
-LineGraphWithLegendsHidden.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-LineGraphWithLegendsHidden.storyName = "line graph with legends hidden";
-LineGraphWithLegendsHidden.parameters = {
-  useReadySignal: true,
+export const LineGraphWithLegendsHidden: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, showLegend: false }} />;
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  name: "line graph with legends hidden",
+
+  parameters: {
+    useReadySignal: true,
+  },
 };
 
 const useStyles = makeStyles()(() => ({
@@ -491,17 +521,186 @@ const useStyles = makeStyles()(() => ({
   },
 }));
 
-export const InALineGraphWithMultiplePlotsXAxesAreSynced: Story = () => {
-  const readySignal = useReadySignal({ count: 6 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  const { classes } = useStyles();
+export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 6 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    const { classes } = useStyles();
 
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} className={classes.PanelSetup}>
-      <Plot
-        overrideConfig={{
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame} className={classes.PanelSetup}>
+        <Plot
+          overrideConfig={{
+            ...exampleConfig,
+            paths: [
+              {
+                value: "/some_topic/location.pose.acceleration",
+                enabled: true,
+                timestampMethod: "receiveTime",
+              },
+            ],
+          }}
+        />
+        <Plot
+          overrideConfig={{
+            ...exampleConfig,
+            paths: [
+              {
+                value: "/some_topic/location_subset.pose.velocity",
+                enabled: true,
+                timestampMethod: "receiveTime",
+              },
+            ],
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  name: "in a line graph with multiple plots, x-axes are synced",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const LineGraphAfterZoom: StoryObj = {
+  render: () => {
+    const pauseState = useRef<"init" | "zoom" | "ready">("init");
+    const readyState = useReadySignal();
+
+    const doZoom = useCallback(() => {
+      const canvasEl = document.querySelector("canvas");
+      // Zoom is a continuous event, so we need to simulate wheel multiple times
+      if (canvasEl) {
+        for (let i = 0; i < 5; i++) {
+          triggerWheel(canvasEl.parentElement!, 1);
+        }
+      }
+
+      // indicate our next render completion should mark the scene ready
+      pauseState.current = "ready";
+    }, []);
+
+    const pauseFrame = useCallback(() => {
+      return () => {
+        switch (pauseState.current) {
+          case "init":
+            pauseState.current = "zoom";
+            break;
+          case "zoom":
+            doZoom();
+            break;
+          default:
+            readyState();
+            break;
+        }
+      };
+    }, [doZoom, readyState]);
+
+    return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
+  },
+
+  name: "line graph after zoom",
+
+  parameters: {
+    useReadySignal: true,
+    colorScheme: "dark",
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const TimestampMethodHeaderStamp: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
           ...exampleConfig,
           paths: [
+            {
+              value: "/some_topic/location_shuffled.pose.velocity",
+              enabled: true,
+              timestampMethod: "headerStamp",
+            },
+            { value: "/boolean_topic.data", enabled: true, timestampMethod: "headerStamp" },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "timestampMethod: headerStamp",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const LongPath: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        style={{ maxWidth: 250 }}
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "long path",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const DisabledPath: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: false,
+              timestampMethod: "receiveTime",
+            },
             {
               value: "/some_topic/location.pose.acceleration",
               enabled: true,
@@ -510,830 +709,788 @@ export const InALineGraphWithMultiplePlotsXAxesAreSynced: Story = () => {
           ],
         }}
       />
-      <Plot
-        overrideConfig={{
+    );
+  },
+
+  name: "disabled path",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const ReferenceLine: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            { value: "0", enabled: true, timestampMethod: "receiveTime" }, // Test typing a period for decimal values. value: "1.", enabled: true, timestampMethod: "receiveTime",
+            { value: "1.", enabled: true, timestampMethod: "receiveTime" },
+            { value: "1.5", enabled: true, timestampMethod: "receiveTime" },
+            { value: "1", enabled: false, timestampMethod: "receiveTime" },
+          ],
+          minYValue: "-1",
+          maxYValue: "2",
+        }}
+      />
+    );
+  },
+
+  name: "reference line",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const WithMinAndMaxYValues: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        includeSettings
+        pauseFrame={pauseFrame}
+        config={{
           ...exampleConfig,
           paths: [
             {
-              value: "/some_topic/location_subset.pose.velocity",
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          minYValue: "1",
+          maxYValue: "2.8",
+        }}
+      />
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
+
+  name: "with min and max Y values",
+
+  play: async () => {
+    const label = await screen.findByText("Y Axis");
+    userEvent.click(label);
+  },
+};
+
+export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          minYValue: "1",
+        }}
+      />
+    );
+  },
+
+  name: "with just min Y value less than minimum value",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          minYValue: "1.4",
+        }}
+      />
+    );
+  },
+
+  name: "with just min Y value more than minimum value",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          minYValue: "5",
+        }}
+      />
+    );
+  },
+
+  name: "with just min Y value more than maximum value",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          maxYValue: "1.8",
+        }}
+      />
+    );
+  },
+
+  name: "with just max Y value less than maximum value",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          maxYValue: "2.8",
+        }}
+      />
+    );
+  },
+
+  name: "with just max Y value more than maximum value",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          maxYValue: "1",
+        }}
+      />
+    );
+  },
+
+  name: "with just max Y value less than minimum value",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/state.items[:].speed",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+            { value: "3", enabled: true, timestampMethod: "receiveTime" },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "scatter plot plus line graph plus reference line",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const IndexBasedXAxisForArray: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          xAxisVal: "index",
+          paths: [
+            {
+              value: "/some_topic/state.items[:].speed",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            }, // Should show up only in the legend: For now index plots always use playback data, and ignore preloaded data.
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "index-based x-axis for array",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const CustomXAxisTopic: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          xAxisVal: "custom",
+          paths: [
+            {
+              value: "/some_topic/location.pose.acceleration",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
+        }}
+      />
+    );
+  },
+
+  name: "custom x-axis topic",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const CustomXAxisTopicWithXLimits: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          xAxisVal: "custom",
+          minXValue: 1.3,
+          maxXValue: 1.8,
+          paths: [
+            {
+              value: "/some_topic/location.pose.acceleration",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
+        }}
+      />
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
+
+  name: "custom x-axis topic with x limits",
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const CurrentCustomXAxisTopic: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    // As above, but just shows a single point instead of the whole line.
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          xAxisVal: "currentCustom",
+          paths: [
+            {
+              value: "/some_topic/location.pose.acceleration",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
+        }}
+      />
+    );
+  },
+
+  name: "current custom x-axis topic",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          xAxisVal: "custom",
+          paths: [
+            // Extra items in y-axis
+            {
+              value: "/some_topic/location.pose.acceleration",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            }, // Same number of items
+            {
+              value: "/some_topic/location_subset.pose.acceleration",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            }, // Fewer items in y-axis
+            {
+              value: "/some_topic/state.items[:].speed",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          xAxisPath: { value: "/some_topic/location_subset.pose.velocity", enabled: true },
+        }}
+      />
+    );
+  },
+
+  name: "custom x-axis topic with mismatched data lengths",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const SuperCloseValues: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        fixture={{
+          datatypes: new Map(
+            Object.entries({
+              "std_msgs/Float32": {
+                definitions: [{ name: "data", type: "float32", isArray: false }],
+              },
+            }),
+          ),
+          topics: [{ name: "/some_number", schemaName: "std_msgs/Float32" }],
+          activeData: {
+            startTime: { sec: 0, nsec: 0 },
+            endTime: { sec: 10, nsec: 0 },
+            isPlaying: false,
+            speed: 0.2,
+          },
+          frame: {
+            "/some_number": [
+              {
+                topic: "/some_number",
+                receiveTime: { sec: 0, nsec: 0 },
+                message: { data: 1.8548483304974972 },
+                schemaName: "std_msgs/Float32",
+                sizeInBytes: 0,
+              },
+              {
+                topic: "/some_number",
+                receiveTime: { sec: 1, nsec: 0 },
+                message: { data: 1.8548483304974974 },
+                schemaName: "std_msgs/Float32",
+                sizeInBytes: 0,
+              },
+            ],
+          },
+        }}
+        config={{
+          ...exampleConfig,
+          paths: [{ value: "/some_number.data", enabled: true, timestampMethod: "receiveTime" }],
+        }}
+      />
+    );
+  },
+
+  name: "super close values",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const TimeValues: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          xAxisVal: "custom",
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          xAxisPath: { value: "/some_topic/location.header.stamp", enabled: true },
+        }}
+      />
+    );
+  },
+
+  name: "time values",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const PreloadedDataInBinaryBlocks: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
+        config={{
+          ...exampleConfig,
+          paths: [
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "headerStamp" },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "preloaded data in binary blocks",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const MixedStreamedAndPreloadedData: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        fixture={withEndTime(fixture, { sec: 3, nsec: 0 })}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/state.items[0].speed",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "mixed streamed and preloaded data",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+export const PreloadedDataAndItsDerivative: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
+        config={{
+          ...exampleConfig,
+          paths: [
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
+            {
+              value: "/preloaded_topic.data.@derivative",
               enabled: true,
               timestampMethod: "receiveTime",
             },
           ],
         }}
       />
-    </PanelSetup>
-  );
-};
-InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
-  "in a line graph with multiple plots, x-axes are synced";
-InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
-  useReadySignal: true,
-};
-InALineGraphWithMultiplePlotsXAxesAreSynced.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+    );
+  },
+
+  name: "preloaded data and its derivative",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 };
 
-export const LineGraphAfterZoom: Story = () => {
-  const pauseState = useRef<"init" | "zoom" | "ready">("init");
-  const readyState = useReadySignal();
+export const PreloadedDataAndItsNegative: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
-  const doZoom = useCallback(() => {
-    const canvasEl = document.querySelector("canvas");
-    // Zoom is a continuous event, so we need to simulate wheel multiple times
-    if (canvasEl) {
-      for (let i = 0; i < 5; i++) {
-        triggerWheel(canvasEl.parentElement!, 1);
-      }
-    }
-
-    // indicate our next render completion should mark the scene ready
-    pauseState.current = "ready";
-  }, []);
-
-  const pauseFrame = useCallback(() => {
-    return () => {
-      switch (pauseState.current) {
-        case "init":
-          pauseState.current = "zoom";
-          break;
-        case "zoom":
-          doZoom();
-          break;
-        default:
-          readyState();
-          break;
-      }
-    };
-  }, [doZoom, readyState]);
-
-  return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
-};
-LineGraphAfterZoom.storyName = "line graph after zoom";
-LineGraphAfterZoom.parameters = {
-  useReadySignal: true,
-  colorScheme: "dark",
-};
-LineGraphAfterZoom.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const TimestampMethodHeaderStamp: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location_shuffled.pose.velocity",
-            enabled: true,
-            timestampMethod: "headerStamp",
-          },
-          { value: "/boolean_topic.data", enabled: true, timestampMethod: "headerStamp" },
-        ],
-      }}
-    />
-  );
-};
-TimestampMethodHeaderStamp.storyName = "timestampMethod: headerStamp";
-TimestampMethodHeaderStamp.parameters = {
-  useReadySignal: true,
-};
-TimestampMethodHeaderStamp.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const LongPath: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      style={{ maxWidth: 250 }}
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-      }}
-    />
-  );
-};
-LongPath.storyName = "long path";
-LongPath.parameters = {
-  useReadySignal: true,
-};
-LongPath.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const DisabledPath: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: false,
-            timestampMethod: "receiveTime",
-          },
-          {
-            value: "/some_topic/location.pose.acceleration",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-      }}
-    />
-  );
-};
-DisabledPath.storyName = "disabled path";
-DisabledPath.parameters = {
-  useReadySignal: true,
-};
-DisabledPath.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const ReferenceLine: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          { value: "0", enabled: true, timestampMethod: "receiveTime" }, // Test typing a period for decimal values. value: "1.", enabled: true, timestampMethod: "receiveTime",
-          { value: "1.", enabled: true, timestampMethod: "receiveTime" },
-          { value: "1.5", enabled: true, timestampMethod: "receiveTime" },
-          { value: "1", enabled: false, timestampMethod: "receiveTime" },
-        ],
-        minYValue: "-1",
-        maxYValue: "2",
-      }}
-    />
-  );
-};
-ReferenceLine.storyName = "reference line";
-ReferenceLine.parameters = {
-  useReadySignal: true,
-};
-ReferenceLine.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const WithMinAndMaxYValues: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      includeSettings
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        minYValue: "1",
-        maxYValue: "2.8",
-      }}
-    />
-  );
-};
-WithMinAndMaxYValues.parameters = {
-  colorScheme: "light",
-  useReadySignal: true,
-};
-WithMinAndMaxYValues.storyName = "with min and max Y values";
-WithMinAndMaxYValues.play = async () => {
-  const label = await screen.findByText("Y Axis");
-  userEvent.click(label);
-};
-
-export const WithJustMinYValueLessThanMinimumValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        minYValue: "1",
-      }}
-    />
-  );
-};
-WithJustMinYValueLessThanMinimumValue.storyName = "with just min Y value less than minimum value";
-WithJustMinYValueLessThanMinimumValue.parameters = {
-  useReadySignal: true,
-};
-WithJustMinYValueLessThanMinimumValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const WithJustMinYValueMoreThanMinimumValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        minYValue: "1.4",
-      }}
-    />
-  );
-};
-WithJustMinYValueMoreThanMinimumValue.storyName = "with just min Y value more than minimum value";
-WithJustMinYValueMoreThanMinimumValue.parameters = {
-  useReadySignal: true,
-};
-WithJustMinYValueMoreThanMinimumValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const WithJustMinYValueMoreThanMaximumValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        minYValue: "5",
-      }}
-    />
-  );
-};
-WithJustMinYValueMoreThanMaximumValue.storyName = "with just min Y value more than maximum value";
-WithJustMinYValueMoreThanMaximumValue.parameters = {
-  useReadySignal: true,
-};
-WithJustMinYValueMoreThanMaximumValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const WithJustMaxYValueLessThanMaximumValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        maxYValue: "1.8",
-      }}
-    />
-  );
-};
-WithJustMaxYValueLessThanMaximumValue.storyName = "with just max Y value less than maximum value";
-WithJustMaxYValueLessThanMaximumValue.parameters = {
-  useReadySignal: true,
-};
-WithJustMaxYValueLessThanMaximumValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const WithJustMaxYValueMoreThanMaximumValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        maxYValue: "2.8",
-      }}
-    />
-  );
-};
-WithJustMaxYValueMoreThanMaximumValue.storyName = "with just max Y value more than maximum value";
-WithJustMaxYValueMoreThanMaximumValue.parameters = {
-  useReadySignal: true,
-};
-WithJustMaxYValueMoreThanMaximumValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const WithJustMaxYValueLessThanMinimumValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        maxYValue: "1",
-      }}
-    />
-  );
-};
-WithJustMaxYValueLessThanMinimumValue.storyName = "with just max Y value less than minimum value";
-WithJustMaxYValueLessThanMinimumValue.parameters = {
-  useReadySignal: true,
-};
-WithJustMaxYValueLessThanMinimumValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const ScatterPlotPlusLineGraphPlusReferenceLine: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/state.items[:].speed",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-          { value: "3", enabled: true, timestampMethod: "receiveTime" },
-        ],
-      }}
-    />
-  );
-};
-ScatterPlotPlusLineGraphPlusReferenceLine.storyName =
-  "scatter plot plus line graph plus reference line";
-ScatterPlotPlusLineGraphPlusReferenceLine.parameters = {
-  useReadySignal: true,
-};
-ScatterPlotPlusLineGraphPlusReferenceLine.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const IndexBasedXAxisForArray: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        xAxisVal: "index",
-        paths: [
-          {
-            value: "/some_topic/state.items[:].speed",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          }, // Should show up only in the legend: For now index plots always use playback data, and ignore preloaded data.
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
-        ],
-      }}
-    />
-  );
-};
-IndexBasedXAxisForArray.storyName = "index-based x-axis for array";
-IndexBasedXAxisForArray.parameters = {
-  useReadySignal: true,
-};
-IndexBasedXAxisForArray.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const CustomXAxisTopic: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        xAxisVal: "custom",
-        paths: [
-          {
-            value: "/some_topic/location.pose.acceleration",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
-      }}
-    />
-  );
-};
-CustomXAxisTopic.storyName = "custom x-axis topic";
-CustomXAxisTopic.parameters = {
-  useReadySignal: true,
-};
-CustomXAxisTopic.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const CustomXAxisTopicWithXLimits: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        xAxisVal: "custom",
-        minXValue: 1.3,
-        maxXValue: 1.8,
-        paths: [
-          {
-            value: "/some_topic/location.pose.acceleration",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
-      }}
-    />
-  );
-};
-CustomXAxisTopicWithXLimits.parameters = {
-  colorScheme: "light",
-  useReadySignal: true,
-};
-CustomXAxisTopicWithXLimits.storyName = "custom x-axis topic with x limits";
-CustomXAxisTopicWithXLimits.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const CurrentCustomXAxisTopic: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  // As above, but just shows a single point instead of the whole line.
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        xAxisVal: "currentCustom",
-        paths: [
-          {
-            value: "/some_topic/location.pose.acceleration",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
-      }}
-    />
-  );
-};
-CurrentCustomXAxisTopic.storyName = "current custom x-axis topic";
-CurrentCustomXAxisTopic.parameters = {
-  useReadySignal: true,
-};
-CurrentCustomXAxisTopic.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const CustomXAxisTopicWithMismatchedDataLengths: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        xAxisVal: "custom",
-        paths: [
-          // Extra items in y-axis
-          {
-            value: "/some_topic/location.pose.acceleration",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          }, // Same number of items
-          {
-            value: "/some_topic/location_subset.pose.acceleration",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          }, // Fewer items in y-axis
-          {
-            value: "/some_topic/state.items[:].speed",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        xAxisPath: { value: "/some_topic/location_subset.pose.velocity", enabled: true },
-      }}
-    />
-  );
-};
-CustomXAxisTopicWithMismatchedDataLengths.storyName =
-  "custom x-axis topic with mismatched data lengths";
-CustomXAxisTopicWithMismatchedDataLengths.parameters = {
-  useReadySignal: true,
-};
-CustomXAxisTopicWithMismatchedDataLengths.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const SuperCloseValues: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      fixture={{
-        datatypes: new Map(
-          Object.entries({
-            "std_msgs/Float32": {
-              definitions: [{ name: "data", type: "float32", isArray: false }],
-            },
-          }),
-        ),
-        topics: [{ name: "/some_number", schemaName: "std_msgs/Float32" }],
-        activeData: {
-          startTime: { sec: 0, nsec: 0 },
-          endTime: { sec: 10, nsec: 0 },
-          isPlaying: false,
-          speed: 0.2,
-        },
-        frame: {
-          "/some_number": [
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
+        config={{
+          ...exampleConfig,
+          paths: [
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
             {
-              topic: "/some_number",
-              receiveTime: { sec: 0, nsec: 0 },
-              message: { data: 1.8548483304974972 },
-              schemaName: "std_msgs/Float32",
-              sizeInBytes: 0,
-            },
-            {
-              topic: "/some_number",
-              receiveTime: { sec: 1, nsec: 0 },
-              message: { data: 1.8548483304974974 },
-              schemaName: "std_msgs/Float32",
-              sizeInBytes: 0,
+              value: "/preloaded_topic.data.@negative",
+              enabled: true,
+              timestampMethod: "receiveTime",
             },
           ],
-        },
-      }}
-      config={{
-        ...exampleConfig,
-        paths: [{ value: "/some_number.data", enabled: true, timestampMethod: "receiveTime" }],
-      }}
-    />
-  );
-};
-SuperCloseValues.storyName = "super close values";
-SuperCloseValues.parameters = {
-  useReadySignal: true,
-};
-SuperCloseValues.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+        }}
+      />
+    );
+  },
+
+  name: "preloaded data and its negative",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 };
 
-export const TimeValues: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+export const PreloadedDataAndItsAbsoluteValue: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      config={{
-        ...exampleConfig,
-        xAxisVal: "custom",
-        paths: [
-          {
-            value: "/some_topic/location.pose.velocity",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-        xAxisPath: { value: "/some_topic/location.header.stamp", enabled: true },
-      }}
-    />
-  );
-};
-TimeValues.storyName = "time values";
-TimeValues.parameters = {
-  useReadySignal: true,
-};
-TimeValues.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
+        config={{
+          ...exampleConfig,
+          paths: [
+            { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
+            {
+              value: "/preloaded_topic.data.@abs",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+        }}
+      />
+    );
+  },
 
-export const PreloadedDataInBinaryBlocks: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  name: "preloaded data and its absolute value",
 
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
-      config={{
-        ...exampleConfig,
-        paths: [
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "headerStamp" },
-        ],
-      }}
-    />
-  );
-};
-PreloadedDataInBinaryBlocks.storyName = "preloaded data in binary blocks";
-PreloadedDataInBinaryBlocks.parameters = {
-  useReadySignal: true,
-};
-PreloadedDataInBinaryBlocks.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
+  parameters: {
+    useReadySignal: true,
+  },
 
-export const MixedStreamedAndPreloadedData: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      fixture={withEndTime(fixture, { sec: 3, nsec: 0 })}
-      config={{
-        ...exampleConfig,
-        paths: [
-          {
-            value: "/some_topic/state.items[0].speed",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
-        ],
-      }}
-    />
-  );
-};
-MixedStreamedAndPreloadedData.storyName = "mixed streamed and preloaded data";
-MixedStreamedAndPreloadedData.parameters = {
-  useReadySignal: true,
-};
-MixedStreamedAndPreloadedData.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const PreloadedDataAndItsDerivative: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
-      config={{
-        ...exampleConfig,
-        paths: [
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
-          {
-            value: "/preloaded_topic.data.@derivative",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-      }}
-    />
-  );
-};
-PreloadedDataAndItsDerivative.storyName = "preloaded data and its derivative";
-PreloadedDataAndItsDerivative.parameters = {
-  useReadySignal: true,
-};
-PreloadedDataAndItsDerivative.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const PreloadedDataAndItsNegative: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
-      config={{
-        ...exampleConfig,
-        paths: [
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
-          {
-            value: "/preloaded_topic.data.@negative",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-      }}
-    />
-  );
-};
-PreloadedDataAndItsNegative.storyName = "preloaded data and its negative";
-PreloadedDataAndItsNegative.parameters = {
-  useReadySignal: true,
-};
-PreloadedDataAndItsNegative.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-
-export const PreloadedDataAndItsAbsoluteValue: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-
-  return (
-    <PlotWrapper
-      pauseFrame={pauseFrame}
-      fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}
-      config={{
-        ...exampleConfig,
-        paths: [
-          { value: "/preloaded_topic.data", enabled: true, timestampMethod: "receiveTime" },
-          {
-            value: "/preloaded_topic.data.@abs",
-            enabled: true,
-            timestampMethod: "receiveTime",
-          },
-        ],
-      }}
-    />
-  );
-};
-PreloadedDataAndItsAbsoluteValue.storyName = "preloaded data and its absolute value";
-PreloadedDataAndItsAbsoluteValue.parameters = {
-  useReadySignal: true,
-};
-PreloadedDataAndItsAbsoluteValue.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 };

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -374,7 +374,7 @@ export default {
 };
 
 export const LineGraph: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
@@ -392,7 +392,7 @@ export const LineGraph: StoryObj = {
 };
 
 export const LineGraphWithXMinMax: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -416,7 +416,7 @@ export const LineGraphWithXMinMax: StoryObj = {
 };
 
 export const LineGraphWithXRange: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -441,7 +441,7 @@ export const LineGraphWithXRange: StoryObj = {
 };
 
 export const LineGraphWithNoTitle: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, title: undefined }} />;
@@ -459,7 +459,7 @@ export const LineGraphWithNoTitle: StoryObj = {
 };
 
 export const LineGraphWithSettings: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -485,7 +485,7 @@ export const LineGraphWithSettings: StoryObj = {
   },
 };
 
-export const LineGraphWithSettingsChinese = {
+export const LineGraphWithSettingsChinese: StoryObj = {
   ...LineGraphWithSettings,
   play: LineGraphWithSettings.play,
   parameters: {
@@ -495,7 +495,7 @@ export const LineGraphWithSettingsChinese = {
 };
 
 export const LineGraphWithLegendsHidden: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, showLegend: false }} />;
@@ -523,7 +523,7 @@ const useStyles = makeStyles()(() => ({
 }));
 
 export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 6 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     const { classes } = useStyles();
@@ -570,7 +570,7 @@ export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
 };
 
 export const LineGraphAfterZoom: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const pauseState = useRef<"init" | "zoom" | "ready">("init");
     const readyState = useReadySignal();
 
@@ -619,7 +619,7 @@ export const LineGraphAfterZoom: StoryObj = {
 };
 
 export const TimestampMethodHeaderStamp: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -653,7 +653,7 @@ export const TimestampMethodHeaderStamp: StoryObj = {
 };
 
 export const LongPath: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -687,7 +687,7 @@ export const LongPath: StoryObj = {
 };
 
 export const DisabledPath: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -725,7 +725,7 @@ export const DisabledPath: StoryObj = {
 };
 
 export const ReferenceLine: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -759,7 +759,7 @@ export const ReferenceLine: StoryObj = {
 };
 
 export const WithMinAndMaxYValues: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -797,7 +797,7 @@ export const WithMinAndMaxYValues: StoryObj = {
 };
 
 export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -831,7 +831,7 @@ export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
 };
 
 export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -865,7 +865,7 @@ export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
 };
 
 export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -899,7 +899,7 @@ export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
 };
 
 export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -933,7 +933,7 @@ export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
 };
 
 export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -967,7 +967,7 @@ export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
 };
 
 export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1001,7 +1001,7 @@ export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
 };
 
 export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1040,7 +1040,7 @@ export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
 };
 
 export const IndexBasedXAxisForArray: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1075,7 +1075,7 @@ export const IndexBasedXAxisForArray: StoryObj = {
 };
 
 export const CustomXAxisTopic: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1110,7 +1110,7 @@ export const CustomXAxisTopic: StoryObj = {
 };
 
 export const CustomXAxisTopicWithXLimits: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1148,7 +1148,7 @@ export const CustomXAxisTopicWithXLimits: StoryObj = {
 };
 
 export const CurrentCustomXAxisTopic: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1184,7 +1184,7 @@ export const CurrentCustomXAxisTopic: StoryObj = {
 };
 
 export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1230,7 +1230,7 @@ export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
 };
 
 export const SuperCloseValues: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1291,7 +1291,7 @@ export const SuperCloseValues: StoryObj = {
 };
 
 export const TimeValues: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1326,7 +1326,7 @@ export const TimeValues: StoryObj = {
 };
 
 export const PreloadedDataInBinaryBlocks: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1357,7 +1357,7 @@ export const PreloadedDataInBinaryBlocks: StoryObj = {
 };
 
 export const MixedStreamedAndPreloadedData: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1392,7 +1392,7 @@ export const MixedStreamedAndPreloadedData: StoryObj = {
 };
 
 export const PreloadedDataAndItsDerivative: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1427,7 +1427,7 @@ export const PreloadedDataAndItsDerivative: StoryObj = {
 };
 
 export const PreloadedDataAndItsNegative: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1462,7 +1462,7 @@ export const PreloadedDataAndItsNegative: StoryObj = {
 };
 
 export const PreloadedDataAndItsAbsoluteValue: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 import { shuffle } from "lodash";
 import { useCallback, useRef } from "react";
@@ -374,7 +374,7 @@ export default {
 };
 
 export const LineGraph: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
@@ -392,7 +392,7 @@ export const LineGraph: StoryObj = {
 };
 
 export const LineGraphWithXMinMax: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -416,7 +416,7 @@ export const LineGraphWithXMinMax: StoryObj = {
 };
 
 export const LineGraphWithXRange: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -441,7 +441,7 @@ export const LineGraphWithXRange: StoryObj = {
 };
 
 export const LineGraphWithNoTitle: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, title: undefined }} />;
@@ -459,7 +459,7 @@ export const LineGraphWithNoTitle: StoryObj = {
 };
 
 export const LineGraphWithSettings: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -485,16 +485,17 @@ export const LineGraphWithSettings: StoryObj = {
   },
 };
 
-export const LineGraphWithSettingsChinese = Object.assign(LineGraphWithSettings.bind(undefined), {
+export const LineGraphWithSettingsChinese = {
+  ...LineGraphWithSettings,
   play: LineGraphWithSettings.play,
   parameters: {
     ...LineGraphWithSettings.parameters,
     forceLanguage: "zh",
   },
-});
+};
 
 export const LineGraphWithLegendsHidden: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, showLegend: false }} />;
@@ -522,7 +523,7 @@ const useStyles = makeStyles()(() => ({
 }));
 
 export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 6 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     const { classes } = useStyles();
@@ -569,7 +570,7 @@ export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
 };
 
 export const LineGraphAfterZoom: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const pauseState = useRef<"init" | "zoom" | "ready">("init");
     const readyState = useReadySignal();
 
@@ -618,7 +619,7 @@ export const LineGraphAfterZoom: StoryObj = {
 };
 
 export const TimestampMethodHeaderStamp: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -652,7 +653,7 @@ export const TimestampMethodHeaderStamp: StoryObj = {
 };
 
 export const LongPath: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -686,7 +687,7 @@ export const LongPath: StoryObj = {
 };
 
 export const DisabledPath: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -724,7 +725,7 @@ export const DisabledPath: StoryObj = {
 };
 
 export const ReferenceLine: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -758,7 +759,7 @@ export const ReferenceLine: StoryObj = {
 };
 
 export const WithMinAndMaxYValues: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -796,7 +797,7 @@ export const WithMinAndMaxYValues: StoryObj = {
 };
 
 export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -830,7 +831,7 @@ export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
 };
 
 export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -864,7 +865,7 @@ export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
 };
 
 export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -898,7 +899,7 @@ export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
 };
 
 export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -932,7 +933,7 @@ export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
 };
 
 export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -966,7 +967,7 @@ export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
 };
 
 export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1000,7 +1001,7 @@ export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
 };
 
 export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1039,7 +1040,7 @@ export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
 };
 
 export const IndexBasedXAxisForArray: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1074,7 +1075,7 @@ export const IndexBasedXAxisForArray: StoryObj = {
 };
 
 export const CustomXAxisTopic: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1109,7 +1110,7 @@ export const CustomXAxisTopic: StoryObj = {
 };
 
 export const CustomXAxisTopicWithXLimits: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1147,7 +1148,7 @@ export const CustomXAxisTopicWithXLimits: StoryObj = {
 };
 
 export const CurrentCustomXAxisTopic: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1183,7 +1184,7 @@ export const CurrentCustomXAxisTopic: StoryObj = {
 };
 
 export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1229,7 +1230,7 @@ export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
 };
 
 export const SuperCloseValues: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1290,7 +1291,7 @@ export const SuperCloseValues: StoryObj = {
 };
 
 export const TimeValues: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1325,7 +1326,7 @@ export const TimeValues: StoryObj = {
 };
 
 export const PreloadedDataInBinaryBlocks: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1356,7 +1357,7 @@ export const PreloadedDataInBinaryBlocks: StoryObj = {
 };
 
 export const MixedStreamedAndPreloadedData: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1391,7 +1392,7 @@ export const MixedStreamedAndPreloadedData: StoryObj = {
 };
 
 export const PreloadedDataAndItsDerivative: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1426,7 +1427,7 @@ export const PreloadedDataAndItsDerivative: StoryObj = {
 };
 
 export const PreloadedDataAndItsNegative: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
@@ -1461,7 +1462,7 @@ export const PreloadedDataAndItsNegative: StoryObj = {
 };
 
 export const PreloadedDataAndItsAbsoluteValue: StoryObj = {
-  render: () => {
+  render: function Story(): JSX.Element {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { action } from "@storybook/addon-actions";
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import Publish from "@foxglove/studio-base/panels/Publish";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
@@ -48,112 +48,126 @@ export default {
   title: "panels/Publish",
 };
 
-export const ExampleCanPublishAdvanced: StoryFn = () => {
-  const allowPublish = true;
-  return (
-    <PanelSetup fixture={getFixture({ allowPublish })}>
-      <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-    </PanelSetup>
-  );
+export const ExampleCanPublishAdvanced: StoryObj = {
+  render: () => {
+    const allowPublish = true;
+    return (
+      <PanelSetup fixture={getFixture({ allowPublish })}>
+        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
+      </PanelSetup>
+    );
+  },
+
+  name: "example can publish, advanced",
 };
 
-ExampleCanPublishAdvanced.storyName = "example can publish, advanced";
+export const CustomButtonColor: StoryObj = {
+  render: () => {
+    const allowPublish = true;
+    return (
+      <PanelSetup fixture={getFixture({ allowPublish })}>
+        <Publish
+          overrideConfig={publishConfig({
+            advancedView: true,
+            value: advancedJSON,
+            buttonColor: "#ffbf49",
+          })}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const CustomButtonColor: StoryFn = () => {
-  const allowPublish = true;
-  return (
-    <PanelSetup fixture={getFixture({ allowPublish })}>
-      <Publish
-        overrideConfig={publishConfig({
-          advancedView: true,
-          value: advancedJSON,
-          buttonColor: "#ffbf49",
-        })}
-      />
-    </PanelSetup>
-  );
+  name: "custom button color",
 };
 
-CustomButtonColor.storyName = "custom button color";
+export const ExampleCantPublishAdvanced: StoryObj = {
+  render: () => {
+    const allowPublish = false;
+    return (
+      <PanelSetup fixture={getFixture({ allowPublish })}>
+        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
+      </PanelSetup>
+    );
+  },
 
-export const ExampleCantPublishAdvanced: StoryFn = () => {
-  const allowPublish = false;
-  return (
-    <PanelSetup fixture={getFixture({ allowPublish })}>
-      <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-    </PanelSetup>
-  );
+  name: "example can't publish, advanced",
 };
 
-ExampleCantPublishAdvanced.storyName = "example can't publish, advanced";
+export const ExampleCantPublishNotAdvanced: StoryObj = {
+  render: () => {
+    const allowPublish = false;
+    return (
+      <PanelSetup fixture={getFixture({ allowPublish })}>
+        <Publish overrideConfig={publishConfig({ advancedView: false, value: advancedJSON })} />
+      </PanelSetup>
+    );
+  },
 
-export const ExampleCantPublishNotAdvanced: StoryFn = () => {
-  const allowPublish = false;
-  return (
-    <PanelSetup fixture={getFixture({ allowPublish })}>
-      <Publish overrideConfig={publishConfig({ advancedView: false, value: advancedJSON })} />
-    </PanelSetup>
-  );
+  name: "example can't publish, not advanced",
 };
 
-ExampleCantPublishNotAdvanced.storyName = "example can't publish, not advanced";
+export const ExampleWithDatatypeThatNoLongerExists: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={{ topics: [], datatypes: new Map(), frame: {}, capabilities: [] }}>
+        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
+      </PanelSetup>
+    );
+  },
 
-export const ExampleWithDatatypeThatNoLongerExists: StoryFn = () => {
-  return (
-    <PanelSetup fixture={{ topics: [], datatypes: new Map(), frame: {}, capabilities: [] }}>
-      <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-    </PanelSetup>
-  );
+  name: "Example with datatype that no longer exists",
 };
 
-ExampleWithDatatypeThatNoLongerExists.storyName = "Example with datatype that no longer exists";
+export const ExampleWithValidPresetJson: StoryObj = {
+  render: () => {
+    const fixture = {
+      topics: [],
+      datatypes: new Map(
+        Object.entries({
+          "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
+        }),
+      ),
+      frame: {},
+      capabilities: [PlayerCapabilities.advertise],
+      setPublishers: action("setPublishers"),
+      publish: action("publish"),
+    };
 
-export const ExampleWithValidPresetJson: StoryFn = () => {
-  const fixture = {
-    topics: [],
-    datatypes: new Map(
-      Object.entries({
-        "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-      }),
-    ),
-    frame: {},
-    capabilities: [PlayerCapabilities.advertise],
-    setPublishers: action("setPublishers"),
-    publish: action("publish"),
-  };
+    const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
 
-  const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
+    return (
+      <PanelSetup fixture={fixture}>
+        <Publish overrideConfig={publishConfig({ advancedView: true, value: validJSON })} />
+      </PanelSetup>
+    );
+  },
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <Publish overrideConfig={publishConfig({ advancedView: true, value: validJSON })} />
-    </PanelSetup>
-  );
+  name: "example with valid preset JSON",
 };
 
-ExampleWithValidPresetJson.storyName = "example with valid preset JSON";
+export const ExampleWithInvalidPresetJson: StoryObj = {
+  render: () => {
+    const fixture = {
+      topics: [],
+      datatypes: new Map(
+        Object.entries({
+          "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
+        }),
+      ),
+      frame: {},
+      capabilities: [PlayerCapabilities.advertise],
+      setPublishers: action("setPublishers"),
+      publish: action("publish"),
+    };
 
-export const ExampleWithInvalidPresetJson: StoryFn = () => {
-  const fixture = {
-    topics: [],
-    datatypes: new Map(
-      Object.entries({
-        "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-      }),
-    ),
-    frame: {},
-    capabilities: [PlayerCapabilities.advertise],
-    setPublishers: action("setPublishers"),
-    publish: action("publish"),
-  };
+    const invalid = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
 
-  const invalid = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
+    return (
+      <PanelSetup fixture={fixture}>
+        <Publish overrideConfig={publishConfig({ advancedView: true, value: invalid })} />
+      </PanelSetup>
+    );
+  },
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <Publish overrideConfig={publishConfig({ advancedView: true, value: invalid })} />
-    </PanelSetup>
-  );
+  name: "example with invalid preset JSON",
 };
-
-ExampleWithInvalidPresetJson.storyName = "example with invalid preset JSON";

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { action } from "@storybook/addon-actions";
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import Publish from "@foxglove/studio-base/panels/Publish";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -50,385 +50,450 @@ export default {
   title: "panels/RawMessages",
 };
 
-export const Default: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+export const Default: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
+
+  name: "default",
 };
 
-Default.storyName = "default";
+export const Schemaless: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={{
+          topics: [{ name: "foo", schemaName: undefined }],
+          datatypes: new Map(),
+          frame: {
+            ["foo"]: [
+              {
+                topic: "foo",
+                schemaName: "",
+                message: { bar: 1 },
+                receiveTime: { sec: 0, nsec: 0 },
+                sizeInBytes: 0,
+              },
+            ],
+          },
+        }}
+      >
+        <RawMessages overrideConfig={{ topicPath: "foo", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const Schemaless: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={{
-        topics: [{ name: "foo", schemaName: undefined }],
-        datatypes: new Map(),
-        frame: {
-          ["foo"]: [
+  name: "schemaless",
+};
+
+export const Collapsed: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "none" } as any
+          }
+        />
+      </PanelSetup>
+    );
+  },
+
+  name: "collapsed",
+};
+
+export const Expanded: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "all" } as any
+          }
+        />
+      </PanelSetup>
+    );
+  },
+
+  name: "expanded",
+};
+
+export const Overridden: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <RawMessages
+          overrideConfig={
             {
-              topic: "foo",
-              schemaName: "",
-              message: { bar: 1 },
-              receiveTime: { sec: 0, nsec: 0 },
-              sizeInBytes: 0,
-            },
-          ],
-        },
-      }}
-    >
-      <RawMessages overrideConfig={{ topicPath: "foo", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+              topicPath: "/msgs/big_topic",
+              ...noDiffConfig,
+              expansion: { LotsOfStuff: "c", timestamp_array: "e" },
+            } as any
+          }
+        />
+      </PanelSetup>
+    );
+  },
+
+  name: "overridden",
 };
 
-Schemaless.storyName = "schemaless";
+export const WithReceiveTime: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/foo", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const Collapsed: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages
-        overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "none" } as any}
-      />
-    </PanelSetup>
-  );
+  name: "with receiveTime",
 };
 
-Collapsed.storyName = "collapsed";
+export const DisplayBigValueNum: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/num.value", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const Expanded: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages
-        overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "all" } as any}
-      />
-    </PanelSetup>
-  );
+  name: "display big value - num",
 };
 
-Expanded.storyName = "expanded";
+export const DisplayMessageWithBigintValue: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/bigint", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const Overridden: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture} includeSettings>
-      <RawMessages
-        overrideConfig={
-          {
-            topicPath: "/msgs/big_topic",
-            ...noDiffConfig,
-            expansion: { LotsOfStuff: "c", timestamp_array: "e" },
-          } as any
-        }
-      />
-    </PanelSetup>
-  );
+  name: "display message with bigint value",
 };
 
-Overridden.storyName = "overridden";
+export const DisplayBigintValue: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/bigint.value", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const WithReceiveTime: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/foo", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display bigint value",
 };
 
-WithReceiveTime.storyName = "with receiveTime";
+export const DisplayBigValueText: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/text.value", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBigValueNum: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/num.value", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display big value - text",
 };
 
-DisplayBigValueNum.storyName = "display big value - num";
+export const DisplayBigValueTextTruncated: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
+        <RawMessages
+          overrideConfig={{ topicPath: "/baz/text.value_long", ...noDiffConfig } as any}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayMessageWithBigintValue: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/bigint", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display big value - text truncated",
 };
 
-DisplayMessageWithBigintValue.storyName = "display message with bigint value";
+export const DisplayBigValueTextWithNewlines: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
+        <RawMessages
+          overrideConfig={{ topicPath: "/baz/text.value_with_newlines", ...noDiffConfig } as any}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBigintValue: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/bigint.value", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display big value - text with newlines",
 };
 
-DisplayBigintValue.storyName = "display bigint value";
+export const DisplayBigValueSingleElementArray: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/array.value", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBigValueText: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/text.value", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display big value - single element array",
 };
 
-DisplayBigValueText.storyName = "display big value - text";
+export const DisplaySingleObjectArray: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={{ topicPath: "/baz/array/obj.value", ...noDiffConfig } as any}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBigValueTextTruncated: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/text.value_long", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display single object array",
 };
 
-DisplayBigValueTextTruncated.storyName = "display big value - text truncated";
+export const DisplayBasicEnum: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={enumFixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/enum", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBigValueTextWithNewlines: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
-      <RawMessages
-        overrideConfig={{ topicPath: "/baz/text.value_with_newlines", ...noDiffConfig } as any}
-      />
-    </PanelSetup>
-  );
+  name: "display basic enum",
 };
 
-DisplayBigValueTextWithNewlines.storyName = "display big value - text with newlines";
+export const DisplayAdvancedEnumUsage: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={enumAdvancedFixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/enum_advanced", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBigValueSingleElementArray: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/array.value", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display advanced enum usage",
 };
 
-DisplayBigValueSingleElementArray.storyName = "display big value - single element array";
+export const WithMissingData: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={withMissingData}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/missing_data", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplaySingleObjectArray: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/array/obj.value", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "with missing data",
 };
 
-DisplaySingleObjectArray.storyName = "display single object array";
+export const WithATruncatedLongString: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/text", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayBasicEnum: StoryFn = () => {
-  return (
-    <PanelSetup fixture={enumFixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/enum", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "with a truncated long string",
 };
 
-DisplayBasicEnum.storyName = "display basic enum";
+export const DisplayGeometryTypesLength: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages overrideConfig={{ topicPath: "/geometry/types", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayAdvancedEnumUsage: StoryFn = () => {
-  return (
-    <PanelSetup fixture={enumAdvancedFixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/enum_advanced", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display geometry types - length",
 };
 
-DisplayAdvancedEnumUsage.storyName = "display advanced enum usage";
+export const DisplayDiff: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={topicsToDiffFixture}>
+        <RawMessages
+          overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: false } as any}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const WithMissingData: StoryFn = () => {
-  return (
-    <PanelSetup fixture={withMissingData}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/missing_data", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display diff",
 };
 
-WithMissingData.storyName = "with missing data";
+export const DisplayFullDiff: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={topicsToDiffFixture}>
+        <RawMessages
+          overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: true } as any}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const WithATruncatedLongString: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/baz/text", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display full diff",
 };
 
-WithATruncatedLongString.storyName = "with a truncated long string";
+export const DisplayDiffWithIdFields: StoryObj = {
+  render: () => {
+    const config = {
+      ...diffConfig,
+      topicPath: "/baz/enum_advanced_array.value",
+      diffTopicPath: "/another/baz/enum_advanced_array.value",
+      showFullMessageForDiff: false,
+      expansion: "all",
+    };
+    return (
+      <PanelSetup fixture={topicsWithIdsToDiffFixture}>
+        <RawMessages overrideConfig={config as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayGeometryTypesLength: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages overrideConfig={{ topicPath: "/geometry/types", ...noDiffConfig } as any} />
-    </PanelSetup>
-  );
+  name: "display diff with ID fields",
 };
 
-DisplayGeometryTypesLength.storyName = "display geometry types - length";
+export const EmptyDiffMessage: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={{ topics: [], frame: {} }}>
+        <RawMessages overrideConfig={{ ...diffConfig, showFullMessageForDiff: false } as any} />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayDiff: StoryFn = () => {
-  return (
-    <PanelSetup fixture={topicsToDiffFixture}>
-      <RawMessages
-        overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: false } as any}
-      />
-    </PanelSetup>
-  );
+  name: "empty diff message",
 };
 
-DisplayDiff.storyName = "display diff";
+export const DiffSameMessages: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={{
+            topicPath: "/foo",
+            diffMethod: "custom",
+            diffTopicPath: "/foo",
+            diffEnabled: true,
+            showFullMessageForDiff: false,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayFullDiff: StoryFn = () => {
-  return (
-    <PanelSetup fixture={topicsToDiffFixture}>
-      <RawMessages
-        overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: true } as any}
-      />
-    </PanelSetup>
-  );
+  name: "diff same messages",
 };
 
-DisplayFullDiff.storyName = "display full diff";
+export const DiffConsecutiveMessages: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={{
+            topicPath: "/foo",
+            diffMethod: PREV_MSG_METHOD,
+            diffTopicPath: "",
+            diffEnabled: true,
+            showFullMessageForDiff: true,
+            expansion: "all",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DisplayDiffWithIdFields: StoryFn = () => {
-  const config = {
-    ...diffConfig,
-    topicPath: "/baz/enum_advanced_array.value",
-    diffTopicPath: "/another/baz/enum_advanced_array.value",
-    showFullMessageForDiff: false,
-    expansion: "all",
-  };
-  return (
-    <PanelSetup fixture={topicsWithIdsToDiffFixture}>
-      <RawMessages overrideConfig={config as any} />
-    </PanelSetup>
-  );
+  name: "diff consecutive messages",
 };
 
-DisplayDiffWithIdFields.storyName = "display diff with ID fields";
+export const DiffConsecutiveMessagesWithFilter: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={multipleMessagesFilter}>
+        <RawMessages
+          overrideConfig={{
+            topicPath: "/foo{type==2}",
+            diffMethod: PREV_MSG_METHOD,
+            diffTopicPath: "",
+            diffEnabled: true,
+            showFullMessageForDiff: true,
+            expansion: "all",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const EmptyDiffMessage: StoryFn = () => {
-  return (
-    <PanelSetup fixture={{ topics: [], frame: {} }}>
-      <RawMessages overrideConfig={{ ...diffConfig, showFullMessageForDiff: false } as any} />
-    </PanelSetup>
-  );
+  name: "diff consecutive messages with filter",
 };
 
-EmptyDiffMessage.storyName = "empty diff message";
+export const DiffConsecutiveMessagesWithBigint: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={{
+            topicPath: "/baz/bigint",
+            diffMethod: PREV_MSG_METHOD,
+            diffTopicPath: "",
+            diffEnabled: true,
+            showFullMessageForDiff: true,
+            expansion: "all",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DiffSameMessages: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages
-        overrideConfig={{
-          topicPath: "/foo",
-          diffMethod: "custom",
-          diffTopicPath: "/foo",
-          diffEnabled: true,
-          showFullMessageForDiff: false,
-        }}
-      />
-    </PanelSetup>
-  );
+  name: "diff consecutive messages with bigint",
 };
 
-DiffSameMessages.storyName = "diff same messages";
+export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <RawMessages
+          overrideConfig={{
+            topicPath: "/foo",
+            diffMethod: PREV_MSG_METHOD,
+            diffTopicPath: "/another/baz/enum_advanced",
+            diffEnabled: false,
+            showFullMessageForDiff: true,
+            expansion: "all",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DiffConsecutiveMessages: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages
-        overrideConfig={{
-          topicPath: "/foo",
-          diffMethod: PREV_MSG_METHOD,
-          diffTopicPath: "",
-          diffEnabled: true,
-          showFullMessageForDiff: true,
-          expansion: "all",
-        }}
-      />
-    </PanelSetup>
-  );
+  name: "display correct message when diff is disabled, even with diff method & topic set",
 };
 
-DiffConsecutiveMessages.storyName = "diff consecutive messages";
+export const MultipleMessagesWithTopLevelFilter: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={multipleNumberMessagesFixture}>
+        <RawMessages
+          overrideConfig={
+            {
+              topicPath: "/multiple_number_messages{value==2}",
+              ...noDiffConfig,
+            } as any
+          }
+        />
+      </PanelSetup>
+    );
+  },
 
-export const DiffConsecutiveMessagesWithFilter: StoryFn = () => {
-  return (
-    <PanelSetup fixture={multipleMessagesFilter}>
-      <RawMessages
-        overrideConfig={{
-          topicPath: "/foo{type==2}",
-          diffMethod: PREV_MSG_METHOD,
-          diffTopicPath: "",
-          diffEnabled: true,
-          showFullMessageForDiff: true,
-          expansion: "all",
-        }}
-      />
-    </PanelSetup>
-  );
+  name: "multiple messages with top-level filter",
 };
-
-DiffConsecutiveMessagesWithFilter.storyName = "diff consecutive messages with filter";
-
-export const DiffConsecutiveMessagesWithBigint: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages
-        overrideConfig={{
-          topicPath: "/baz/bigint",
-          diffMethod: PREV_MSG_METHOD,
-          diffTopicPath: "",
-          diffEnabled: true,
-          showFullMessageForDiff: true,
-          expansion: "all",
-        }}
-      />
-    </PanelSetup>
-  );
-};
-
-DiffConsecutiveMessagesWithBigint.storyName = "diff consecutive messages with bigint";
-
-export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <RawMessages
-        overrideConfig={{
-          topicPath: "/foo",
-          diffMethod: PREV_MSG_METHOD,
-          diffTopicPath: "/another/baz/enum_advanced",
-          diffEnabled: false,
-          showFullMessageForDiff: true,
-          expansion: "all",
-        }}
-      />
-    </PanelSetup>
-  );
-};
-
-DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet.storyName =
-  "display correct message when diff is disabled, even with diff method & topic set";
-
-export const MultipleMessagesWithTopLevelFilter: StoryFn = () => {
-  return (
-    <PanelSetup fixture={multipleNumberMessagesFixture}>
-      <RawMessages
-        overrideConfig={
-          {
-            topicPath: "/multiple_number_messages{value==2}",
-            ...noDiffConfig,
-          } as any
-        }
-      />
-    </PanelSetup>
-  );
-};
-
-MultipleMessagesWithTopLevelFilter.storyName = "multiple messages with top-level filter";

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useCallback } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -118,7 +118,7 @@ export default {
   },
 };
 
-export const ColorPalette: Story = () => {
+export const ColorPalette: StoryFn = () => {
   return (
     <div style={{ width: "100%", padding: "1rem" }}>
       {expandedLineColors.map((color) => (
@@ -128,156 +128,184 @@ export const ColorPalette: Story = () => {
   );
 };
 
-export const OnePath: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-      <StateTransitions
-        overrideConfig={{
-          paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
-};
-OnePath.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-OnePath.parameters = { useReadySignal: true };
+export const OnePath: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+        <StateTransitions
+          overrideConfig={{
+            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const WithSettings: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} includeSettings>
-      <StateTransitions
-        overrideConfig={{
-          paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
-};
-WithSettings.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-WithSettings.parameters = { useReadySignal: true };
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 
-export const MultiplePaths: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-      <StateTransitions
-        overrideConfig={{
-          paths: new Array(5).fill({
-            value: "/some/topic/with/state.state",
-            timestampMethod: "receiveTime",
-          }),
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
+  parameters: { useReadySignal: true },
 };
-MultiplePaths.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-MultiplePaths.parameters = { useReadySignal: true };
 
-export const MultiplePathsWithHover: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup
-      fixture={fixture}
-      pauseFrame={pauseFrame}
-      onMount={() => {
-        const mouseEnterContainer = document.querySelectorAll(
-          "[data-testid~=panel-mouseenter-container",
-        )[0]!;
-        TestUtils.Simulate.mouseEnter(mouseEnterContainer);
-      }}
-      style={{ width: 370 }}
-    >
-      <StateTransitions
-        overrideConfig={{
-          paths: new Array(5).fill({
-            value: "/some/topic/with/state.state",
-            timestampMethod: "receiveTime",
-          }),
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
-};
-MultiplePathsWithHover.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-MultiplePathsWithHover.parameters = { useReadySignal: true };
+export const WithSettings: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame} includeSettings>
+        <StateTransitions
+          overrideConfig={{
+            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-export const LongPath: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ maxWidth: 100 }}>
-      <StateTransitions
-        overrideConfig={{
-          paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
-};
-LongPath.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-LongPath.parameters = { useReadySignal: true };
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 
-export const JsonPath: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-      <StateTransitions
-        overrideConfig={{
-          paths: [{ value: "/some/topic/with/state.data.value", timestampMethod: "receiveTime" }],
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
+  parameters: { useReadySignal: true },
 };
-JsonPath.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-JsonPath.parameters = { useReadySignal: true };
 
-export const ColorClash: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-      <StateTransitions
-        overrideConfig={{
-          paths: [
-            { value: "/some/topic/with/string_state.data.value", timestampMethod: "receiveTime" },
-          ],
-          isSynced: true,
+export const MultiplePaths: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+        <StateTransitions
+          overrideConfig={{
+            paths: new Array(5).fill({
+              value: "/some/topic/with/state.state",
+              timestampMethod: "receiveTime",
+            }),
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
+};
+
+export const MultiplePathsWithHover: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup
+        fixture={fixture}
+        pauseFrame={pauseFrame}
+        onMount={() => {
+          const mouseEnterContainer = document.querySelectorAll(
+            "[data-testid~=panel-mouseenter-container",
+          )[0]!;
+          TestUtils.Simulate.mouseEnter(mouseEnterContainer);
         }}
-      />
-    </PanelSetup>
-  );
+        style={{ width: 370 }}
+      >
+        <StateTransitions
+          overrideConfig={{
+            paths: new Array(5).fill({
+              value: "/some/topic/with/state.state",
+              timestampMethod: "receiveTime",
+            }),
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
 };
-ColorClash.play = async (ctx) => {
-  await ctx.parameters.storyReady;
+
+export const LongPath: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ maxWidth: 100 }}>
+        <StateTransitions
+          overrideConfig={{
+            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
 };
-ColorClash.parameters = { useReadySignal: true };
+
+export const JsonPath: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+        <StateTransitions
+          overrideConfig={{
+            paths: [{ value: "/some/topic/with/state.data.value", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
+};
+
+export const ColorClash: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+        <StateTransitions
+          overrideConfig={{
+            paths: [
+              { value: "/some/topic/with/string_state.data.value", timestampMethod: "receiveTime" },
+            ],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
+};
 
 const messageCache: BlockCache = {
   blocks: [
@@ -327,28 +355,32 @@ const messageCache: BlockCache = {
   startTime: systemStateMessages[0]!.header.stamp,
 };
 
-export const Blocks: Story = () => {
-  const readySignal = useReadySignal({ count: 3 });
-  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+export const Blocks: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
-  const blockFixture = { ...fixture, progress: { messageCache } };
+    const blockFixture = { ...fixture, progress: { messageCache } };
 
-  return (
-    <PanelSetup fixture={blockFixture} pauseFrame={pauseFrame}>
-      <StateTransitions
-        overrideConfig={{
-          paths: [
-            { value: "/some/topic/with/state.state", timestampMethod: "receiveTime" },
-            { value: "/blocks.state", timestampMethod: "receiveTime" },
-            { value: "/blocks.state", timestampMethod: "receiveTime" },
-          ],
-          isSynced: true,
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={blockFixture} pauseFrame={pauseFrame}>
+        <StateTransitions
+          overrideConfig={{
+            paths: [
+              { value: "/some/topic/with/state.state", timestampMethod: "receiveTime" },
+              { value: "/blocks.state", timestampMethod: "receiveTime" },
+              { value: "/blocks.state", timestampMethod: "receiveTime" },
+            ],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: { useReadySignal: true },
 };
-Blocks.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-Blocks.parameters = { useReadySignal: true };

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useCallback } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -118,18 +118,20 @@ export default {
   },
 };
 
-export const ColorPalette: StoryFn = () => {
-  return (
-    <div style={{ width: "100%", padding: "1rem" }}>
-      {expandedLineColors.map((color) => (
-        <div key={color} style={{ backgroundColor: color, height: "1rem" }} />
-      ))}
-    </div>
-  );
+export const ColorPalette: StoryObj = {
+  render: function Story() {
+    return (
+      <div style={{ width: "100%", padding: "1rem" }}>
+        {expandedLineColors.map((color) => (
+          <div key={color} style={{ backgroundColor: color, height: "1rem" }} />
+        ))}
+      </div>
+    );
+  },
 };
 
 export const OnePath: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -152,7 +154,7 @@ export const OnePath: StoryObj = {
 };
 
 export const WithSettings: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -175,7 +177,7 @@ export const WithSettings: StoryObj = {
 };
 
 export const MultiplePaths: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -201,7 +203,7 @@ export const MultiplePaths: StoryObj = {
 };
 
 export const MultiplePathsWithHover: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -237,7 +239,7 @@ export const MultiplePathsWithHover: StoryObj = {
 };
 
 export const LongPath: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -260,7 +262,7 @@ export const LongPath: StoryObj = {
 };
 
 export const JsonPath: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -283,7 +285,7 @@ export const JsonPath: StoryObj = {
 };
 
 export const ColorClash: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
@@ -356,7 +358,7 @@ const messageCache: BlockCache = {
 };
 
 export const Blocks: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { noop } from "lodash";
 import React, { ReactNode } from "react";
 

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { noop } from "lodash";
 import React, { ReactNode } from "react";
 
@@ -50,65 +50,79 @@ export default {
   title: "panels/Tab/ToolbarTab",
 };
 
-export const Default: StoryFn = () => (
-  <Container>
-    <ToolbarTab {...baseProps} />
-  </Container>
-);
+export const Default: StoryObj = {
+  render: () => (
+    <Container>
+      <ToolbarTab {...baseProps} />
+    </Container>
+  ),
 
-Default.storyName = "default";
+  name: "default",
+};
 
-export const ActiveWithCloseIcon: StoryFn = () => (
-  <Container>
-    <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 3 }} />
-  </Container>
-);
+export const ActiveWithCloseIcon: StoryObj = {
+  render: () => (
+    <Container>
+      <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 3 }} />
+    </Container>
+  ),
 
-ActiveWithCloseIcon.storyName = "active with close icon";
+  name: "active with close icon",
+};
 
-export const ActiveWithoutCloseIcon: StoryFn = () => (
-  <Container>
-    <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 1 }} />
-  </Container>
-);
+export const ActiveWithoutCloseIcon: StoryObj = {
+  render: () => (
+    <Container>
+      <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 1 }} />
+    </Container>
+  ),
 
-ActiveWithoutCloseIcon.storyName = "active without close icon";
+  name: "active without close icon",
+};
 
-export const Hidden: StoryFn = () => (
-  <Container>
-    <ToolbarTab {...{ ...baseProps, hidden: true }} />
-  </Container>
-);
+export const Hidden: StoryObj = {
+  render: () => (
+    <Container>
+      <ToolbarTab {...{ ...baseProps, hidden: true }} />
+    </Container>
+  ),
 
-Hidden.storyName = "hidden";
+  name: "hidden",
+};
 
-export const Highlight: StoryFn = () => (
-  <Container>
-    <ToolbarTab {...{ ...baseProps, highlight: "before" }} />
-  </Container>
-);
+export const Highlight: StoryObj = {
+  render: () => (
+    <Container>
+      <ToolbarTab {...{ ...baseProps, highlight: "before" }} />
+    </Container>
+  ),
 
-Highlight.storyName = "highlight";
+  name: "highlight",
+};
 
-export const Dragging: StoryFn = () => (
-  <Container>
-    <ToolbarTab {...{ ...baseProps, isDragging: true }} />
-  </Container>
-);
+export const Dragging: StoryObj = {
+  render: () => (
+    <Container>
+      <ToolbarTab {...{ ...baseProps, isDragging: true }} />
+    </Container>
+  ),
 
-Dragging.storyName = "dragging";
+  name: "dragging",
+};
 
-export const Editing: StoryFn = () => (
-  <Container
-    ref={async (el) => {
-      await tick();
-      if (el) {
-        el.querySelectorAll("input")[0]?.click();
-      }
-    }}
-  >
-    <ToolbarTab {...{ ...baseProps, isActive: true }} />
-  </Container>
-);
+export const Editing: StoryObj = {
+  render: () => (
+    <Container
+      ref={async (el) => {
+        await tick();
+        if (el) {
+          el.querySelectorAll("input")[0]?.click();
+        }
+      }}
+    >
+      <ToolbarTab {...{ ...baseProps, isActive: true }} />
+    </Container>
+  ),
 
-Editing.storyName = "editing";
+  name: "editing",
+};

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { fireEvent } from "@storybook/testing-library";
 
 import Panel from "@foxglove/studio-base/components/Panel";
@@ -95,13 +95,13 @@ export default {
   },
 
   decorators: [
-    (StoryFn: Story): JSX.Element => {
+    (Wrapped: StoryFn): JSX.Element => {
       const storage = new MockLayoutStorage(LayoutManager.LOCAL_STORAGE_NAMESPACE, []);
 
       return (
         <LayoutStorageContext.Provider value={storage}>
           <LayoutManagerProvider>
-            <StoryFn />
+            <Wrapped />
           </LayoutManagerProvider>
         </LayoutStorageContext.Provider>
       );
@@ -109,411 +109,435 @@ export default {
   ],
 };
 
-export const Default: Story = () => (
-  <PanelSetup fixture={fixture}>
-    <Tab />
-  </PanelSetup>
-);
-
-Default.storyName = "default";
-Default.parameters = { colorScheme: "both-row" };
-
-export const ShowingPanelList: Story = () => (
-  <PanelSetup fixture={fixture} panelCatalog={new MockPanelCatalog()}>
-    <Tab />
-  </PanelSetup>
-);
-
-ShowingPanelList.storyName = "showing panel list";
-
-export const ShowingPanelListLight: Story = () => (
-  <PanelSetup fixture={fixture} panelCatalog={new MockPanelCatalog()}>
-    <Tab />
-  </PanelSetup>
-);
-
-ShowingPanelListLight.storyName = "showing panel list light";
-ShowingPanelListLight.parameters = { colorScheme: "light" };
-
-export const PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": {
-            activeTabIdx: -1,
-            tabs: [],
-          },
-        },
-      }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-          (
-            document.querySelectorAll('[data-testid="panel-menu-item Some Panel"]')[0] as any
-          ).click();
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
+export const Default: StoryObj = {
+  render: () => (
+    <PanelSetup fixture={fixture}>
+      <Tab />
     </PanelSetup>
-  );
+  ),
+
+  name: "default",
+  parameters: { colorScheme: "both-row" },
 };
 
-PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName =
-  "picking a panel from the panel list creates a new tab if there are none";
-
-export const PickingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": {
-            activeTabIdx: 0,
-            tabs: [{ title: "First tab", layout: undefined }],
-          },
-        },
-      }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-          (
-            document.querySelectorAll('[data-testid="panel-menu-item Some Panel"]')[0] as any
-          ).click();
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
+export const ShowingPanelList: StoryObj = {
+  render: () => (
+    <PanelSetup fixture={fixture} panelCatalog={new MockPanelCatalog()}>
+      <Tab />
     </PanelSetup>
-  );
+  ),
+
+  name: "showing panel list",
 };
 
-PickingAPanelFromThePanelListUpdatesTheTabsLayout.storyName =
-  "picking a panel from the panel list updates the tab's layout";
-
-export const DraggingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": {
-            activeTabIdx: 0,
-            tabs: [{ title: "First tab", layout: undefined }],
-          },
-        },
-      }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-
-          const imageItem = document.querySelectorAll(
-            '[data-testid="panel-menu-item Some Panel"]',
-          )[0];
-          const panel = document.querySelectorAll('[data-testid="empty-drop-target"]')[0];
-          dragAndDrop(imageItem!, panel!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
+export const ShowingPanelListLight: StoryObj = {
+  render: () => (
+    <PanelSetup fixture={fixture} panelCatalog={new MockPanelCatalog()}>
+      <Tab />
     </PanelSetup>
-  );
+  ),
+
+  name: "showing panel list light",
+  parameters: { colorScheme: "light" },
 };
 
-DraggingAPanelFromThePanelListUpdatesTheTabsLayout.storyName =
-  "dragging a panel from the panel list updates the tab's layout";
-
-export const DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": {
-            activeTabIdx: -1,
-            tabs: [],
-          },
-        },
-      }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-
-          const imageItem = document.querySelectorAll(
-            '[data-testid="panel-menu-item Some Panel"]',
-          )[0];
-          const panel = document.querySelectorAll('[data-testid="empty-drop-target"]')[0];
-          dragAndDrop(imageItem!, panel!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-    </PanelSetup>
-  );
-};
-
-DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName =
-  "dragging a panel from the panel list creates a new tab if there are none";
-
-export const WithChosenActiveTab: Story = () => (
-  <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture}>
-    <Tab
-      overrideConfig={{
-        activeTabIdx: 1,
-        tabs: [
-          {
-            title: "Tab A",
-            layout: undefined,
-          },
-          {
-            title: "Tab B",
-            layout: {
-              direction: "row",
-              first: {
-                direction: "column",
-                first: "Sample1!2xqjjqw",
-                second: "Sample2!81fx2n",
-                splitPercentage: 60,
-              },
-              second: {
-                direction: "column",
-                first: "Sample2!3dor2gy",
-                second: "Sample1!3wrafzj",
-                splitPercentage: 40,
-              },
+export const PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": {
+              activeTabIdx: -1,
+              tabs: [],
             },
           },
-          {
-            title: "Tab C",
-            layout: undefined,
+        }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
+            (
+              document.querySelectorAll('[data-testid="panel-menu-item Some Panel"]')[0] as any
+            ).click();
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  name: "picking a panel from the panel list creates a new tab if there are none",
+};
+
+export const PickingAPanelFromThePanelListUpdatesTheTabsLayout: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": {
+              activeTabIdx: 0,
+              tabs: [{ title: "First tab", layout: undefined }],
+            },
           },
-        ],
-      }}
-    />
-  </PanelSetup>
-);
+        }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
+            (
+              document.querySelectorAll('[data-testid="panel-menu-item Some Panel"]')[0] as any
+            ).click();
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
 
-WithChosenActiveTab.storyName = "with chosen active tab";
-WithChosenActiveTab.parameters = { colorScheme: "both-row" };
-
-export const AddTab: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": { activeTabIdx: 0, tabs: [{ title: "Tab A", layout: undefined }] },
-        },
-      }}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          const addTabBtn = document.querySelector("[data-testid=add-tab]");
-          if (addTabBtn) {
-            (addTabBtn as any).click();
-          }
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-    </PanelSetup>
-  );
+  name: "picking a panel from the panel list updates the tab's layout",
 };
 
-AddTab.storyName = "add tab";
-
-export const RemoveTab: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": { activeTabIdx: 0, tabs: manyTabs.slice(0, 5) },
-        },
-      }}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          const removeTabBtn = document.querySelector("[data-testid=tab-icon]");
-          if (removeTabBtn) {
-            (removeTabBtn as any).click();
-          }
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-    </PanelSetup>
-  );
-};
-
-RemoveTab.storyName = "remove tab";
-
-export const ReorderTabsWithinTabPanelByDroppingOnTab: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": { activeTabIdx: 0, tabs: manyTabs.slice(0, 5) },
-        },
-      }}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-          const tabs = document.querySelectorAll("[draggable=true]");
-
-          // Drag and drop the first tab onto the third tab
-          dragAndDrop(tabs[0]!, tabs[2]!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-      <SExpectedResult>Expected result: #2, #3, #1, #4, #5</SExpectedResult>
-    </PanelSetup>
-  );
-};
-
-ReorderTabsWithinTabPanelByDroppingOnTab.storyName =
-  "reorder tabs within Tab panel by dropping on tab";
-
-export const MoveTabToDifferentTabPanel: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        layout: {
-          first: "Tab!a",
-          second: "Tab!b",
-          direction: "row",
-          splitPercentage: 50,
-        },
-        savedProps: {
-          "Tab!a": { activeTabIdx: 0, tabs: manyTabs.slice(0, 2) },
-          "Tab!b": { activeTabIdx: 0, tabs: manyTabs.slice(2, 3) },
-        },
-      }}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-          const tabs = document.querySelectorAll("[data-testid=toolbar-tab]");
-          dragAndDrop(tabs[0]!, tabs[2]!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-      <SExpectedResult style={{ left: 0 }}>Should have only #2</SExpectedResult>
-      <SExpectedResult style={{ left: "50%" }}>Should have #1 and #3</SExpectedResult>
-    </PanelSetup>
-  );
-};
-
-MoveTabToDifferentTabPanel.storyName = "move tab to different Tab panel";
-
-export const PreventDraggingSelectedParentTabIntoChildTabPanel: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={{
-        ...fixture,
-        savedProps: {
-          "Tab!a": {
-            activeTabIdx: 0,
-            tabs: [{ title: "Parent tab", layout: "Tab!b" }, manyTabs[0]],
+export const DraggingAPanelFromThePanelListUpdatesTheTabsLayout: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": {
+              activeTabIdx: 0,
+              tabs: [{ title: "First tab", layout: undefined }],
+            },
           },
-          "Tab!b": { activeTabIdx: 0, tabs: manyTabs.slice(3, 6) },
-        },
-      }}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          await tick();
-          const tabs = document.querySelectorAll("[draggable=true]");
+        }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
 
-          fireEvent.dragStart(tabs[0]!);
-          fireEvent.dragOver(tabs[2]!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-      <SExpectedResult style={{ left: 0 }}>
-        the first tab should be hidden (we never dropped it)
-      </SExpectedResult>
-      <SExpectedResult style={{ top: "50px" }}>tab content should be hidden</SExpectedResult>
-    </PanelSetup>
-  );
+            const imageItem = document.querySelectorAll(
+              '[data-testid="panel-menu-item Some Panel"]',
+            )[0];
+            const panel = document.querySelectorAll('[data-testid="empty-drop-target"]')[0];
+            dragAndDrop(imageItem!, panel!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  name: "dragging a panel from the panel list updates the tab's layout",
 };
 
-PreventDraggingSelectedParentTabIntoChildTabPanel.storyName =
-  "prevent dragging selected parent tab into child tab panel";
+export const DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": {
+              activeTabIdx: -1,
+              tabs: [],
+            },
+          },
+        }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
 
-export const DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={nestedTabLayoutFixture}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          // Create a new tab on the left side
-          (
-            document.querySelectorAll('[data-testid~="Tab!Left"] [data-testid="add-tab"]')[0] as any
-          ).click();
+            const imageItem = document.querySelectorAll(
+              '[data-testid="panel-menu-item Some Panel"]',
+            )[0];
+            const panel = document.querySelectorAll('[data-testid="empty-drop-target"]')[0];
+            dragAndDrop(imageItem!, panel!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
 
-          const dragHandle = document.querySelector(
-            '[data-testid~="Tab!RightInner"] [data-testid="panel-menu"]',
-          );
-
-          const target = document.querySelector(
-            '[data-testid~="Tab!Left"] [data-testid="empty-drop-target"]',
-          );
-          dragAndDrop(dragHandle!, target!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
-    </PanelSetup>
-  );
+  name: "dragging a panel from the panel list creates a new tab if there are none",
 };
 
-DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs.storyName =
-  "dragging and dropping a nested tab panel does not remove any tabs";
-
-export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = () => {
-  return (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={nestedTabLayoutFixture2}
-      style={{ width: "100%" }}
-      onMount={() => {
-        setTimeout(async () => {
-          const dragHandle = document.querySelector(
-            '[data-testid~="Sample1"] [data-testid="mosaic-drag-handle"]',
-          );
-
-          const target = document
-            .querySelector('[data-testid="unknown!inner4"]')
-            ?.parentElement?.parentElement?.parentElement?.querySelector(".drop-target.left");
-
-          dragAndDrop(dragHandle!, target!);
-        }, DEFAULT_TIMEOUT);
-      }}
-    >
-      <PanelLayout />
+export const WithChosenActiveTab: StoryObj = {
+  render: () => (
+    <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture}>
+      <Tab
+        overrideConfig={{
+          activeTabIdx: 1,
+          tabs: [
+            {
+              title: "Tab A",
+              layout: undefined,
+            },
+            {
+              title: "Tab B",
+              layout: {
+                direction: "row",
+                first: {
+                  direction: "column",
+                  first: "Sample1!2xqjjqw",
+                  second: "Sample2!81fx2n",
+                  splitPercentage: 60,
+                },
+                second: {
+                  direction: "column",
+                  first: "Sample2!3dor2gy",
+                  second: "Sample1!3wrafzj",
+                  splitPercentage: 40,
+                },
+              },
+            },
+            {
+              title: "Tab C",
+              layout: undefined,
+            },
+          ],
+        }}
+      />
     </PanelSetup>
-  );
+  ),
+
+  name: "with chosen active tab",
+  parameters: { colorScheme: "both-row" },
 };
 
-SupportsDraggingBetweenTabsAnywhereInTheLayout.storyName =
-  "supports dragging between tabs anywhere in the layout";
+export const AddTab: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": { activeTabIdx: 0, tabs: [{ title: "Tab A", layout: undefined }] },
+          },
+        }}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            const addTabBtn = document.querySelector("[data-testid=add-tab]");
+            if (addTabBtn) {
+              (addTabBtn as any).click();
+            }
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  name: "add tab",
+};
+
+export const RemoveTab: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": { activeTabIdx: 0, tabs: manyTabs.slice(0, 5) },
+          },
+        }}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            const removeTabBtn = document.querySelector("[data-testid=tab-icon]");
+            if (removeTabBtn) {
+              (removeTabBtn as any).click();
+            }
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  name: "remove tab",
+};
+
+export const ReorderTabsWithinTabPanelByDroppingOnTab: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": { activeTabIdx: 0, tabs: manyTabs.slice(0, 5) },
+          },
+        }}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
+            const tabs = document.querySelectorAll("[draggable=true]");
+
+            // Drag and drop the first tab onto the third tab
+            dragAndDrop(tabs[0]!, tabs[2]!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+        <SExpectedResult>Expected result: #2, #3, #1, #4, #5</SExpectedResult>
+      </PanelSetup>
+    );
+  },
+
+  name: "reorder tabs within Tab panel by dropping on tab",
+};
+
+export const MoveTabToDifferentTabPanel: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          layout: {
+            first: "Tab!a",
+            second: "Tab!b",
+            direction: "row",
+            splitPercentage: 50,
+          },
+          savedProps: {
+            "Tab!a": { activeTabIdx: 0, tabs: manyTabs.slice(0, 2) },
+            "Tab!b": { activeTabIdx: 0, tabs: manyTabs.slice(2, 3) },
+          },
+        }}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
+            const tabs = document.querySelectorAll("[data-testid=toolbar-tab]");
+            dragAndDrop(tabs[0]!, tabs[2]!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+        <SExpectedResult style={{ left: 0 }}>Should have only #2</SExpectedResult>
+        <SExpectedResult style={{ left: "50%" }}>Should have #1 and #3</SExpectedResult>
+      </PanelSetup>
+    );
+  },
+
+  name: "move tab to different Tab panel",
+};
+
+export const PreventDraggingSelectedParentTabIntoChildTabPanel: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={{
+          ...fixture,
+          savedProps: {
+            "Tab!a": {
+              activeTabIdx: 0,
+              tabs: [{ title: "Parent tab", layout: "Tab!b" }, manyTabs[0]],
+            },
+            "Tab!b": { activeTabIdx: 0, tabs: manyTabs.slice(3, 6) },
+          },
+        }}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            await tick();
+            const tabs = document.querySelectorAll("[draggable=true]");
+
+            fireEvent.dragStart(tabs[0]!);
+            fireEvent.dragOver(tabs[2]!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+        <SExpectedResult style={{ left: 0 }}>
+          the first tab should be hidden (we never dropped it)
+        </SExpectedResult>
+        <SExpectedResult style={{ top: "50px" }}>tab content should be hidden</SExpectedResult>
+      </PanelSetup>
+    );
+  },
+
+  name: "prevent dragging selected parent tab into child tab panel",
+};
+
+export const DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={nestedTabLayoutFixture}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            // Create a new tab on the left side
+            (
+              document.querySelectorAll(
+                '[data-testid~="Tab!Left"] [data-testid="add-tab"]',
+              )[0] as any
+            ).click();
+
+            const dragHandle = document.querySelector(
+              '[data-testid~="Tab!RightInner"] [data-testid="panel-menu"]',
+            );
+
+            const target = document.querySelector(
+              '[data-testid~="Tab!Left"] [data-testid="empty-drop-target"]',
+            );
+            dragAndDrop(dragHandle!, target!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  name: "dragging and dropping a nested tab panel does not remove any tabs",
+};
+
+export const SupportsDraggingBetweenTabsAnywhereInTheLayout: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        panelCatalog={new MockPanelCatalog()}
+        fixture={nestedTabLayoutFixture2}
+        style={{ width: "100%" }}
+        onMount={() => {
+          setTimeout(async () => {
+            const dragHandle = document.querySelector(
+              '[data-testid~="Sample1"] [data-testid="mosaic-drag-handle"]',
+            );
+
+            const target = document
+              .querySelector('[data-testid="unknown!inner4"]')
+              ?.parentElement?.parentElement?.parentElement?.querySelector(".drop-target.left");
+
+            dragAndDrop(dragHandle!, target!);
+          }, DEFAULT_TIMEOUT);
+        }}
+      >
+        <PanelLayout />
+      </PanelSetup>
+    );
+  },
+
+  name: "supports dragging between tabs anywhere in the layout",
+};

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import Table from "@foxglove/studio-base/panels/Table";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import Table from "@foxglove/studio-base/panels/Table";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
@@ -53,205 +53,239 @@ export default {
   title: "panels/Table",
 };
 
-export const NoTopicPath: StoryFn = () => {
-  return (
-    <PanelSetup fixture={{ frame: {}, topics: [] }}>
-      <Table overrideConfig={{ topicPath: "" }} />
-    </PanelSetup>
-  );
+export const NoTopicPath: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={{ frame: {}, topics: [] }}>
+        <Table overrideConfig={{ topicPath: "" }} />
+      </PanelSetup>
+    );
+  },
+
+  name: "no topic path",
 };
 
-NoTopicPath.storyName = "no topic path";
+export const NoData: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={{ frame: {}, topics: [] }}>
+        <Table overrideConfig={{ topicPath: "/unknown" }} />
+      </PanelSetup>
+    );
+  },
 
-export const NoData: StoryFn = () => {
-  return (
-    <PanelSetup fixture={{ frame: {}, topics: [] }}>
-      <Table overrideConfig={{ topicPath: "/unknown" }} />
-    </PanelSetup>
-  );
+  name: "no data",
 };
 
-NoData.storyName = "no data";
+export const Arrays: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
 
-export const Arrays: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
+  name: "arrays",
 };
 
-Arrays.storyName = "arrays";
+export const ExpandRows: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={() => {
+          setImmediate(() => {
+            (
+              document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
+            ).click();
+          });
+        }}
+      >
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
 
-export const ExpandRows: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        setImmediate(() => {
-          (
-            document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
-          ).click();
-        });
-      }}
-    >
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
+  name: "expand rows",
+  parameters: { colorScheme: "dark" },
 };
 
-ExpandRows.storyName = "expand rows";
-ExpandRows.parameters = { colorScheme: "dark" };
+export const ExpandCellsWithNestedObjects: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={() => {
+          setImmediate(() => {
+            (
+              document.querySelectorAll(
+                "[data-testid=expand-cell-obj-0]",
+              )[0] as HTMLTableCellElement
+            ).click();
+          });
+        }}
+      >
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
 
-export const ExpandCellsWithNestedObjects: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        setImmediate(() => {
-          (
-            document.querySelectorAll("[data-testid=expand-cell-obj-0]")[0] as HTMLTableCellElement
-          ).click();
-        });
-      }}
-    >
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
+  name: "expand cells with nested objects",
+  parameters: { colorScheme: "dark" },
 };
 
-ExpandCellsWithNestedObjects.storyName = "expand cells with nested objects";
-ExpandCellsWithNestedObjects.parameters = { colorScheme: "dark" };
+export const ExpandCellsWithNestedArrays: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={() => {
+          setImmediate(() => {
+            (
+              document.querySelectorAll(
+                "[data-testid=expand-cell-arr-0]",
+              )[0] as HTMLTableCellElement
+            ).click();
+          });
+        }}
+      >
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
 
-export const ExpandCellsWithNestedArrays: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        setImmediate(() => {
-          (
-            document.querySelectorAll("[data-testid=expand-cell-arr-0]")[0] as HTMLTableCellElement
-          ).click();
-        });
-      }}
-    >
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
+  name: "expand cells with nested arrays",
+  parameters: { colorScheme: "dark" },
 };
 
-ExpandCellsWithNestedArrays.storyName = "expand cells with nested arrays";
-ExpandCellsWithNestedArrays.parameters = { colorScheme: "dark" };
+export const ExpandNestedCells: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={() => {
+          setImmediate(() => {
+            (
+              document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
+            ).click();
+            (
+              document.querySelectorAll(
+                "[data-testid=expand-cell-arr-obj-0]",
+              )[0] as HTMLTableCellElement
+            ).click();
+          });
+        }}
+      >
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
 
-export const ExpandNestedCells: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        setImmediate(() => {
-          (
-            document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
-          ).click();
-          (
-            document.querySelectorAll(
-              "[data-testid=expand-cell-arr-obj-0]",
-            )[0] as HTMLTableCellElement
-          ).click();
-        });
-      }}
-    >
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
+  name: "expand nested cells",
+  parameters: { colorScheme: "dark" },
 };
 
-ExpandNestedCells.storyName = "expand nested cells";
-ExpandNestedCells.parameters = { colorScheme: "dark" };
+export const ExpandMultipleRows: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={() => {
+          setImmediate(() => {
+            (
+              document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
+            ).click();
+            (
+              document.querySelectorAll("[data-testid=expand-row-1]")[0] as HTMLTableCellElement
+            ).click();
+          });
+        }}
+      >
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
 
-export const ExpandMultipleRows: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        setImmediate(() => {
-          (
-            document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
-          ).click();
-          (
-            document.querySelectorAll("[data-testid=expand-row-1]")[0] as HTMLTableCellElement
-          ).click();
-        });
-      }}
-    >
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
+  name: "expand multiple rows",
+  parameters: { colorScheme: "dark" },
 };
 
-ExpandMultipleRows.storyName = "expand multiple rows";
-ExpandMultipleRows.parameters = { colorScheme: "dark" };
-
-export const Filtering: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
-    </PanelSetup>
-  );
-};
-
-Filtering.storyName = "filtering";
-
-export const Sorting: StoryFn = () => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        setImmediate(() => {
-          (
-            document.querySelectorAll("[data-testid=column-header-val]")[0] as HTMLTableCellElement
-          ).click();
-          (
-            document.querySelectorAll("[data-testid=column-header-val]")[0] as HTMLTableCellElement
-          ).click();
-        });
-      }}
-    >
-      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-    </PanelSetup>
-  );
-};
-
-Sorting.storyName = "sorting";
-Sorting.parameters = { colorScheme: "dark" };
-
-export const HandlesPrimitives: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Table overrideConfig={{ topicPath: "/my_arr.array[:].val" }} />
-    </PanelSetup>
-  );
-};
-
-HandlesPrimitives.storyName = "handles primitives";
-
-export const HandlesArraysOfPrimitives: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <Table overrideConfig={{ topicPath: "/my_arr.array[:].primitiveArray" }} />
-    </PanelSetup>
-  );
-};
-
-HandlesArraysOfPrimitives.storyName = "handles arrays of primitives";
-
-export const ConstrainedWidth: StoryFn = () => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <div style={{ width: "100px" }}>
+export const Filtering: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
         <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
-      </div>
-    </PanelSetup>
-  );
+      </PanelSetup>
+    );
+  },
+
+  name: "filtering",
 };
 
-ConstrainedWidth.storyName = "constrained width";
+export const Sorting: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        fixture={fixture}
+        onMount={() => {
+          setImmediate(() => {
+            (
+              document.querySelectorAll(
+                "[data-testid=column-header-val]",
+              )[0] as HTMLTableCellElement
+            ).click();
+            (
+              document.querySelectorAll(
+                "[data-testid=column-header-val]",
+              )[0] as HTMLTableCellElement
+            ).click();
+          });
+        }}
+      >
+        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+      </PanelSetup>
+    );
+  },
+
+  name: "sorting",
+  parameters: { colorScheme: "dark" },
+};
+
+export const HandlesPrimitives: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Table overrideConfig={{ topicPath: "/my_arr.array[:].val" }} />
+      </PanelSetup>
+    );
+  },
+
+  name: "handles primitives",
+};
+
+export const HandlesArraysOfPrimitives: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <Table overrideConfig={{ topicPath: "/my_arr.array[:].primitiveArray" }} />
+      </PanelSetup>
+    );
+  },
+
+  name: "handles arrays of primitives",
+};
+
+export const ConstrainedWidth: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <div style={{ width: "100px" }}>
+          <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
+        </div>
+      </PanelSetup>
+    );
+  },
+
+  name: "constrained width",
+};

--- a/packages/studio-base/src/panels/Teleop/DirectionalPad.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/DirectionalPad.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
+import { StoryObj } from "@storybook/react";
 
 import DirectionalPad from "./DirectionalPad";
 
@@ -11,14 +12,14 @@ export default {
   component: DirectionalPad,
 };
 
-export const Basic = {
-  render: (): JSX.Element => {
+export const Basic: StoryObj = {
+  render: () => {
     return <DirectionalPad onAction={action("click")} />;
   },
 };
 
-export const Disabled = {
-  render: (): JSX.Element => {
+export const Disabled: StoryObj = {
+  render: () => {
     return <DirectionalPad disabled onAction={action("click")} />;
   },
 };

--- a/packages/studio-base/src/panels/Teleop/DirectionalPad.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/DirectionalPad.stories.tsx
@@ -11,10 +11,14 @@ export default {
   component: DirectionalPad,
 };
 
-export const Basic = (): JSX.Element => {
-  return <DirectionalPad onAction={action("click")} />;
+export const Basic = {
+  render: (): JSX.Element => {
+    return <DirectionalPad onAction={action("click")} />;
+  },
 };
 
-export const Disabled = (): JSX.Element => {
-  return <DirectionalPad disabled onAction={action("click")} />;
+export const Disabled = {
+  render: (): JSX.Element => {
+    return <DirectionalPad disabled onAction={action("click")} />;
+  },
 };

--- a/packages/studio-base/src/panels/Teleop/index.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.stories.tsx
@@ -32,7 +32,7 @@ export const Unconfigured = (): JSX.Element => {
 };
 
 export const WithSettings = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
   },
 

--- a/packages/studio-base/src/panels/Teleop/index.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.stories.tsx
@@ -27,8 +27,10 @@ export default {
   ],
 };
 
-export const Unconfigured = (): JSX.Element => {
-  return <TeleopPanel />;
+export const Unconfigured = {
+  render: (): JSX.Element => {
+    return <TeleopPanel />;
+  },
 };
 
 export const WithSettings = {
@@ -42,6 +44,8 @@ export const WithSettings = {
   },
 };
 
-export const WithTopic = (): JSX.Element => {
-  return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
+export const WithTopic = {
+  render: (): JSX.Element => {
+    return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
+  },
 };

--- a/packages/studio-base/src/panels/Teleop/index.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { Story, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext } from "@storybook/react";
 
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -14,7 +14,7 @@ export default {
   title: "panels/Teleop",
   component: TeleopPanel,
   decorators: [
-    (StoryComponent: Story, context: StoryContext): JSX.Element => {
+    (StoryComponent: StoryFn, context: StoryContext): JSX.Element => {
       return (
         <PanelSetup
           fixture={{ capabilities: [PlayerCapabilities.advertise], publish: action("publish") }}
@@ -31,12 +31,15 @@ export const Unconfigured = (): JSX.Element => {
   return <TeleopPanel />;
 };
 
-export const WithSettings = (): JSX.Element => {
-  return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
-};
-WithSettings.parameters = {
-  colorScheme: "light",
-  includeSettings: true,
+export const WithSettings = {
+  render: (): JSX.Element => {
+    return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
+  },
+
+  parameters: {
+    colorScheme: "light",
+    includeSettings: true,
+  },
 };
 
 export const WithTopic = (): JSX.Element => {

--- a/packages/studio-base/src/panels/Teleop/index.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { action } from "@storybook/addon-actions";
-import { StoryFn, StoryContext } from "@storybook/react";
+import { StoryFn, StoryContext, StoryObj } from "@storybook/react";
 
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -27,14 +27,14 @@ export default {
   ],
 };
 
-export const Unconfigured = {
-  render: (): JSX.Element => {
+export const Unconfigured: StoryObj = {
+  render: () => {
     return <TeleopPanel />;
   },
 };
 
-export const WithSettings = {
-  render: function Story(): JSX.Element {
+export const WithSettings: StoryObj = {
+  render: function Story() {
     return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
   },
 
@@ -44,8 +44,8 @@ export const WithSettings = {
   },
 };
 
-export const WithTopic = {
-  render: (): JSX.Element => {
+export const WithTopic: StoryObj = {
+  render: () => {
     return <TeleopPanel overrideConfig={{ topic: "/abc" }} />;
   },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -326,7 +326,7 @@ export default {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
         <PanelSetupWithData title="Default without clicked object">

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Stack } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
@@ -352,46 +352,48 @@ export const DefaultLight: StoryFn = DefaultStory.bind(undefined);
 DefaultLight.storyName = "default light";
 DefaultLight.parameters = { colorScheme: "light" };
 
-export const PointCloud: StoryFn = () => {
-  const cloud1 = { ...selectedObject.object, ...POINT_CLOUD_MESSAGE };
-  const cloud2 = {
-    ...selectedObject.object,
-    ...POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
-  };
+export const PointCloud: StoryObj = {
+  render: () => {
+    const cloud1 = { ...selectedObject.object, ...POINT_CLOUD_MESSAGE };
+    const cloud2 = {
+      ...selectedObject.object,
+      ...POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+    };
 
-  return (
-    <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
-      <PanelSetupWithData title="default with point color">
-        <Interactions
-          {...(sharedProps as any)}
-          selectedObject={{
-            instanceIndex: 0,
-            object: {
-              ...cloud1,
-              type: 102,
-              interactionData: { topic: "/foo/bar", originalMessage: POINT_CLOUD_MESSAGE },
-            },
-          }}
-        />
-      </PanelSetupWithData>
-      <PanelSetupWithData title="with additional fields">
-        <Interactions
-          {...(sharedProps as any)}
-          selectedObject={{
-            instanceIndex: 0,
-            object: {
-              ...cloud2,
-              type: 102,
-              interactionData: {
-                topic: "/foo/bar",
-                originalMessage: POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+    return (
+      <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
+        <PanelSetupWithData title="default with point color">
+          <Interactions
+            {...(sharedProps as any)}
+            selectedObject={{
+              instanceIndex: 0,
+              object: {
+                ...cloud1,
+                type: 102,
+                interactionData: { topic: "/foo/bar", originalMessage: POINT_CLOUD_MESSAGE },
               },
-            },
-          }}
-        />
-      </PanelSetupWithData>
-    </Stack>
-  );
-};
+            }}
+          />
+        </PanelSetupWithData>
+        <PanelSetupWithData title="with additional fields">
+          <Interactions
+            {...(sharedProps as any)}
+            selectedObject={{
+              instanceIndex: 0,
+              object: {
+                ...cloud2,
+                type: 102,
+                interactionData: {
+                  topic: "/foo/bar",
+                  originalMessage: POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+                },
+              },
+            }}
+          />
+        </PanelSetupWithData>
+      </Stack>
+    );
+  },
 
-PointCloud.storyName = "PointCloud";
+  name: "PointCloud",
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Stack } from "@mui/material";
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
@@ -315,23 +315,6 @@ function PanelSetupWithData({
   );
 }
 
-const DefaultStory: StoryFn = () => {
-  return (
-    <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
-      <PanelSetupWithData title="Default without clicked object">
-        <Interactions
-          {...(sharedProps as any)}
-          selectedObject={undefined}
-          interactionsTabType={OBJECT_TAB_TYPE}
-        />
-      </PanelSetupWithData>
-      <PanelSetupWithData title="With interactionData">
-        <Interactions {...(sharedProps as any)} />
-      </PanelSetupWithData>
-    </Stack>
-  );
-};
-
 export default {
   title: "panels/ThreeDeeRender/Interactions/Interaction",
 
@@ -342,15 +325,32 @@ export default {
   excludeStories: ["POINT_CLOUD_MESSAGE", "POINT_CLOUD_WITH_ADDITIONAL_FIELDS"],
 };
 
-export const Default: StoryFn = DefaultStory.bind(undefined);
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
+        <PanelSetupWithData title="Default without clicked object">
+          <Interactions
+            {...(sharedProps as any)}
+            selectedObject={undefined}
+            interactionsTabType={OBJECT_TAB_TYPE}
+          />
+        </PanelSetupWithData>
+        <PanelSetupWithData title="With interactionData">
+          <Interactions {...(sharedProps as any)} />
+        </PanelSetupWithData>
+      </Stack>
+    );
+  },
+  name: "default",
+  parameters: { colorScheme: "dark" },
+};
 
-Default.storyName = "default";
-Default.parameters = { colorScheme: "dark" };
-
-export const DefaultLight: StoryFn = DefaultStory.bind(undefined);
-
-DefaultLight.storyName = "default light";
-DefaultLight.parameters = { colorScheme: "light" };
+export const DefaultLight: StoryObj = {
+  ...Default,
+  name: "default light",
+  parameters: { colorScheme: "light" },
+};
 
 export const PointCloud: StoryObj = {
   render: () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
@@ -67,7 +67,7 @@ export default {
 };
 
 export const Light: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <Box height="100vh" width="100vh" bgcolor="background.default">
         <InteractionContextMenu onClose={() => {}} {...sharedProps} />
@@ -79,7 +79,7 @@ export const Light: StoryObj = {
 };
 
 export const Dark: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <Box height="100vh" width="100vh" bgcolor="background.default">
         <InteractionContextMenu onClose={() => {}} {...sharedProps} />

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Box } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 
 import { InteractionContextMenu } from "./InteractionContextMenu";
 
@@ -65,22 +66,22 @@ export default {
   component: InteractionContextMenu,
 };
 
-export function Light(): JSX.Element {
+export const Light: StoryFn = (): JSX.Element => {
   return (
     <Box height="100vh" width="100vh" bgcolor="background.default">
       <InteractionContextMenu onClose={() => {}} {...sharedProps} />
     </Box>
   );
-}
+};
 
 Light.parameters = { colorScheme: "light" };
 
-export function Dark(): JSX.Element {
+export const Dark: StoryFn = (): JSX.Element => {
   return (
     <Box height="100vh" width="100vh" bgcolor="background.default">
       <InteractionContextMenu onClose={() => {}} {...sharedProps} />
     </Box>
   );
-}
+};
 
 Dark.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Box } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { InteractionContextMenu } from "./InteractionContextMenu";
 
@@ -66,22 +66,26 @@ export default {
   component: InteractionContextMenu,
 };
 
-export const Light: StoryFn = (): JSX.Element => {
-  return (
-    <Box height="100vh" width="100vh" bgcolor="background.default">
-      <InteractionContextMenu onClose={() => {}} {...sharedProps} />
-    </Box>
-  );
+export const Light: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <Box height="100vh" width="100vh" bgcolor="background.default">
+        <InteractionContextMenu onClose={() => {}} {...sharedProps} />
+      </Box>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
 };
 
-Light.parameters = { colorScheme: "light" };
+export const Dark: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <Box height="100vh" width="100vh" bgcolor="background.default">
+        <InteractionContextMenu onClose={() => {}} {...sharedProps} />
+      </Box>
+    );
+  },
 
-export const Dark: StoryFn = (): JSX.Element => {
-  return (
-    <Box height="100vh" width="100vh" bgcolor="background.default">
-      <InteractionContextMenu onClose={() => {}} {...sharedProps} />
-    </Box>
-  );
+  parameters: { colorScheme: "dark" },
 };
-
-Dark.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -25,147 +25,150 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const ArrowMarkers: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/arrows", schemaName: "visualization_msgs/Marker" },
-  ];
+export const ArrowMarkers: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/arrows", schemaName: "visualization_msgs/Marker" },
+    ];
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
-      child_frame_id: BASE_LINK_FRAME_ID,
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
+        child_frame_id: BASE_LINK_FRAME_ID,
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      child_frame_id: SENSOR_FRAME_ID,
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
+        child_frame_id: SENSOR_FRAME_ID,
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const arrow1: MessageEvent<Partial<Marker>> = {
-    topic: "/arrows",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      id: 0,
-      ns: "",
-      type: 0,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0.4, y: 0, z: 1 },
-        orientation: QUAT_IDENTITY,
+    const arrow1: MessageEvent<Partial<Marker>> = {
+      topic: "/arrows",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
+        id: 0,
+        ns: "",
+        type: 0,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0.4, y: 0, z: 1 },
+          orientation: QUAT_IDENTITY,
+        },
+        scale: { x: 0.75, y: 0.001, z: 0.25 },
+        color: makeColor("#f44336", 0.5),
+        lifetime: { sec: 0, nsec: 0 },
       },
-      scale: { x: 0.75, y: 0.001, z: 0.25 },
-      color: makeColor("#f44336", 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const arrow2: MessageEvent<Partial<Marker>> = {
-    topic: "/arrows",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      id: 1,
-      ns: "",
-      type: 0,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0.3, z: 0 },
-        orientation: { x: 0, y: 0, z: Math.SQRT1_2, w: Math.SQRT1_2 },
+    const arrow2: MessageEvent<Partial<Marker>> = {
+      topic: "/arrows",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        id: 1,
+        ns: "",
+        type: 0,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0, y: 0.3, z: 0 },
+          orientation: { x: 0, y: 0, z: Math.SQRT1_2, w: Math.SQRT1_2 },
+        },
+        scale: { x: 0.3, y: 0.05, z: 0.05 },
+        color: makeColor("#4caf50", 0.5),
+        lifetime: { sec: 0, nsec: 0 },
       },
-      scale: { x: 0.3, y: 0.05, z: 0.05 },
-      color: makeColor("#4caf50", 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const arrow3: MessageEvent<Partial<Marker>> = {
-    topic: "/arrows",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      id: 2,
-      ns: "",
-      type: 0,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0, z: 0.35 },
-        orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
+    const arrow3: MessageEvent<Partial<Marker>> = {
+      topic: "/arrows",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        id: 2,
+        ns: "",
+        type: 0,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0, y: 0, z: 0.35 },
+          orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
+        },
+        scale: { x: 0.05, y: 0.1, z: 0.15 },
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 0.3, y: 0, z: 0 },
+        ],
+        color: makeColor("#2196f3", 0.5),
+        lifetime: { sec: 0, nsec: 0 },
       },
-      scale: { x: 0.05, y: 0.1, z: 0.15 },
-      points: [
-        { x: 0, y: 0, z: 0 },
-        { x: 0.3, y: 0, z: 0 },
-      ],
-      color: makeColor("#2196f3", 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/arrows": [arrow1, arrow2, arrow3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/arrows": [arrow1, arrow2, arrow3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          cameraState: {
-            distance: 4,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: rad2deg(-1),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/arrows": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            cameraState: {
+              distance: 4,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [-0.6, 0.5, 0],
+              thetaOffset: rad2deg(-1),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/arrows": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-ArrowMarkers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
@@ -26,7 +26,7 @@ export default {
 };
 
 export const ArrowMarkers: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
       { name: "/arrows", schemaName: "visualization_msgs/Marker" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -23,8 +25,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-ArrowMarkers.parameters = { colorScheme: "dark" };
-export function ArrowMarkers(): JSX.Element {
+export const ArrowMarkers: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
     { name: "/arrows", schemaName: "visualization_msgs/Marker" },
@@ -166,4 +167,5 @@ export function ArrowMarkers(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+ArrowMarkers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
@@ -26,7 +26,7 @@ export default {
 };
 
 export const AutoSelectFrame: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
       { name: "/markers", schemaName: "visualization_msgs/Marker" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -25,99 +25,102 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const AutoSelectFrame: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-  ];
+export const AutoSelectFrame: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+    ];
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
-      child_frame_id: BASE_LINK_FRAME_ID,
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
+        child_frame_id: BASE_LINK_FRAME_ID,
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      child_frame_id: SENSOR_FRAME_ID,
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
+        child_frame_id: SENSOR_FRAME_ID,
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const arrow: MessageEvent<Partial<Marker>> = {
-    topic: "/markers",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      id: 1,
-      ns: "",
-      type: 0,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0.3, z: 0 },
-        orientation: { x: 0, y: 0, z: Math.SQRT1_2, w: Math.SQRT1_2 },
+    const arrow: MessageEvent<Partial<Marker>> = {
+      topic: "/markers",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
+        id: 1,
+        ns: "",
+        type: 0,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0, y: 0.3, z: 0 },
+          orientation: { x: 0, y: 0, z: Math.SQRT1_2, w: Math.SQRT1_2 },
+        },
+        scale: { x: 0.3, y: 0.05, z: 0.05 },
+        color: makeColor("#4caf50", 0.5),
+        lifetime: { sec: 0, nsec: 0 },
       },
-      scale: { x: 0.3, y: 0.05, z: 0.05 },
-      color: makeColor("#4caf50", 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/markers": [arrow],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/markers": [arrow],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: undefined,
-          cameraState: {
-            distance: 4,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: rad2deg(-1),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: undefined,
+            cameraState: {
+              distance: 4,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [-0.6, 0.5, 0],
+              thetaOffset: rad2deg(-1),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-AutoSelectFrame.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -23,8 +25,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-AutoSelectFrame.parameters = { colorScheme: "dark" };
-export function AutoSelectFrame(): JSX.Element {
+export const AutoSelectFrame: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
@@ -118,4 +119,5 @@ export function AutoSelectFrame(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+AutoSelectFrame.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -25,7 +25,7 @@ export default {
 };
 
 export const CameraInfoRender: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
       { name: "/rational_polynomial", schemaName: "sensor_msgs/CameraInfo" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -24,156 +24,160 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const CameraInfoRender: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/rational_polynomial", schemaName: "sensor_msgs/CameraInfo" },
-    { name: "/none", schemaName: "sensor_msgs/CameraInfo" },
-    { name: "/empty", schemaName: "sensor_msgs/CameraInfo" },
-  ];
+export const CameraInfoRender: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/rational_polynomial", schemaName: "sensor_msgs/CameraInfo" },
+      { name: "/none", schemaName: "sensor_msgs/CameraInfo" },
+      { name: "/empty", schemaName: "sensor_msgs/CameraInfo" },
+    ];
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
-      child_frame_id: BASE_LINK_FRAME_ID,
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
+        child_frame_id: BASE_LINK_FRAME_ID,
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      child_frame_id: SENSOR_FRAME_ID,
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
+        child_frame_id: SENSOR_FRAME_ID,
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const cam1: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/rational_polynomial",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 480,
-      width: 640,
-      distortion_model: "rational_polynomial",
-      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
-      K: [
-        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
-        1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
-        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
-      ],
-    },
-    schemaName: "sensor_msgs/CameraInfo",
-    sizeInBytes: 0,
-  };
+    const cam1: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/rational_polynomial",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 480,
+        width: 640,
+        distortion_model: "rational_polynomial",
+        D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+        K: [
+          381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0,
+          0, 1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+          233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+        ],
+      },
+      schemaName: "sensor_msgs/CameraInfo",
+      sizeInBytes: 0,
+    };
 
-  const cam2: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/none",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 900,
-      width: 1600,
-      distortion_model: "",
-      D: [],
-      K: [
-        1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0, 1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0, 0,
-        0, 1, 0,
-      ],
-    },
-    schemaName: "sensor_msgs/CameraInfo",
-    sizeInBytes: 0,
-  };
+    const cam2: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/none",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 900,
+        width: 1600,
+        distortion_model: "",
+        D: [],
+        K: [
+          1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0,
+          1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0,
+          0, 0, 1, 0,
+        ],
+      },
+      schemaName: "sensor_msgs/CameraInfo",
+      sizeInBytes: 0,
+    };
 
-  const cam3: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/empty",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 1080,
-      width: 1920,
-    },
-    schemaName: "sensor_msgs/CameraInfo",
-    sizeInBytes: 0,
-  };
+    const cam3: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/empty",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 1080,
+        width: 1920,
+      },
+      schemaName: "sensor_msgs/CameraInfo",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/rational_polynomial": [cam1],
-      "/none": [cam2],
-      "/empty": [cam3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/rational_polynomial": [cam1],
+        "/none": [cam2],
+        "/empty": [cam3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: SENSOR_FRAME_ID,
-          scene: {
-            labelScaleFactor: 0.1,
-          },
-          cameraState: {
-            distance: 1.85,
-            perspective: true,
-            phi: rad2deg(0),
-            targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(Math.PI),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/rational_polynomial": {
-              visible: true,
-              color: "rgba(0, 255, 0, 1)",
-              distance: 0.25,
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: SENSOR_FRAME_ID,
+            scene: {
+              labelScaleFactor: 0.1,
             },
-            "/none": {
-              visible: true,
-              color: "rgba(0, 255, 255, 1)",
-              distance: 0.5,
-              planarProjectionFactor: 1,
+            cameraState: {
+              distance: 1.85,
+              perspective: true,
+              phi: rad2deg(0),
+              targetOffset: [0, 0, 0],
+              thetaOffset: rad2deg(Math.PI),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
             },
-            "/empty": {
-              visible: true,
-              color: "rgba(255, 0, 0, 1)",
-              distance: 0.75,
+            topics: {
+              "/rational_polynomial": {
+                visible: true,
+                color: "rgba(0, 255, 0, 1)",
+                distance: 0.25,
+              },
+              "/none": {
+                visible: true,
+                color: "rgba(0, 255, 255, 1)",
+                distance: 0.5,
+                planarProjectionFactor: 1,
+              },
+              "/empty": {
+                visible: true,
+                color: "rgba(255, 0, 0, 1)",
+                distance: 0.75,
+              },
             },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-CameraInfoRender.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -22,8 +24,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-CameraInfoRender.parameters = { colorScheme: "dark" };
-export function CameraInfoRender(): JSX.Element {
+export const CameraInfoRender: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
     { name: "/rational_polynomial", schemaName: "sensor_msgs/CameraInfo" },
@@ -174,4 +175,5 @@ export function CameraInfoRender(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+CameraInfoRender.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -71,8 +73,7 @@ const baseLabel: MessageEvent<Marker> = {
   sizeInBytes: 0,
 };
 
-ColladaUpAxisObserve.parameters = { colorScheme: "dark" };
-export function ColladaUpAxisObserve(): JSX.Element {
+export const ColladaUpAxisObserve: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/labels", schemaName: "visualization_msgs/Marker" },
@@ -151,10 +152,10 @@ export function ColladaUpAxisObserve(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+ColladaUpAxisObserve.parameters = { colorScheme: "dark" };
 
-ColladaUpAxisIgnore.parameters = { colorScheme: "dark" };
-export function ColladaUpAxisIgnore(): JSX.Element {
+export const ColladaUpAxisIgnore: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/labels", schemaName: "visualization_msgs/Marker" },
@@ -234,4 +235,5 @@ export function ColladaUpAxisIgnore(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+ColladaUpAxisIgnore.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
@@ -74,7 +74,7 @@ const baseLabel: MessageEvent<Marker> = {
 };
 
 export const ColladaUpAxisObserve: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/labels", schemaName: "visualization_msgs/Marker" },
@@ -159,7 +159,7 @@ export const ColladaUpAxisObserve: StoryObj = {
 };
 
 export const ColladaUpAxisIgnore: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/labels", schemaName: "visualization_msgs/Marker" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -73,167 +73,173 @@ const baseLabel: MessageEvent<Marker> = {
   sizeInBytes: 0,
 };
 
-export const ColladaUpAxisObserve: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/labels", schemaName: "visualization_msgs/Marker" },
-  ];
+export const ColladaUpAxisObserve: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/labels", schemaName: "visualization_msgs/Marker" },
+    ];
 
-  const yup = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "yup",
-      pose: { position: { x: -1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: COLLADA_CONE_Y_UP_MESH_RESOURCE,
-    },
-  };
+    const yup = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "yup",
+        pose: { position: { x: -1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: COLLADA_CONE_Y_UP_MESH_RESOURCE,
+      },
+    };
 
-  const zup = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "zup",
-      pose: { position: { x: 1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: COLLADA_CONE_Z_UP_MESH_RESOURCE,
-    },
-  };
+    const zup = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "zup",
+        pose: { position: { x: 1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: COLLADA_CONE_Z_UP_MESH_RESOURCE,
+      },
+    };
 
-  const yupLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "yup",
-      pose: { position: { x: -1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "Y-Up",
-    },
-  };
+    const yupLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "yup",
+        pose: { position: { x: -1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "Y-Up",
+      },
+    };
 
-  const zupLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "zup",
-      pose: { position: { x: 1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "Z-Up",
-    },
-  };
+    const zupLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "zup",
+        pose: { position: { x: 1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "Z-Up",
+      },
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [yup, zup],
-      "/labels": [yupLabel, zupLabel],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [yup, zup],
+        "/labels": [yupLabel, zupLabel],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          scene: {
-            transforms: {
-              showLabel: false,
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
             },
-          },
-          cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
-          topics: {
-            "/markers": { visible: true },
-            "/labels": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
-};
-ColladaUpAxisObserve.parameters = { colorScheme: "dark" };
-
-export const ColladaUpAxisIgnore: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/labels", schemaName: "visualization_msgs/Marker" },
-  ];
-
-  const yup = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "yup",
-      pose: { position: { x: -1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: COLLADA_CONE_Y_UP_MESH_RESOURCE,
-    },
-  };
-
-  const zup = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "zup",
-      pose: { position: { x: 1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: COLLADA_CONE_Z_UP_MESH_RESOURCE,
-    },
-  };
-
-  const yupLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "yup",
-      pose: { position: { x: -1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "Y-Up",
-    },
-  };
-
-  const zupLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "zup",
-      pose: { position: { x: 1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "Z-Up",
-    },
-  };
-
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [yup, zup],
-      "/labels": [yupLabel, zupLabel],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          scene: {
-            transforms: {
-              showLabel: false,
+            scene: {
+              transforms: {
+                showLabel: false,
+              },
             },
-            ignoreColladaUpAxis: true,
-          },
-          cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
-          topics: {
-            "/markers": { visible: true },
-            "/labels": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
+            topics: {
+              "/markers": { visible: true },
+              "/labels": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-ColladaUpAxisIgnore.parameters = { colorScheme: "dark" };
+
+export const ColladaUpAxisIgnore: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/labels", schemaName: "visualization_msgs/Marker" },
+    ];
+
+    const yup = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "yup",
+        pose: { position: { x: -1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: COLLADA_CONE_Y_UP_MESH_RESOURCE,
+      },
+    };
+
+    const zup = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "zup",
+        pose: { position: { x: 1, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: COLLADA_CONE_Z_UP_MESH_RESOURCE,
+      },
+    };
+
+    const yupLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "yup",
+        pose: { position: { x: -1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "Y-Up",
+      },
+    };
+
+    const zupLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "zup",
+        pose: { position: { x: 1, y: -2, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "Z-Up",
+      },
+    };
+
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [yup, zup],
+        "/labels": [yupLabel, zupLabel],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            scene: {
+              transforms: {
+                showLabel: false,
+              },
+              ignoreColladaUpAxis: true,
+            },
+            cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
+            topics: {
+              "/markers": { visible: true },
+              "/labels": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import useDelayedFixture from "./useDelayedFixture";
@@ -12,7 +14,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-export function CustomBackgroundColor(): JSX.Element {
+export const CustomBackgroundColor: StoryFn = (): JSX.Element => {
   const fixture = useDelayedFixture({
     topics: [],
     frame: {},
@@ -32,4 +34,4 @@ export function CustomBackgroundColor(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -14,24 +14,26 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const CustomBackgroundColor: StoryFn = (): JSX.Element => {
-  const fixture = useDelayedFixture({
-    topics: [],
-    frame: {},
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+export const CustomBackgroundColor: StoryObj = {
+  render: function Story() {
+    const fixture = useDelayedFixture({
+      topics: [],
+      frame: {},
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          scene: { backgroundColor: "#2d7566" },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            scene: { backgroundColor: "#2d7566" },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -18,76 +18,79 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const FramelessMarkers: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [{ name: "/markers", schemaName: "visualization_msgs/Marker" }];
+export const FramelessMarkers: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [{ name: "/markers", schemaName: "visualization_msgs/Marker" }];
 
-  type FramelessHeader = Omit<Header, "frame_id">;
-  type FramelessCubeMaker = Omit<Marker, "header"> & { header: FramelessHeader };
+    type FramelessHeader = Omit<Header, "frame_id">;
+    type FramelessCubeMaker = Omit<Marker, "header"> & { header: FramelessHeader };
 
-  const cube: MessageEvent<FramelessCubeMaker> = {
-    topic: "/markers",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 } },
-      id: 0,
-      ns: "",
-      type: 1,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: -1, y: 1, z: 0 },
-        orientation: { x: 0, y: 0, z: 0, w: 1 },
+    const cube: MessageEvent<FramelessCubeMaker> = {
+      topic: "/markers",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 } },
+        id: 0,
+        ns: "",
+        type: 1,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: -1, y: 1, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        scale: { x: 0.5, y: 0.5, z: 0.5 },
+        color: makeColor(TEST_COLORS.MARKER_GREEN1, 0.5),
+        lifetime: { sec: 0, nsec: 0 },
+        points: [],
+        colors: [],
+        text: "",
+        mesh_resource: "",
+        mesh_use_embedded_materials: false,
       },
-      scale: { x: 0.5, y: 0.5, z: 0.5 },
-      color: makeColor(TEST_COLORS.MARKER_GREEN1, 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-      points: [],
-      colors: [],
-      text: "",
-      mesh_resource: "",
-      mesh_use_embedded_materials: false,
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [cube],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [cube],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 5.5,
-            perspective: true,
-            phi: rad2deg(0.5),
-            targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 5.5,
+              perspective: true,
+              phi: rad2deg(0.5),
+              targetOffset: [-0.5, 0.75, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark", chromatic: { delay: 100 } },
 };
-FramelessMarkers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -16,8 +18,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-FramelessMarkers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
-export function FramelessMarkers(): JSX.Element {
+export const FramelessMarkers: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/markers", schemaName: "visualization_msgs/Marker" }];
 
   type FramelessHeader = Omit<Header, "frame_id">;
@@ -88,4 +89,5 @@ export function FramelessMarkers(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+FramelessMarkers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
@@ -19,7 +19,7 @@ export default {
 };
 
 export const FramelessMarkers: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [{ name: "/markers", schemaName: "visualization_msgs/Marker" }];
 
     type FramelessHeader = Omit<Header, "frame_id">;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -16,8 +18,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-GeometryMsgs_Polygon.parameters = { colorScheme: "dark" };
-export function GeometryMsgs_Polygon(): JSX.Element {
+export const GeometryMsgs_Polygon: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/polygon", schemaName: "geometry_msgs/PolygonStamped" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -105,4 +106,5 @@ export function GeometryMsgs_Polygon(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+GeometryMsgs_Polygon.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
@@ -19,7 +19,7 @@ export default {
 };
 
 export const GeometryMsgs_Polygon: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/polygon", schemaName: "geometry_msgs/PolygonStamped" },
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -18,93 +18,96 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const GeometryMsgs_Polygon: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/polygon", schemaName: "geometry_msgs/PolygonStamped" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const GeometryMsgs_Polygon: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/polygon", schemaName: "geometry_msgs/PolygonStamped" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const polygon: MessageEvent<PolygonStamped> = {
-    topic: "/polygon",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      polygon: {
-        points: [
-          { x: -1, y: -1, z: 0 },
-          { x: 0, y: 0, z: 2 },
-          { x: 1, y: 1, z: 0 },
-        ],
+    const polygon: MessageEvent<PolygonStamped> = {
+      topic: "/polygon",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        polygon: {
+          points: [
+            { x: -1, y: -1, z: 0 },
+            { x: 0, y: 0, z: 2 },
+            { x: 1, y: 1, z: 0 },
+          ],
+        },
       },
-    },
-    schemaName: "geometry_msgs/PolygonStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/PolygonStamped",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/polygon": [polygon],
-      "/tf": [tf1, tf2],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/polygon": [polygon],
+        "/tf": [tf1, tf2],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          cameraState: {
-            distance: 8.25,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [-0.7, 2.1, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/polygon": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            cameraState: {
+              distance: 8.25,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [-0.7, 2.1, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/polygon": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-GeometryMsgs_Polygon.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
@@ -23,7 +23,7 @@ type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 export const GeometryMsgs_PoseArray: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/baselink_path", schemaName: "geometry_msgs/PoseArray" },
       { name: "/sensor_path", schemaName: "geometry_msgs/PoseArray" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -22,157 +22,160 @@ export default {
 type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-export const GeometryMsgs_PoseArray: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/baselink_path", schemaName: "geometry_msgs/PoseArray" },
-    { name: "/sensor_path", schemaName: "geometry_msgs/PoseArray" },
-    { name: "/sensor_path2", schemaName: "geometry_msgs/PoseArray" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const GeometryMsgs_PoseArray: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/baselink_path", schemaName: "geometry_msgs/PoseArray" },
+      { name: "/sensor_path", schemaName: "geometry_msgs/PoseArray" },
+      { name: "/sensor_path2", schemaName: "geometry_msgs/PoseArray" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: vec4ToOrientation(
-          quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
-        ),
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: vec4ToOrientation(
+            quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
+          ),
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf3: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 10, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: 5, z: 1 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf3: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 10, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: 5, z: 1 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const q = (): quat => [0, 0, 0, 1];
-  const identity = q();
-  const makeOrientation = (i: number) => {
-    const o = quat.rotateZ(q(), identity, (Math.PI / 2) * (i / 9));
-    return { x: o[0], y: o[1], z: o[2], w: o[3] };
-  };
+    const q = (): quat => [0, 0, 0, 1];
+    const identity = q();
+    const makeOrientation = (i: number) => {
+      const o = quat.rotateZ(q(), identity, (Math.PI / 2) * (i / 9));
+      return { x: o[0], y: o[1], z: o[2], w: o[3] };
+    };
 
-  const baseLinkPath: MessageEvent<PoseArray> = {
-    topic: "/baselink_path",
-    receiveTime: { sec: 3, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      poses: [...Array(10)].map((_, i) => ({
-        position: { x: 3, y: i / 4, z: 1 },
-        orientation: makeOrientation(i),
-      })),
-    },
-    schemaName: "geometry_msgs/PoseArray",
-    sizeInBytes: 0,
-  };
+    const baseLinkPath: MessageEvent<PoseArray> = {
+      topic: "/baselink_path",
+      receiveTime: { sec: 3, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        poses: [...Array(10)].map((_, i) => ({
+          position: { x: 3, y: i / 4, z: 1 },
+          orientation: makeOrientation(i),
+        })),
+      },
+      schemaName: "geometry_msgs/PoseArray",
+      sizeInBytes: 0,
+    };
 
-  const sensorPath: MessageEvent<PoseArray> = {
-    topic: "/sensor_path",
-    receiveTime: { sec: 3, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      poses: [...Array(10)].map((_, i) => ({
-        position: { x: 2, y: i / 4, z: 0 },
-        orientation: makeOrientation(i),
-      })),
-    },
-    schemaName: "geometry_msgs/PoseArray",
-    sizeInBytes: 0,
-  };
+    const sensorPath: MessageEvent<PoseArray> = {
+      topic: "/sensor_path",
+      receiveTime: { sec: 3, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        poses: [...Array(10)].map((_, i) => ({
+          position: { x: 2, y: i / 4, z: 0 },
+          orientation: makeOrientation(i),
+        })),
+      },
+      schemaName: "geometry_msgs/PoseArray",
+      sizeInBytes: 0,
+    };
 
-  const sensorPath2: MessageEvent<PoseArray> = {
-    topic: "/sensor_path2",
-    receiveTime: { sec: 3, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      poses: [...Array(10)].map((_, i) => ({
-        position: { x: -i / 4, y: 2, z: 0 },
-        orientation: makeOrientation(i),
-      })),
-    },
-    schemaName: "geometry_msgs/PoseArray",
-    sizeInBytes: 0,
-  };
+    const sensorPath2: MessageEvent<PoseArray> = {
+      topic: "/sensor_path2",
+      receiveTime: { sec: 3, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        poses: [...Array(10)].map((_, i) => ({
+          position: { x: -i / 4, y: 2, z: 0 },
+          orientation: makeOrientation(i),
+        })),
+      },
+      schemaName: "geometry_msgs/PoseArray",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/baselink_path": [baseLinkPath],
-      "/sensor_path": [sensorPath],
-      "/sensor_path2": [sensorPath2],
-      "/tf": [tf1, tf2, tf3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 3, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/baselink_path": [baseLinkPath],
+        "/sensor_path": [sensorPath],
+        "/sensor_path2": [sensorPath2],
+        "/tf": [tf1, tf2, tf3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 3, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          topics: {
-            "/sensor_path": {
-              visible: true,
-              type: "arrow",
-              gradient: ["rgba(0, 255, 0, 0.2)", "rgba(0, 255, 127, 1.0)"],
-              arrowScale: [1, 0.5, 0.01],
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            topics: {
+              "/sensor_path": {
+                visible: true,
+                type: "arrow",
+                gradient: ["rgba(0, 255, 0, 0.2)", "rgba(0, 255, 127, 1.0)"],
+                arrowScale: [1, 0.5, 0.01],
+              },
+              "/sensor_path2": {
+                visible: true,
+                axisScale: 0.5,
+              },
+              "/baselink_path": {
+                visible: true,
+                type: "arrow",
+              },
             },
-            "/sensor_path2": {
-              visible: true,
-              axisScale: 0.5,
+            cameraState: {
+              distance: 15,
+              perspective: true,
+              phi: rad2deg(0.25),
+              targetOffset: [0, 2, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
             },
-            "/baselink_path": {
-              visible: true,
-              type: "arrow",
-            },
-          },
-          cameraState: {
-            distance: 15,
-            perspective: true,
-            phi: rad2deg(0.25),
-            targetOffset: [0, 2, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-GeometryMsgs_PoseArray.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -21,8 +22,7 @@ export default {
 type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-GeometryMsgs_PoseArray.parameters = { colorScheme: "dark" };
-export function GeometryMsgs_PoseArray(): JSX.Element {
+export const GeometryMsgs_PoseArray: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/baselink_path", schemaName: "geometry_msgs/PoseArray" },
     { name: "/sensor_path", schemaName: "geometry_msgs/PoseArray" },
@@ -174,4 +174,5 @@ export function GeometryMsgs_PoseArray(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+GeometryMsgs_PoseArray.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -22,8 +23,7 @@ type Vec4 = [number, number, number, number];
 
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-GeometryMsgs_PoseStamped.parameters = { colorScheme: "dark" };
-export function GeometryMsgs_PoseStamped(): JSX.Element {
+export const GeometryMsgs_PoseStamped: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
     { name: "/pose1", schemaName: "geometry_msgs/PoseStamped" },
@@ -160,4 +160,5 @@ export function GeometryMsgs_PoseStamped(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+GeometryMsgs_PoseStamped.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -23,142 +23,145 @@ type Vec4 = [number, number, number, number];
 
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-export const GeometryMsgs_PoseStamped: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/pose1", schemaName: "geometry_msgs/PoseStamped" },
-    { name: "/pose2", schemaName: "geometry_msgs/PoseStamped" },
-    { name: "/pose3", schemaName: "geometry_msgs/PoseStamped" },
-  ];
+export const GeometryMsgs_PoseStamped: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/pose1", schemaName: "geometry_msgs/PoseStamped" },
+      { name: "/pose2", schemaName: "geometry_msgs/PoseStamped" },
+      { name: "/pose3", schemaName: "geometry_msgs/PoseStamped" },
+    ];
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: -5, z: 0 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: -5, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const pose1: MessageEvent<PoseStamped> = {
-    topic: "/pose1",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      pose: {
-        position: { x: 2, y: 0, z: 0 },
-        orientation: QUAT_IDENTITY,
+    const pose1: MessageEvent<PoseStamped> = {
+      topic: "/pose1",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        pose: {
+          position: { x: 2, y: 0, z: 0 },
+          orientation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/PoseStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/PoseStamped",
+      sizeInBytes: 0,
+    };
 
-  const pose2: MessageEvent<PoseStamped> = {
-    topic: "/pose2",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      pose: {
-        position: { x: 0, y: 3, z: 0 },
-        orientation: vec4ToOrientation(
-          quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
-        ),
+    const pose2: MessageEvent<PoseStamped> = {
+      topic: "/pose2",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        pose: {
+          position: { x: 0, y: 3, z: 0 },
+          orientation: vec4ToOrientation(
+            quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
+          ),
+        },
       },
-    },
-    schemaName: "geometry_msgs/PoseStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/PoseStamped",
+      sizeInBytes: 0,
+    };
 
-  const pose3: MessageEvent<PoseStamped> = {
-    topic: "/pose3",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      pose: {
-        position: { x: 0, y: 2, z: 0 },
-        orientation: vec4ToOrientation(
-          quat.rotateZ(quat.create(), quat.create(), Math.PI / 4) as Vec4,
-        ),
+    const pose3: MessageEvent<PoseStamped> = {
+      topic: "/pose3",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        pose: {
+          position: { x: 0, y: 2, z: 0 },
+          orientation: vec4ToOrientation(
+            quat.rotateZ(quat.create(), quat.create(), Math.PI / 4) as Vec4,
+          ),
+        },
       },
-    },
-    schemaName: "geometry_msgs/PoseStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/PoseStamped",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/pose1": [pose1],
-      "/pose2": [pose2],
-      "/pose3": [pose3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/pose1": [pose1],
+        "/pose2": [pose2],
+        "/pose3": [pose3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          topics: {
-            "/pose1": {
-              visible: true,
-              type: "arrow",
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            topics: {
+              "/pose1": {
+                visible: true,
+                type: "arrow",
+              },
+              "/pose2": {
+                visible: true,
+                type: "arrow",
+                arrowScale: [2, 1, 1],
+                color: "rgba(0, 255, 0, 0.3)",
+              },
+              "/pose3": {
+                visible: true,
+                axisScale: Math.sqrt(8),
+              },
             },
-            "/pose2": {
-              visible: true,
-              type: "arrow",
-              arrowScale: [2, 1, 1],
-              color: "rgba(0, 255, 0, 0.3)",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
             },
-            "/pose3": {
-              visible: true,
-              axisScale: Math.sqrt(8),
+            cameraState: {
+              distance: 15,
+              perspective: false,
+              phi: rad2deg(0),
+              targetOffset: [-0.6, 0.5, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
             },
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 15,
-            perspective: false,
-            phi: rad2deg(0),
-            targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-GeometryMsgs_PoseStamped.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
@@ -24,7 +24,7 @@ type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 export const GeometryMsgs_PoseStamped: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
       { name: "/pose1", schemaName: "geometry_msgs/PoseStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import { CompressedImage, RawImage } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
@@ -179,10 +179,15 @@ const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }) => {
   );
 };
 
-export const ImageModeRosRawImage: Story = () => <ImageModeRosImage imageType="raw" />;
-ImageModeRosRawImage.parameters = { colorScheme: "light" };
-export const ImageModeRosPngImage: Story = () => <ImageModeRosImage imageType="png" />;
-ImageModeRosPngImage.parameters = { colorScheme: "light" };
+export const ImageModeRosRawImage: StoryObj = {
+  render: () => <ImageModeRosImage imageType="raw" />,
+  parameters: { colorScheme: "light" },
+};
+
+export const ImageModeRosPngImage: StoryObj = {
+  render: () => <ImageModeRosImage imageType="png" />,
+  parameters: { colorScheme: "light" },
+};
 
 const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => {
   const topics: Topic[] = [
@@ -342,19 +347,27 @@ const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => 
   );
 };
 
-export const ImageModeFoxgloveRawImage: Story = () => <ImageModeFoxgloveImage imageType="raw" />;
-ImageModeFoxgloveRawImage.parameters = { colorScheme: "light" };
-export const ImageModeFoxglovePngImage: Story = () => <ImageModeFoxgloveImage imageType="png" />;
-ImageModeFoxglovePngImage.parameters = { colorScheme: "light" };
+export const ImageModeFoxgloveRawImage: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  parameters: { colorScheme: "light" },
+};
 
-export const ImageModeResizeHandled: Story = () => <ImageModeFoxgloveImage imageType="raw" />;
-ImageModeResizeHandled.parameters = { colorScheme: "light" };
-ImageModeResizeHandled.play = async () => {
-  const canvas = document.querySelector("canvas")!;
-  // Input attaches resize listener to parent element, so we need to resize that.
-  const parentEl = canvas.parentElement!;
-  await delay(30);
-  parentEl.style.width = "50%";
-  canvas.dispatchEvent(new Event("resize"));
-  await delay(30);
+export const ImageModeFoxglovePngImage: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="png" />,
+  parameters: { colorScheme: "light" },
+};
+
+export const ImageModeResizeHandled: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  parameters: { colorScheme: "light" },
+
+  play: async () => {
+    const canvas = document.querySelector("canvas")!;
+    // Input attaches resize listener to parent element, so we need to resize that.
+    const parentEl = canvas.parentElement!;
+    await delay(30);
+    parentEl.style.width = "50%";
+    canvas.dispatchEvent(new Event("resize"));
+    await delay(30);
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { CompressedImage, RawImage } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useState } from "react";
 import { create } from "zustand";
 
@@ -21,694 +21,706 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const ImageRender: Story = () => {
-  const topics: Topic[] = [
-    { name: "/cam1/info", schemaName: "sensor_msgs/CameraInfo" },
-    { name: "/cam2/info", schemaName: "sensor_msgs/CameraInfo" },
-    { name: "/cam1/png", schemaName: "sensor_msgs/CompressedImage" },
-    { name: "/cam2/raw", schemaName: "sensor_msgs/Image" },
-  ];
+export const ImageRender: StoryObj = {
+  render: () => {
+    const topics: Topic[] = [
+      { name: "/cam1/info", schemaName: "sensor_msgs/CameraInfo" },
+      { name: "/cam2/info", schemaName: "sensor_msgs/CameraInfo" },
+      { name: "/cam1/png", schemaName: "sensor_msgs/CompressedImage" },
+      { name: "/cam2/raw", schemaName: "sensor_msgs/Image" },
+    ];
 
-  const cam1: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam1/info",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 480,
-      width: 640,
-      distortion_model: "rational_polynomial",
-      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
-      K: [
-        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
-        1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
-        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
-      ],
-    },
-    schemaName: "sensor_msgs/CameraInfo",
-    sizeInBytes: 0,
-  };
+    const cam1: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam1/info",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 480,
+        width: 640,
+        distortion_model: "rational_polynomial",
+        D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+        K: [
+          381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0,
+          0, 1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+          233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+        ],
+      },
+      schemaName: "sensor_msgs/CameraInfo",
+      sizeInBytes: 0,
+    };
 
-  const cam2: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam2/info",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 900,
-      width: 1600,
-      distortion_model: "",
-      D: [],
-      K: [
-        1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0, 1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0, 0,
-        0, 1, 0,
-      ],
-    },
-    schemaName: "sensor_msgs/CameraInfo",
-    sizeInBytes: 0,
-  };
+    const cam2: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam2/info",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 900,
+        width: 1600,
+        distortion_model: "",
+        D: [],
+        K: [
+          1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0,
+          1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0,
+          0, 0, 1, 0,
+        ],
+      },
+      schemaName: "sensor_msgs/CameraInfo",
+      sizeInBytes: 0,
+    };
 
-  const cam1Png: MessageEvent<Partial<RosCompressedImage>> = {
-    topic: "/cam1/png",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      format: "png",
-      data: PNG_TEST_IMAGE,
-    },
-    schemaName: "sensor_msgs/CompressedImage",
-    sizeInBytes: 0,
-  };
+    const cam1Png: MessageEvent<Partial<RosCompressedImage>> = {
+      topic: "/cam1/png",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        format: "png",
+        data: PNG_TEST_IMAGE,
+      },
+      schemaName: "sensor_msgs/CompressedImage",
+      sizeInBytes: 0,
+    };
 
-  // Create a Uint8Array 8x8 RGBA image
-  const SIZE = 8;
-  const rgba8 = new Uint8Array(SIZE * SIZE * 4);
-  for (let y = 0; y < SIZE; y++) {
-    for (let x = 0; x < SIZE; x++) {
-      const i = (y * SIZE + x) * 4;
-      rgba8[i + 0] = Math.trunc((x / (SIZE - 1)) * 255);
-      rgba8[i + 1] = Math.trunc((y / (SIZE - 1)) * 255);
-      rgba8[i + 2] = 0;
-      rgba8[i + 3] = 255;
+    // Create a Uint8Array 8x8 RGBA image
+    const SIZE = 8;
+    const rgba8 = new Uint8Array(SIZE * SIZE * 4);
+    for (let y = 0; y < SIZE; y++) {
+      for (let x = 0; x < SIZE; x++) {
+        const i = (y * SIZE + x) * 4;
+        rgba8[i + 0] = Math.trunc((x / (SIZE - 1)) * 255);
+        rgba8[i + 1] = Math.trunc((y / (SIZE - 1)) * 255);
+        rgba8[i + 2] = 0;
+        rgba8[i + 3] = 255;
+      }
     }
-  }
 
-  const cam2Raw: MessageEvent<Partial<Image>> = {
-    topic: "/cam2/raw",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: SIZE,
-      width: SIZE,
-      encoding: "rgba8",
-      is_bigendian: false,
-      step: SIZE * 4,
-      data: rgba8,
-    },
-    schemaName: "sensor_msgs/Image",
-    sizeInBytes: 0,
-  };
+    const cam2Raw: MessageEvent<Partial<Image>> = {
+      topic: "/cam2/raw",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: SIZE,
+        width: SIZE,
+        encoding: "rgba8",
+        is_bigendian: false,
+        step: SIZE * 4,
+        data: rgba8,
+      },
+      schemaName: "sensor_msgs/Image",
+      sizeInBytes: 0,
+    };
 
-  const fixture: Fixture = {
-    topics,
-    frame: {
-      "/cam1/info": [cam1],
-      "/cam2/info": [cam2],
-      "/cam1/png": [cam1Png],
-      "/cam2/raw": [cam2Raw],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  };
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: SENSOR_FRAME_ID,
-          scene: {
-            labelScaleFactor: 0,
-          },
-          cameraState: {
-            distance: 1.5,
-            perspective: true,
-            phi: rad2deg(0.975),
-            targetOffset: [0, 0.4, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/cam1/info": {
-              visible: true,
-              color: "rgba(0, 255, 0, 1)",
-              distance: 0.5,
-              planarProjectionFactor: 1,
-            },
-            "/cam2/info": {
-              visible: true,
-              color: "rgba(0, 255, 255, 1)",
-              distance: 0.25,
-            },
-            "/cam1/png": {
-              visible: true,
-              color: "rgba(255, 255, 255, 1)",
-              distance: 0.5,
-            },
-            "/cam2/raw": {
-              visible: true,
-              color: "rgba(255, 255, 255, 0.75)",
-              distance: 0.25,
-            },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
-};
-ImageRender.parameters = { colorScheme: "light" };
-
-export const FoxgloveImage: Story = () => {
-  const topics: Topic[] = [
-    { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
-    { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
-  ];
-
-  const cam1: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam1/info",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 480,
-      width: 640,
-      distortion_model: "rational_polynomial",
-      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
-      K: [
-        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
-        1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
-        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
-      ],
-    },
-    schemaName: "foxglove.CameraCalibration",
-    sizeInBytes: 0,
-  };
-
-  const cam2: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam2/info",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 900,
-      width: 1600,
-      distortion_model: "",
-      D: [],
-      K: [
-        1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0, 1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0, 0,
-        0, 1, 0,
-      ],
-    },
-    schemaName: "foxglove.CameraCalibration",
-    sizeInBytes: 0,
-  };
-
-  const cam1Png: MessageEvent<Partial<CompressedImage>> = {
-    topic: "/cam1/png",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: SENSOR_FRAME_ID,
-      format: "png",
-      data: PNG_TEST_IMAGE,
-    },
-    schemaName: "foxglove.CompressedImage",
-    sizeInBytes: 0,
-  };
-
-  // Create a Uint8Array 8x8 RGBA image
-  const SIZE = 8;
-  const rgba8 = new Uint8Array(SIZE * SIZE * 4);
-  for (let y = 0; y < SIZE; y++) {
-    for (let x = 0; x < SIZE; x++) {
-      const i = (y * SIZE + x) * 4;
-      rgba8[i + 0] = Math.trunc((x / (SIZE - 1)) * 255);
-      rgba8[i + 1] = Math.trunc((y / (SIZE - 1)) * 255);
-      rgba8[i + 2] = 0;
-      rgba8[i + 3] = 255;
-    }
-  }
-
-  const cam2Raw: MessageEvent<Partial<RawImage>> = {
-    topic: "/cam2/raw",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: SENSOR_FRAME_ID,
-      height: SIZE,
-      width: SIZE,
-      encoding: "rgba8",
-      step: SIZE * 4,
-      data: rgba8,
-    },
-    schemaName: "foxglove.RawImage",
-    sizeInBytes: 0,
-  };
-
-  const fixture: Fixture = {
-    topics,
-    frame: {
-      "/cam1/info": [cam1],
-      "/cam2/info": [cam2],
-      "/cam1/png": [cam1Png],
-      "/cam2/raw": [cam2Raw],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  };
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: SENSOR_FRAME_ID,
-          scene: {
-            labelScaleFactor: 0,
-          },
-          cameraState: {
-            distance: 1.5,
-            perspective: true,
-            phi: rad2deg(0.975),
-            targetOffset: [0, 0.4, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/cam1/info": {
-              visible: true,
-              color: "rgba(0, 255, 0, 1)",
-              distance: 0.5,
-              planarProjectionFactor: 1,
-            },
-            "/cam2/info": {
-              visible: true,
-              color: "rgba(0, 255, 255, 1)",
-              distance: 0.25,
-            },
-            "/cam1/png": {
-              visible: true,
-              color: "rgba(255, 255, 255, 1)",
-              distance: 0.5,
-            },
-            "/cam2/raw": {
-              visible: true,
-              color: "rgba(255, 255, 255, 0.75)",
-              distance: 0.25,
-            },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
-};
-FoxgloveImage.parameters = { colorScheme: "light" };
-
-// Send an image message then send a camera info message
-// The 3d panel should correctly display the image message upon receipt of camera info
-export const ImageThenInfo: Story = () => {
-  const topics: Topic[] = [
-    { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
-    { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
-  ];
-
-  const cam1: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam1/info",
-    receiveTime: { sec: 0, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 480,
-      width: 640,
-      distortion_model: "rational_polynomial",
-      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
-      K: [
-        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
-        1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
-        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
-      ],
-    },
-    schemaName: "foxglove.CameraCalibration",
-    sizeInBytes: 0,
-  };
-
-  const cam1Png: MessageEvent<Partial<CompressedImage>> = {
-    topic: "/cam1/png",
-    receiveTime: { sec: 0, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: SENSOR_FRAME_ID,
-      format: "png",
-      data: PNG_TEST_IMAGE,
-    },
-    schemaName: "foxglove.CompressedImage",
-    sizeInBytes: 0,
-  };
-
-  const [useFixture] = useState(() =>
-    create<Fixture>((set) => ({
+    const fixture: Fixture = {
       topics,
-      capabilities: [],
       frame: {
+        "/cam1/info": [cam1],
+        "/cam2/info": [cam2],
         "/cam1/png": [cam1Png],
+        "/cam2/raw": [cam2Raw],
       },
-      activeData: {
-        currentTime: { sec: 0, nsec: 0 },
-      },
-      setSubscriptions: (_id, payload) => {
-        if (payload.find((item) => item.topic === "/cam1/info")) {
-          set({
-            frame: {
-              "/cam1/info": [cam1],
-            },
-          });
-        }
-      },
-    })),
-  );
-
-  const fixture = useFixture();
-  const [activeFixture, pauseFrame] = useFixtureQueue(fixture);
-
-  return (
-    <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: SENSOR_FRAME_ID,
-          scene: {
-            labelScaleFactor: 0,
-          },
-          cameraState: {
-            distance: 1.5,
-            perspective: true,
-            phi: rad2deg(0.975),
-            targetOffset: [0, 0.4, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/cam1/info": {
-              visible: true,
-              color: "rgba(0, 255, 0, 1)",
-              distance: 0.5,
-              planarProjectionFactor: 1,
-            },
-            "/cam1/png": {
-              visible: true,
-              color: "rgba(255, 255, 255, 1)",
-              distance: 0.5,
-            },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
-};
-ImageThenInfo.parameters = { colorScheme: "light" };
-
-// Send an image info message then send the image in the next frame
-export const InfoThenImage: Story = () => {
-  const topics: Topic[] = [
-    { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
-    { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
-  ];
-
-  const cam1: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam1/info",
-    receiveTime: { sec: 0, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 480,
-      width: 640,
-      distortion_model: "rational_polynomial",
-      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
-      K: [
-        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
-        1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
-        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
-      ],
-    },
-    schemaName: "foxglove.CameraCalibration",
-    sizeInBytes: 0,
-  };
-
-  const cam1Png: MessageEvent<Partial<CompressedImage>> = {
-    topic: "/cam1/png",
-    receiveTime: { sec: 0, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: SENSOR_FRAME_ID,
-      format: "png",
-      data: PNG_TEST_IMAGE,
-    },
-    schemaName: "foxglove.CompressedImage",
-    sizeInBytes: 0,
-  };
-
-  const [useFixture] = useState(() =>
-    create<Fixture>((set) => ({
-      topics,
       capabilities: [],
-      frame: {
-        "/cam1/info": [cam1],
-      },
       activeData: {
         currentTime: { sec: 0, nsec: 0 },
       },
-      setSubscriptions: (_id, payload) => {
-        if (payload.find((item) => item.topic === "/cam1/png")) {
-          set({
-            frame: {
-              "/cam1/png": [cam1Png],
-            },
-          });
-        }
-      },
-    })),
-  );
+    };
 
-  const fixture = useFixture();
-  const [activeFixture, pauseFrame] = useFixtureQueue(fixture);
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: SENSOR_FRAME_ID,
+            scene: {
+              labelScaleFactor: 0,
+            },
+            cameraState: {
+              distance: 1.5,
+              perspective: true,
+              phi: rad2deg(0.975),
+              targetOffset: [0, 0.4, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/cam1/info": {
+                visible: true,
+                color: "rgba(0, 255, 0, 1)",
+                distance: 0.5,
+                planarProjectionFactor: 1,
+              },
+              "/cam2/info": {
+                visible: true,
+                color: "rgba(0, 255, 255, 1)",
+                distance: 0.25,
+              },
+              "/cam1/png": {
+                visible: true,
+                color: "rgba(255, 255, 255, 1)",
+                distance: 0.5,
+              },
+              "/cam2/raw": {
+                visible: true,
+                color: "rgba(255, 255, 255, 0.75)",
+                distance: 0.25,
+              },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-  return (
-    <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: SENSOR_FRAME_ID,
-          scene: {
-            labelScaleFactor: 0,
-          },
-          cameraState: {
-            distance: 1.5,
-            perspective: true,
-            phi: rad2deg(0.975),
-            targetOffset: [0, 0.4, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/cam1/info": {
-              visible: true,
-              color: "rgba(0, 255, 0, 1)",
-              distance: 0.5,
-              planarProjectionFactor: 1,
-            },
-            "/cam1/png": {
-              visible: true,
-              color: "rgba(255, 255, 255, 1)",
-              distance: 0.5,
-            },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+  parameters: { colorScheme: "light" },
 };
-InfoThenImage.parameters = { colorScheme: "light" };
 
-// Sending an image message after an existing image should update the displayed image
-// A passing story will show a green image
-export const UpdateImageToGreen: Story = () => {
-  const topics: Topic[] = [
-    { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
-    { name: "/cam1/raw", schemaName: "foxglove.RawImage" },
-  ];
+export const FoxgloveImage: StoryObj = {
+  render: () => {
+    const topics: Topic[] = [
+      { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
+      { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
+    ];
 
-  const cam1: MessageEvent<Partial<CameraInfo>> = {
-    topic: "/cam1/info",
-    receiveTime: { sec: 0, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      height: 480,
-      width: 640,
-      distortion_model: "rational_polynomial",
-      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
-      K: [
-        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
-        1,
-      ],
-      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-      P: [
-        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
-        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
-      ],
-    },
-    schemaName: "foxglove.CameraCalibration",
-    sizeInBytes: 0,
-  };
+    const cam1: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam1/info",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 480,
+        width: 640,
+        distortion_model: "rational_polynomial",
+        D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+        K: [
+          381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0,
+          0, 1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+          233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+        ],
+      },
+      schemaName: "foxglove.CameraCalibration",
+      sizeInBytes: 0,
+    };
 
-  // Create a Uint8Array 8x8 RGBA image
-  const SIZE = 8;
-  const rgba8_red = new Uint8Array(SIZE * SIZE * 4);
-  const rgba8_green = new Uint8Array(SIZE * SIZE * 4);
+    const cam2: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam2/info",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 900,
+        width: 1600,
+        distortion_model: "",
+        D: [],
+        K: [
+          1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0,
+          1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0,
+          0, 0, 1, 0,
+        ],
+      },
+      schemaName: "foxglove.CameraCalibration",
+      sizeInBytes: 0,
+    };
 
-  for (let y = 0; y < SIZE; y++) {
-    for (let x = 0; x < SIZE; x++) {
-      const i = (y * SIZE + x) * 4;
-      rgba8_red[i + 0] = 255;
-      rgba8_red[i + 1] = 0;
-      rgba8_red[i + 2] = 0;
-      rgba8_red[i + 3] = 255;
+    const cam1Png: MessageEvent<Partial<CompressedImage>> = {
+      topic: "/cam1/png",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: SENSOR_FRAME_ID,
+        format: "png",
+        data: PNG_TEST_IMAGE,
+      },
+      schemaName: "foxglove.CompressedImage",
+      sizeInBytes: 0,
+    };
 
-      rgba8_green[i + 0] = 0;
-      rgba8_green[i + 1] = 255;
-      rgba8_green[i + 2] = 0;
-      rgba8_green[i + 3] = 255;
+    // Create a Uint8Array 8x8 RGBA image
+    const SIZE = 8;
+    const rgba8 = new Uint8Array(SIZE * SIZE * 4);
+    for (let y = 0; y < SIZE; y++) {
+      for (let x = 0; x < SIZE; x++) {
+        const i = (y * SIZE + x) * 4;
+        rgba8[i + 0] = Math.trunc((x / (SIZE - 1)) * 255);
+        rgba8[i + 1] = Math.trunc((y / (SIZE - 1)) * 255);
+        rgba8[i + 2] = 0;
+        rgba8[i + 3] = 255;
+      }
     }
-  }
 
-  const cam1Raw: MessageEvent<Partial<RawImage>> = {
-    topic: "/cam1/raw",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: SENSOR_FRAME_ID,
-      height: SIZE,
-      width: SIZE,
-      encoding: "rgba8",
-      step: SIZE * 4,
-      data: rgba8_red,
-    },
-    schemaName: "foxglove.RawImage",
-    sizeInBytes: 0,
-  };
+    const cam2Raw: MessageEvent<Partial<RawImage>> = {
+      topic: "/cam2/raw",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: SENSOR_FRAME_ID,
+        height: SIZE,
+        width: SIZE,
+        encoding: "rgba8",
+        step: SIZE * 4,
+        data: rgba8,
+      },
+      schemaName: "foxglove.RawImage",
+      sizeInBytes: 0,
+    };
 
-  const [useFixture] = useState(() =>
-    create<Fixture>((set) => ({
+    const fixture: Fixture = {
       topics,
-      capabilities: [],
       frame: {
         "/cam1/info": [cam1],
-        "/cam1/raw": [cam1Raw],
+        "/cam2/info": [cam2],
+        "/cam1/png": [cam1Png],
+        "/cam2/raw": [cam2Raw],
       },
+      capabilities: [],
       activeData: {
         currentTime: { sec: 0, nsec: 0 },
       },
-      setSubscriptions: (_id, payload) => {
-        if (payload.find((item) => item.topic === "/cam1/raw")) {
-          set({
-            frame: {
-              "/cam1/raw": [
-                {
-                  topic: "/cam1/raw",
-                  receiveTime: { sec: 10, nsec: 0 },
-                  message: {
-                    timestamp: { sec: 0, nsec: 0 },
-                    frame_id: SENSOR_FRAME_ID,
-                    height: SIZE,
-                    width: SIZE,
-                    encoding: "rgba8",
-                    step: SIZE * 4,
-                    data: rgba8_green,
-                  },
-                  schemaName: "foxglove.RawImage",
-                  sizeInBytes: 0,
-                },
-              ],
-            },
-          });
-        }
-      },
-    })),
-  );
+    };
 
-  const fixture = useFixture();
-  const [activeFixture, pauseFrame] = useFixtureQueue(fixture);
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: SENSOR_FRAME_ID,
+            scene: {
+              labelScaleFactor: 0,
+            },
+            cameraState: {
+              distance: 1.5,
+              perspective: true,
+              phi: rad2deg(0.975),
+              targetOffset: [0, 0.4, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/cam1/info": {
+                visible: true,
+                color: "rgba(0, 255, 0, 1)",
+                distance: 0.5,
+                planarProjectionFactor: 1,
+              },
+              "/cam2/info": {
+                visible: true,
+                color: "rgba(0, 255, 255, 1)",
+                distance: 0.25,
+              },
+              "/cam1/png": {
+                visible: true,
+                color: "rgba(255, 255, 255, 1)",
+                distance: 0.5,
+              },
+              "/cam2/raw": {
+                visible: true,
+                color: "rgba(255, 255, 255, 0.75)",
+                distance: 0.25,
+              },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-  return (
-    <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: SENSOR_FRAME_ID,
-          scene: {
-            labelScaleFactor: 0,
-          },
-          cameraState: {
-            distance: 1.5,
-            perspective: true,
-            phi: rad2deg(0.975),
-            targetOffset: [0, 0.4, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/cam1/info": {
-              visible: true,
-              color: "rgba(0, 255, 0, 1)",
-              distance: 0.5,
-              planarProjectionFactor: 1,
-            },
-            "/cam1/raw": {
-              visible: true,
-              color: "rgba(255, 255, 255, 1)",
-              distance: 0.5,
-            },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+  parameters: { colorScheme: "light" },
 };
-UpdateImageToGreen.parameters = { colorScheme: "light" };
+
+export const ImageThenInfo: StoryObj = {
+  render: () => {
+    const topics: Topic[] = [
+      { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
+      { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
+    ];
+
+    const cam1: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam1/info",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 480,
+        width: 640,
+        distortion_model: "rational_polynomial",
+        D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+        K: [
+          381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0,
+          0, 1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+          233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+        ],
+      },
+      schemaName: "foxglove.CameraCalibration",
+      sizeInBytes: 0,
+    };
+
+    const cam1Png: MessageEvent<Partial<CompressedImage>> = {
+      topic: "/cam1/png",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: SENSOR_FRAME_ID,
+        format: "png",
+        data: PNG_TEST_IMAGE,
+      },
+      schemaName: "foxglove.CompressedImage",
+      sizeInBytes: 0,
+    };
+
+    const [useFixture] = useState(() =>
+      create<Fixture>((set) => ({
+        topics,
+        capabilities: [],
+        frame: {
+          "/cam1/png": [cam1Png],
+        },
+        activeData: {
+          currentTime: { sec: 0, nsec: 0 },
+        },
+        setSubscriptions: (_id, payload) => {
+          if (payload.find((item) => item.topic === "/cam1/info")) {
+            set({
+              frame: {
+                "/cam1/info": [cam1],
+              },
+            });
+          }
+        },
+      })),
+    );
+
+    const fixture = useFixture();
+    const [activeFixture, pauseFrame] = useFixtureQueue(fixture);
+
+    return (
+      <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: SENSOR_FRAME_ID,
+            scene: {
+              labelScaleFactor: 0,
+            },
+            cameraState: {
+              distance: 1.5,
+              perspective: true,
+              phi: rad2deg(0.975),
+              targetOffset: [0, 0.4, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/cam1/info": {
+                visible: true,
+                color: "rgba(0, 255, 0, 1)",
+                distance: 0.5,
+                planarProjectionFactor: 1,
+              },
+              "/cam1/png": {
+                visible: true,
+                color: "rgba(255, 255, 255, 1)",
+                distance: 0.5,
+              },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
+};
+
+export const InfoThenImage: StoryObj = {
+  render: () => {
+    const topics: Topic[] = [
+      { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
+      { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
+    ];
+
+    const cam1: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam1/info",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 480,
+        width: 640,
+        distortion_model: "rational_polynomial",
+        D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+        K: [
+          381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0,
+          0, 1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+          233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+        ],
+      },
+      schemaName: "foxglove.CameraCalibration",
+      sizeInBytes: 0,
+    };
+
+    const cam1Png: MessageEvent<Partial<CompressedImage>> = {
+      topic: "/cam1/png",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: SENSOR_FRAME_ID,
+        format: "png",
+        data: PNG_TEST_IMAGE,
+      },
+      schemaName: "foxglove.CompressedImage",
+      sizeInBytes: 0,
+    };
+
+    const [useFixture] = useState(() =>
+      create<Fixture>((set) => ({
+        topics,
+        capabilities: [],
+        frame: {
+          "/cam1/info": [cam1],
+        },
+        activeData: {
+          currentTime: { sec: 0, nsec: 0 },
+        },
+        setSubscriptions: (_id, payload) => {
+          if (payload.find((item) => item.topic === "/cam1/png")) {
+            set({
+              frame: {
+                "/cam1/png": [cam1Png],
+              },
+            });
+          }
+        },
+      })),
+    );
+
+    const fixture = useFixture();
+    const [activeFixture, pauseFrame] = useFixtureQueue(fixture);
+
+    return (
+      <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: SENSOR_FRAME_ID,
+            scene: {
+              labelScaleFactor: 0,
+            },
+            cameraState: {
+              distance: 1.5,
+              perspective: true,
+              phi: rad2deg(0.975),
+              targetOffset: [0, 0.4, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/cam1/info": {
+                visible: true,
+                color: "rgba(0, 255, 0, 1)",
+                distance: 0.5,
+                planarProjectionFactor: 1,
+              },
+              "/cam1/png": {
+                visible: true,
+                color: "rgba(255, 255, 255, 1)",
+                distance: 0.5,
+              },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
+};
+
+export const UpdateImageToGreen: StoryObj = {
+  render: () => {
+    const topics: Topic[] = [
+      { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
+      { name: "/cam1/raw", schemaName: "foxglove.RawImage" },
+    ];
+
+    const cam1: MessageEvent<Partial<CameraInfo>> = {
+      topic: "/cam1/info",
+      receiveTime: { sec: 0, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        height: 480,
+        width: 640,
+        distortion_model: "rational_polynomial",
+        D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+        K: [
+          381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0,
+          0, 1,
+        ],
+        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+        P: [
+          381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+          233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+        ],
+      },
+      schemaName: "foxglove.CameraCalibration",
+      sizeInBytes: 0,
+    };
+
+    // Create a Uint8Array 8x8 RGBA image
+    const SIZE = 8;
+    const rgba8_red = new Uint8Array(SIZE * SIZE * 4);
+    const rgba8_green = new Uint8Array(SIZE * SIZE * 4);
+
+    for (let y = 0; y < SIZE; y++) {
+      for (let x = 0; x < SIZE; x++) {
+        const i = (y * SIZE + x) * 4;
+        rgba8_red[i + 0] = 255;
+        rgba8_red[i + 1] = 0;
+        rgba8_red[i + 2] = 0;
+        rgba8_red[i + 3] = 255;
+
+        rgba8_green[i + 0] = 0;
+        rgba8_green[i + 1] = 255;
+        rgba8_green[i + 2] = 0;
+        rgba8_green[i + 3] = 255;
+      }
+    }
+
+    const cam1Raw: MessageEvent<Partial<RawImage>> = {
+      topic: "/cam1/raw",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: SENSOR_FRAME_ID,
+        height: SIZE,
+        width: SIZE,
+        encoding: "rgba8",
+        step: SIZE * 4,
+        data: rgba8_red,
+      },
+      schemaName: "foxglove.RawImage",
+      sizeInBytes: 0,
+    };
+
+    const [useFixture] = useState(() =>
+      create<Fixture>((set) => ({
+        topics,
+        capabilities: [],
+        frame: {
+          "/cam1/info": [cam1],
+          "/cam1/raw": [cam1Raw],
+        },
+        activeData: {
+          currentTime: { sec: 0, nsec: 0 },
+        },
+        setSubscriptions: (_id, payload) => {
+          if (payload.find((item) => item.topic === "/cam1/raw")) {
+            set({
+              frame: {
+                "/cam1/raw": [
+                  {
+                    topic: "/cam1/raw",
+                    receiveTime: { sec: 10, nsec: 0 },
+                    message: {
+                      timestamp: { sec: 0, nsec: 0 },
+                      frame_id: SENSOR_FRAME_ID,
+                      height: SIZE,
+                      width: SIZE,
+                      encoding: "rgba8",
+                      step: SIZE * 4,
+                      data: rgba8_green,
+                    },
+                    schemaName: "foxglove.RawImage",
+                    sizeInBytes: 0,
+                  },
+                ],
+              },
+            });
+          }
+        },
+      })),
+    );
+
+    const fixture = useFixture();
+    const [activeFixture, pauseFrame] = useFixtureQueue(fixture);
+
+    return (
+      <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: SENSOR_FRAME_ID,
+            scene: {
+              labelScaleFactor: 0,
+            },
+            cameraState: {
+              distance: 1.5,
+              perspective: true,
+              phi: rad2deg(0.975),
+              targetOffset: [0, 0.4, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/cam1/info": {
+                visible: true,
+                color: "rgba(0, 255, 0, 1)",
+                distance: 0.5,
+                planarProjectionFactor: 1,
+              },
+              "/cam1/raw": {
+                visible: true,
+                color: "rgba(255, 255, 255, 1)",
+                distance: 0.5,
+              },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { create } from "zustand";
 
@@ -22,7 +22,7 @@ export default {
 };
 
 export const ImageRender: StoryObj = {
-  render: () => {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/cam1/info", schemaName: "sensor_msgs/CameraInfo" },
       { name: "/cam2/info", schemaName: "sensor_msgs/CameraInfo" },
@@ -185,7 +185,7 @@ export const ImageRender: StoryObj = {
 };
 
 export const FoxgloveImage: StoryObj = {
-  render: () => {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
       { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
@@ -349,7 +349,7 @@ export const FoxgloveImage: StoryObj = {
 };
 
 export const ImageThenInfo: StoryObj = {
-  render: () => {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
       { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
@@ -462,7 +462,7 @@ export const ImageThenInfo: StoryObj = {
 };
 
 export const InfoThenImage: StoryObj = {
-  render: () => {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
       { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
@@ -575,7 +575,7 @@ export const InfoThenImage: StoryObj = {
 };
 
 export const UpdateImageToGreen: StoryObj = {
-  render: () => {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
       { name: "/cam1/raw", schemaName: "foxglove.RawImage" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -18,119 +18,121 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const LabelMarkers: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/labels", schemaName: "visualization_msgs/Marker" },
-  ];
+export const LabelMarkers: StoryObj = {
+  render: function Story() {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/labels", schemaName: "visualization_msgs/Marker" },
+    ];
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: SENSOR_FRAME_ID,
-      transform: {
-        translation: { x: 0, y: 1, z: 0 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-
-  let id = 0;
-  const makeLabel = (
-    text: string,
-    position: Vector3,
-    colorHex: string,
-    alpha = 1,
-  ): MessageEvent<Partial<Marker>> => {
-    return {
-      topic: "/labels",
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
       receiveTime: { sec: 10, nsec: 0 },
       message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-        id: id++,
-        ns: "",
-        action: 0,
-        type: MarkerType.TEXT_VIEW_FACING,
-        text,
-        frame_locked: true,
-        color: makeColor(colorHex, alpha),
-        pose: { position, orientation: QUAT_IDENTITY },
-        scale: { x: 0, y: 0, z: 0.1 },
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-      schemaName: "visualization_msgs/Marker",
+      schemaName: "geometry_msgs/TransformStamped",
       sizeInBytes: 0,
     };
-  };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: SENSOR_FRAME_ID,
+        transform: {
+          translation: { x: 0, y: 1, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
+      },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const label1 = makeLabel("Hello, world!", { x: -2, y: 1, z: 0 }, "#e60049");
-  const label2 = makeLabel("Hello, world!", { x: -1, y: 1, z: 0 }, "#0bb4ff");
-  const label3 = makeLabel("Hello, world!", { x: 0, y: 1, z: 0 }, "#50e991");
-  const label4 = makeLabel("Hello, world!", { x: 1, y: 1, z: 0 }, "#e6d800");
-  const label5 = makeLabel("Hello, world!", { x: -2, y: 0, z: 0 }, "#9b19f5");
-  const label6 = makeLabel("Hello, world!", { x: -1, y: 0, z: 0 }, "#ffa300");
-  const label7 = makeLabel("Hello, world!", { x: 1, y: 0, z: 0 }, "#dc0ab4");
-  const label8 = makeLabel("Hello, world!", { x: -2, y: -1, z: 0 }, "#b3d4ff");
-  const label9 = makeLabel("Hello, world!", { x: -1, y: -1, z: 0 }, "#00bfa0");
-  const label10 = makeLabel("Hello, world!", { x: 0, y: -1, z: 0 }, "#b30000");
-  const label11 = makeLabel("Hello, world!", { x: 1, y: -1, z: 0 }, "#7c1158");
+    let id = 0;
+    const makeLabel = (
+      text: string,
+      position: Vector3,
+      colorHex: string,
+      alpha = 1,
+    ): MessageEvent<Partial<Marker>> => {
+      return {
+        topic: "/labels",
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+          id: id++,
+          ns: "",
+          action: 0,
+          type: MarkerType.TEXT_VIEW_FACING,
+          text,
+          frame_locked: true,
+          color: makeColor(colorHex, alpha),
+          pose: { position, orientation: QUAT_IDENTITY },
+          scale: { x: 0, y: 0, z: 0.1 },
+        },
+        schemaName: "visualization_msgs/Marker",
+        sizeInBytes: 0,
+      };
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      // prettier-ignore
-      "/labels": [label1, label2, label3, label4, label5, label6, label7, label8, label9, label10, label11],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const label1 = makeLabel("Hello, world!", { x: -2, y: 1, z: 0 }, "#e60049");
+    const label2 = makeLabel("Hello, world!", { x: -1, y: 1, z: 0 }, "#0bb4ff");
+    const label3 = makeLabel("Hello, world!", { x: 0, y: 1, z: 0 }, "#50e991");
+    const label4 = makeLabel("Hello, world!", { x: 1, y: 1, z: 0 }, "#e6d800");
+    const label5 = makeLabel("Hello, world!", { x: -2, y: 0, z: 0 }, "#9b19f5");
+    const label6 = makeLabel("Hello, world!", { x: -1, y: 0, z: 0 }, "#ffa300");
+    const label7 = makeLabel("Hello, world!", { x: 1, y: 0, z: 0 }, "#dc0ab4");
+    const label8 = makeLabel("Hello, world!", { x: -2, y: -1, z: 0 }, "#b3d4ff");
+    const label9 = makeLabel("Hello, world!", { x: -1, y: -1, z: 0 }, "#00bfa0");
+    const label10 = makeLabel("Hello, world!", { x: 0, y: -1, z: 0 }, "#b30000");
+    const label11 = makeLabel("Hello, world!", { x: 1, y: -1, z: 0 }, "#7c1158");
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          cameraState: {
-            distance: 5.5,
-            perspective: true,
-            phi: rad2deg(0.5),
-            targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          topics: {
-            "/labels": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        // prettier-ignore
+        "/labels": [label1, label2, label3, label4, label5, label6, label7, label8, label9, label10, label11],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            cameraState: {
+              distance: 5.5,
+              perspective: true,
+              phi: rad2deg(0.5),
+              targetOffset: [-0.5, 0.75, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            topics: {
+              "/labels": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -16,7 +18,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-export function LabelMarkers(): JSX.Element {
+export const LabelMarkers: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
     { name: "/labels", schemaName: "visualization_msgs/Marker" },
@@ -131,4 +133,4 @@ export function LabelMarkers(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const LargeTransform: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -17,8 +19,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-LargeTransform.parameters = { colorScheme: "dark" };
-export function LargeTransform(): JSX.Element {
+export const LargeTransform: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -115,4 +116,5 @@ export function LargeTransform(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+LargeTransform.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
@@ -19,102 +19,105 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const LargeTransform: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "odom",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const LargeTransform: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "odom",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "odom" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "odom" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const pass1 = makePass({
-    id: 1,
-    frame_id: "map",
-    stamp: fromSec(0),
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-    pose: { position: { x: 1e7, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
-  const pass2 = makePass({
-    id: 2,
-    frame_id: "base_link",
-    stamp: fromSec(0),
-    colorHex: TEST_COLORS.MARKER_GREEN2,
-  });
-  const pass3 = makePass({
-    id: 3,
-    frame_id: "odom",
-    stamp: fromSec(0),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    pose: { position: { x: 2, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
+    const pass1 = makePass({
+      id: 1,
+      frame_id: "map",
+      stamp: fromSec(0),
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+      pose: { position: { x: 1e7, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
+    const pass2 = makePass({
+      id: 2,
+      frame_id: "base_link",
+      stamp: fromSec(0),
+      colorHex: TEST_COLORS.MARKER_GREEN2,
+    });
+    const pass3 = makePass({
+      id: 3,
+      frame_id: "odom",
+      stamp: fromSec(0),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      pose: { position: { x: 2, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [pass1, pass2, pass3],
-      "/tf": [tf1, tf2],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [pass1, pass2, pass3],
+        "/tf": [tf1, tf2],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          layers: {
-            grid: {
-              layerId: "foxglove.Grid",
-              position: [0, 0, -0.25],
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            layers: {
+              grid: {
+                layerId: "foxglove.Grid",
+                position: [0, 0, -0.25],
+              },
             },
-          },
-          cameraState: {
-            distance: 3,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: {
+              distance: 3,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [0, 0, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-LargeTransform.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const MarkerLifetimes: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
@@ -19,166 +19,169 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const MarkerLifetimes: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 1, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: VEC3_ZERO,
-        rotation: QUAT_IDENTITY,
+export const MarkerLifetimes: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 1, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: VEC3_ZERO,
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: -1, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: -1, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const pass1 = makePass({
-    id: 1,
-    frame_id: "base_link",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-    pose: { position: { x: -1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
-  const pass2 = makePass({
-    id: 2,
-    frame_id: "sensor",
-    stamp: fromSec(2),
-    colorHex: TEST_COLORS.MARKER_GREEN2,
-    pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
-  const pass3 = makePass({
-    receiveTime: { sec: 1, nsec: 0 },
-    id: 3,
-    frame_id: "sensor",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    lifetime: { sec: 1, nsec: 0 },
-    pose: { position: { x: 2, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const pass1 = makePass({
+      id: 1,
+      frame_id: "base_link",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+      pose: { position: { x: -1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
+    const pass2 = makePass({
+      id: 2,
+      frame_id: "sensor",
+      stamp: fromSec(2),
+      colorHex: TEST_COLORS.MARKER_GREEN2,
+      pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
+    const pass3 = makePass({
+      receiveTime: { sec: 1, nsec: 0 },
+      id: 3,
+      frame_id: "sensor",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      lifetime: { sec: 1, nsec: 0 },
+      pose: { position: { x: 2, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
 
-  const pass4 = makePass({
-    id: 4,
-    frame_id: "base_link",
-    stamp: fromSec(0),
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-    pose: { position: { x: -1, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
-    // Even though there is no transform from base_link to map at t0, we clamp
-    // to the earliest available transform and render with that
-  });
-  const pass5 = makePass({
-    id: 5,
-    frame_id: "base_link",
-    stamp: fromSec(3),
-    colorHex: TEST_COLORS.MARKER_GREEN2,
-    pose: { position: { x: 0, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
-    // Even though t3 is ahead of currentTime (t2), we clamp to the latest
-    // available transform and render with that
-  });
-  const pass6 = makePass({
-    receiveTime: { sec: 2, nsec: -1 },
-    id: 6,
-    frame_id: "base_link",
-    stamp: fromSec(0),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    lifetime: { sec: 0, nsec: 1 },
-    pose: { position: { x: 1, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
-    // Expires now, this is the last nanosecond it will be shown
-  });
-  const fail1 = makeFail({
-    id: 1,
-    frame_id: "missing",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_RED1,
-    pose: { position: { x: -1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-    description: `No transform(s) for coordinate frame "missing"`,
-  });
-  const fail2 = makeFail({
-    receiveTime: { sec: 1, nsec: 0 },
-    id: 2,
-    frame_id: "sensor",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_RED2,
-    lifetime: { sec: 0, nsec: 1 },
-    pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-    description: `Expired at t1:1, currentTime is t2`,
-  });
-  const fail3 = makeFail({
-    receiveTime: { sec: 1, nsec: 0 },
-    id: 3,
-    frame_id: "sensor",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_RED3,
-    lifetime: { sec: 1, nsec: -1 },
-    pose: { position: { x: 2, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-    description: `Expired 1ns ago (t1 + 1s - 1ns)`,
-  });
-  const fail4 = makeFail({
-    receiveTime: { sec: 2, nsec: -2 },
-    id: 6,
-    frame_id: "base_link",
-    stamp: fromSec(0),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    lifetime: { sec: 0, nsec: 1 },
-    pose: { position: { x: -1, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
-    description: `Expired 1ns ago (t2 - 2ns + 1ns)`,
-  });
+    const pass4 = makePass({
+      id: 4,
+      frame_id: "base_link",
+      stamp: fromSec(0),
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+      pose: { position: { x: -1, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
+      // Even though there is no transform from base_link to map at t0, we clamp
+      // to the earliest available transform and render with that
+    });
+    const pass5 = makePass({
+      id: 5,
+      frame_id: "base_link",
+      stamp: fromSec(3),
+      colorHex: TEST_COLORS.MARKER_GREEN2,
+      pose: { position: { x: 0, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
+      // Even though t3 is ahead of currentTime (t2), we clamp to the latest
+      // available transform and render with that
+    });
+    const pass6 = makePass({
+      receiveTime: { sec: 2, nsec: -1 },
+      id: 6,
+      frame_id: "base_link",
+      stamp: fromSec(0),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      lifetime: { sec: 0, nsec: 1 },
+      pose: { position: { x: 1, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
+      // Expires now, this is the last nanosecond it will be shown
+    });
+    const fail1 = makeFail({
+      id: 1,
+      frame_id: "missing",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_RED1,
+      pose: { position: { x: -1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+      description: `No transform(s) for coordinate frame "missing"`,
+    });
+    const fail2 = makeFail({
+      receiveTime: { sec: 1, nsec: 0 },
+      id: 2,
+      frame_id: "sensor",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_RED2,
+      lifetime: { sec: 0, nsec: 1 },
+      pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+      description: `Expired at t1:1, currentTime is t2`,
+    });
+    const fail3 = makeFail({
+      receiveTime: { sec: 1, nsec: 0 },
+      id: 3,
+      frame_id: "sensor",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_RED3,
+      lifetime: { sec: 1, nsec: -1 },
+      pose: { position: { x: 2, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+      description: `Expired 1ns ago (t1 + 1s - 1ns)`,
+    });
+    const fail4 = makeFail({
+      receiveTime: { sec: 2, nsec: -2 },
+      id: 6,
+      frame_id: "base_link",
+      stamp: fromSec(0),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      lifetime: { sec: 0, nsec: 1 },
+      pose: { position: { x: -1, y: -1, z: 0 }, orientation: QUAT_IDENTITY },
+      description: `Expired 1ns ago (t2 - 2ns + 1ns)`,
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/markers": [pass1, pass2, pass3, pass4, pass5, pass6, fail1, fail2, fail3, fail4],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 2, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/markers": [pass1, pass2, pass3, pass4, pass5, pass6, fail1, fail2, fail3, fail4],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 2, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          cameraState: {
-            distance: 3,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            cameraState: {
+              distance: 3,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [0, 0, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-MarkerLifetimes.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -17,8 +19,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-MarkerLifetimes.parameters = { colorScheme: "dark" };
-export function MarkerLifetimes(): JSX.Element {
+export const MarkerLifetimes: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -179,4 +180,5 @@ export function MarkerLifetimes(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+MarkerLifetimes.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -19,7 +19,7 @@ export default {
 };
 
 export const Marker_PointCloud2_Alignment: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -16,8 +18,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-Marker_PointCloud2_Alignment.parameters = { colorScheme: "dark" };
-export function Marker_PointCloud2_Alignment(): JSX.Element {
+export const Marker_PointCloud2_Alignment: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
@@ -173,4 +174,5 @@ export function Marker_PointCloud2_Alignment(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+Marker_PointCloud2_Alignment.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -18,161 +18,164 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const Marker_PointCloud2_Alignment: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const Marker_PointCloud2_Alignment: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 1.482, y: 0, z: 1.7861 },
-        rotation: { x: 0.010471, y: 0.008726, z: -0.000091, w: 0.999907 },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 1.482, y: 0, z: 1.7861 },
+          rotation: { x: 0.010471, y: 0.008726, z: -0.000091, w: 0.999907 },
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const points: MessageEvent<Marker> = {
-    topic: "/markers",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      id: 0,
-      ns: "",
-      type: MarkerType.POINTS,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: VEC3_ZERO,
-        orientation: QUAT_IDENTITY,
+    const points: MessageEvent<Marker> = {
+      topic: "/markers",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        id: 0,
+        ns: "",
+        type: MarkerType.POINTS,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: VEC3_ZERO,
+          orientation: QUAT_IDENTITY,
+        },
+        scale: { x: 0.017, y: 0.017, z: 0.017 },
+        color: makeColor("#3f51b5", 0.25),
+
+        points: [
+          { x: 0, y: 0.25, z: 0 },
+          { x: 0.25, y: -0.25, z: 0 },
+          { x: -0.25, y: -0.25, z: 0 },
+        ],
+        colors: [makeColor("#f44336"), makeColor("#4caf50"), makeColor("#2196f3")],
+        lifetime: { sec: 0, nsec: 0 },
+        text: "",
+        mesh_resource: "",
+        mesh_use_embedded_materials: false,
       },
-      scale: { x: 0.017, y: 0.017, z: 0.017 },
-      color: makeColor("#3f51b5", 0.25),
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-      points: [
-        { x: 0, y: 0.25, z: 0 },
-        { x: 0.25, y: -0.25, z: 0 },
-        { x: -0.25, y: -0.25, z: 0 },
-      ],
-      colors: [makeColor("#f44336"), makeColor("#4caf50"), makeColor("#2196f3")],
-      lifetime: { sec: 0, nsec: 0 },
-      text: "",
-      mesh_resource: "",
-      mesh_use_embedded_materials: false,
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+    function writePoint(
+      view: DataView,
+      i: number,
+      x: number,
+      y: number,
+      z: number,
+      colorHex: string,
+    ) {
+      const offset = i * 16;
+      const c = makeColor(colorHex);
+      view.setFloat32(offset + 0, x, true);
+      view.setFloat32(offset + 4, y, true);
+      view.setFloat32(offset + 8, z, true);
+      view.setUint32(offset + 12, packRvizRgba(c.r, c.g, c.b, c.a), true);
+    }
 
-  function writePoint(
-    view: DataView,
-    i: number,
-    x: number,
-    y: number,
-    z: number,
-    colorHex: string,
-  ) {
-    const offset = i * 16;
-    const c = makeColor(colorHex);
-    view.setFloat32(offset + 0, x, true);
-    view.setFloat32(offset + 4, y, true);
-    view.setFloat32(offset + 8, z, true);
-    view.setUint32(offset + 12, packRvizRgba(c.r, c.g, c.b, c.a), true);
-  }
+    const data = new Uint8Array(3 * 16);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    writePoint(view, 0, 0, 0.25, 0, "#f44336");
+    writePoint(view, 1, 0.25, -0.25, 0, "#4caf50");
+    writePoint(view, 2, -0.25, -0.25, 0, "#2196f3");
 
-  const data = new Uint8Array(3 * 16);
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  writePoint(view, 0, 0, 0.25, 0, "#f44336");
-  writePoint(view, 1, 0.25, -0.25, 0, "#4caf50");
-  writePoint(view, 2, -0.25, -0.25, 0, "#2196f3");
+    const pointCloud: MessageEvent<PointCloud2> = {
+      topic: "/pointcloud",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        height: 1,
+        width: 3,
+        fields: [
+          { name: "x", offset: 0, datatype: 7, count: 1 },
+          { name: "y", offset: 4, datatype: 7, count: 1 },
+          { name: "z", offset: 8, datatype: 7, count: 1 },
+          { name: "rgba", offset: 12, datatype: 6, count: 1 },
+        ],
+        is_bigendian: false,
+        point_step: 16,
+        row_step: 3 * 16,
+        data,
+        is_dense: true,
+      },
+      schemaName: "sensor_msgs/PointCloud2",
+      sizeInBytes: 0,
+    };
 
-  const pointCloud: MessageEvent<PointCloud2> = {
-    topic: "/pointcloud",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      height: 1,
-      width: 3,
-      fields: [
-        { name: "x", offset: 0, datatype: 7, count: 1 },
-        { name: "y", offset: 4, datatype: 7, count: 1 },
-        { name: "z", offset: 8, datatype: 7, count: 1 },
-        { name: "rgba", offset: 12, datatype: 6, count: 1 },
-      ],
-      is_bigendian: false,
-      point_step: 16,
-      row_step: 3 * 16,
-      data,
-      is_dense: true,
-    },
-    schemaName: "sensor_msgs/PointCloud2",
-    sizeInBytes: 0,
-  };
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [points],
+        "/pointcloud": [pointCloud],
+        "/tf": [tf1, tf2],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [points],
-      "/pointcloud": [pointCloud],
-      "/tf": [tf1, tf2],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          topics: {
-            "/markers": { visible: true },
-            "/pointcloud": {
-              visible: true,
-              pointSize: 30,
-              colorMode: "rgba",
-              colorField: "rgba",
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            topics: {
+              "/markers": { visible: true },
+              "/pointcloud": {
+                visible: true,
+                pointSize: 30,
+                colorMode: "rgba",
+                colorField: "rgba",
+              },
             },
-          },
-          followTf: "base_link",
-          cameraState: {
-            distance: 4,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [-0.22, 2.07, 0],
-            thetaOffset: rad2deg(-0.65),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            followTf: "base_link",
+            cameraState: {
+              distance: 4,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [-0.22, 2.07, 0],
+              thetaOffset: rad2deg(-0.65),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-Marker_PointCloud2_Alignment.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -551,15 +551,21 @@ function AllMarkers(props: { showOutlines: boolean }): JSX.Element {
   );
 }
 
-export const Markers: StoryFn = (): JSX.Element => {
-  return <AllMarkers showOutlines={true} />;
-};
-Markers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
+export const Markers: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <AllMarkers showOutlines={true} />;
+  },
 
-export const MarkersNoOutlines: StoryFn = (): JSX.Element => {
-  return <AllMarkers showOutlines={false} />;
+  parameters: { colorScheme: "dark", chromatic: { delay: 100 } },
 };
-MarkersNoOutlines.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
+
+export const MarkersNoOutlines: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <AllMarkers showOutlines={false} />;
+  },
+
+  parameters: { colorScheme: "dark", chromatic: { delay: 100 } },
+};
 
 export const EmptyLineStrip: StoryObj = {
   render: () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -551,14 +551,14 @@ function AllMarkers(props: { showOutlines: boolean }): JSX.Element {
   );
 }
 
-export function Markers(): JSX.Element {
+export const Markers: StoryFn = (): JSX.Element => {
   return <AllMarkers showOutlines={true} />;
-}
+};
 Markers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
 
-export function MarkersNoOutlines(): JSX.Element {
+export const MarkersNoOutlines: StoryFn = (): JSX.Element => {
   return <AllMarkers showOutlines={false} />;
-}
+};
 MarkersNoOutlines.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
 
 export const EmptyLineStrip: StoryObj = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { useEffect, useState } from "react";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -568,7 +568,7 @@ export const MarkersNoOutlines: StoryObj = {
 };
 
 export const EmptyLineStrip: StoryObj = {
-  render: () => {
+  render: function Story() {
     const readySignal = useReadySignal();
     const topics: Topic[] = [
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { useEffect, useState } from "react";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -561,143 +561,143 @@ export function MarkersNoOutlines(): JSX.Element {
 }
 MarkersNoOutlines.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
 
-/**
- * Regression test: ability to reduce the number of points in a LineStrip marker to 0 after it is first rendered.
- * @see https://github.com/foxglove/studio/issues/3954
- */
-export const EmptyLineStrip: Story = () => {
-  const readySignal = useReadySignal();
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-  ];
+export const EmptyLineStrip: StoryObj = {
+  render: () => {
+    const readySignal = useReadySignal();
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+    ];
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-
-  const lineStrip: MessageEvent<Partial<Marker>> = {
-    topic: "/markers",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      id: 4,
-      ns: "",
-      type: 4,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: -2, y: 0, z: 0 },
-        orientation: { x: 0, y: 0, z: 0, w: 1 },
-      },
-      scale: { x: 0.1, y: 0.1, z: 0.1 },
-      color: makeColor("#3f51b5", 0.5),
-      points: [
-        { x: 0, y: 0.25, z: 0 },
-        { x: 0.25, y: -0.25, z: 0 },
-        { x: -0.25, y: -0.25, z: 0 },
-        { x: 0, y: 0.25, z: 0 },
-      ],
-      colors: [
-        makeColor("#f44336", 0.5),
-        makeColor("#4caf50", 1),
-        makeColor("#2196f3", 1),
-        makeColor("#ffeb3b", 0.5),
-      ],
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
-
-  const [fixture, setFixture] = useState<Fixture>({
-    topics,
-    frame: {
-      "/tf": [tf1],
-      "/markers": [lineStrip],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
-
-  useEffect(() => {
-    let timeOutID2: NodeJS.Timeout;
-
-    const timeOutID = setTimeout(() => {
-      setFixture((oldFixture) => ({
-        ...oldFixture,
-        frame: {
-          "/markers": [
-            {
-              topic: "/markers",
-              receiveTime: { sec: 11, nsec: 0 },
-              sizeInBytes: 0,
-              message: {
-                ...(oldFixture.frame!["/markers"]![0]!.message as Marker),
-                points: [],
-                colors: [],
-              },
-              schemaName: "visualization_msgs/Marker",
-            },
-          ],
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
         },
-      }));
-      timeOutID2 = setTimeout(() => readySignal(), 100);
-    }, 500);
-
-    return () => {
-      clearTimeout(timeOutID);
-      clearTimeout(timeOutID2);
+      },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
     };
-  }, [readySignal]);
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
+    const lineStrip: MessageEvent<Partial<Marker>> = {
+      topic: "/markers",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        id: 4,
+        ns: "",
+        type: 4,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: -2, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        scale: { x: 0.1, y: 0.1, z: 0.1 },
+        color: makeColor("#3f51b5", 0.5),
+        points: [
+          { x: 0, y: 0.25, z: 0 },
+          { x: 0.25, y: -0.25, z: 0 },
+          { x: -0.25, y: -0.25, z: 0 },
+          { x: 0, y: 0.25, z: 0 },
+        ],
+        colors: [
+          makeColor("#f44336", 0.5),
+          makeColor("#4caf50", 1),
+          makeColor("#2196f3", 1),
+          makeColor("#ffeb3b", 0.5),
+        ],
+        lifetime: { sec: 0, nsec: 0 },
+      },
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
+
+    const [fixture, setFixture] = useState<Fixture>({
+      topics,
+      frame: {
+        "/tf": [tf1],
+        "/markers": [lineStrip],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    useEffect(() => {
+      let timeOutID2: NodeJS.Timeout;
+
+      const timeOutID = setTimeout(() => {
+        setFixture((oldFixture) => ({
+          ...oldFixture,
+          frame: {
+            "/markers": [
+              {
+                topic: "/markers",
+                receiveTime: { sec: 11, nsec: 0 },
+                sizeInBytes: 0,
+                message: {
+                  ...(oldFixture.frame!["/markers"]![0]!.message as Marker),
+                  points: [],
+                  colors: [],
+                },
+                schemaName: "visualization_msgs/Marker",
+              },
+            ],
           },
-          cameraState: {
-            distance: 5.5,
-            perspective: true,
-            phi: rad2deg(0.5),
-            targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
-};
-EmptyLineStrip.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-EmptyLineStrip.parameters = {
-  colorScheme: "dark",
-  chromatic: { delay: 100 },
-  useReadySignal: true,
+        }));
+        timeOutID2 = setTimeout(() => readySignal(), 100);
+      }, 500);
+
+      return () => {
+        clearTimeout(timeOutID);
+        clearTimeout(timeOutID2);
+      };
+    }, [readySignal]);
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 5.5,
+              perspective: true,
+              phi: rad2deg(0.5),
+              targetOffset: [-0.5, 0.75, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  parameters: {
+    colorScheme: "dark",
+    chromatic: { delay: 100 },
+    useReadySignal: true,
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -552,7 +552,7 @@ function AllMarkers(props: { showOutlines: boolean }): JSX.Element {
 }
 
 export const Markers: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <AllMarkers showOutlines={true} />;
   },
 
@@ -560,7 +560,7 @@ export const Markers: StoryObj = {
 };
 
 export const MarkersNoOutlines: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <AllMarkers showOutlines={false} />;
   },
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -19,72 +19,76 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const MeasurementTool: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [{ name: "/tf", schemaName: "geometry_msgs/TransformStamped" }];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const MeasurementTool: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [{ name: "/tf", schemaName: "geometry_msgs/TransformStamped" }];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: { "/tf": [tf1] },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 5.5,
-            perspective: true,
-            phi: rad2deg(0.5),
-            targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
-};
-MeasurementTool.parameters = { colorScheme: "dark", chromatic: { delay: 200 } };
-MeasurementTool.play = async () => {
-  document.querySelector<HTMLElement>("[data-testid=measure-button]")!.click();
-  await delay(100);
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("click", { clientX: 100, clientY: 100 }));
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("mousedown", { clientX: 300, clientY: 200 }));
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("click", { clientX: 300, clientY: 200 }));
-  await delay(100);
+    const fixture = useDelayedFixture({
+      topics,
+      frame: { "/tf": [tf1] },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 5.5,
+              perspective: true,
+              phi: rad2deg(0.5),
+              targetOffset: [-0.5, 0.75, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark", chromatic: { delay: 200 } },
+
+  play: async () => {
+    document.querySelector<HTMLElement>("[data-testid=measure-button]")!.click();
+    await delay(100);
+    document
+      .querySelector("canvas")!
+      .dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
+    document
+      .querySelector("canvas")!
+      .dispatchEvent(new MouseEvent("click", { clientX: 100, clientY: 100 }));
+    document
+      .querySelector("canvas")!
+      .dispatchEvent(new MouseEvent("mousedown", { clientX: 300, clientY: 200 }));
+    document
+      .querySelector("canvas")!
+      .dispatchEvent(new MouseEvent("click", { clientX: 300, clientY: 200 }));
+    await delay(100);
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const MeasurementTool: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [{ name: "/tf", schemaName: "geometry_msgs/TransformStamped" }];
     const tf1: MessageEvent<TransformStamped> = {
       topic: "/tf",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -17,25 +19,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-MeasurementTool.parameters = { colorScheme: "dark", chromatic: { delay: 200 } };
-MeasurementTool.play = async () => {
-  document.querySelector<HTMLElement>("[data-testid=measure-button]")!.click();
-  await delay(100);
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("click", { clientX: 100, clientY: 100 }));
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("mousedown", { clientX: 300, clientY: 200 }));
-  document
-    .querySelector("canvas")!
-    .dispatchEvent(new MouseEvent("click", { clientX: 300, clientY: 200 }));
-  await delay(100);
-};
-export function MeasurementTool(): JSX.Element {
+export const MeasurementTool: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/tf", schemaName: "geometry_msgs/TransformStamped" }];
   const tf1: MessageEvent<TransformStamped> = {
     topic: "/tf",
@@ -85,4 +69,22 @@ export function MeasurementTool(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+MeasurementTool.parameters = { colorScheme: "dark", chromatic: { delay: 200 } };
+MeasurementTool.play = async () => {
+  document.querySelector<HTMLElement>("[data-testid=measure-button]")!.click();
+  await delay(100);
+  document
+    .querySelector("canvas")!
+    .dispatchEvent(new MouseEvent("mousedown", { clientX: 100, clientY: 100 }));
+  document
+    .querySelector("canvas")!
+    .dispatchEvent(new MouseEvent("click", { clientX: 100, clientY: 100 }));
+  document
+    .querySelector("canvas")!
+    .dispatchEvent(new MouseEvent("mousedown", { clientX: 300, clientY: 200 }));
+  document
+    .querySelector("canvas")!
+    .dispatchEvent(new MouseEvent("click", { clientX: 300, clientY: 200 }));
+  await delay(100);
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -24,178 +24,181 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const MeshMarkerOrientation: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/labels", schemaName: "visualization_msgs/Marker" },
-  ];
+export const MeshMarkerOrientation: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/labels", schemaName: "visualization_msgs/Marker" },
+    ];
 
-  const baseMeshMarker: MessageEvent<Marker> = {
-    topic: "/markers",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
-      id: 0,
-      ns: "",
-      type: 10,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0, z: 0 },
-        orientation: { x: 0, y: 0, z: 0, w: 1 },
+    const baseMeshMarker: MessageEvent<Marker> = {
+      topic: "/markers",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
+        id: 0,
+        ns: "",
+        type: 10,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        scale: { x: 1, y: 1, z: 1 },
+        color: { r: 1, g: 1, b: 1, a: 1 },
+        points: [],
+        colors: [],
+        text: "",
+        mesh_resource: "",
+        mesh_use_embedded_materials: true,
+        lifetime: { sec: 0, nsec: 0 },
       },
-      scale: { x: 1, y: 1, z: 1 },
-      color: { r: 1, g: 1, b: 1, a: 1 },
-      points: [],
-      colors: [],
-      text: "",
-      mesh_resource: "",
-      mesh_use_embedded_materials: true,
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const baseLabel: MessageEvent<Marker> = {
-    topic: "/labels",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
-      id: 0,
-      ns: "",
-      type: 9,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0, z: 0 },
-        orientation: { x: 0, y: 0, z: 0, w: 1 },
+    const baseLabel: MessageEvent<Marker> = {
+      topic: "/labels",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
+        id: 0,
+        ns: "",
+        type: 9,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        scale: { x: 0, y: 0, z: 0.2 },
+        color: { r: 1, g: 1, b: 1, a: 1 },
+        points: [],
+        colors: [],
+        text: "",
+        mesh_resource: "",
+        mesh_use_embedded_materials: false,
+        lifetime: { sec: 0, nsec: 0 },
       },
-      scale: { x: 0, y: 0, z: 0.2 },
-      color: { r: 1, g: 1, b: 1, a: 1 },
-      points: [],
-      colors: [],
-      text: "",
-      mesh_resource: "",
-      mesh_use_embedded_materials: false,
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    schemaName: "visualization_msgs/Marker",
-    sizeInBytes: 0,
-  };
+      schemaName: "visualization_msgs/Marker",
+      sizeInBytes: 0,
+    };
 
-  const glbMesh = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "glb",
-      pose: { position: { x: -2, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: GLTF_AXES_MESH_RESOURCE,
-    },
-  };
+    const glbMesh = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "glb",
+        pose: { position: { x: -2, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: GLTF_AXES_MESH_RESOURCE,
+      },
+    };
 
-  const daeMesh = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "dae",
-      pose: { position: { x: 0, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: COLLADA_AXES_MESH_RESOURCE,
-    },
-  };
+    const daeMesh = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "dae",
+        pose: { position: { x: 0, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: COLLADA_AXES_MESH_RESOURCE,
+      },
+    };
 
-  const stlMesh: MessageEvent<Marker> = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "stl",
-      pose: { position: { x: 2, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: STL_AXES_MESH_RESOURCE,
-    },
-  };
+    const stlMesh: MessageEvent<Marker> = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "stl",
+        pose: { position: { x: 2, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: STL_AXES_MESH_RESOURCE,
+      },
+    };
 
-  const objMesh: MessageEvent<Marker> = {
-    ...baseMeshMarker,
-    message: {
-      ...baseMeshMarker.message,
-      ns: "obj",
-      pose: { position: { x: 4, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      mesh_resource: OBJ_AXES_MESH_RESOURCE,
-    },
-  };
+    const objMesh: MessageEvent<Marker> = {
+      ...baseMeshMarker,
+      message: {
+        ...baseMeshMarker.message,
+        ns: "obj",
+        pose: { position: { x: 4, y: 0, z: 0.25 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        mesh_resource: OBJ_AXES_MESH_RESOURCE,
+      },
+    };
 
-  const glbLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "glb",
-      pose: { position: { x: -2, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "glTF",
-    },
-  };
+    const glbLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "glb",
+        pose: { position: { x: -2, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "glTF",
+      },
+    };
 
-  const daeLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "dae",
-      pose: { position: { x: 0, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "COLLADA",
-    },
-  };
+    const daeLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "dae",
+        pose: { position: { x: 0, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "COLLADA",
+      },
+    };
 
-  const stlLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "stl",
-      pose: { position: { x: 2, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "STL",
-    },
-  };
+    const stlLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "stl",
+        pose: { position: { x: 2, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "STL",
+      },
+    };
 
-  const objLabel = {
-    ...baseLabel,
-    message: {
-      ...baseLabel.message,
-      ns: "obj",
-      pose: { position: { x: 4, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
-      text: "OBJ",
-    },
-  };
+    const objLabel = {
+      ...baseLabel,
+      message: {
+        ...baseLabel.message,
+        ns: "obj",
+        pose: { position: { x: 4, y: -1, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } },
+        text: "OBJ",
+      },
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [glbMesh, daeMesh, stlMesh, objMesh],
-      "/labels": [glbLabel, daeLabel, stlLabel, objLabel],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [glbMesh, daeMesh, stlMesh, objMesh],
+        "/labels": [glbLabel, daeLabel, stlLabel, objLabel],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          scene: {
-            transforms: {
-              showLabel: false,
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
             },
-          },
-          cameraState: { ...DEFAULT_CAMERA_STATE, distance: 6, thetaOffset: 50 },
-          topics: {
-            "/markers": { visible: true },
-            "/labels": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            scene: {
+              transforms: {
+                showLabel: false,
+              },
+            },
+            cameraState: { ...DEFAULT_CAMERA_STATE, distance: 6, thetaOffset: 50 },
+            topics: {
+              "/markers": { visible: true },
+              "/labels": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-MeshMarkerOrientation.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -22,8 +24,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-MeshMarkerOrientation.parameters = { colorScheme: "dark" };
-export function MeshMarkerOrientation(): JSX.Element {
+export const MeshMarkerOrientation: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/labels", schemaName: "visualization_msgs/Marker" },
@@ -196,4 +197,5 @@ export function MeshMarkerOrientation(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+MeshMarkerOrientation.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
@@ -25,7 +25,7 @@ export default {
 };
 
 export const MeshMarkerOrientation: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/labels", schemaName: "visualization_msgs/Marker" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -19,141 +19,144 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const MeshMarkers: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markersOutline", schemaName: "visualization_msgs/Marker" },
-    { name: "/markersNoOutline", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
+export const MeshMarkers: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markersOutline", schemaName: "visualization_msgs/Marker" },
+      { name: "/markersNoOutline", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
 
-  function getMeshesInFrame(topic: string, frame_id: string) {
-    const stlMesh: MessageEvent<Marker> = {
-      topic,
+    function getMeshesInFrame(topic: string, frame_id: string) {
+      const stlMesh: MessageEvent<Marker> = {
+        topic,
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id },
+          id: 0,
+          ns: "stl",
+          type: 10,
+          action: 0,
+          frame_locked: false,
+          pose: {
+            position: { x: 0, y: -1, z: 0 },
+            orientation: { x: 0, y: 0, z: 0, w: 1 },
+          },
+          scale: { x: 0.5, y: 0.5, z: 0.5 },
+          color: makeColor("#8bc34a", 0.5),
+          points: [],
+          colors: [],
+          text: "",
+          mesh_resource: STL_CUBE_MESH_RESOURCE,
+          mesh_use_embedded_materials: true,
+          lifetime: { sec: 0, nsec: 0 },
+        },
+        schemaName: "visualization_msgs/Marker",
+        sizeInBytes: 0,
+      };
+
+      const stlColoredMesh = {
+        ...stlMesh,
+        message: {
+          ...stlMesh.message,
+          id: 1,
+          mesh_use_embedded_materials: false,
+          pose: { position: { x: -1, y: 0, z: 0 }, orientation: stlMesh.message.pose.orientation },
+        },
+      };
+
+      const objMesh: MessageEvent<Marker> = {
+        topic,
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id },
+          id: 0,
+          ns: "obj",
+          type: 10,
+          action: 0,
+          frame_locked: false,
+          pose: {
+            position: { x: 1, y: 0, z: 0 },
+            orientation: { x: 0, y: 0, z: 0, w: 1 },
+          },
+          scale: { x: 0.25, y: 0.25, z: 0.25 },
+          color: makeColor("#ff0000"),
+          points: [],
+          colors: [],
+          text: "",
+          mesh_resource: OBJ_CUBE_MESH_RESOURCE,
+          mesh_use_embedded_materials: true,
+          lifetime: { sec: 0, nsec: 0 },
+        },
+        schemaName: "visualization_msgs/Marker",
+        sizeInBytes: 0,
+      };
+      return [stlMesh, stlColoredMesh, objMesh];
+    }
+
+    const outlineMeshes = getMeshesInFrame("/markersOutline", "outline");
+    const noOutlineMeshes = getMeshesInFrame("/markersNoOutline", "no-outline");
+
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
       receiveTime: { sec: 10, nsec: 0 },
       message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id },
-        id: 0,
-        ns: "stl",
-        type: 10,
-        action: 0,
-        frame_locked: false,
-        pose: {
-          position: { x: 0, y: -1, z: 0 },
-          orientation: { x: 0, y: 0, z: 0, w: 1 },
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
+        child_frame_id: "outline",
+        transform: {
+          translation: { x: 0, y: -1, z: 0 },
+          rotation: QUAT_IDENTITY,
         },
-        scale: { x: 0.5, y: 0.5, z: 0.5 },
-        color: makeColor("#8bc34a", 0.5),
-        points: [],
-        colors: [],
-        text: "",
-        mesh_resource: STL_CUBE_MESH_RESOURCE,
-        mesh_use_embedded_materials: true,
-        lifetime: { sec: 0, nsec: 0 },
       },
-      schemaName: "visualization_msgs/Marker",
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
+        child_frame_id: "no-outline",
+        transform: {
+          translation: { x: 0, y: 1, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
+      },
+      schemaName: "geometry_msgs/TransformStamped",
       sizeInBytes: 0,
     };
 
-    const stlColoredMesh = {
-      ...stlMesh,
-      message: {
-        ...stlMesh.message,
-        id: 1,
-        mesh_use_embedded_materials: false,
-        pose: { position: { x: -1, y: 0, z: 0 }, orientation: stlMesh.message.pose.orientation },
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markersOutline": outlineMeshes,
+        "/markersNoOutline": noOutlineMeshes,
+        "/tf": [tf1, tf2],
       },
-    };
-
-    const objMesh: MessageEvent<Marker> = {
-      topic,
-      receiveTime: { sec: 10, nsec: 0 },
-      message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id },
-        id: 0,
-        ns: "obj",
-        type: 10,
-        action: 0,
-        frame_locked: false,
-        pose: {
-          position: { x: 1, y: 0, z: 0 },
-          orientation: { x: 0, y: 0, z: 0, w: 1 },
-        },
-        scale: { x: 0.25, y: 0.25, z: 0.25 },
-        color: makeColor("#ff0000"),
-        points: [],
-        colors: [],
-        text: "",
-        mesh_resource: OBJ_CUBE_MESH_RESOURCE,
-        mesh_use_embedded_materials: true,
-        lifetime: { sec: 0, nsec: 0 },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
       },
-      schemaName: "visualization_msgs/Marker",
-      sizeInBytes: 0,
-    };
-    return [stlMesh, stlColoredMesh, objMesh];
-  }
+    });
 
-  const outlineMeshes = getMeshesInFrame("/markersOutline", "outline");
-  const noOutlineMeshes = getMeshesInFrame("/markersNoOutline", "no-outline");
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
+            topics: {
+              "/markersOutline": { visible: true },
+              "/markersNoOutline": { visible: true, showOutlines: false },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
-      child_frame_id: "outline",
-      transform: {
-        translation: { x: 0, y: -1, z: 0 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "" },
-      child_frame_id: "no-outline",
-      transform: {
-        translation: { x: 0, y: 1, z: 0 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markersOutline": outlineMeshes,
-      "/markersNoOutline": noOutlineMeshes,
-      "/tf": [tf1, tf2],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
-          topics: {
-            "/markersOutline": { visible: true },
-            "/markersNoOutline": { visible: true, showOutlines: false },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+  parameters: { colorScheme: "dark" },
 };
-MeshMarkers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -17,8 +19,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-MeshMarkers.parameters = { colorScheme: "dark" };
-export function MeshMarkers(): JSX.Element {
+export const MeshMarkers: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markersOutline", schemaName: "visualization_msgs/Marker" },
     { name: "/markersNoOutline", schemaName: "visualization_msgs/Marker" },
@@ -154,4 +155,5 @@ export function MeshMarkers(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+MeshMarkers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const MeshMarkers: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markersOutline", schemaName: "visualization_msgs/Marker" },
       { name: "/markersNoOutline", schemaName: "visualization_msgs/Marker" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -18,8 +19,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-NavMsgs_Path.parameters = { colorScheme: "dark" };
-export function NavMsgs_Path(): JSX.Element {
+export const NavMsgs_Path: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/baselink_path", schemaName: "nav_msgs/Path" },
     { name: "/sensor_path", schemaName: "nav_msgs/Path" },
@@ -148,4 +148,5 @@ export function NavMsgs_Path(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+NavMsgs_Path.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const NavMsgs_Path: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/baselink_path", schemaName: "nav_msgs/Path" },
       { name: "/sensor_path", schemaName: "nav_msgs/Path" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -19,134 +19,137 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const NavMsgs_Path: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/baselink_path", schemaName: "nav_msgs/Path" },
-    { name: "/sensor_path", schemaName: "nav_msgs/Path" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf3: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 10, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: 5, z: 1 },
-        rotation: QUAT_IDENTITY,
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-
-  const q = (): quat => [0, 0, 0, 1];
-  const identity = q();
-  const makeOrientation = (i: number) => {
-    const o = quat.rotateZ(q(), identity, Math.PI * 2 * (i / 10));
-    return { x: o[0], y: o[1], z: o[2], w: o[3] };
-  };
-
-  const baseLinkPath: MessageEvent<NavPath> = {
-    topic: "/baselink_path",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      poses: [...Array(10)].map((_, i) => ({
-        header: {
-          seq: 0,
-          stamp: { sec: i, nsec: 0 },
-          frame_id: i % 2 === 0 ? "base_link" : "sensor",
+export const NavMsgs_Path: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/baselink_path", schemaName: "nav_msgs/Path" },
+      { name: "/sensor_path", schemaName: "nav_msgs/Path" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
         },
-        pose: { position: { x: i - 5, y: 0, z: 0 }, orientation: makeOrientation(i) },
-      })),
-    },
-    schemaName: "nav_msgs/Path",
-    sizeInBytes: 0,
-  };
+      },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: QUAT_IDENTITY,
+        },
+      },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf3: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 10, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: 5, z: 1 },
+          rotation: QUAT_IDENTITY,
+        },
+      },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const sensorPath: MessageEvent<NavPath> = {
-    topic: "/sensor_path",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      poses: [...Array(10)].map((_, i) => ({
-        header: { seq: 0, stamp: { sec: i, nsec: 0 }, frame_id: "sensor" },
-        pose: { position: { x: i - 5, y: 0, z: i % 2 }, orientation: makeOrientation(i) },
-      })),
-    },
-    schemaName: "nav_msgs/Path",
-    sizeInBytes: 0,
-  };
+    const q = (): quat => [0, 0, 0, 1];
+    const identity = q();
+    const makeOrientation = (i: number) => {
+      const o = quat.rotateZ(q(), identity, Math.PI * 2 * (i / 10));
+      return { x: o[0], y: o[1], z: o[2], w: o[3] };
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/baselink_path": [baseLinkPath],
-      "/sensor_path": [sensorPath],
-      "/tf": [tf1, tf2, tf3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 3, nsec: 0 },
-    },
-  });
+    const baseLinkPath: MessageEvent<NavPath> = {
+      topic: "/baselink_path",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        poses: [...Array(10)].map((_, i) => ({
+          header: {
+            seq: 0,
+            stamp: { sec: i, nsec: 0 },
+            frame_id: i % 2 === 0 ? "base_link" : "sensor",
+          },
+          pose: { position: { x: i - 5, y: 0, z: 0 }, orientation: makeOrientation(i) },
+        })),
+      },
+      schemaName: "nav_msgs/Path",
+      sizeInBytes: 0,
+    };
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 15,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [0, 2, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/baselink_path": { visible: true },
-            "/sensor_path": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    const sensorPath: MessageEvent<NavPath> = {
+      topic: "/sensor_path",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        poses: [...Array(10)].map((_, i) => ({
+          header: { seq: 0, stamp: { sec: i, nsec: 0 }, frame_id: "sensor" },
+          pose: { position: { x: i - 5, y: 0, z: i % 2 }, orientation: makeOrientation(i) },
+        })),
+      },
+      schemaName: "nav_msgs/Path",
+      sizeInBytes: 0,
+    };
+
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/baselink_path": [baseLinkPath],
+        "/sensor_path": [sensorPath],
+        "/tf": [tf1, tf2, tf3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 3, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 15,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [0, 2, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/baselink_path": { visible: true },
+              "/sensor_path": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-NavMsgs_Path.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -157,12 +157,15 @@ export const Occupancy_Grid_Costmap: StoryFn = (): JSX.Element => {
   return <BaseStory />;
 };
 
-export const Occupancy_Grid_Costmap_With_Settings: StoryFn = (): JSX.Element => {
-  return <BaseStory includeSettings />;
-};
-Occupancy_Grid_Costmap_With_Settings.play = async () => {
-  const label = await screen.findByText("/custom");
-  userEvent.click(label);
+export const Occupancy_Grid_Costmap_With_Settings: StoryObj = {
+  render: function Story(): JSX.Element {
+    return <BaseStory includeSettings />;
+  },
+
+  play: async () => {
+    const label = await screen.findByText("/custom");
+    userEvent.click(label);
+  },
 };
 
 export const OccupancyGridCostmapWithSettingsChinese = Object.assign(

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -153,8 +153,10 @@ function BaseStory({ includeSettings = false }: { includeSettings?: boolean }): 
   );
 }
 
-export const Occupancy_Grid_Costmap: StoryFn = (): JSX.Element => {
-  return <BaseStory />;
+export const Occupancy_Grid_Costmap: StoryObj = {
+  render: (): JSX.Element => {
+    return <BaseStory />;
+  },
 };
 
 export const Occupancy_Grid_Costmap_With_Settings: StoryObj = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -154,13 +154,13 @@ function BaseStory({ includeSettings = false }: { includeSettings?: boolean }): 
 }
 
 export const Occupancy_Grid_Costmap: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <BaseStory />;
   },
 };
 
 export const Occupancy_Grid_Costmap_With_Settings: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return <BaseStory includeSettings />;
   },
 
@@ -170,7 +170,7 @@ export const Occupancy_Grid_Costmap_With_Settings: StoryObj = {
   },
 };
 
-export const OccupancyGridCostmapWithSettingsChinese = {
+export const OccupancyGridCostmapWithSettingsChinese: StoryObj = {
   ...Occupancy_Grid_Costmap_With_Settings,
   parameters: { forceLanguage: "zh" },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -168,7 +168,7 @@ export const Occupancy_Grid_Costmap_With_Settings: StoryObj = {
   },
 };
 
-export const OccupancyGridCostmapWithSettingsChinese = Object.assign(
-  Occupancy_Grid_Costmap_With_Settings.bind(undefined),
-  { play: Occupancy_Grid_Costmap_With_Settings.play, parameters: { forceLanguage: "zh" } },
-);
+export const OccupancyGridCostmapWithSettingsChinese = {
+  ...Occupancy_Grid_Costmap_With_Settings,
+  parameters: { forceLanguage: "zh" },
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -152,13 +153,13 @@ function BaseStory({ includeSettings = false }: { includeSettings?: boolean }): 
   );
 }
 
-export function Occupancy_Grid_Costmap(): JSX.Element {
+export const Occupancy_Grid_Costmap: StoryFn = (): JSX.Element => {
   return <BaseStory />;
-}
+};
 
-export function Occupancy_Grid_Costmap_With_Settings(): JSX.Element {
+export const Occupancy_Grid_Costmap_With_Settings: StoryFn = (): JSX.Element => {
   return <BaseStory includeSettings />;
-}
+};
 Occupancy_Grid_Costmap_With_Settings.play = async () => {
   const label = await screen.findByText("/custom");
   userEvent.click(label);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -22,8 +24,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-PoseMarkers.parameters = { colorScheme: "dark" };
-export function PoseMarkers(): JSX.Element {
+export const PoseMarkers: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
     { name: "/pose", schemaName: "geometry_msgs/PoseStamped" },
@@ -207,4 +208,5 @@ export function PoseMarkers(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+PoseMarkers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
@@ -25,7 +25,7 @@ export default {
 };
 
 export const PoseMarkers: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
       { name: "/pose", schemaName: "geometry_msgs/PoseStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -24,189 +24,195 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const PoseMarkers: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/pose", schemaName: "geometry_msgs/PoseStamped" },
-    { name: "/pose_with_covariance", schemaName: "geometry_msgs/PoseWithCovarianceStamped" },
-    { name: "/pose_with_hidden_covariance", schemaName: "geometry_msgs/PoseWithCovarianceStamped" },
-    { name: "/pose_axis_with_covariance", schemaName: "geometry_msgs/PoseWithCovarianceStamped" },
-  ];
-
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
-      child_frame_id: BASE_LINK_FRAME_ID,
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const PoseMarkers: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/pose", schemaName: "geometry_msgs/PoseStamped" },
+      { name: "/pose_with_covariance", schemaName: "geometry_msgs/PoseWithCovarianceStamped" },
+      {
+        name: "/pose_with_hidden_covariance",
+        schemaName: "geometry_msgs/PoseWithCovarianceStamped",
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      child_frame_id: SENSOR_FRAME_ID,
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
-      },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      { name: "/pose_axis_with_covariance", schemaName: "geometry_msgs/PoseWithCovarianceStamped" },
+    ];
 
-  const pose1: MessageEvent<Partial<PoseStamped>> = {
-    topic: "/pose",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      pose: {
-        position: { x: 0, y: 0, z: -1 },
-        orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
-      },
-    },
-    schemaName: "geometry_msgs/PoseStamped",
-    sizeInBytes: 0,
-  };
-
-  const pose2: MessageEvent<Partial<PoseWithCovarianceStamped>> = {
-    topic: "/pose_with_covariance",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
-      pose: {
-        pose: {
-          position: { x: 0, y: 0, z: 0 },
-          orientation: QUAT_IDENTITY,
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: FIXED_FRAME_ID },
+        child_frame_id: BASE_LINK_FRAME_ID,
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
         },
-        // prettier-ignore
-        covariance: [
-          2 * 2, 0, 0, 0, 0, 0,
-          0, 0.15 * 0.15, 0, 0, 0, 0,
-          0, 0, 0.3 * 0.3, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-        ],
       },
-    },
-    schemaName: "geometry_msgs/PoseWithCovarianceStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
+        child_frame_id: SENSOR_FRAME_ID,
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+        },
+      },
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const pose3: MessageEvent<Partial<PoseWithCovarianceStamped>> = {
-    topic: "/pose_with_hidden_covariance",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      pose: {
+    const pose1: MessageEvent<Partial<PoseStamped>> = {
+      topic: "/pose",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
         pose: {
-          position: { x: -1, y: 0, z: -1 },
+          position: { x: 0, y: 0, z: -1 },
           orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
         },
-        // prettier-ignore
-        covariance: [
-          1, 0, 0, 0, 0, 0,
-          0, 1, 0, 0, 0, 0,
-          0, 0, 1, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-        ],
       },
-    },
-    schemaName: "geometry_msgs/PoseWithCovarianceStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/PoseStamped",
+      sizeInBytes: 0,
+    };
 
-  const pose4: MessageEvent<Partial<PoseWithCovarianceStamped>> = {
-    topic: "/pose_axis_with_covariance",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
-      pose: {
+    const pose2: MessageEvent<Partial<PoseWithCovarianceStamped>> = {
+      topic: "/pose_with_covariance",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: BASE_LINK_FRAME_ID },
         pose: {
-          position: { x: 1, y: 0, z: -1 },
-          orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
+          pose: {
+            position: { x: 0, y: 0, z: 0 },
+            orientation: QUAT_IDENTITY,
+          },
+          // prettier-ignore
+          covariance: [
+            2 * 2, 0, 0, 0, 0, 0,
+            0, 0.15 * 0.15, 0, 0, 0, 0,
+            0, 0, 0.3 * 0.3, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+          ],
         },
-        // prettier-ignore
-        covariance: [
-          1, 0, 0, 0, 0, 0,
-          0, 1, 0, 0, 0, 0,
-          0, 0, 1, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-          0, 0, 0, 0, 0, 0,
-        ],
       },
-    },
-    schemaName: "geometry_msgs/PoseWithCovarianceStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/PoseWithCovarianceStamped",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/pose": [pose1],
-      "/pose_with_covariance": [pose2],
-      "/pose_with_hidden_covariance": [pose3],
-      "/pose_axis_with_covariance": [pose4],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const pose3: MessageEvent<Partial<PoseWithCovarianceStamped>> = {
+      topic: "/pose_with_hidden_covariance",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        pose: {
+          pose: {
+            position: { x: -1, y: 0, z: -1 },
+            orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
+          },
+          // prettier-ignore
+          covariance: [
+            1, 0, 0, 0, 0, 0,
+            0, 1, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+          ],
+        },
+      },
+      schemaName: "geometry_msgs/PoseWithCovarianceStamped",
+      sizeInBytes: 0,
+    };
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "base_link",
-          cameraState: {
-            distance: 4,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: rad2deg(-1),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
+    const pose4: MessageEvent<Partial<PoseWithCovarianceStamped>> = {
+      topic: "/pose_axis_with_covariance",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+        pose: {
+          pose: {
+            position: { x: 1, y: 0, z: -1 },
+            orientation: { x: 0, y: -Math.SQRT1_2, z: 0, w: Math.SQRT1_2 },
           },
-          topics: {
-            "/pose": {
-              visible: true,
-              type: "arrow",
-              color: "rgba(107, 220, 255, 0.5)",
+          // prettier-ignore
+          covariance: [
+            1, 0, 0, 0, 0, 0,
+            0, 1, 0, 0, 0, 0,
+            0, 0, 1, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+          ],
+        },
+      },
+      schemaName: "geometry_msgs/PoseWithCovarianceStamped",
+      sizeInBytes: 0,
+    };
+
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/pose": [pose1],
+        "/pose_with_covariance": [pose2],
+        "/pose_with_hidden_covariance": [pose3],
+        "/pose_axis_with_covariance": [pose4],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "base_link",
+            cameraState: {
+              distance: 4,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [-0.6, 0.5, 0],
+              thetaOffset: rad2deg(-1),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
             },
-            "/pose_with_covariance": {
-              visible: true,
-              type: "arrow",
+            topics: {
+              "/pose": {
+                visible: true,
+                type: "arrow",
+                color: "rgba(107, 220, 255, 0.5)",
+              },
+              "/pose_with_covariance": {
+                visible: true,
+                type: "arrow",
+              },
+              "/pose_with_hidden_covariance": {
+                visible: true,
+                type: "arrow",
+                showCovariance: false,
+                covarianceColor: "rgba(255, 0, 0, 1)",
+              },
+              "/pose_axis_with_covariance": {
+                visible: true,
+              },
             },
-            "/pose_with_hidden_covariance": {
-              visible: true,
-              type: "arrow",
-              showCovariance: false,
-              covarianceColor: "rgba(255, 0, 0, 1)",
-            },
-            "/pose_axis_with_covariance": {
-              visible: true,
-            },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-PoseMarkers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PublishClickTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PublishClickTool.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { screen } from "@storybook/testing-library";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -20,7 +21,8 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const Point = Object.assign(PublishClickToolTemplate.bind({}), {
+export const Point: StoryObj<{ type: PublishClickType }> = {
+  render: PublishClickToolTemplate,
   parameters: { colorScheme: "dark" },
   args: { type: "point" },
   play: async () => {
@@ -34,9 +36,10 @@ export const Point = Object.assign(PublishClickToolTemplate.bind({}), {
     await delay(10);
     await new Promise((resolve) => requestAnimationFrame(resolve));
   },
-});
+};
 
-export const PosePosition = Object.assign(PublishClickToolTemplate.bind({}), {
+export const PosePosition: StoryObj<{ type: PublishClickType }> = {
+  render: PublishClickToolTemplate,
   parameters: { colorScheme: "dark" },
   args: { type: "pose" },
   play: async () => {
@@ -50,9 +53,10 @@ export const PosePosition = Object.assign(PublishClickToolTemplate.bind({}), {
     await delay(10);
     await new Promise((resolve) => requestAnimationFrame(resolve));
   },
-});
+};
 
-export const PoseComplete = Object.assign(PublishClickToolTemplate.bind({}), {
+export const PoseComplete: StoryObj<{ type: PublishClickType }> = {
+  render: PublishClickToolTemplate,
   parameters: { colorScheme: "dark" },
   args: { type: "pose" },
   play: async () => {
@@ -72,9 +76,10 @@ export const PoseComplete = Object.assign(PublishClickToolTemplate.bind({}), {
     await delay(100);
     await new Promise((resolve) => requestAnimationFrame(resolve));
   },
-});
+};
 
-export const PoseEstimatePosition = Object.assign(PublishClickToolTemplate.bind({}), {
+export const PoseEstimatePosition: StoryObj<{ type: PublishClickType }> = {
+  render: PublishClickToolTemplate,
   parameters: { colorScheme: "dark" },
   args: { type: "pose_estimate" },
   play: async () => {
@@ -88,9 +93,10 @@ export const PoseEstimatePosition = Object.assign(PublishClickToolTemplate.bind(
     await delay(100);
     await new Promise((resolve) => requestAnimationFrame(resolve));
   },
-});
+};
 
-export const PoseEstimateComplete = Object.assign(PublishClickToolTemplate.bind({}), {
+export const PoseEstimateComplete: StoryObj<{ type: PublishClickType }> = {
+  render: PublishClickToolTemplate,
   parameters: { colorScheme: "dark" },
   args: { type: "pose_estimate" },
   play: async () => {
@@ -110,7 +116,7 @@ export const PoseEstimateComplete = Object.assign(PublishClickToolTemplate.bind(
     await delay(100);
     await new Promise((resolve) => requestAnimationFrame(resolve));
   },
-});
+};
 
 function PublishClickToolTemplate({ type }: { type: PublishClickType }): JSX.Element {
   const topics: Topic[] = [{ name: "/tf", schemaName: "geometry_msgs/TransformStamped" }];

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import * as THREE from "three";
 import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
 import { TeapotGeometry } from "three/examples/jsm/geometries/TeapotGeometry";
@@ -320,114 +320,117 @@ function makeStoryScene({
   };
 }
 
-export const BasicEntities: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "transforms", schemaName: "foxglove.FrameTransform" },
-    { name: "scene1", schemaName: "foxglove.SceneUpdate" },
-    { name: "scene2", schemaName: "foxglove.SceneUpdate" },
-    { name: "scene3", schemaName: "foxglove.SceneUpdate" },
-  ];
+export const BasicEntities: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "transforms", schemaName: "foxglove.FrameTransform" },
+      { name: "scene1", schemaName: "foxglove.SceneUpdate" },
+      { name: "scene2", schemaName: "foxglove.SceneUpdate" },
+      { name: "scene3", schemaName: "foxglove.SceneUpdate" },
+    ];
 
-  const scene1 = makeStoryScene({ topic: "scene1", frameId: "frame1" });
-  const scene2 = makeStoryScene({ topic: "scene2", frameId: "frame2" });
-  const scene3 = makeStoryScene({ topic: "scene3", frameId: "frame3" });
+    const scene1 = makeStoryScene({ topic: "scene1", frameId: "frame1" });
+    const scene2 = makeStoryScene({ topic: "scene2", frameId: "frame2" });
+    const scene3 = makeStoryScene({ topic: "scene3", frameId: "frame3" });
 
-  const tf1: MessageEvent<FrameTransform> = {
-    topic: "transforms",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "map",
-      child_frame_id: "root",
-      translation: { x: 1e7, y: 0, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<FrameTransform> = {
-    topic: "transforms",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "root",
-      child_frame_id: "frame1",
-      translation: { x: -5, y: -4, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const tf3: MessageEvent<FrameTransform> = {
-    topic: "transforms",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: -1, nsec: 0 },
-      parent_frame_id: "root",
-      child_frame_id: "frame2",
-      translation: { x: -1, y: -4, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const tf4: MessageEvent<FrameTransform> = {
-    topic: "transforms",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: -1, nsec: 0 },
-      parent_frame_id: "root",
-      child_frame_id: "frame3",
-      translation: { x: 3, y: -4, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
+    const tf1: MessageEvent<FrameTransform> = {
+      topic: "transforms",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "map",
+        child_frame_id: "root",
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<FrameTransform> = {
+      topic: "transforms",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "root",
+        child_frame_id: "frame1",
+        translation: { x: -5, y: -4, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const tf3: MessageEvent<FrameTransform> = {
+      topic: "transforms",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: -1, nsec: 0 },
+        parent_frame_id: "root",
+        child_frame_id: "frame2",
+        translation: { x: -1, y: -4, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const tf4: MessageEvent<FrameTransform> = {
+      topic: "transforms",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: -1, nsec: 0 },
+        parent_frame_id: "root",
+        child_frame_id: "frame3",
+        translation: { x: 3, y: -4, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
 
-  const fixture = {
-    topics,
-    frame: {
-      transforms: [tf1, tf2, tf3, tf4],
-      scene1: [scene1],
-      scene2: [scene2],
-      scene3: [scene3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  };
+    const fixture = {
+      topics,
+      frame: {
+        transforms: [tf1, tf2, tf3, tf4],
+        scene1: [scene1],
+        scene2: [scene2],
+        scene3: [scene3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    };
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          ...ThreeDeePanel.defaultConfig,
-          followTf: "root",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 14,
-            perspective: true,
-            phi: 40,
-            targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: 45,
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            scene1: { visible: true },
-            scene2: { visible: true, color: "#6324c7ff" },
-            scene3: { visible: true, showOutlines: false },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            ...ThreeDeePanel.defaultConfig,
+            followTf: "root",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 14,
+              perspective: true,
+              phi: 40,
+              targetOffset: [0, 0, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: 45,
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              scene1: { visible: true },
+              scene2: { visible: true, color: "#6324c7ff" },
+              scene3: { visible: true, showOutlines: false },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "light", chromatic: { delay: 100 } },
 };
-BasicEntities.parameters = { colorScheme: "light", chromatic: { delay: 100 } };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -321,7 +321,7 @@ function makeStoryScene({
 }
 
 export const BasicEntities: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "transforms", schemaName: "foxglove.FrameTransform" },
       { name: "scene1", schemaName: "foxglove.SceneUpdate" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import * as THREE from "three";
 import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
 import { TeapotGeometry } from "three/examples/jsm/geometries/TeapotGeometry";
@@ -319,8 +320,7 @@ function makeStoryScene({
   };
 }
 
-BasicEntities.parameters = { colorScheme: "light", chromatic: { delay: 100 } };
-export function BasicEntities(): JSX.Element {
+export const BasicEntities: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "transforms", schemaName: "foxglove.FrameTransform" },
     { name: "scene1", schemaName: "foxglove.SceneUpdate" },
@@ -429,4 +429,5 @@ export function BasicEntities(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+BasicEntities.parameters = { colorScheme: "light", chromatic: { delay: 100 } };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
@@ -157,64 +157,72 @@ function SensorMsgs_LaserScan({
   );
 }
 
-export const Square = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const Square = {
+  render: SensorMsgs_LaserScan,
   args: {
     settings: {
       pointShape: "square",
     },
   },
-});
+};
 
-export const Size20 = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const Size20 = {
+  render: SensorMsgs_LaserScan,
   args: {
     settings: {
       pointSize: 20,
     },
   },
-});
+};
 
-export const FlatColor = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const FlatColor = {
+  render: SensorMsgs_LaserScan,
   args: {
     settings: {
       colorMode: "flat",
       flatColor: "#ff00ff",
     },
   },
-});
+};
 
-export const CustomGradient = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const CustomGradient = {
+  render: SensorMsgs_LaserScan,
   args: {
     settings: {
       colorMode: "gradient",
       gradient: ["#00ffff", "#0000ff"],
     },
   },
-});
+};
 
-export const RangeLimits = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const RangeLimits = {
+  render: SensorMsgs_LaserScan,
   args: {
     rangeMin: 2,
     rangeMax: 3,
   },
-});
+};
 
-export const Time0 = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const Time0 = {
+  render: SensorMsgs_LaserScan,
   args: {
     time: 0,
   },
-});
+};
 
-export const Time5 = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const Time5 = {
+  render: SensorMsgs_LaserScan,
   args: {
     time: 5,
   },
-});
+};
 
-export const Time10 = Object.assign(SensorMsgs_LaserScan.bind({}), {
+export const Time10 = {
+  render: SensorMsgs_LaserScan,
   args: {
     time: 10,
   },
-});
+};
 
 export const ComparisonWithPointCloudColors: StoryObj = {
   render: function Story() {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import * as THREE from "three";
 
 import { fromSec } from "@foxglove/rostime";
@@ -215,7 +216,7 @@ export const Time10 = Object.assign(SensorMsgs_LaserScan.bind({}), {
   },
 });
 
-export function ComparisonWithPointCloudColors(): JSX.Element {
+export const ComparisonWithPointCloudColors: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/scan", schemaName: "sensor_msgs/LaserScan" },
     { name: "/cloud", schemaName: "sensor_msgs/PointCloud2" },
@@ -354,4 +355,4 @@ export function ComparisonWithPointCloudColors(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
@@ -157,7 +157,7 @@ function SensorMsgs_LaserScan({
   );
 }
 
-export const Square = {
+export const Square: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     settings: {
@@ -166,7 +166,7 @@ export const Square = {
   },
 };
 
-export const Size20 = {
+export const Size20: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     settings: {
@@ -175,7 +175,7 @@ export const Size20 = {
   },
 };
 
-export const FlatColor = {
+export const FlatColor: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     settings: {
@@ -185,7 +185,7 @@ export const FlatColor = {
   },
 };
 
-export const CustomGradient = {
+export const CustomGradient: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     settings: {
@@ -195,7 +195,7 @@ export const CustomGradient = {
   },
 };
 
-export const RangeLimits = {
+export const RangeLimits: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     rangeMin: 2,
@@ -203,166 +203,167 @@ export const RangeLimits = {
   },
 };
 
-export const Time0 = {
+export const Time0: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     time: 0,
   },
 };
 
-export const Time5 = {
+export const Time5: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     time: 5,
   },
 };
 
-export const Time10 = {
+export const Time10: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> = {
   render: SensorMsgs_LaserScan,
   args: {
     time: 10,
   },
 };
 
-export const ComparisonWithPointCloudColors: StoryObj = {
-  render: function Story() {
-    const topics: Topic[] = [
-      { name: "/scan", schemaName: "sensor_msgs/LaserScan" },
-      { name: "/cloud", schemaName: "sensor_msgs/PointCloud2" },
-      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    ];
-    const tf1: MessageEvent<TransformStamped> = {
-      topic: "/tf",
-      receiveTime: { sec: 10, nsec: 0 },
-      message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-        child_frame_id: "base_link",
-        transform: {
-          translation: { x: 1e7, y: 0, z: 0 },
-          rotation: QUAT_IDENTITY,
+export const ComparisonWithPointCloudColors: StoryObj<Parameters<typeof SensorMsgs_LaserScan>[0]> =
+  {
+    render: function Story() {
+      const topics: Topic[] = [
+        { name: "/scan", schemaName: "sensor_msgs/LaserScan" },
+        { name: "/cloud", schemaName: "sensor_msgs/PointCloud2" },
+        { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      ];
+      const tf1: MessageEvent<TransformStamped> = {
+        topic: "/tf",
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+          child_frame_id: "base_link",
+          transform: {
+            translation: { x: 1e7, y: 0, z: 0 },
+            rotation: QUAT_IDENTITY,
+          },
         },
-      },
-      schemaName: "geometry_msgs/TransformStamped",
-      sizeInBytes: 0,
-    };
+        schemaName: "geometry_msgs/TransformStamped",
+        sizeInBytes: 0,
+      };
 
-    const count = 50;
+      const count = 50;
 
-    const ranges = new Float32Array(count);
-    const intensities = new Float32Array(count);
-    const pointCloudData = new Float32Array(4 * count);
-    const angleMax = Math.PI / 4;
-    const radius = 2;
+      const ranges = new Float32Array(count);
+      const intensities = new Float32Array(count);
+      const pointCloudData = new Float32Array(4 * count);
+      const angleMax = Math.PI / 4;
+      const radius = 2;
 
-    for (let i = 0; i < count; i++) {
-      const t = i / (count - 1);
-      ranges[i] = radius / Math.cos(angleMax * t);
-      intensities[i] = t;
-      pointCloudData[4 * i + 0] = 1; // x
-      pointCloudData[4 * i + 1] = radius * t; // y
-      pointCloudData[4 * i + 2] = 0; // z
-      pointCloudData[4 * i + 3] = t; // intensity
-    }
+      for (let i = 0; i < count; i++) {
+        const t = i / (count - 1);
+        ranges[i] = radius / Math.cos(angleMax * t);
+        intensities[i] = t;
+        pointCloudData[4 * i + 0] = 1; // x
+        pointCloudData[4 * i + 1] = radius * t; // y
+        pointCloudData[4 * i + 2] = 0; // z
+        pointCloudData[4 * i + 3] = t; // intensity
+      }
 
-    const laserScan: MessageEvent<LaserScan> = {
-      topic: "/scan",
-      receiveTime: { sec: 10, nsec: 0 },
-      message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-        angle_min: 0,
-        angle_max: angleMax,
-        angle_increment: angleMax / (count - 1),
-        time_increment: 0,
-        scan_time: 0,
-        range_min: -Infinity,
-        range_max: Infinity,
-        ranges,
-        intensities,
-      },
-      schemaName: "sensor_msgs/LaserScan",
-      sizeInBytes: 0,
-    };
+      const laserScan: MessageEvent<LaserScan> = {
+        topic: "/scan",
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+          angle_min: 0,
+          angle_max: angleMax,
+          angle_increment: angleMax / (count - 1),
+          time_increment: 0,
+          scan_time: 0,
+          range_min: -Infinity,
+          range_max: Infinity,
+          ranges,
+          intensities,
+        },
+        schemaName: "sensor_msgs/LaserScan",
+        sizeInBytes: 0,
+      };
 
-    const pointCloud: MessageEvent<PointCloud2> = {
-      topic: "/cloud",
-      receiveTime: { sec: 10, nsec: 0 },
-      message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-        height: 1,
-        width: count,
-        fields: [
-          { name: "x", offset: 0, datatype: 7, count: 1 },
-          { name: "y", offset: 4, datatype: 7, count: 1 },
-          { name: "z", offset: 8, datatype: 7, count: 1 },
-          { name: "intensity", offset: 12, datatype: 7, count: 1 },
-        ],
-        is_bigendian: false,
-        point_step: 16,
-        row_step: count * 16,
-        data: new Uint8Array(
-          pointCloudData.buffer,
-          pointCloudData.byteOffset,
-          pointCloudData.byteLength,
-        ),
-        is_dense: true,
-      },
-      schemaName: "sensor_msgs/PointCloud2",
-      sizeInBytes: 0,
-    };
+      const pointCloud: MessageEvent<PointCloud2> = {
+        topic: "/cloud",
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+          height: 1,
+          width: count,
+          fields: [
+            { name: "x", offset: 0, datatype: 7, count: 1 },
+            { name: "y", offset: 4, datatype: 7, count: 1 },
+            { name: "z", offset: 8, datatype: 7, count: 1 },
+            { name: "intensity", offset: 12, datatype: 7, count: 1 },
+          ],
+          is_bigendian: false,
+          point_step: 16,
+          row_step: count * 16,
+          data: new Uint8Array(
+            pointCloudData.buffer,
+            pointCloudData.byteOffset,
+            pointCloudData.byteLength,
+          ),
+          is_dense: true,
+        },
+        schemaName: "sensor_msgs/PointCloud2",
+        sizeInBytes: 0,
+      };
 
-    const fixture = useDelayedFixture({
-      topics,
-      frame: {
-        "/scan": [laserScan],
-        "/cloud": [pointCloud],
-        "/tf": [tf1],
-      },
-      capabilities: [],
-      activeData: {
-        currentTime: fromSec(0),
-      },
-    });
+      const fixture = useDelayedFixture({
+        topics,
+        frame: {
+          "/scan": [laserScan],
+          "/cloud": [pointCloud],
+          "/tf": [tf1],
+        },
+        capabilities: [],
+        activeData: {
+          currentTime: fromSec(0),
+        },
+      });
 
-    return (
-      <PanelSetup fixture={fixture}>
-        <ThreeDeePanel
-          overrideConfig={{
-            followTf: "base_link",
-            scene: { enableStats: false },
-            topics: {
-              "/scan": {
-                visible: true,
-                pointSize: 10,
-                colorMode: "colormap",
-                colorMap: "turbo",
-                colorField: "intensity",
+      return (
+        <PanelSetup fixture={fixture}>
+          <ThreeDeePanel
+            overrideConfig={{
+              followTf: "base_link",
+              scene: { enableStats: false },
+              topics: {
+                "/scan": {
+                  visible: true,
+                  pointSize: 10,
+                  colorMode: "colormap",
+                  colorMap: "turbo",
+                  colorField: "intensity",
+                },
+                "/cloud": {
+                  visible: true,
+                  pointSize: 10,
+                  colorMode: "colormap",
+                  colorMap: "turbo",
+                  colorField: "intensity",
+                },
               },
-              "/cloud": {
-                visible: true,
-                pointSize: 10,
-                colorMode: "colormap",
-                colorMap: "turbo",
-                colorField: "intensity",
+              layers: {
+                grid: { layerId: "foxglove.Grid" },
               },
-            },
-            layers: {
-              grid: { layerId: "foxglove.Grid" },
-            },
-            cameraState: {
-              distance: 5,
-              perspective: false,
-              phi: rad2deg(0),
-              targetOffset: [0, 1, 0],
-              thetaOffset: rad2deg(0),
-              fovy: rad2deg(0.75),
-              near: 0.01,
-              far: 5000,
-              target: [0, 0, 0],
-              targetOrientation: [0, 0, 0, 1],
-            },
-          }}
-        />
-      </PanelSetup>
-    );
-  },
-};
+              cameraState: {
+                distance: 5,
+                perspective: false,
+                phi: rad2deg(0),
+                targetOffset: [0, 1, 0],
+                thetaOffset: rad2deg(0),
+                fovy: rad2deg(0.75),
+                near: 0.01,
+                far: 5000,
+                target: [0, 0, 0],
+                targetOrientation: [0, 0, 0, 1],
+              },
+            }}
+          />
+        </PanelSetup>
+      );
+    },
+  };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import * as THREE from "three";
 
 import { fromSec } from "@foxglove/rostime";
@@ -216,143 +216,145 @@ export const Time10 = Object.assign(SensorMsgs_LaserScan.bind({}), {
   },
 });
 
-export const ComparisonWithPointCloudColors: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/scan", schemaName: "sensor_msgs/LaserScan" },
-    { name: "/cloud", schemaName: "sensor_msgs/PointCloud2" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const ComparisonWithPointCloudColors: StoryObj = {
+  render: function Story() {
+    const topics: Topic[] = [
+      { name: "/scan", schemaName: "sensor_msgs/LaserScan" },
+      { name: "/cloud", schemaName: "sensor_msgs/PointCloud2" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const count = 50;
+    const count = 50;
 
-  const ranges = new Float32Array(count);
-  const intensities = new Float32Array(count);
-  const pointCloudData = new Float32Array(4 * count);
-  const angleMax = Math.PI / 4;
-  const radius = 2;
+    const ranges = new Float32Array(count);
+    const intensities = new Float32Array(count);
+    const pointCloudData = new Float32Array(4 * count);
+    const angleMax = Math.PI / 4;
+    const radius = 2;
 
-  for (let i = 0; i < count; i++) {
-    const t = i / (count - 1);
-    ranges[i] = radius / Math.cos(angleMax * t);
-    intensities[i] = t;
-    pointCloudData[4 * i + 0] = 1; // x
-    pointCloudData[4 * i + 1] = radius * t; // y
-    pointCloudData[4 * i + 2] = 0; // z
-    pointCloudData[4 * i + 3] = t; // intensity
-  }
+    for (let i = 0; i < count; i++) {
+      const t = i / (count - 1);
+      ranges[i] = radius / Math.cos(angleMax * t);
+      intensities[i] = t;
+      pointCloudData[4 * i + 0] = 1; // x
+      pointCloudData[4 * i + 1] = radius * t; // y
+      pointCloudData[4 * i + 2] = 0; // z
+      pointCloudData[4 * i + 3] = t; // intensity
+    }
 
-  const laserScan: MessageEvent<LaserScan> = {
-    topic: "/scan",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      angle_min: 0,
-      angle_max: angleMax,
-      angle_increment: angleMax / (count - 1),
-      time_increment: 0,
-      scan_time: 0,
-      range_min: -Infinity,
-      range_max: Infinity,
-      ranges,
-      intensities,
-    },
-    schemaName: "sensor_msgs/LaserScan",
-    sizeInBytes: 0,
-  };
+    const laserScan: MessageEvent<LaserScan> = {
+      topic: "/scan",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        angle_min: 0,
+        angle_max: angleMax,
+        angle_increment: angleMax / (count - 1),
+        time_increment: 0,
+        scan_time: 0,
+        range_min: -Infinity,
+        range_max: Infinity,
+        ranges,
+        intensities,
+      },
+      schemaName: "sensor_msgs/LaserScan",
+      sizeInBytes: 0,
+    };
 
-  const pointCloud: MessageEvent<PointCloud2> = {
-    topic: "/cloud",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      height: 1,
-      width: count,
-      fields: [
-        { name: "x", offset: 0, datatype: 7, count: 1 },
-        { name: "y", offset: 4, datatype: 7, count: 1 },
-        { name: "z", offset: 8, datatype: 7, count: 1 },
-        { name: "intensity", offset: 12, datatype: 7, count: 1 },
-      ],
-      is_bigendian: false,
-      point_step: 16,
-      row_step: count * 16,
-      data: new Uint8Array(
-        pointCloudData.buffer,
-        pointCloudData.byteOffset,
-        pointCloudData.byteLength,
-      ),
-      is_dense: true,
-    },
-    schemaName: "sensor_msgs/PointCloud2",
-    sizeInBytes: 0,
-  };
+    const pointCloud: MessageEvent<PointCloud2> = {
+      topic: "/cloud",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        height: 1,
+        width: count,
+        fields: [
+          { name: "x", offset: 0, datatype: 7, count: 1 },
+          { name: "y", offset: 4, datatype: 7, count: 1 },
+          { name: "z", offset: 8, datatype: 7, count: 1 },
+          { name: "intensity", offset: 12, datatype: 7, count: 1 },
+        ],
+        is_bigendian: false,
+        point_step: 16,
+        row_step: count * 16,
+        data: new Uint8Array(
+          pointCloudData.buffer,
+          pointCloudData.byteOffset,
+          pointCloudData.byteLength,
+        ),
+        is_dense: true,
+      },
+      schemaName: "sensor_msgs/PointCloud2",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/scan": [laserScan],
-      "/cloud": [pointCloud],
-      "/tf": [tf1],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: fromSec(0),
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/scan": [laserScan],
+        "/cloud": [pointCloud],
+        "/tf": [tf1],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: fromSec(0),
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          scene: { enableStats: false },
-          topics: {
-            "/scan": {
-              visible: true,
-              pointSize: 10,
-              colorMode: "colormap",
-              colorMap: "turbo",
-              colorField: "intensity",
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            scene: { enableStats: false },
+            topics: {
+              "/scan": {
+                visible: true,
+                pointSize: 10,
+                colorMode: "colormap",
+                colorMap: "turbo",
+                colorField: "intensity",
+              },
+              "/cloud": {
+                visible: true,
+                pointSize: 10,
+                colorMode: "colormap",
+                colorMap: "turbo",
+                colorField: "intensity",
+              },
             },
-            "/cloud": {
-              visible: true,
-              pointSize: 10,
-              colorMode: "colormap",
-              colorMap: "turbo",
-              colorField: "intensity",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
             },
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 5,
-            perspective: false,
-            phi: rad2deg(0),
-            targetOffset: [0, 1, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: {
+              distance: 5,
+              perspective: false,
+              phi: rad2deg(0),
+              targetOffset: [0, 1, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { vec3 } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -160,178 +160,180 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
   );
 }
 
-export const SensorMsgs_PointCloud2_Intensity: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 1e7, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const SensorMsgs_PointCloud2_Intensity: StoryObj = {
+  render: function Story() {
+    const topics: Topic[] = [
+      { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 1e7, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  SensorMsgs_PointCloud2_Intensity.parameters = { colorScheme: "dark" };
-  const tf2: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
-      child_frame_id: "sensor",
-      transform: {
-        translation: { x: 0, y: 0, z: 1 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    SensorMsgs_PointCloud2_Intensity.parameters = { colorScheme: "dark" };
+    const tf2: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+        child_frame_id: "sensor",
+        transform: {
+          translation: { x: 0, y: 0, z: 1 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const WIDTH = 128;
-  const HW = 5;
-  const SCALE = 10 / WIDTH;
-  const SCALE_2 = 0.5 * SCALE;
-  const STEP = 13;
-  const METABALLS: [number, number, number, number][] = [
-    [0, 0, 2, 1.5],
-    [2.2, 2, 3, 0.75],
-    [2.1, -0.1, 4, 0.5],
-    [-1.2, -1, 1, 0.5],
-  ];
+    const WIDTH = 128;
+    const HW = 5;
+    const SCALE = 10 / WIDTH;
+    const SCALE_2 = 0.5 * SCALE;
+    const STEP = 13;
+    const METABALLS: [number, number, number, number][] = [
+      [0, 0, 2, 1.5],
+      [2.2, 2, 3, 0.75],
+      [2.1, -0.1, 4, 0.5],
+      [-1.2, -1, 1, 0.5],
+    ];
 
-  const tempVec: vec3 = [0, 0, 0];
-  function inside(p: vec3): number {
-    let sum = 0;
-    for (const metaball of METABALLS) {
-      tempVec[0] = metaball[0];
-      tempVec[1] = metaball[1];
-      tempVec[2] = metaball[2];
-      const r = metaball[3];
-      const d2 = Math.max(Number.EPSILON, vec3.squaredDistance(p, tempVec) - r * r);
-      sum += Math.pow(1 / d2, 2);
+    const tempVec: vec3 = [0, 0, 0];
+    function inside(p: vec3): number {
+      let sum = 0;
+      for (const metaball of METABALLS) {
+        tempVec[0] = metaball[0];
+        tempVec[1] = metaball[1];
+        tempVec[2] = metaball[2];
+        const r = metaball[3];
+        const d2 = Math.max(Number.EPSILON, vec3.squaredDistance(p, tempVec) - r * r);
+        sum += Math.pow(1 / d2, 2);
+      }
+      return sum >= 1 ? 1 : 0;
     }
-    return sum >= 1 ? 1 : 0;
-  }
 
-  function countInside(xi: number, yi: number, zi: number): number {
-    const p0: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE - SCALE_2];
-    const p1: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE - SCALE_2];
-    const p2: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE - SCALE_2];
-    const p3: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE - SCALE_2];
-    const p4: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE + SCALE_2];
-    const p5: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE + SCALE_2];
-    const p6: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE + SCALE_2];
-    const p7: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE + SCALE_2];
+    function countInside(xi: number, yi: number, zi: number): number {
+      const p0: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE - SCALE_2];
+      const p1: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE - SCALE_2];
+      const p2: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE - SCALE_2];
+      const p3: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE - SCALE_2];
+      const p4: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE + SCALE_2];
+      const p5: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW - SCALE_2, zi * SCALE + SCALE_2];
+      const p6: vec3 = [xi * SCALE - HW - SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE + SCALE_2];
+      const p7: vec3 = [xi * SCALE - HW + SCALE_2, yi * SCALE - HW + SCALE_2, zi * SCALE + SCALE_2];
 
-    return (
-      inside(p0) +
-      inside(p1) +
-      inside(p2) +
-      inside(p3) +
-      inside(p4) +
-      inside(p5) +
-      inside(p6) +
-      inside(p7)
-    );
-  }
+      return (
+        inside(p0) +
+        inside(p1) +
+        inside(p2) +
+        inside(p3) +
+        inside(p4) +
+        inside(p5) +
+        inside(p6) +
+        inside(p7)
+      );
+    }
 
-  const data = new Uint8Array(WIDTH * WIDTH * WIDTH * STEP);
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  for (let zi = 0; zi < WIDTH; zi++) {
-    for (let yi = 0; yi < WIDTH; yi++) {
-      for (let xi = 0; xi < WIDTH; xi++) {
-        const i = (zi * WIDTH + yi) * WIDTH * STEP + xi * STEP;
-        const count = countInside(xi, yi, zi);
-        if (count !== 0 && count !== 8) {
-          view.setFloat32(i + 0, xi * SCALE - HW, true);
-          view.setFloat32(i + 4, yi * SCALE - HW, true);
-          view.setFloat32(i + 8, zi * SCALE, true);
-          const position = xi * 0.5 + yi * 0.5 + zi * 0.5;
-          const surface = ((count / 7) * 255) / 2 + (xi / 2 + yi / 2 + zi / 2);
-          view.setUint8(i + 12, Math.trunc(position * 0.8 + surface * 0.2));
-        } else {
-          view.setFloat32(i + 0, Number.NaN, true);
-          view.setFloat32(i + 4, Number.NaN, true);
-          view.setFloat32(i + 8, Number.NaN, true);
-          view.setUint8(i + 12, 255);
+    const data = new Uint8Array(WIDTH * WIDTH * WIDTH * STEP);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    for (let zi = 0; zi < WIDTH; zi++) {
+      for (let yi = 0; yi < WIDTH; yi++) {
+        for (let xi = 0; xi < WIDTH; xi++) {
+          const i = (zi * WIDTH + yi) * WIDTH * STEP + xi * STEP;
+          const count = countInside(xi, yi, zi);
+          if (count !== 0 && count !== 8) {
+            view.setFloat32(i + 0, xi * SCALE - HW, true);
+            view.setFloat32(i + 4, yi * SCALE - HW, true);
+            view.setFloat32(i + 8, zi * SCALE, true);
+            const position = xi * 0.5 + yi * 0.5 + zi * 0.5;
+            const surface = ((count / 7) * 255) / 2 + (xi / 2 + yi / 2 + zi / 2);
+            view.setUint8(i + 12, Math.trunc(position * 0.8 + surface * 0.2));
+          } else {
+            view.setFloat32(i + 0, Number.NaN, true);
+            view.setFloat32(i + 4, Number.NaN, true);
+            view.setFloat32(i + 8, Number.NaN, true);
+            view.setUint8(i + 12, 255);
+          }
         }
       }
     }
-  }
 
-  const pointCloud: MessageEvent<PointCloud2> = {
-    topic: "/pointcloud",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      height: 1,
-      width: WIDTH * WIDTH * WIDTH,
-      fields: [
-        { name: "x", offset: 0, datatype: 7, count: 1 },
-        { name: "y", offset: 4, datatype: 7, count: 1 },
-        { name: "z", offset: 8, datatype: 7, count: 1 },
-        { name: "intensity", offset: 12, datatype: 2, count: 1 },
-      ],
-      is_bigendian: false,
-      point_step: 13,
-      row_step: WIDTH * WIDTH * WIDTH * STEP,
-      data,
-      is_dense: false,
-    },
-    schemaName: "sensor_msgs/PointCloud2",
-    sizeInBytes: 0,
-  };
+    const pointCloud: MessageEvent<PointCloud2> = {
+      topic: "/pointcloud",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        height: 1,
+        width: WIDTH * WIDTH * WIDTH,
+        fields: [
+          { name: "x", offset: 0, datatype: 7, count: 1 },
+          { name: "y", offset: 4, datatype: 7, count: 1 },
+          { name: "z", offset: 8, datatype: 7, count: 1 },
+          { name: "intensity", offset: 12, datatype: 2, count: 1 },
+        ],
+        is_bigendian: false,
+        point_step: 13,
+        row_step: WIDTH * WIDTH * WIDTH * STEP,
+        data,
+        is_dense: false,
+      },
+      schemaName: "sensor_msgs/PointCloud2",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/pointcloud": [pointCloud],
-      "/tf": [tf1, tf2],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/pointcloud": [pointCloud],
+        "/tf": [tf1, tf2],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          topics: {
-            "/pointcloud": {
-              visible: true,
-              pointSize: 5,
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            topics: {
+              "/pointcloud": {
+                visible: true,
+                pointSize: 5,
+              },
             },
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 13.5,
-            perspective: true,
-            phi: rad2deg(1.22),
-            targetOffset: [0.25, -0.5, 3],
-            thetaOffset: rad2deg(-0.33),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 13.5,
+              perspective: true,
+              phi: rad2deg(1.22),
+              targetOffset: [0.25, -0.5, 3],
+              thetaOffset: rad2deg(-0.33),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
 export const SensorMsgs_PointCloud2_TwoDimensions: StoryObj = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -19,14 +19,14 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const SensorMsgs_PointCloud2_RGBA = {
-  render: (): JSX.Element => <SensorMsgs_PointCloud2 rgbaFieldName="rgba" />,
+export const SensorMsgs_PointCloud2_RGBA: StoryObj = {
+  render: () => <SensorMsgs_PointCloud2 rgbaFieldName="rgba" />,
 
   parameters: { colorScheme: "dark" },
 };
 
-export const SensorMsgs_PointCloud2_RGB = {
-  render: (): JSX.Element => <SensorMsgs_PointCloud2 rgbaFieldName="rgb" />,
+export const SensorMsgs_PointCloud2_RGB: StoryObj = {
+  render: () => <SensorMsgs_PointCloud2 rgbaFieldName="rgb" />,
 
   parameters: { colorScheme: "dark" },
 };
@@ -337,7 +337,7 @@ export const SensorMsgs_PointCloud2_Intensity: StoryObj = {
 };
 
 export const SensorMsgs_PointCloud2_TwoDimensions: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [{ name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" }];
 
     const SCALE = 10 / 128;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -161,6 +161,7 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
 }
 
 export const SensorMsgs_PointCloud2_Intensity: StoryObj = {
+  parameters: { colorScheme: "dark" },
   render: function Story() {
     const topics: Topic[] = [
       { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
@@ -180,7 +181,6 @@ export const SensorMsgs_PointCloud2_Intensity: StoryObj = {
       schemaName: "geometry_msgs/TransformStamped",
       sizeInBytes: 0,
     };
-    SensorMsgs_PointCloud2_Intensity.parameters = { colorScheme: "dark" };
     const tf2: MessageEvent<TransformStamped> = {
       topic: "/tf",
       receiveTime: { sec: 10, nsec: 0 },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -18,15 +18,17 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const SensorMsgs_PointCloud2_RGBA = (): JSX.Element => (
-  <SensorMsgs_PointCloud2 rgbaFieldName="rgba" />
-);
-SensorMsgs_PointCloud2_RGBA.parameters = { colorScheme: "dark" };
+export const SensorMsgs_PointCloud2_RGBA = {
+  render: (): JSX.Element => <SensorMsgs_PointCloud2 rgbaFieldName="rgba" />,
 
-export const SensorMsgs_PointCloud2_RGB = (): JSX.Element => (
-  <SensorMsgs_PointCloud2 rgbaFieldName="rgb" />
-);
-SensorMsgs_PointCloud2_RGB.parameters = { colorScheme: "dark" };
+  parameters: { colorScheme: "dark" },
+};
+
+export const SensorMsgs_PointCloud2_RGB = {
+  render: (): JSX.Element => <SensorMsgs_PointCloud2 rgbaFieldName="rgb" />,
+
+  parameters: { colorScheme: "dark" },
+};
 
 function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): JSX.Element {
   const topics: Topic[] = [

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { vec3 } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -334,85 +334,87 @@ export const SensorMsgs_PointCloud2_Intensity: StoryFn = (): JSX.Element => {
   );
 };
 
-// Render a flat plane if we only have two dimensions
-export const SensorMsgs_PointCloud2_TwoDimensions: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [{ name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" }];
+export const SensorMsgs_PointCloud2_TwoDimensions: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [{ name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" }];
 
-  const SCALE = 10 / 128;
+    const SCALE = 10 / 128;
 
-  function f(x: number, y: number) {
-    return (x / 128 - 0.5) ** 2 + (y / 128 - 0.5) ** 2;
-  }
-
-  const data = new Uint8Array(128 * 128 * 12);
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  for (let y = 0; y < 128; y++) {
-    for (let x = 0; x < 128; x++) {
-      const i = (y * 128 + x) * 12;
-      view.setFloat32(i + 0, x * SCALE - 5, true);
-      view.setFloat32(i + 4, y * SCALE - 5, true);
-      view.setFloat32(i + 8, f(x, y) * 5, true);
+    function f(x: number, y: number) {
+      return (x / 128 - 0.5) ** 2 + (y / 128 - 0.5) ** 2;
     }
-  }
 
-  const pointCloud: MessageEvent<PointCloud2> = {
-    topic: "/pointcloud",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
-      height: 1,
-      width: 128 * 128,
-      fields: [
-        { name: "x", offset: 0, datatype: 7, count: 1 },
-        { name: "y", offset: 4, datatype: 7, count: 1 },
-      ],
-      is_bigendian: false,
-      point_step: 12,
-      row_step: 128 * 128 * 12,
-      data,
-      is_dense: true,
-    },
-    schemaName: "sensor_msgs/PointCloud2",
-    sizeInBytes: 0,
-  };
+    const data = new Uint8Array(128 * 128 * 12);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    for (let y = 0; y < 128; y++) {
+      for (let x = 0; x < 128; x++) {
+        const i = (y * 128 + x) * 12;
+        view.setFloat32(i + 0, x * SCALE - 5, true);
+        view.setFloat32(i + 4, y * SCALE - 5, true);
+        view.setFloat32(i + 8, f(x, y) * 5, true);
+      }
+    }
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/pointcloud": [pointCloud],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const pointCloud: MessageEvent<PointCloud2> = {
+      topic: "/pointcloud",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+        height: 1,
+        width: 128 * 128,
+        fields: [
+          { name: "x", offset: 0, datatype: 7, count: 1 },
+          { name: "y", offset: 4, datatype: 7, count: 1 },
+        ],
+        is_bigendian: false,
+        point_step: 12,
+        row_step: 128 * 128 * 12,
+        data,
+        is_dense: true,
+      },
+      schemaName: "sensor_msgs/PointCloud2",
+      sizeInBytes: 0,
+    };
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "sensor",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 13.5,
-            perspective: true,
-            phi: rad2deg(1.22),
-            targetOffset: [0.25, -0.5, 0],
-            thetaOffset: rad2deg(-0.33),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/pointcloud": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/pointcloud": [pointCloud],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "sensor",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 13.5,
+              perspective: true,
+              phi: rad2deg(1.22),
+              targetOffset: [0.25, -0.5, 0],
+              thetaOffset: rad2deg(-0.33),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/pointcloud": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-SensorMsgs_PointCloud2_TwoDimensions.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { vec3 } from "gl-matrix";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -159,8 +160,7 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
   );
 }
 
-SensorMsgs_PointCloud2_Intensity.parameters = { colorScheme: "dark" };
-export function SensorMsgs_PointCloud2_Intensity(): JSX.Element {
+export const SensorMsgs_PointCloud2_Intensity: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -179,6 +179,7 @@ export function SensorMsgs_PointCloud2_Intensity(): JSX.Element {
     schemaName: "geometry_msgs/TransformStamped",
     sizeInBytes: 0,
   };
+  SensorMsgs_PointCloud2_Intensity.parameters = { colorScheme: "dark" };
   const tf2: MessageEvent<TransformStamped> = {
     topic: "/tf",
     receiveTime: { sec: 10, nsec: 0 },
@@ -331,11 +332,10 @@ export function SensorMsgs_PointCloud2_Intensity(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
 // Render a flat plane if we only have two dimensions
-SensorMsgs_PointCloud2_TwoDimensions.parameters = { colorScheme: "dark" };
-export function SensorMsgs_PointCloud2_TwoDimensions(): JSX.Element {
+export const SensorMsgs_PointCloud2_TwoDimensions: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/pointcloud", schemaName: "sensor_msgs/PointCloud2" }];
 
   const SCALE = 10 / 128;
@@ -414,4 +414,5 @@ export function SensorMsgs_PointCloud2_TwoDimensions(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+SensorMsgs_PointCloud2_TwoDimensions.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { DeepWritable } from "ts-essentials";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -20,123 +20,126 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const SphereListPointsTransform: StoryFn = (): JSX.Element => {
-  function makeSphere(
-    id: string,
-    color: string,
-    scale: number,
-  ): MessageEvent<DeepWritable<SphereListMarker>> {
-    return {
-      topic: "/sphere",
+export const SphereListPointsTransform: StoryObj = {
+  render: function Story(): JSX.Element {
+    function makeSphere(
+      id: string,
+      color: string,
+      scale: number,
+    ): MessageEvent<DeepWritable<SphereListMarker>> {
+      return {
+        topic: "/sphere",
+        receiveTime: { sec: 10, nsec: 0 },
+        message: {
+          header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
+          id,
+          ns: "",
+          type: 7,
+          action: 0,
+          frame_locked: false,
+          pose: {
+            position: { x: 0, y: 0, z: 0 },
+            orientation: { x: 0, y: 0, z: 0, w: 1 },
+          },
+          points: [
+            {
+              x: 0,
+              y: 0,
+              z: 0,
+            },
+          ],
+          scale: { x: scale, y: scale, z: scale },
+          color: makeColor(color, 1),
+          lifetime: { sec: 0, nsec: 0 },
+        },
+        schemaName: "visualization_msgs/Marker",
+        sizeInBytes: 0,
+      };
+    }
+
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+      { name: "/sphere", schemaName: "visualization_msgs/Marker" },
+    ];
+
+    const tf1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
       receiveTime: { sec: 10, nsec: 0 },
       message: {
-        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
-        id,
-        ns: "",
-        type: 7,
-        action: 0,
-        frame_locked: false,
-        pose: {
-          position: { x: 0, y: 0, z: 0 },
-          orientation: { x: 0, y: 0, z: 0, w: 1 },
-        },
-        points: [
-          {
-            x: 0,
-            y: 0,
-            z: 0,
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_link" },
+        child_frame_id: "camera_color_optical_frame",
+        transform: {
+          translation: { x: 0.5, y: -0.5, z: 0 },
+          rotation: {
+            x: -0.5,
+            y: 0.5,
+            z: -0.5,
+            w: 0.5,
           },
-        ],
-        scale: { x: scale, y: scale, z: scale },
-        color: makeColor(color, 1),
-        lifetime: { sec: 0, nsec: 0 },
+        },
       },
-      schemaName: "visualization_msgs/Marker",
+      schemaName: "geometry_msgs/TransformStamped",
       sizeInBytes: 0,
     };
-  }
 
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-    { name: "/sphere", schemaName: "visualization_msgs/Marker" },
-  ];
+    const sphere1 = makeSphere("sphere1", "#ff0000", 0.1);
+    sphere1.message.pose.position.x = 0.5;
 
-  const tf1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_link" },
-      child_frame_id: "camera_color_optical_frame",
-      transform: {
-        translation: { x: 0.5, y: -0.5, z: 0 },
-        rotation: {
-          x: -0.5,
-          y: 0.5,
-          z: -0.5,
-          w: 0.5,
-        },
+    const sphere2 = makeSphere("sphere2", "#00ff00", 0.1);
+    sphere2.message.pose.position.y = 0.5;
+
+    const sphere3 = makeSphere("sphere3", "#0000ff", 0.1);
+    sphere3.message.pose.position.z = 0.5;
+
+    const sphere4 = makeSphere("sphere4", "#ff0000", 0.2);
+    sphere4.message.points[0]!.x = 0.75;
+
+    const sphere5 = makeSphere("sphere5", "#00ff00", 0.2);
+    sphere5.message.points[0]!.y = 0.75;
+
+    const sphere6 = makeSphere("sphere6", "#0000ff", 0.2);
+    sphere6.message.points[0]!.z = 0.75;
+
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1],
+        "/sphere": [sphere1, sphere2, sphere3, sphere4, sphere5, sphere6],
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  const sphere1 = makeSphere("sphere1", "#ff0000", 0.1);
-  sphere1.message.pose.position.x = 0.5;
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "camera_link",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 4,
+              perspective: true,
+              phi: rad2deg(1.2),
+              targetOffset: [0.5, 0, 0],
+              thetaOffset: rad2deg(-0.5),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/sphere": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 
-  const sphere2 = makeSphere("sphere2", "#00ff00", 0.1);
-  sphere2.message.pose.position.y = 0.5;
-
-  const sphere3 = makeSphere("sphere3", "#0000ff", 0.1);
-  sphere3.message.pose.position.z = 0.5;
-
-  const sphere4 = makeSphere("sphere4", "#ff0000", 0.2);
-  sphere4.message.points[0]!.x = 0.75;
-
-  const sphere5 = makeSphere("sphere5", "#00ff00", 0.2);
-  sphere5.message.points[0]!.y = 0.75;
-
-  const sphere6 = makeSphere("sphere6", "#0000ff", 0.2);
-  sphere6.message.points[0]!.z = 0.75;
-
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1],
-      "/sphere": [sphere1, sphere2, sphere3, sphere4, sphere5, sphere6],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "camera_link",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 4,
-            perspective: true,
-            phi: rad2deg(1.2),
-            targetOffset: [0.5, 0, 0],
-            thetaOffset: rad2deg(-0.5),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/sphere": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+  parameters: { colorScheme: "dark" },
 };
-SphereListPointsTransform.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
@@ -21,7 +21,7 @@ export default {
 };
 
 export const SphereListPointsTransform: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     function makeSphere(
       id: string,
       color: string,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { DeepWritable } from "ts-essentials";
 
 import { MessageEvent } from "@foxglove/studio";
@@ -19,8 +20,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-SphereListPointsTransform.parameters = { colorScheme: "dark" };
-export function SphereListPointsTransform(): JSX.Element {
+export const SphereListPointsTransform: StoryFn = (): JSX.Element => {
   function makeSphere(
     id: string,
     color: string,
@@ -138,4 +138,5 @@ export function SphereListPointsTransform(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+SphereListPointsTransform.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
@@ -22,7 +22,7 @@ export default {
 };
 
 export const TransformInterpolation: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -124,7 +124,7 @@ export const TransformInterpolation: StoryObj = {
 };
 
 export const TransformOffsets: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
@@ -21,221 +21,227 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const TransformInterpolation: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf_t1: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 1, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: VEC3_ZERO,
-        rotation: QUAT_IDENTITY,
+export const TransformInterpolation: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf_t1: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 1, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: VEC3_ZERO,
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf_t3: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 3, nsec: 0 }, frame_id: "map" },
-      child_frame_id: "base_link",
-      transform: {
-        translation: { x: 2, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf_t3: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 3, nsec: 0 }, frame_id: "map" },
+        child_frame_id: "base_link",
+        transform: {
+          translation: { x: 2, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const pass1 = makePass({
-    id: 1,
-    frame_id: "base_link",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-  });
-  const pass2 = makePass({
-    id: 2,
-    frame_id: "base_link",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN2,
-    frame_locked: true,
-  });
-  const pass3 = makePass({
-    id: 3,
-    frame_id: "base_link",
-    stamp: fromSec(2),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const pass1 = makePass({
+      id: 1,
+      frame_id: "base_link",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+    });
+    const pass2 = makePass({
+      id: 2,
+      frame_id: "base_link",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN2,
+      frame_locked: true,
+    });
+    const pass3 = makePass({
+      id: 3,
+      frame_id: "base_link",
+      stamp: fromSec(2),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [pass1, pass2, pass3],
-      "/tf": [tf_t1, tf_t3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 2, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [pass1, pass2, pass3],
+        "/tf": [tf_t1, tf_t3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 2, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          layers: {
-            grid: {
-              layerId: "foxglove.Grid",
-              position: [0, 0, -0.25],
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            layers: {
+              grid: {
+                layerId: "foxglove.Grid",
+                position: [0, 0, -0.25],
+              },
             },
-          },
-          cameraState: {
-            distance: 3,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: {
+              distance: 3,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [0, 0, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-TransformInterpolation.parameters = { colorScheme: "dark" };
 
-export const TransformOffsets: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
-  ];
-  const tf_ab: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "a" },
-      child_frame_id: "b",
-      transform: {
-        translation: { x: -1, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+export const TransformOffsets: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+    ];
+    const tf_ab: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "a" },
+        child_frame_id: "b",
+        transform: {
+          translation: { x: -1, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf_bc: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "b" },
-      child_frame_id: "c",
-      transform: {
-        translation: { x: -1, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf_bc: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "b" },
+        child_frame_id: "c",
+        transform: {
+          translation: { x: -1, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
-  const tf_cd: MessageEvent<TransformStamped> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "c" },
-      child_frame_id: "d",
-      transform: {
-        translation: { x: -1, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
+    const tf_cd: MessageEvent<TransformStamped> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "c" },
+        child_frame_id: "d",
+        transform: {
+          translation: { x: -1, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "geometry_msgs/TransformStamped",
-    sizeInBytes: 0,
-  };
+      schemaName: "geometry_msgs/TransformStamped",
+      sizeInBytes: 0,
+    };
 
-  const pass1 = makePass({
-    id: 1,
-    frame_id: "d",
-    stamp: fromSec(1),
-    frame_locked: true,
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-  });
+    const pass1 = makePass({
+      id: 1,
+      frame_id: "d",
+      stamp: fromSec(1),
+      frame_locked: true,
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [pass1],
-      "/tf": [tf_ab, tf_bc, tf_cd],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 2, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [pass1],
+        "/tf": [tf_ab, tf_bc, tf_cd],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 2, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "b",
-          layers: {
-            grid: {
-              layerId: "foxglove.Grid",
-              position: [0, 0, -0.25],
-              frameId: "a",
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "b",
+            layers: {
+              grid: {
+                layerId: "foxglove.Grid",
+                position: [0, 0, -0.25],
+                frameId: "a",
+              },
             },
-          },
-          scene: {
+            scene: {
+              transforms: {
+                editable: true,
+              },
+            },
             transforms: {
-              editable: true,
+              "frame:b": {
+                xyzOffset: [0, 1, 0],
+                rpyOffset: [45, 0, 0],
+              },
+              "frame:c": {
+                xyzOffset: [0, 1, 0],
+                rpyOffset: [-45, 0, 0],
+              },
+              "frame:d": {
+                xyzOffset: [0, 1, 0],
+              },
             },
-          },
-          transforms: {
-            "frame:b": {
-              xyzOffset: [0, 1, 0],
-              rpyOffset: [45, 0, 0],
+            cameraState: {
+              perspective: true,
+              distance: 5,
+              phi: 36,
+              thetaOffset: 0,
+              targetOffset: [-0.1, 0.5, 0],
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+              fovy: 45,
+              near: 0.01,
+              far: 5000,
             },
-            "frame:c": {
-              xyzOffset: [0, 1, 0],
-              rpyOffset: [-45, 0, 0],
+            topics: {
+              "/markers": { visible: true },
             },
-            "frame:d": {
-              xyzOffset: [0, 1, 0],
-            },
-          },
-          cameraState: {
-            perspective: true,
-            distance: 5,
-            phi: 36,
-            thetaOffset: 0,
-            targetOffset: [-0.1, 0.5, 0],
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-            fovy: 45,
-            near: 0.01,
-            far: 5000,
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-TransformOffsets.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -19,8 +21,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-TransformInterpolation.parameters = { colorScheme: "dark" };
-export function TransformInterpolation(): JSX.Element {
+export const TransformInterpolation: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -116,10 +117,10 @@ export function TransformInterpolation(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+TransformInterpolation.parameters = { colorScheme: "dark" };
 
-TransformOffsets.parameters = { colorScheme: "dark" };
-export function TransformOffsets(): JSX.Element {
+export const TransformOffsets: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -236,4 +237,5 @@ export function TransformOffsets(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+TransformOffsets.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -102,60 +102,63 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const Urdfs: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [{ name: "/robot_description", schemaName: "std_msgs/String" }];
-  const robot_description: MessageEvent<{ data: string }> = {
-    topic: "/robot_description",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      data: URDF,
-    },
-    schemaName: "std_msgs/String",
-    sizeInBytes: 0,
-  };
+export const Urdfs: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [{ name: "/robot_description", schemaName: "std_msgs/String" }];
+    const robot_description: MessageEvent<{ data: string }> = {
+      topic: "/robot_description",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        data: URDF,
+      },
+      schemaName: "std_msgs/String",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/robot_description": [robot_description],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: undefined,
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/robot_description": [robot_description],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: undefined,
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          scene: {
-            transforms: {
-              axisScale: 3,
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            scene: {
+              transforms: {
+                axisScale: 3,
+              },
             },
-          },
-          layers: {
-            grid: {
-              layerId: "foxglove.Grid",
-              position: [0, 0, 0],
+            layers: {
+              grid: {
+                layerId: "foxglove.Grid",
+                position: [0, 0, 0],
+              },
+              urdf: {
+                layerId: "foxglove.Urdf",
+                url: encodeURI(`data:text/xml;utf8,${URDF2}`),
+              },
             },
-            urdf: {
-              layerId: "foxglove.Urdf",
-              url: encodeURI(`data:text/xml;utf8,${URDF2}`),
+            cameraState: {
+              distance: 6,
             },
-          },
-          cameraState: {
-            distance: 6,
-          },
-          topics: {
-            "/robot_description": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            topics: {
+              "/robot_description": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-Urdfs.parameters = { colorScheme: "dark" };
 
 function makeColorAttribute(hex: string, alpha = 1): string {
   const c = makeColor(hex, alpha);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
@@ -103,7 +103,7 @@ export default {
 };
 
 export const Urdfs: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [{ name: "/robot_description", schemaName: "std_msgs/String" }];
     const robot_description: MessageEvent<{ data: string }> = {
       topic: "/robot_description",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { MessageEvent } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -100,8 +102,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-Urdfs.parameters = { colorScheme: "dark" };
-export function Urdfs(): JSX.Element {
+export const Urdfs: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/robot_description", schemaName: "std_msgs/String" }];
   const robot_description: MessageEvent<{ data: string }> = {
     topic: "/robot_description",
@@ -153,7 +154,8 @@ export function Urdfs(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+Urdfs.parameters = { colorScheme: "dark" };
 
 function makeColorAttribute(hex: string, alpha = 1): string {
   const c = makeColor(hex, alpha);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/VelodyneScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/VelodyneScan.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { VelodyneScan } from "@foxglove/studio-base/types/Messages";
@@ -1289,7 +1291,7 @@ const velodyneScan: VelodyneScan = {
   ],
 };
 
-export function VelodyneScan_Intensity(): JSX.Element {
+export const VelodyneScan_Intensity: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/velodyne_packets", schemaName: "velodyne_msgs/VelodyneScan" }];
 
   const fixture = useDelayedFixture({
@@ -1344,4 +1346,4 @@ export function VelodyneScan_Intensity(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/VelodyneScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/VelodyneScan.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -1291,59 +1291,63 @@ const velodyneScan: VelodyneScan = {
   ],
 };
 
-export const VelodyneScan_Intensity: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [{ name: "/velodyne_packets", schemaName: "velodyne_msgs/VelodyneScan" }];
+export const VelodyneScan_Intensity: StoryObj = {
+  render: function Story() {
+    const topics: Topic[] = [
+      { name: "/velodyne_packets", schemaName: "velodyne_msgs/VelodyneScan" },
+    ];
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/velodyne_packets": [
-        {
-          topic: "/velodyne_packets",
-          schemaName: "velodyne_msgs/VelodyneScan",
-          message: velodyneScan,
-          receiveTime: { sec: 0, nsec: 0 },
-          sizeInBytes: 0,
-        },
-      ],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/velodyne_packets": [
+          {
+            topic: "/velodyne_packets",
+            schemaName: "velodyne_msgs/VelodyneScan",
+            message: velodyneScan,
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 0,
+          },
+        ],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: velodyneScan.header.frame_id,
-          topics: {
-            "/velodyne_packets": {
-              visible: true,
-              pointSize: 5,
-              colorMode: "colormap",
-              colorMap: "turbo",
-              colorField: "intensity",
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: velodyneScan.header.frame_id,
+            topics: {
+              "/velodyne_packets": {
+                visible: true,
+                pointSize: 5,
+                colorMode: "colormap",
+                colorMap: "turbo",
+                colorField: "intensity",
+              },
             },
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 13.5,
-            perspective: true,
-            phi: rad2deg(1.22),
-            targetOffset: [0.25, -0.5, 0],
-            thetaOffset: rad2deg(-0.33),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 13.5,
+              perspective: true,
+              phi: rad2deg(1.22),
+              targetOffset: [0.25, -0.5, 0],
+              thetaOffset: rad2deg(-0.33),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { fromSec } from "@foxglove/rostime";
 import type { FrameTransform } from "@foxglove/schemas";
@@ -22,103 +22,106 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const FoxgloveFrameTransform: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "foxglove.FrameTransform" },
-  ];
-  const tf_t1: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 1, nsec: 0 },
-      parent_frame_id: "map",
-      child_frame_id: "base_link",
-      translation: VEC3_ZERO,
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  // backwards compatibility with legacy message format
-  const tf_t3: MessageEvent<LegacyFrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 3, nsec: 0 },
-      parent_frame_id: "map",
-      child_frame_id: "base_link",
-      transform: {
-        timestamp: { sec: 3, nsec: 0 },
-        translation: { x: 2, y: 0, z: 0 },
+export const FoxgloveFrameTransform: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "foxglove.FrameTransform" },
+    ];
+    const tf_t1: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 1, nsec: 0 },
+        parent_frame_id: "map",
+        child_frame_id: "base_link",
+        translation: VEC3_ZERO,
         rotation: QUAT_IDENTITY,
       },
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const pass1 = makePass({
-    id: 1,
-    frame_id: "base_link",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-  });
-  const pass2 = makePass({
-    id: 2,
-    frame_id: "base_link",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN2,
-    frame_locked: true,
-  });
-  const pass3 = makePass({
-    id: 3,
-    frame_id: "base_link",
-    stamp: fromSec(2),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
-  });
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    // backwards compatibility with legacy message format
+    const tf_t3: MessageEvent<LegacyFrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 3, nsec: 0 },
+        parent_frame_id: "map",
+        child_frame_id: "base_link",
+        transform: {
+          timestamp: { sec: 3, nsec: 0 },
+          translation: { x: 2, y: 0, z: 0 },
+          rotation: QUAT_IDENTITY,
+        },
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const pass1 = makePass({
+      id: 1,
+      frame_id: "base_link",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+    });
+    const pass2 = makePass({
+      id: 2,
+      frame_id: "base_link",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN2,
+      frame_locked: true,
+    });
+    const pass3 = makePass({
+      id: 3,
+      frame_id: "base_link",
+      stamp: fromSec(2),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      pose: { position: { x: 1, y: 0, z: 0 }, orientation: QUAT_IDENTITY },
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [pass1, pass2, pass3],
-      "/tf": [tf_t1, tf_t3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 2, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [pass1, pass2, pass3],
+        "/tf": [tf_t1, tf_t3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 2, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          layers: {
-            grid: {
-              layerId: "foxglove.Grid",
-              position: [0, 0, -0.25],
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            layers: {
+              grid: {
+                layerId: "foxglove.Grid",
+                position: [0, 0, -0.25],
+              },
             },
-          },
-          cameraState: {
-            distance: 3,
-            perspective: true,
-            phi: rad2deg(1),
-            targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: {
+              distance: 3,
+              perspective: true,
+              phi: rad2deg(1),
+              targetOffset: [0, 0, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-FoxgloveFrameTransform.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { fromSec } from "@foxglove/rostime";
 import type { FrameTransform } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
@@ -20,8 +22,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-FoxgloveFrameTransform.parameters = { colorScheme: "dark" };
-export function FoxgloveFrameTransform(): JSX.Element {
+export const FoxgloveFrameTransform: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/tf", schemaName: "foxglove.FrameTransform" },
@@ -119,4 +120,5 @@ export function FoxgloveFrameTransform(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+FoxgloveFrameTransform.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
@@ -23,7 +23,7 @@ export default {
 };
 
 export const FoxgloveFrameTransform: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/tf", schemaName: "foxglove.FrameTransform" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import { fromSec } from "@foxglove/rostime";
 import type { FrameTransforms } from "@foxglove/schemas";
@@ -19,106 +19,109 @@ export default {
   component: ThreeDeePanel,
 };
 
-export const FoxgloveFrameTransforms: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/markers", schemaName: "visualization_msgs/Marker" },
-    { name: "/tf", schemaName: "foxglove.FrameTransforms" },
-  ];
-  const tf_t1: MessageEvent<FrameTransforms> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    schemaName: "foxglove.FrameTransforms",
-    message: {
-      transforms: [
-        {
-          timestamp: { sec: 1, nsec: 0 },
-          parent_frame_id: "base_link",
-          child_frame_id: "sensor_1",
-          translation: { x: 1, y: 0, z: 0 },
-          rotation: QUAT_IDENTITY,
-        },
-        {
-          timestamp: { sec: 2, nsec: 0 },
-          parent_frame_id: "base_link",
-          child_frame_id: "sensor_2",
-          translation: { x: 2, y: 0, z: 0 },
-          rotation: QUAT_IDENTITY,
-        },
-        {
-          timestamp: { sec: 3, nsec: 0 },
-          parent_frame_id: "base_link",
-          child_frame_id: "sensor_3",
-          translation: { x: 3, y: 0, z: 0 },
-          rotation: QUAT_IDENTITY,
-        },
-      ],
-    },
-    sizeInBytes: 0,
-  };
-  const pass1 = makePass({
-    id: 1,
-    frame_id: "sensor_1",
-    stamp: fromSec(1),
-    colorHex: TEST_COLORS.MARKER_GREEN1,
-    pose: { position: { x: 0, y: 1, z: 0 }, orientation: QUAT_IDENTITY },
-  });
-  const pass2 = makePass({
-    id: 2,
-    frame_id: "sensor_2",
-    stamp: fromSec(2),
-    colorHex: TEST_COLORS.MARKER_GREEN2,
-    frame_locked: true,
-    pose: { position: { x: 0, y: 2, z: 0 }, orientation: QUAT_IDENTITY },
-  });
-  const pass3 = makePass({
-    id: 3,
-    frame_id: "sensor_3",
-    stamp: fromSec(3),
-    colorHex: TEST_COLORS.MARKER_GREEN3,
-    pose: { position: { x: 0, y: 3, z: 0 }, orientation: QUAT_IDENTITY },
-  });
+export const FoxgloveFrameTransforms: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/markers", schemaName: "visualization_msgs/Marker" },
+      { name: "/tf", schemaName: "foxglove.FrameTransforms" },
+    ];
+    const tf_t1: MessageEvent<FrameTransforms> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      schemaName: "foxglove.FrameTransforms",
+      message: {
+        transforms: [
+          {
+            timestamp: { sec: 1, nsec: 0 },
+            parent_frame_id: "base_link",
+            child_frame_id: "sensor_1",
+            translation: { x: 1, y: 0, z: 0 },
+            rotation: QUAT_IDENTITY,
+          },
+          {
+            timestamp: { sec: 2, nsec: 0 },
+            parent_frame_id: "base_link",
+            child_frame_id: "sensor_2",
+            translation: { x: 2, y: 0, z: 0 },
+            rotation: QUAT_IDENTITY,
+          },
+          {
+            timestamp: { sec: 3, nsec: 0 },
+            parent_frame_id: "base_link",
+            child_frame_id: "sensor_3",
+            translation: { x: 3, y: 0, z: 0 },
+            rotation: QUAT_IDENTITY,
+          },
+        ],
+      },
+      sizeInBytes: 0,
+    };
+    const pass1 = makePass({
+      id: 1,
+      frame_id: "sensor_1",
+      stamp: fromSec(1),
+      colorHex: TEST_COLORS.MARKER_GREEN1,
+      pose: { position: { x: 0, y: 1, z: 0 }, orientation: QUAT_IDENTITY },
+    });
+    const pass2 = makePass({
+      id: 2,
+      frame_id: "sensor_2",
+      stamp: fromSec(2),
+      colorHex: TEST_COLORS.MARKER_GREEN2,
+      frame_locked: true,
+      pose: { position: { x: 0, y: 2, z: 0 }, orientation: QUAT_IDENTITY },
+    });
+    const pass3 = makePass({
+      id: 3,
+      frame_id: "sensor_3",
+      stamp: fromSec(3),
+      colorHex: TEST_COLORS.MARKER_GREEN3,
+      pose: { position: { x: 0, y: 3, z: 0 }, orientation: QUAT_IDENTITY },
+    });
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/markers": [pass1, pass2, pass3],
-      "/tf": [tf_t1],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 2, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/markers": [pass1, pass2, pass3],
+        "/tf": [tf_t1],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 2, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "sensor_1",
-          layers: {
-            grid: {
-              layerId: "foxglove.Grid",
-              position: [0, 0, -0.25],
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "sensor_1",
+            layers: {
+              grid: {
+                layerId: "foxglove.Grid",
+                position: [0, 0, -0.25],
+              },
             },
-          },
-          cameraState: {
-            distance: 5,
-            perspective: true,
-            phi: rad2deg(0.7),
-            targetOffset: [0, 0.5, 0],
-            thetaOffset: rad2deg(Math.PI / 3),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/markers": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: {
+              distance: 5,
+              perspective: true,
+              phi: rad2deg(0.7),
+              targetOffset: [0, 0.5, 0],
+              thetaOffset: rad2deg(Math.PI / 3),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/markers": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-FoxgloveFrameTransforms.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const FoxgloveFrameTransforms: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/markers", schemaName: "visualization_msgs/Marker" },
       { name: "/tf", schemaName: "foxglove.FrameTransforms" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import { fromSec } from "@foxglove/rostime";
 import type { FrameTransforms } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
@@ -17,8 +19,7 @@ export default {
   component: ThreeDeePanel,
 };
 
-FoxgloveFrameTransforms.parameters = { colorScheme: "dark" };
-export function FoxgloveFrameTransforms(): JSX.Element {
+export const FoxgloveFrameTransforms: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/markers", schemaName: "visualization_msgs/Marker" },
     { name: "/tf", schemaName: "foxglove.FrameTransforms" },
@@ -119,4 +120,5 @@ export function FoxgloveFrameTransforms(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+FoxgloveFrameTransforms.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
@@ -664,13 +664,23 @@ function Row_Stride_Grid(): JSX.Element {
     </PanelSetup>
   );
 }
-export const Foxglove_Grid_Uint8_Values = (): JSX.Element => <Foxglove_Grid_Uint8 />;
-export const Foxglove_Grid_Uint8_Values_Clamped = (): JSX.Element => (
-  <Foxglove_Grid_Uint8 minValue={30} maxValue={80} />
-);
-export const Foxglove_Grid_RGBA_Values = (): JSX.Element => <Foxglove_Grid_RGBA />;
-export const Foxglove_Grid_Float_Values = (): JSX.Element => <Foxglove_Grid_Float />;
-export const Foxglove_Grid_Float_Values_Clamped = (): JSX.Element => (
-  <Foxglove_Grid_Float minValue={0.05} maxValue={0.1} />
-);
-export const Foxglove_Grid_Padded_Row = (): JSX.Element => <Row_Stride_Grid />;
+
+export const Foxglove_Grid_Uint8_Values = {
+  render: (): JSX.Element => <Foxglove_Grid_Uint8 />,
+};
+
+export const Foxglove_Grid_Uint8_Values_Clamped = {
+  render: (): JSX.Element => <Foxglove_Grid_Uint8 minValue={30} maxValue={80} />,
+};
+
+export const Foxglove_Grid_RGBA_Values = {
+  render: (): JSX.Element => <Foxglove_Grid_RGBA />,
+};
+
+export const Foxglove_Grid_Float_Values = { render: (): JSX.Element => <Foxglove_Grid_Float /> };
+
+export const Foxglove_Grid_Float_Values_Clamped = {
+  render: (): JSX.Element => <Foxglove_Grid_Float minValue={0.05} maxValue={0.1} />,
+};
+
+export const Foxglove_Grid_Padded_Row = { render: (): JSX.Element => <Row_Stride_Grid /> };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
+
 import { Grid, NumericType } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 import { LayerSettingsFoxgloveGrid } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/FoxgloveGrid";
@@ -665,22 +667,26 @@ function Row_Stride_Grid(): JSX.Element {
   );
 }
 
-export const Foxglove_Grid_Uint8_Values = {
-  render: (): JSX.Element => <Foxglove_Grid_Uint8 />,
+export const Foxglove_Grid_Uint8_Values: StoryObj = {
+  render: () => <Foxglove_Grid_Uint8 />,
 };
 
-export const Foxglove_Grid_Uint8_Values_Clamped = {
-  render: (): JSX.Element => <Foxglove_Grid_Uint8 minValue={30} maxValue={80} />,
+export const Foxglove_Grid_Uint8_Values_Clamped: StoryObj = {
+  render: () => <Foxglove_Grid_Uint8 minValue={30} maxValue={80} />,
 };
 
-export const Foxglove_Grid_RGBA_Values = {
-  render: (): JSX.Element => <Foxglove_Grid_RGBA />,
+export const Foxglove_Grid_RGBA_Values: StoryObj = {
+  render: () => <Foxglove_Grid_RGBA />,
 };
 
-export const Foxglove_Grid_Float_Values = { render: (): JSX.Element => <Foxglove_Grid_Float /> };
-
-export const Foxglove_Grid_Float_Values_Clamped = {
-  render: (): JSX.Element => <Foxglove_Grid_Float minValue={0.05} maxValue={0.1} />,
+export const Foxglove_Grid_Float_Values: StoryObj = {
+  render: () => <Foxglove_Grid_Float />,
 };
 
-export const Foxglove_Grid_Padded_Row = { render: (): JSX.Element => <Row_Stride_Grid /> };
+export const Foxglove_Grid_Float_Values_Clamped: StoryObj = {
+  render: () => <Foxglove_Grid_Float minValue={0.05} maxValue={0.1} />,
+};
+
+export const Foxglove_Grid_Padded_Row: StoryObj = {
+  render: () => <Row_Stride_Grid />,
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
@@ -156,64 +156,72 @@ function Foxglove_LaserScan({
   );
 }
 
-export const Square = Object.assign(Foxglove_LaserScan.bind({}), {
+export const Square = {
+  render: Foxglove_LaserScan,
   args: {
     settings: {
       pointShape: "square",
     },
   },
-});
+};
 
-export const Size20 = Object.assign(Foxglove_LaserScan.bind({}), {
+export const Size20 = {
+  render: Foxglove_LaserScan,
   args: {
     settings: {
       pointSize: 20,
     },
   },
-});
+};
 
-export const FlatColor = Object.assign(Foxglove_LaserScan.bind({}), {
+export const FlatColor = {
+  render: Foxglove_LaserScan,
   args: {
     settings: {
       colorMode: "flat",
       flatColor: "#ff00ff",
     },
   },
-});
+};
 
-export const CustomGradient = Object.assign(Foxglove_LaserScan.bind({}), {
+export const CustomGradient = {
+  render: Foxglove_LaserScan,
   args: {
     settings: {
       colorMode: "gradient",
       gradient: ["#00ffff", "#0000ff"],
     },
   },
-});
+};
 
-export const RangeLimits = Object.assign(Foxglove_LaserScan.bind({}), {
+export const RangeLimits = {
+  render: Foxglove_LaserScan,
   args: {
     rangeMin: 2,
     rangeMax: 3,
   },
-});
+};
 
-export const Time0 = Object.assign(Foxglove_LaserScan.bind({}), {
+export const Time0 = {
+  render: Foxglove_LaserScan,
   args: {
     time: 0,
   },
-});
+};
 
-export const Time5 = Object.assign(Foxglove_LaserScan.bind({}), {
+export const Time5 = {
+  render: Foxglove_LaserScan,
   args: {
     time: 5,
   },
-});
+};
 
-export const Time10 = Object.assign(Foxglove_LaserScan.bind({}), {
+export const Time10 = {
+  render: Foxglove_LaserScan,
   args: {
     time: 10,
   },
-});
+};
 
 export const ComparisonWithPointCloudColors: StoryObj = {
   render: function Story() {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import * as THREE from "three";
 
 import { fromSec } from "@foxglove/rostime";
@@ -215,136 +215,138 @@ export const Time10 = Object.assign(Foxglove_LaserScan.bind({}), {
   },
 });
 
-export const ComparisonWithPointCloudColors: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/scan", schemaName: "foxglove.LaserScan" },
-    { name: "/cloud", schemaName: "foxglove.PointCloud" },
-    { name: "/tf", schemaName: "foxglove.FrameTransform" },
-  ];
-  const tf1: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "map",
-      child_frame_id: "base_link",
-      translation: { x: 1e7, y: 0, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
+export const ComparisonWithPointCloudColors: StoryObj = {
+  render: function Story() {
+    const topics: Topic[] = [
+      { name: "/scan", schemaName: "foxglove.LaserScan" },
+      { name: "/cloud", schemaName: "foxglove.PointCloud" },
+      { name: "/tf", schemaName: "foxglove.FrameTransform" },
+    ];
+    const tf1: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "map",
+        child_frame_id: "base_link",
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
 
-  const count = 50;
+    const count = 50;
 
-  const ranges = new Float32Array(count);
-  const intensities = new Float32Array(count);
-  const pointCloudData = new Float32Array(4 * count);
-  const angleMax = Math.PI / 4;
-  const radius = 2;
+    const ranges = new Float32Array(count);
+    const intensities = new Float32Array(count);
+    const pointCloudData = new Float32Array(4 * count);
+    const angleMax = Math.PI / 4;
+    const radius = 2;
 
-  for (let i = 0; i < count; i++) {
-    const t = i / (count - 1);
-    ranges[i] = radius / Math.cos(angleMax * t);
-    intensities[i] = t;
-    pointCloudData[4 * i + 0] = 1; // x
-    pointCloudData[4 * i + 1] = radius * t; // y
-    pointCloudData[4 * i + 2] = 0; // z
-    pointCloudData[4 * i + 3] = t; // intensity
-  }
+    for (let i = 0; i < count; i++) {
+      const t = i / (count - 1);
+      ranges[i] = radius / Math.cos(angleMax * t);
+      intensities[i] = t;
+      pointCloudData[4 * i + 0] = 1; // x
+      pointCloudData[4 * i + 1] = radius * t; // y
+      pointCloudData[4 * i + 2] = 0; // z
+      pointCloudData[4 * i + 3] = t; // intensity
+    }
 
-  const laserScan: MessageEvent<LaserScan> = {
-    topic: "/scan",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "base_link",
-      pose: emptyPose(),
-      start_angle: 0,
-      end_angle: angleMax,
-      ranges: ranges as unknown as number[],
-      intensities: intensities as unknown as number[],
-    },
-    schemaName: "foxglove.LaserScan",
-    sizeInBytes: 0,
-  };
+    const laserScan: MessageEvent<LaserScan> = {
+      topic: "/scan",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "base_link",
+        pose: emptyPose(),
+        start_angle: 0,
+        end_angle: angleMax,
+        ranges: ranges as unknown as number[],
+        intensities: intensities as unknown as number[],
+      },
+      schemaName: "foxglove.LaserScan",
+      sizeInBytes: 0,
+    };
 
-  const pointCloud: MessageEvent<PointCloud> = {
-    topic: "/cloud",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "base_link",
-      pose: emptyPose(),
-      point_stride: 16,
-      fields: [
-        { name: "x", offset: 0, type: 7 },
-        { name: "y", offset: 4, type: 7 },
-        { name: "z", offset: 8, type: 7 },
-        { name: "intensity", offset: 12, type: 7 },
-      ],
-      data: new Uint8Array(
-        pointCloudData.buffer,
-        pointCloudData.byteOffset,
-        pointCloudData.byteLength,
-      ),
-    },
-    schemaName: "foxglove.PointCloud",
-    sizeInBytes: 0,
-  };
+    const pointCloud: MessageEvent<PointCloud> = {
+      topic: "/cloud",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "base_link",
+        pose: emptyPose(),
+        point_stride: 16,
+        fields: [
+          { name: "x", offset: 0, type: 7 },
+          { name: "y", offset: 4, type: 7 },
+          { name: "z", offset: 8, type: 7 },
+          { name: "intensity", offset: 12, type: 7 },
+        ],
+        data: new Uint8Array(
+          pointCloudData.buffer,
+          pointCloudData.byteOffset,
+          pointCloudData.byteLength,
+        ),
+      },
+      schemaName: "foxglove.PointCloud",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/scan": [laserScan],
-      "/cloud": [pointCloud],
-      "/tf": [tf1],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: fromSec(0),
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/scan": [laserScan],
+        "/cloud": [pointCloud],
+        "/tf": [tf1],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: fromSec(0),
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          scene: { enableStats: false },
-          topics: {
-            "/scan": {
-              visible: true,
-              pointSize: 10,
-              colorMode: "colormap",
-              colorMap: "turbo",
-              colorField: "intensity",
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            scene: { enableStats: false },
+            topics: {
+              "/scan": {
+                visible: true,
+                pointSize: 10,
+                colorMode: "colormap",
+                colorMap: "turbo",
+                colorField: "intensity",
+              },
+              "/cloud": {
+                visible: true,
+                pointSize: 10,
+                colorMode: "colormap",
+                colorMap: "turbo",
+                colorField: "intensity",
+              },
             },
-            "/cloud": {
-              visible: true,
-              pointSize: 10,
-              colorMode: "colormap",
-              colorMap: "turbo",
-              colorField: "intensity",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
             },
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 5,
-            perspective: false,
-            phi: rad2deg(0),
-            targetOffset: [0, 1, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+            cameraState: {
+              distance: 5,
+              perspective: false,
+              phi: rad2deg(0),
+              targetOffset: [0, 1, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import * as THREE from "three";
 
 import { fromSec } from "@foxglove/rostime";
@@ -214,7 +215,7 @@ export const Time10 = Object.assign(Foxglove_LaserScan.bind({}), {
   },
 });
 
-export function ComparisonWithPointCloudColors(): JSX.Element {
+export const ComparisonWithPointCloudColors: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/scan", schemaName: "foxglove.LaserScan" },
     { name: "/cloud", schemaName: "foxglove.PointCloud" },
@@ -346,4 +347,4 @@ export function ComparisonWithPointCloudColors(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
@@ -156,7 +156,7 @@ function Foxglove_LaserScan({
   );
 }
 
-export const Square = {
+export const Square: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     settings: {
@@ -165,7 +165,7 @@ export const Square = {
   },
 };
 
-export const Size20 = {
+export const Size20: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     settings: {
@@ -174,7 +174,7 @@ export const Size20 = {
   },
 };
 
-export const FlatColor = {
+export const FlatColor: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     settings: {
@@ -184,7 +184,7 @@ export const FlatColor = {
   },
 };
 
-export const CustomGradient = {
+export const CustomGradient: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     settings: {
@@ -194,7 +194,7 @@ export const CustomGradient = {
   },
 };
 
-export const RangeLimits = {
+export const RangeLimits: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     rangeMin: 2,
@@ -202,21 +202,21 @@ export const RangeLimits = {
   },
 };
 
-export const Time0 = {
+export const Time0: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     time: 0,
   },
 };
 
-export const Time5 = {
+export const Time5: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     time: 5,
   },
 };
 
-export const Time10 = {
+export const Time10: StoryObj<Parameters<typeof Foxglove_LaserScan>[0]> = {
   render: Foxglove_LaserScan,
   args: {
     time: 10,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -376,7 +376,6 @@ export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensi
   },
 );
 
-// Render a flat plane if we only have two dimensions
 export const Foxglove_PointCloud_TwoDimensions: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/pointcloud", schemaName: "foxglove.PointCloud" }];
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { vec3 } from "gl-matrix";
 
 import type { PointCloud } from "@foxglove/schemas";
@@ -28,12 +28,15 @@ export const Foxglove_PointCloud_RGBA = (): JSX.Element => <Foxglove_PointCloud 
 export const Foxglove_PointCloud_RGBA_Square = (): JSX.Element => (
   <Foxglove_PointCloud pointShape="square" />
 );
+
 export const Foxglove_PointCloud_Gradient = (): JSX.Element => (
   <Foxglove_PointCloud colorMode="gradient" />
 );
+
 export const Foxglove_PointCloud_Gradient_Clamped = (): JSX.Element => (
   <Foxglove_PointCloud colorMode="gradient" minValue={-2} maxValue={2} />
 );
+
 export const Foxglove_PointCloud_Stixels = (): JSX.Element => (
   <Foxglove_PointCloud colorMode="gradient" stixelsEnabled={true} />
 );
@@ -376,80 +379,82 @@ export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensi
   },
 );
 
-export const Foxglove_PointCloud_TwoDimensions: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [{ name: "/pointcloud", schemaName: "foxglove.PointCloud" }];
+export const Foxglove_PointCloud_TwoDimensions: StoryObj = {
+  render: function Story() {
+    const topics: Topic[] = [{ name: "/pointcloud", schemaName: "foxglove.PointCloud" }];
 
-  const SCALE = 10 / 128;
+    const SCALE = 10 / 128;
 
-  function f(x: number, y: number) {
-    return (x / 128 - 0.5) ** 2 + (y / 128 - 0.5) ** 2;
-  }
-
-  const data = new Uint8Array(128 * 128 * 12);
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  for (let y = 0; y < 128; y++) {
-    for (let x = 0; x < 128; x++) {
-      const i = (y * 128 + x) * 12;
-      view.setFloat32(i + 0, x * SCALE - 5, true);
-      view.setFloat32(i + 4, y * SCALE - 5, true);
-      view.setFloat32(i + 8, f(x, y) * 5, true);
+    function f(x: number, y: number) {
+      return (x / 128 - 0.5) ** 2 + (y / 128 - 0.5) ** 2;
     }
-  }
 
-  const pointCloud: MessageEvent<PointCloud> = {
-    topic: "/pointcloud",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "sensor",
-      point_stride: 12,
-      pose: { position: VEC3_ZERO, orientation: { x: 0.707, y: 0, z: 0, w: 0.707 } },
-      fields: [
-        { name: "x", offset: 0, type: 7 },
-        { name: "y", offset: 4, type: 7 },
-      ],
-      data,
-    },
-    schemaName: "foxglove.PointCloud",
-    sizeInBytes: 0,
-  };
+    const data = new Uint8Array(128 * 128 * 12);
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    for (let y = 0; y < 128; y++) {
+      for (let x = 0; x < 128; x++) {
+        const i = (y * 128 + x) * 12;
+        view.setFloat32(i + 0, x * SCALE - 5, true);
+        view.setFloat32(i + 4, y * SCALE - 5, true);
+        view.setFloat32(i + 8, f(x, y) * 5, true);
+      }
+    }
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/pointcloud": [pointCloud],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const pointCloud: MessageEvent<PointCloud> = {
+      topic: "/pointcloud",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "sensor",
+        point_stride: 12,
+        pose: { position: VEC3_ZERO, orientation: { x: 0.707, y: 0, z: 0, w: 0.707 } },
+        fields: [
+          { name: "x", offset: 0, type: 7 },
+          { name: "y", offset: 4, type: 7 },
+        ],
+        data,
+      },
+      schemaName: "foxglove.PointCloud",
+      sizeInBytes: 0,
+    };
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "sensor",
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 13.5,
-            perspective: true,
-            phi: rad2deg(1.22),
-            targetOffset: [0.25, -0.5, 0],
-            thetaOffset: rad2deg(-0.33),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-          topics: {
-            "/pointcloud": { visible: true },
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/pointcloud": [pointCloud],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "sensor",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
+            },
+            cameraState: {
+              distance: 13.5,
+              perspective: true,
+              phi: rad2deg(1.22),
+              targetOffset: [0.25, -0.5, 0],
+              thetaOffset: rad2deg(-0.33),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
+            },
+            topics: {
+              "/pointcloud": { visible: true },
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -23,23 +23,27 @@ export default {
   },
 };
 
-export const Foxglove_PointCloud_RGBA = (): JSX.Element => <Foxglove_PointCloud />;
+export const Foxglove_PointCloud_RGBA = {
+  render: (): JSX.Element => <Foxglove_PointCloud />,
+};
 
-export const Foxglove_PointCloud_RGBA_Square = (): JSX.Element => (
-  <Foxglove_PointCloud pointShape="square" />
-);
+export const Foxglove_PointCloud_RGBA_Square = {
+  render: (): JSX.Element => <Foxglove_PointCloud pointShape="square" />,
+};
 
-export const Foxglove_PointCloud_Gradient = (): JSX.Element => (
-  <Foxglove_PointCloud colorMode="gradient" />
-);
+export const Foxglove_PointCloud_Gradient = {
+  render: (): JSX.Element => <Foxglove_PointCloud colorMode="gradient" />,
+};
 
-export const Foxglove_PointCloud_Gradient_Clamped = (): JSX.Element => (
-  <Foxglove_PointCloud colorMode="gradient" minValue={-2} maxValue={2} />
-);
+export const Foxglove_PointCloud_Gradient_Clamped = {
+  render: (): JSX.Element => (
+    <Foxglove_PointCloud colorMode="gradient" minValue={-2} maxValue={2} />
+  ),
+};
 
-export const Foxglove_PointCloud_Stixels = (): JSX.Element => (
-  <Foxglove_PointCloud colorMode="gradient" stixelsEnabled={true} />
-);
+export const Foxglove_PointCloud_Stixels = {
+  render: (): JSX.Element => <Foxglove_PointCloud colorMode="gradient" stixelsEnabled={true} />,
+};
 
 function Foxglove_PointCloud({
   pointShape = "circle",
@@ -369,15 +373,17 @@ function Foxglove_PointCloud_Intensity_Base({
   );
 }
 
-export const Foxglove_PointCloud_Intensity = Foxglove_PointCloud_Intensity_Base.bind(undefined, {});
+export const Foxglove_PointCloud_Intensity: StoryObj = {
+  render: () => Foxglove_PointCloud_Intensity_Base({}),
+};
 
-export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensity_Base.bind(
-  undefined,
-  {
-    minValue: 80,
-    maxValue: 130,
-  },
-);
+export const Foxglove_PointCloud_Intensity_Clamped: StoryObj = {
+  render: () =>
+    Foxglove_PointCloud_Intensity_Base({
+      minValue: 80,
+      maxValue: 130,
+    }),
+};
 
 export const Foxglove_PointCloud_TwoDimensions: StoryObj = {
   render: function Story() {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -23,26 +23,24 @@ export default {
   },
 };
 
-export const Foxglove_PointCloud_RGBA = {
-  render: (): JSX.Element => <Foxglove_PointCloud />,
+export const Foxglove_PointCloud_RGBA: StoryObj = {
+  render: () => <Foxglove_PointCloud />,
 };
 
-export const Foxglove_PointCloud_RGBA_Square = {
-  render: (): JSX.Element => <Foxglove_PointCloud pointShape="square" />,
+export const Foxglove_PointCloud_RGBA_Square: StoryObj = {
+  render: () => <Foxglove_PointCloud pointShape="square" />,
 };
 
-export const Foxglove_PointCloud_Gradient = {
-  render: (): JSX.Element => <Foxglove_PointCloud colorMode="gradient" />,
+export const Foxglove_PointCloud_Gradient: StoryObj = {
+  render: () => <Foxglove_PointCloud colorMode="gradient" />,
 };
 
-export const Foxglove_PointCloud_Gradient_Clamped = {
-  render: (): JSX.Element => (
-    <Foxglove_PointCloud colorMode="gradient" minValue={-2} maxValue={2} />
-  ),
+export const Foxglove_PointCloud_Gradient_Clamped: StoryObj = {
+  render: () => <Foxglove_PointCloud colorMode="gradient" minValue={-2} maxValue={2} />,
 };
 
-export const Foxglove_PointCloud_Stixels = {
-  render: (): JSX.Element => <Foxglove_PointCloud colorMode="gradient" stixelsEnabled={true} />,
+export const Foxglove_PointCloud_Stixels: StoryObj = {
+  render: () => <Foxglove_PointCloud colorMode="gradient" stixelsEnabled={true} />,
 };
 
 function Foxglove_PointCloud({

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { vec3 } from "gl-matrix";
 
 import type { PointCloud } from "@foxglove/schemas";
@@ -376,7 +377,7 @@ export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensi
 );
 
 // Render a flat plane if we only have two dimensions
-export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {
+export const Foxglove_PointCloud_TwoDimensions: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [{ name: "/pointcloud", schemaName: "foxglove.PointCloud" }];
 
   const SCALE = 10 / 128;
@@ -452,4 +453,4 @@ export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
@@ -24,7 +24,7 @@ type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 export const Foxglove_PoseInFrame: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/tf", schemaName: "foxglove.FrameTransform" },
       { name: "/pose1", schemaName: "foxglove.PoseInFrame" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { FrameTransform, PoseInFrame } from "@foxglove/schemas";
@@ -22,8 +23,7 @@ type Vec4 = [number, number, number, number];
 
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-Foxglove_PoseInFrame.parameters = { colorScheme: "dark" };
-export function Foxglove_PoseInFrame(): JSX.Element {
+export const Foxglove_PoseInFrame: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/tf", schemaName: "foxglove.FrameTransform" },
     { name: "/pose1", schemaName: "foxglove.PoseInFrame" },
@@ -161,4 +161,5 @@ export function Foxglove_PoseInFrame(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+Foxglove_PoseInFrame.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { FrameTransform, PoseInFrame } from "@foxglove/schemas";
@@ -23,143 +23,146 @@ type Vec4 = [number, number, number, number];
 
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-export const Foxglove_PoseInFrame: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/tf", schemaName: "foxglove.FrameTransform" },
-    { name: "/pose1", schemaName: "foxglove.PoseInFrame" },
-    { name: "/pose2", schemaName: "foxglove.PoseInFrame" },
-    { name: "/pose3", schemaName: "foxglove.PoseInFrame" },
-  ];
+export const Foxglove_PoseInFrame: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/tf", schemaName: "foxglove.FrameTransform" },
+      { name: "/pose1", schemaName: "foxglove.PoseInFrame" },
+      { name: "/pose2", schemaName: "foxglove.PoseInFrame" },
+      { name: "/pose3", schemaName: "foxglove.PoseInFrame" },
+    ];
 
-  const tf1: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "map",
-      child_frame_id: "base_link",
-      translation: { x: 1e7, y: 0, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "base_link",
-      child_frame_id: "sensor",
-      translation: { x: 0, y: -5, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-
-  const pose1: MessageEvent<PoseInFrame> = {
-    topic: "/pose1",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "base_link",
-      pose: {
-        position: { x: 2, y: 0, z: 0 },
-        orientation: QUAT_IDENTITY,
+    const tf1: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "map",
+        child_frame_id: "base_link",
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
       },
-    },
-    schemaName: "foxglove.PoseInFrame",
-    sizeInBytes: 0,
-  };
-
-  const pose2: MessageEvent<PoseInFrame> = {
-    topic: "/pose2",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "sensor",
-      pose: {
-        position: { x: 0, y: 3, z: 0 },
-        orientation: vec4ToOrientation(
-          quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
-        ),
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "base_link",
+        child_frame_id: "sensor",
+        translation: { x: 0, y: -5, z: 0 },
+        rotation: QUAT_IDENTITY,
       },
-    },
-    schemaName: "foxglove.PoseInFrame",
-    sizeInBytes: 0,
-  };
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
 
-  const pose3: MessageEvent<PoseInFrame> = {
-    topic: "/pose3",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "base_link",
-      pose: {
-        position: { x: 0, y: 2, z: 0 },
-        orientation: vec4ToOrientation(
-          quat.rotateZ(quat.create(), quat.create(), Math.PI / 4) as Vec4,
-        ),
+    const pose1: MessageEvent<PoseInFrame> = {
+      topic: "/pose1",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "base_link",
+        pose: {
+          position: { x: 2, y: 0, z: 0 },
+          orientation: QUAT_IDENTITY,
+        },
       },
-    },
-    schemaName: "foxglove.PoseInFrame",
-    sizeInBytes: 0,
-  };
+      schemaName: "foxglove.PoseInFrame",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/tf": [tf1, tf2],
-      "/pose1": [pose1],
-      "/pose2": [pose2],
-      "/pose3": [pose3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 0, nsec: 0 },
-    },
-  });
+    const pose2: MessageEvent<PoseInFrame> = {
+      topic: "/pose2",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "sensor",
+        pose: {
+          position: { x: 0, y: 3, z: 0 },
+          orientation: vec4ToOrientation(
+            quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
+          ),
+        },
+      },
+      schemaName: "foxglove.PoseInFrame",
+      sizeInBytes: 0,
+    };
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          topics: {
-            "/pose1": {
-              visible: true,
-              type: "arrow",
+    const pose3: MessageEvent<PoseInFrame> = {
+      topic: "/pose3",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "base_link",
+        pose: {
+          position: { x: 0, y: 2, z: 0 },
+          orientation: vec4ToOrientation(
+            quat.rotateZ(quat.create(), quat.create(), Math.PI / 4) as Vec4,
+          ),
+        },
+      },
+      schemaName: "foxglove.PoseInFrame",
+      sizeInBytes: 0,
+    };
+
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/tf": [tf1, tf2],
+        "/pose1": [pose1],
+        "/pose2": [pose2],
+        "/pose3": [pose3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    });
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            topics: {
+              "/pose1": {
+                visible: true,
+                type: "arrow",
+              },
+              "/pose2": {
+                visible: true,
+                type: "arrow",
+                arrowScale: [2, 1, 1],
+                color: "rgba(0, 255, 0, 0.3)",
+              },
+              "/pose3": {
+                visible: true,
+                axisScale: Math.sqrt(8),
+              },
             },
-            "/pose2": {
-              visible: true,
-              type: "arrow",
-              arrowScale: [2, 1, 1],
-              color: "rgba(0, 255, 0, 0.3)",
+            layers: {
+              grid: { layerId: "foxglove.Grid" },
             },
-            "/pose3": {
-              visible: true,
-              axisScale: Math.sqrt(8),
+            cameraState: {
+              distance: 15,
+              perspective: false,
+              phi: rad2deg(0),
+              targetOffset: [-0.6, 0.5, 0],
+              thetaOffset: rad2deg(0),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
             },
-          },
-          layers: {
-            grid: { layerId: "foxglove.Grid" },
-          },
-          cameraState: {
-            distance: 15,
-            perspective: false,
-            phi: rad2deg(0),
-            targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: rad2deg(0),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-Foxglove_PoseInFrame.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { FrameTransform, PosesInFrame } from "@foxglove/schemas";
@@ -22,155 +22,160 @@ export default {
 type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-export const Foxglove_PosesInFrame: StoryFn = (): JSX.Element => {
-  const topics: Topic[] = [
-    { name: "/baselink_path", schemaName: "foxglove.PosesInFrame" },
-    { name: "/sensor_path", schemaName: "foxglove.PosesInFrame" },
-    { name: "/sensor_path2", schemaName: "foxglove.PosesInFrame" },
-    { name: "/tf", schemaName: "foxglove.FrameTransform" },
-  ];
-  const tf1: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "map",
-      child_frame_id: "base_link",
-      translation: { x: 1e7, y: 0, z: 0 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const tf2: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      parent_frame_id: "base_link",
-      child_frame_id: "sensor",
-      translation: { x: 0, y: 0, z: 1 },
-      rotation: vec4ToOrientation(quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4),
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
-  const tf3: MessageEvent<FrameTransform> = {
-    topic: "/tf",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 10, nsec: 0 },
-      parent_frame_id: "base_link",
-      child_frame_id: "sensor",
-      translation: { x: 0, y: 5, z: 1 },
-      rotation: QUAT_IDENTITY,
-    },
-    schemaName: "foxglove.FrameTransform",
-    sizeInBytes: 0,
-  };
+export const Foxglove_PosesInFrame: StoryObj = {
+  render: function Story(): JSX.Element {
+    const topics: Topic[] = [
+      { name: "/baselink_path", schemaName: "foxglove.PosesInFrame" },
+      { name: "/sensor_path", schemaName: "foxglove.PosesInFrame" },
+      { name: "/sensor_path2", schemaName: "foxglove.PosesInFrame" },
+      { name: "/tf", schemaName: "foxglove.FrameTransform" },
+    ];
+    const tf1: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "map",
+        child_frame_id: "base_link",
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const tf2: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        parent_frame_id: "base_link",
+        child_frame_id: "sensor",
+        translation: { x: 0, y: 0, z: 1 },
+        rotation: vec4ToOrientation(
+          quat.rotateZ(quat.create(), quat.create(), Math.PI / 2) as Vec4,
+        ),
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
+    const tf3: MessageEvent<FrameTransform> = {
+      topic: "/tf",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        timestamp: { sec: 10, nsec: 0 },
+        parent_frame_id: "base_link",
+        child_frame_id: "sensor",
+        translation: { x: 0, y: 5, z: 1 },
+        rotation: QUAT_IDENTITY,
+      },
+      schemaName: "foxglove.FrameTransform",
+      sizeInBytes: 0,
+    };
 
-  const q = (): quat => [0, 0, 0, 1];
-  const identity = q();
-  const makeOrientation = (i: number) => {
-    const o = quat.rotateZ(q(), identity, (Math.PI / 2) * (i / 9));
-    return { x: o[0], y: o[1], z: o[2], w: o[3] };
-  };
+    const q = (): quat => [0, 0, 0, 1];
+    const identity = q();
+    const makeOrientation = (i: number) => {
+      const o = quat.rotateZ(q(), identity, (Math.PI / 2) * (i / 9));
+      return { x: o[0], y: o[1], z: o[2], w: o[3] };
+    };
 
-  const baseLinkPath: MessageEvent<PosesInFrame> = {
-    topic: "/baselink_path",
-    receiveTime: { sec: 3, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "base_link",
-      poses: [...Array(10)].map((_, i) => ({
-        position: { x: 3, y: i / 4, z: 1 },
-        orientation: makeOrientation(i),
-      })),
-    },
-    schemaName: "foxglove.PosesInFrame",
-    sizeInBytes: 0,
-  };
+    const baseLinkPath: MessageEvent<PosesInFrame> = {
+      topic: "/baselink_path",
+      receiveTime: { sec: 3, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "base_link",
+        poses: [...Array(10)].map((_, i) => ({
+          position: { x: 3, y: i / 4, z: 1 },
+          orientation: makeOrientation(i),
+        })),
+      },
+      schemaName: "foxglove.PosesInFrame",
+      sizeInBytes: 0,
+    };
 
-  const sensorPath: MessageEvent<PosesInFrame> = {
-    topic: "/sensor_path",
-    receiveTime: { sec: 3, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "sensor",
-      poses: [...Array(10)].map((_, i) => ({
-        position: { x: 2, y: i / 4, z: 0 },
-        orientation: makeOrientation(i),
-      })),
-    },
-    schemaName: "foxglove.PosesInFrame",
-    sizeInBytes: 0,
-  };
+    const sensorPath: MessageEvent<PosesInFrame> = {
+      topic: "/sensor_path",
+      receiveTime: { sec: 3, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "sensor",
+        poses: [...Array(10)].map((_, i) => ({
+          position: { x: 2, y: i / 4, z: 0 },
+          orientation: makeOrientation(i),
+        })),
+      },
+      schemaName: "foxglove.PosesInFrame",
+      sizeInBytes: 0,
+    };
 
-  const sensorPath2: MessageEvent<PosesInFrame> = {
-    topic: "/sensor_path2",
-    receiveTime: { sec: 3, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: "sensor",
-      poses: [...Array(10)].map((_, i) => ({
-        position: { x: -i / 4, y: 2, z: 0 },
-        orientation: makeOrientation(i),
-      })),
-    },
-    schemaName: "foxglove.PosesInFrame",
-    sizeInBytes: 0,
-  };
+    const sensorPath2: MessageEvent<PosesInFrame> = {
+      topic: "/sensor_path2",
+      receiveTime: { sec: 3, nsec: 0 },
+      message: {
+        timestamp: { sec: 0, nsec: 0 },
+        frame_id: "sensor",
+        poses: [...Array(10)].map((_, i) => ({
+          position: { x: -i / 4, y: 2, z: 0 },
+          orientation: makeOrientation(i),
+        })),
+      },
+      schemaName: "foxglove.PosesInFrame",
+      sizeInBytes: 0,
+    };
 
-  const fixture = useDelayedFixture({
-    topics,
-    frame: {
-      "/baselink_path": [baseLinkPath],
-      "/sensor_path": [sensorPath],
-      "/sensor_path2": [sensorPath2],
-      "/tf": [tf1, tf2, tf3],
-    },
-    capabilities: [],
-    activeData: {
-      currentTime: { sec: 3, nsec: 0 },
-    },
-  });
+    const fixture = useDelayedFixture({
+      topics,
+      frame: {
+        "/baselink_path": [baseLinkPath],
+        "/sensor_path": [sensorPath],
+        "/sensor_path2": [sensorPath2],
+        "/tf": [tf1, tf2, tf3],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 3, nsec: 0 },
+      },
+    });
 
-  return (
-    <PanelSetup fixture={fixture}>
-      <ThreeDeePanel
-        overrideConfig={{
-          followTf: "base_link",
-          topics: {
-            "/sensor_path": {
-              visible: true,
-              type: "arrow",
-              gradient: ["rgba(0, 255, 0, 0.2)", "rgba(0, 255, 127, 1.0)"],
-              arrowScale: [1, 0.5, 0.01],
+    return (
+      <PanelSetup fixture={fixture}>
+        <ThreeDeePanel
+          overrideConfig={{
+            followTf: "base_link",
+            topics: {
+              "/sensor_path": {
+                visible: true,
+                type: "arrow",
+                gradient: ["rgba(0, 255, 0, 0.2)", "rgba(0, 255, 127, 1.0)"],
+                arrowScale: [1, 0.5, 0.01],
+              },
+              "/sensor_path2": {
+                visible: true,
+                axisScale: 0.5,
+              },
+              "/baselink_path": {
+                visible: true,
+                type: "arrow",
+              },
             },
-            "/sensor_path2": {
-              visible: true,
-              axisScale: 0.5,
+            cameraState: {
+              distance: 15,
+              perspective: true,
+              phi: rad2deg(0.25),
+              targetOffset: [0, 2, 0],
+              thetaOffset: rad2deg(-0.25),
+              fovy: rad2deg(0.75),
+              near: 0.01,
+              far: 5000,
+              target: [0, 0, 0],
+              targetOrientation: [0, 0, 0, 1],
             },
-            "/baselink_path": {
-              visible: true,
-              type: "arrow",
-            },
-          },
-          cameraState: {
-            distance: 15,
-            perspective: true,
-            phi: rad2deg(0.25),
-            targetOffset: [0, 2, 0],
-            thetaOffset: rad2deg(-0.25),
-            fovy: rad2deg(0.75),
-            near: 0.01,
-            far: 5000,
-            target: [0, 0, 0],
-            targetOrientation: [0, 0, 0, 1],
-          },
-        }}
-      />
-    </PanelSetup>
-  );
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: { colorScheme: "dark" },
 };
-Foxglove_PosesInFrame.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
 import { quat } from "gl-matrix";
 
 import { FrameTransform, PosesInFrame } from "@foxglove/schemas";
@@ -21,8 +22,7 @@ export default {
 type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
-Foxglove_PosesInFrame.parameters = { colorScheme: "dark" };
-export function Foxglove_PosesInFrame(): JSX.Element {
+export const Foxglove_PosesInFrame: StoryFn = (): JSX.Element => {
   const topics: Topic[] = [
     { name: "/baselink_path", schemaName: "foxglove.PosesInFrame" },
     { name: "/sensor_path", schemaName: "foxglove.PosesInFrame" },
@@ -172,4 +172,5 @@ export function Foxglove_PosesInFrame(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
+Foxglove_PosesInFrame.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
@@ -23,7 +23,7 @@ type Vec4 = [number, number, number, number];
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 export const Foxglove_PosesInFrame: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     const topics: Topic[] = [
       { name: "/baselink_path", schemaName: "foxglove.PosesInFrame" },
       { name: "/sensor_path", schemaName: "foxglove.PosesInFrame" },

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -24,7 +24,7 @@ export const Empty = (): JSX.Element => {
 };
 
 export const WithSettings = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     return (
       <PanelSetup includeSettings>
         <TopicGraph />
@@ -84,7 +84,7 @@ export const TopicsWithSubscribers = (): JSX.Element => (
 export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="none" />;
 
 export const ReLayout = {
-  render: (): JSX.Element => {
+  render: function Story(): JSX.Element {
     const [fixture, setFixture] = useState<Fixture>({
       frame: {},
       topics: [{ name: "/topic", schemaName: "std_msgs/Header" }],

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -15,12 +15,14 @@ export default {
   component: TopicGraph,
 };
 
-export const Empty = (): JSX.Element => {
-  return (
-    <PanelSetup>
-      <TopicGraph />
-    </PanelSetup>
-  );
+export const Empty = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup>
+        <TopicGraph />
+      </PanelSetup>
+    );
+  },
 };
 
 export const WithSettings = {
@@ -75,13 +77,17 @@ function TopicsStory({
   );
 }
 
-export const AllTopics = (): JSX.Element => <TopicsStory topicVisibility="all" />;
+export const AllTopics = {
+  render: (): JSX.Element => <TopicsStory topicVisibility="all" />,
+};
 
-export const TopicsWithSubscribers = (): JSX.Element => (
-  <TopicsStory topicVisibility="subscribed" />
-);
+export const TopicsWithSubscribers = {
+  render: (): JSX.Element => <TopicsStory topicVisibility="subscribed" />,
+};
 
-export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="none" />;
+export const TopicsHidden = {
+  render: (): JSX.Element => <TopicsStory topicVisibility="none" />,
+};
 
 export const ReLayout = {
   render: function Story(): JSX.Element {

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { useEffect, useState } from "react";
 import { useAsync } from "react-use";
 
@@ -15,8 +16,8 @@ export default {
   component: TopicGraph,
 };
 
-export const Empty = {
-  render: (): JSX.Element => {
+export const Empty: StoryObj = {
+  render: () => {
     return (
       <PanelSetup>
         <TopicGraph />
@@ -25,8 +26,8 @@ export const Empty = {
   },
 };
 
-export const WithSettings = {
-  render: function Story(): JSX.Element {
+export const WithSettings: StoryObj = {
+  render: function Story() {
     return (
       <PanelSetup includeSettings>
         <TopicGraph />
@@ -77,20 +78,20 @@ function TopicsStory({
   );
 }
 
-export const AllTopics = {
-  render: (): JSX.Element => <TopicsStory topicVisibility="all" />,
+export const AllTopics: StoryObj = {
+  render: () => <TopicsStory topicVisibility="all" />,
 };
 
-export const TopicsWithSubscribers = {
-  render: (): JSX.Element => <TopicsStory topicVisibility="subscribed" />,
+export const TopicsWithSubscribers: StoryObj = {
+  render: () => <TopicsStory topicVisibility="subscribed" />,
 };
 
-export const TopicsHidden = {
-  render: (): JSX.Element => <TopicsStory topicVisibility="none" />,
+export const TopicsHidden: StoryObj = {
+  render: () => <TopicsStory topicVisibility="none" />,
 };
 
-export const ReLayout = {
-  render: function Story(): JSX.Element {
+export const ReLayout: StoryObj = {
+  render: function Story() {
     const [fixture, setFixture] = useState<Fixture>({
       frame: {},
       topics: [{ name: "/topic", schemaName: "std_msgs/Header" }],

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -23,15 +23,18 @@ export const Empty = (): JSX.Element => {
   );
 };
 
-export const WithSettings = (): JSX.Element => {
-  return (
-    <PanelSetup includeSettings>
-      <TopicGraph />
-    </PanelSetup>
-  );
-};
-WithSettings.parameters = {
-  colorScheme: "light",
+export const WithSettings = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup includeSettings>
+        <TopicGraph />
+      </PanelSetup>
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
 };
 
 function TopicsStory({
@@ -73,48 +76,51 @@ function TopicsStory({
 }
 
 export const AllTopics = (): JSX.Element => <TopicsStory topicVisibility="all" />;
+
 export const TopicsWithSubscribers = (): JSX.Element => (
   <TopicsStory topicVisibility="subscribed" />
 );
+
 export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="none" />;
 
-// Adding new active data should cause the graph to re-layout
-export const ReLayout = (): JSX.Element => {
-  const [fixture, setFixture] = useState<Fixture>({
-    frame: {},
-    topics: [{ name: "/topic", schemaName: "std_msgs/Header" }],
-    activeData: {
-      publishedTopics: new Map([["/topic", new Set(["pub-1", "pub-2"])]]),
-      subscribedTopics: new Map([["/topic", new Set(["sub-1"])]]),
+export const ReLayout = {
+  render: (): JSX.Element => {
+    const [fixture, setFixture] = useState<Fixture>({
+      frame: {},
+      topics: [{ name: "/topic", schemaName: "std_msgs/Header" }],
+      activeData: {
+        publishedTopics: new Map([["/topic", new Set(["pub-1", "pub-2"])]]),
+        subscribedTopics: new Map([["/topic", new Set(["sub-1"])]]),
+      },
+    });
+
+    useEffect(() => {
+      const timeOutID = setTimeout(() => {
+        setFixture({
+          frame: {},
+          topics: [{ name: "/topic", schemaName: "std_msgs/Header" }],
+          activeData: {
+            publishedTopics: new Map([["/topic", new Set(["pub-1", "pub-2"])]]),
+            subscribedTopics: new Map([["/topic", new Set(["sub-1", "sub-2"])]]),
+          },
+        });
+      }, 100);
+
+      return () => {
+        clearTimeout(timeOutID);
+      };
+    }, []);
+
+    return (
+      <PanelSetup fixture={fixture}>
+        <TopicGraph />
+      </PanelSetup>
+    );
+  },
+
+  parameters: {
+    chromatic: {
+      delay: 200,
     },
-  });
-
-  useEffect(() => {
-    const timeOutID = setTimeout(() => {
-      setFixture({
-        frame: {},
-        topics: [{ name: "/topic", schemaName: "std_msgs/Header" }],
-        activeData: {
-          publishedTopics: new Map([["/topic", new Set(["pub-1", "pub-2"])]]),
-          subscribedTopics: new Map([["/topic", new Set(["sub-1", "sub-2"])]]),
-        },
-      });
-    }, 100);
-
-    return () => {
-      clearTimeout(timeOutID);
-    };
-  }, []);
-
-  return (
-    <PanelSetup fixture={fixture}>
-      <TopicGraph />
-    </PanelSetup>
-  );
-};
-
-ReLayout.parameters = {
-  chromatic: {
-    delay: 200,
   },
 };

--- a/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
@@ -11,6 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { StoryFn } from "@storybook/react";
+
 import VariableSliderPanel from "@foxglove/studio-base/panels/VariableSlider/index";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -31,15 +33,15 @@ export default {
   component: VariableSliderPanel,
 };
 
-export function Example(): JSX.Element {
+export const Example: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <VariableSliderPanel />
     </PanelSetup>
   );
-}
+};
 
-export function NarrowLayout(): JSX.Element {
+export const NarrowLayout: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <div style={{ width: 400 }}>
@@ -47,15 +49,15 @@ export function NarrowLayout(): JSX.Element {
       </div>
     </PanelSetup>
   );
-}
+};
 
-export function WithSettings(): JSX.Element {
+export const WithSettings: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture} includeSettings>
       <VariableSliderPanel />
     </PanelSetup>
   );
-}
+};
 WithSettings.parameters = {
   colorScheme: "light",
 };

--- a/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import VariableSliderPanel from "@foxglove/studio-base/panels/VariableSlider/index";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -33,22 +33,26 @@ export default {
   component: VariableSliderPanel,
 };
 
-export const Example: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <VariableSliderPanel />
-    </PanelSetup>
-  );
+export const Example: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <VariableSliderPanel />
+      </PanelSetup>
+    );
+  },
 };
 
-export const NarrowLayout: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <div style={{ width: 400 }}>
-        <VariableSliderPanel />
-      </div>
-    </PanelSetup>
-  );
+export const NarrowLayout: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <div style={{ width: 400 }}>
+          <VariableSliderPanel />
+        </div>
+      </PanelSetup>
+    );
+  },
 };
 
 export const WithSettings: StoryObj = {

--- a/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
@@ -34,7 +34,7 @@ export default {
 };
 
 export const Example: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <VariableSliderPanel />
@@ -44,7 +44,7 @@ export const Example: StoryObj = {
 };
 
 export const NarrowLayout: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <div style={{ width: 400 }}>
@@ -56,7 +56,7 @@ export const NarrowLayout: StoryObj = {
 };
 
 export const WithSettings: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <PanelSetup fixture={fixture} includeSettings>
         <VariableSliderPanel />

--- a/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import VariableSliderPanel from "@foxglove/studio-base/panels/VariableSlider/index";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -51,13 +51,16 @@ export const NarrowLayout: StoryFn = (): JSX.Element => {
   );
 };
 
-export const WithSettings: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture} includeSettings>
-      <VariableSliderPanel />
-    </PanelSetup>
-  );
-};
-WithSettings.parameters = {
-  colorScheme: "light",
+export const WithSettings: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <VariableSliderPanel />
+      </PanelSetup>
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
 };

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -1,6 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { StoryFn } from "@storybook/react";
+
 import DiagnosticStatusPanel from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
 import { makeDiagnosticMessage } from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.stories";
 import { LEVELS } from "@foxglove/studio-base/panels/diagnostics/util";
@@ -33,15 +35,15 @@ const fixture: Fixture = {
   },
 };
 
-export function Empty(): JSX.Element {
+export const Empty: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticStatusPanel />
     </PanelSetup>
   );
-}
+};
 
-export function Default(): JSX.Element {
+export const Default: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticStatusPanel
@@ -52,9 +54,9 @@ export function Default(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function WithSettings(): JSX.Element {
+export const WithSettings: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture} includeSettings>
       <DiagnosticStatusPanel
@@ -66,12 +68,12 @@ export function WithSettings(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 WithSettings.parameters = {
   colorScheme: "light",
 };
 
-export function SelectedHardwareIDOnly(): JSX.Element {
+export const SelectedHardwareIDOnly: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticStatusPanel
@@ -83,9 +85,9 @@ export function SelectedHardwareIDOnly(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function SelectedName(): JSX.Element {
+export const SelectedName: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticStatusPanel
@@ -97,9 +99,9 @@ export function SelectedName(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function MovedDivider(): JSX.Element {
+export const MovedDivider: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticStatusPanel
@@ -112,4 +114,4 @@ export function MovedDivider(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import DiagnosticStatusPanel from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
 import { makeDiagnosticMessage } from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.stories";
@@ -35,25 +35,29 @@ const fixture: Fixture = {
   },
 };
 
-export const Empty: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticStatusPanel />
-    </PanelSetup>
-  );
+export const Empty: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticStatusPanel />
+      </PanelSetup>
+    );
+  },
 };
 
-export const Default: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticStatusPanel
-        overrideConfig={{
-          topicToRender: "/diagnostics",
-          selectedHardwareId: "levels_id",
-        }}
-      />
-    </PanelSetup>
-  );
+export const Default: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticStatusPanel
+          overrideConfig={{
+            topicToRender: "/diagnostics",
+            selectedHardwareId: "levels_id",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
 export const WithSettings: StoryObj = {
@@ -76,45 +80,51 @@ export const WithSettings: StoryObj = {
   },
 };
 
-export const SelectedHardwareIDOnly: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticStatusPanel
-        overrideConfig={{
-          topicToRender: "/diagnostics",
-          selectedHardwareId: "hardware_id1",
-          selectedName: undefined,
-        }}
-      />
-    </PanelSetup>
-  );
+export const SelectedHardwareIDOnly: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticStatusPanel
+          overrideConfig={{
+            topicToRender: "/diagnostics",
+            selectedHardwareId: "hardware_id1",
+            selectedName: undefined,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const SelectedName: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticStatusPanel
-        overrideConfig={{
-          topicToRender: "/diagnostics",
-          selectedHardwareId: "hardware_id1",
-          selectedName: "name2",
-        }}
-      />
-    </PanelSetup>
-  );
+export const SelectedName: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticStatusPanel
+          overrideConfig={{
+            topicToRender: "/diagnostics",
+            selectedHardwareId: "hardware_id1",
+            selectedName: "name2",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const MovedDivider: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticStatusPanel
-        overrideConfig={{
-          topicToRender: "/diagnostics",
-          selectedHardwareId: "hardware_id1",
-          selectedName: undefined,
-          splitFraction: 0.25,
-        }}
-      />
-    </PanelSetup>
-  );
+export const MovedDivider: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticStatusPanel
+          overrideConfig={{
+            topicToRender: "/diagnostics",
+            selectedHardwareId: "hardware_id1",
+            selectedName: undefined,
+            splitFraction: 0.25,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -36,7 +36,7 @@ const fixture: Fixture = {
 };
 
 export const Empty: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticStatusPanel />
@@ -46,7 +46,7 @@ export const Empty: StoryObj = {
 };
 
 export const Default: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticStatusPanel
@@ -61,7 +61,7 @@ export const Default: StoryObj = {
 };
 
 export const WithSettings: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <PanelSetup fixture={fixture} includeSettings>
         <DiagnosticStatusPanel
@@ -81,7 +81,7 @@ export const WithSettings: StoryObj = {
 };
 
 export const SelectedHardwareIDOnly: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticStatusPanel
@@ -97,7 +97,7 @@ export const SelectedHardwareIDOnly: StoryObj = {
 };
 
 export const SelectedName: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticStatusPanel
@@ -113,7 +113,7 @@ export const SelectedName: StoryObj = {
 };
 
 export const MovedDivider: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticStatusPanel

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import DiagnosticStatusPanel from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
 import { makeDiagnosticMessage } from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.stories";
@@ -56,21 +56,24 @@ export const Default: StoryFn = (): JSX.Element => {
   );
 };
 
-export const WithSettings: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture} includeSettings>
-      <DiagnosticStatusPanel
-        overrideConfig={{
-          topicToRender: "/diagnostics",
-          selectedHardwareId: "hardware_id1",
-          selectedName: "name2",
-        }}
-      />
-    </PanelSetup>
-  );
-};
-WithSettings.parameters = {
-  colorScheme: "light",
+export const WithSettings: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <DiagnosticStatusPanel
+          overrideConfig={{
+            topicToRender: "/diagnostics",
+            selectedHardwareId: "hardware_id1",
+            selectedName: "name2",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
 };
 
 export const SelectedHardwareIDOnly: StoryFn = (): JSX.Element => {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -52,7 +52,7 @@ const fixture: Fixture = {
 };
 
 export const Empty: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={{ ...fixture, frame: {} }}>
         <DiagnosticSummary />
@@ -62,7 +62,7 @@ export const Empty: StoryObj = {
 };
 
 export const Basic: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary />
@@ -72,7 +72,7 @@ export const Basic: StoryObj = {
 };
 
 export const WithSettings: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture} includeSettings>
         <DiagnosticSummary />
@@ -82,7 +82,7 @@ export const WithSettings: StoryObj = {
 };
 
 export const WithPinnedNodes: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary
@@ -102,7 +102,7 @@ export const WithPinnedNodes: StoryObj = {
 };
 
 export const WithPinnedNodesAndFilter: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary
@@ -122,7 +122,7 @@ export const WithPinnedNodesAndFilter: StoryObj = {
 };
 
 export const WithoutSorting: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary
@@ -140,7 +140,7 @@ export const WithoutSorting: StoryObj = {
 };
 
 export const FilteredByHardwareId: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary
@@ -158,7 +158,7 @@ export const FilteredByHardwareId: StoryObj = {
 };
 
 export const FilteredByLevel: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary
@@ -176,7 +176,7 @@ export const FilteredByLevel: StoryObj = {
 };
 
 export const FilteredByHardwareIdAndLevel: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <PanelSetup fixture={fixture}>
         <DiagnosticSummary

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import DiagnosticSummary from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary";
 import {
@@ -51,126 +51,144 @@ const fixture: Fixture = {
   },
 };
 
-export const Empty: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={{ ...fixture, frame: {} }}>
-      <DiagnosticSummary />
-    </PanelSetup>
-  );
+export const Empty: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={{ ...fixture, frame: {} }}>
+        <DiagnosticSummary />
+      </PanelSetup>
+    );
+  },
 };
 
-export const Basic: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary />
-    </PanelSetup>
-  );
+export const Basic: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithSettings: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture} includeSettings>
-      <DiagnosticSummary />
-    </PanelSetup>
-  );
+export const WithSettings: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <DiagnosticSummary />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithPinnedNodes: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary
-        overrideConfig={{
-          minLevel: 0,
-          pinnedIds: [
-            getDiagnosticId("hardware_id1", "name1"),
-            getDiagnosticId("hardware_id3/filter", "name3"),
-          ],
-          topicToRender: "/diagnostics",
-          hardwareIdFilter: "",
-        }}
-      />
-    </PanelSetup>
-  );
+export const WithPinnedNodes: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary
+          overrideConfig={{
+            minLevel: 0,
+            pinnedIds: [
+              getDiagnosticId("hardware_id1", "name1"),
+              getDiagnosticId("hardware_id3/filter", "name3"),
+            ],
+            topicToRender: "/diagnostics",
+            hardwareIdFilter: "",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithPinnedNodesAndFilter: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary
-        overrideConfig={{
-          minLevel: 2,
-          pinnedIds: [
-            getDiagnosticId("hardware_id1", "name1"),
-            getDiagnosticId("hardware_id3/filter", "name3"),
-          ],
-          topicToRender: "/diagnostics",
-          hardwareIdFilter: "",
-        }}
-      />
-    </PanelSetup>
-  );
+export const WithPinnedNodesAndFilter: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary
+          overrideConfig={{
+            minLevel: 2,
+            pinnedIds: [
+              getDiagnosticId("hardware_id1", "name1"),
+              getDiagnosticId("hardware_id3/filter", "name3"),
+            ],
+            topicToRender: "/diagnostics",
+            hardwareIdFilter: "",
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const WithoutSorting: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary
-        overrideConfig={{
-          minLevel: 0,
-          pinnedIds: [],
-          topicToRender: "/diagnostics",
-          hardwareIdFilter: "",
-          sortByLevel: false,
-        }}
-      />
-    </PanelSetup>
-  );
+export const WithoutSorting: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary
+          overrideConfig={{
+            minLevel: 0,
+            pinnedIds: [],
+            topicToRender: "/diagnostics",
+            hardwareIdFilter: "",
+            sortByLevel: false,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const FilteredByHardwareId: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary
-        overrideConfig={{
-          minLevel: 0,
-          pinnedIds: [],
-          topicToRender: "/diagnostics",
-          hardwareIdFilter: "filter",
-          sortByLevel: false,
-        }}
-      />
-    </PanelSetup>
-  );
+export const FilteredByHardwareId: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary
+          overrideConfig={{
+            minLevel: 0,
+            pinnedIds: [],
+            topicToRender: "/diagnostics",
+            hardwareIdFilter: "filter",
+            sortByLevel: false,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const FilteredByLevel: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary
-        overrideConfig={{
-          minLevel: 2,
-          pinnedIds: [],
-          topicToRender: "/diagnostics",
-          hardwareIdFilter: "",
-          sortByLevel: false,
-        }}
-      />
-    </PanelSetup>
-  );
+export const FilteredByLevel: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary
+          overrideConfig={{
+            minLevel: 2,
+            pinnedIds: [],
+            topicToRender: "/diagnostics",
+            hardwareIdFilter: "",
+            sortByLevel: false,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };
 
-export const FilteredByHardwareIdAndLevel: StoryFn = (): JSX.Element => {
-  return (
-    <PanelSetup fixture={fixture}>
-      <DiagnosticSummary
-        overrideConfig={{
-          minLevel: 2,
-          pinnedIds: [],
-          topicToRender: "/diagnostics",
-          hardwareIdFilter: "filter",
-          sortByLevel: false,
-        }}
-      />
-    </PanelSetup>
-  );
+export const FilteredByHardwareIdAndLevel: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <PanelSetup fixture={fixture}>
+        <DiagnosticSummary
+          overrideConfig={{
+            minLevel: 2,
+            pinnedIds: [],
+            topicToRender: "/diagnostics",
+            hardwareIdFilter: "filter",
+            sortByLevel: false,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
 };

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import DiagnosticSummary from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary";
 import {
   DiagnosticStatusArrayMsg,
@@ -49,31 +51,31 @@ const fixture: Fixture = {
   },
 };
 
-export function Empty(): JSX.Element {
+export const Empty: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={{ ...fixture, frame: {} }}>
       <DiagnosticSummary />
     </PanelSetup>
   );
-}
+};
 
-export function Basic(): JSX.Element {
+export const Basic: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary />
     </PanelSetup>
   );
-}
+};
 
-export function WithSettings(): JSX.Element {
+export const WithSettings: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture} includeSettings>
       <DiagnosticSummary />
     </PanelSetup>
   );
-}
+};
 
-export function WithPinnedNodes(): JSX.Element {
+export const WithPinnedNodes: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
@@ -89,9 +91,9 @@ export function WithPinnedNodes(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function WithPinnedNodesAndFilter(): JSX.Element {
+export const WithPinnedNodesAndFilter: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
@@ -107,9 +109,9 @@ export function WithPinnedNodesAndFilter(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function WithoutSorting(): JSX.Element {
+export const WithoutSorting: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
@@ -123,9 +125,9 @@ export function WithoutSorting(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function FilteredByHardwareId(): JSX.Element {
+export const FilteredByHardwareId: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
@@ -139,9 +141,9 @@ export function FilteredByHardwareId(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function FilteredByLevel(): JSX.Element {
+export const FilteredByLevel: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
@@ -155,9 +157,9 @@ export function FilteredByLevel(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};
 
-export function FilteredByHardwareIdAndLevel(): JSX.Element {
+export const FilteredByHardwareIdAndLevel: StoryFn = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
@@ -171,4 +173,4 @@ export function FilteredByHardwareIdAndLevel(): JSX.Element {
       />
     </PanelSetup>
   );
-}
+};

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.stories.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.stories.tsx
@@ -11,14 +11,18 @@ export default {
   component: LaunchPreferenceScreen,
 };
 
-export const Dark = (): ReactElement => {
-  return <LaunchPreferenceScreen />;
+export const Dark = {
+  render: (): ReactElement => {
+    return <LaunchPreferenceScreen />;
+  },
+
+  parameters: { colorScheme: "dark" },
 };
 
-Dark.parameters = { colorScheme: "dark" };
+export const Light = {
+  render: (): ReactElement => {
+    return <LaunchPreferenceScreen />;
+  },
 
-export const Light = (): ReactElement => {
-  return <LaunchPreferenceScreen />;
+  parameters: { colorScheme: "light" },
 };
-
-Light.parameters = { colorScheme: "light" };

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.stories.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { ReactElement } from "react";
 
 import { LaunchPreferenceScreen } from "@foxglove/studio-base/screens/LaunchPreferenceScreen";
@@ -11,7 +12,7 @@ export default {
   component: LaunchPreferenceScreen,
 };
 
-export const Dark = {
+export const Dark: StoryObj = {
   render: (): ReactElement => {
     return <LaunchPreferenceScreen />;
   },
@@ -19,7 +20,7 @@ export const Dark = {
   parameters: { colorScheme: "dark" },
 };
 
-export const Light = {
+export const Light: StoryObj = {
   render: (): ReactElement => {
     return <LaunchPreferenceScreen />;
   },

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.stories.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryObj } from "@storybook/react";
 import { ReactElement } from "react";
 
 import { LaunchingInDesktopScreen } from "@foxglove/studio-base/screens/LaunchingInDesktopScreen";
@@ -11,7 +12,7 @@ export default {
   component: LaunchingInDesktopScreen,
 };
 
-export const LaunchingInDesktopScreenRender = {
+export const LaunchingInDesktopScreenRender: StoryObj = {
   render: (): ReactElement => {
     return <LaunchingInDesktopScreen />;
   },

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.stories.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.stories.tsx
@@ -11,6 +11,8 @@ export default {
   component: LaunchingInDesktopScreen,
 };
 
-export const LaunchingInDesktopScreenRender = (): ReactElement => {
-  return <LaunchingInDesktopScreen />;
+export const LaunchingInDesktopScreenRender = {
+  render: (): ReactElement => {
+    return <LaunchingInDesktopScreen />;
+  },
 };

--- a/packages/studio-base/src/stories/inScreenshotTests.stories.tsx
+++ b/packages/studio-base/src/stories/inScreenshotTests.stories.tsx
@@ -11,7 +11,7 @@ export default {
 };
 
 export const InScreenshotTests: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <div
         style={{

--- a/packages/studio-base/src/stories/inScreenshotTests.stories.tsx
+++ b/packages/studio-base/src/stories/inScreenshotTests.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 
@@ -10,17 +10,19 @@ export default {
   title: "inScreenshotTests",
 };
 
-export const InScreenshotTests: StoryFn = (): JSX.Element => {
-  return (
-    <div
-      style={{
-        padding: "20px",
-        fontSize: "20px",
-        color: "white",
-        backgroundColor: inScreenshotTests() ? "green" : "maroon",
-      }}
-    >
-      inScreenshotTests: {JSON.stringify(inScreenshotTests())}
-    </div>
-  );
+export const InScreenshotTests: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <div
+        style={{
+          padding: "20px",
+          fontSize: "20px",
+          color: "white",
+          backgroundColor: inScreenshotTests() ? "green" : "maroon",
+        }}
+      >
+        inScreenshotTests: {JSON.stringify(inScreenshotTests())}
+      </div>
+    );
+  },
 };

--- a/packages/studio-base/src/stories/inScreenshotTests.stories.tsx
+++ b/packages/studio-base/src/stories/inScreenshotTests.stories.tsx
@@ -2,13 +2,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 
 export default {
   title: "inScreenshotTests",
 };
 
-export function InScreenshotTests(): JSX.Element {
+export const InScreenshotTests: StoryFn = (): JSX.Element => {
   return (
     <div
       style={{
@@ -21,4 +23,4 @@ export function InScreenshotTests(): JSX.Element {
       inScreenshotTests: {JSON.stringify(inScreenshotTests())}
     </div>
   );
-}
+};

--- a/packages/studio-base/src/theme/index.stories.tsx
+++ b/packages/studio-base/src/theme/index.stories.tsx
@@ -145,7 +145,7 @@ function Wrapper({ children }: { children: ReactNode }): JSX.Element {
 }
 
 export const TypographyCatalog: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <Stack gap={1} padding={1}>
         <Wrapper>

--- a/packages/studio-base/src/theme/index.stories.tsx
+++ b/packages/studio-base/src/theme/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box, Typography, useTheme } from "@mui/material";
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 import { ReactNode } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -142,81 +142,84 @@ function Wrapper({ children }: { children: ReactNode }): JSX.Element {
   return <Box sx={{ border: "1px dotted", borderColor: "info.main" }}>{children}</Box>;
 }
 
-export const TypographyCatalog: StoryFn = (): JSX.Element => {
-  return (
-    <Stack gap={1} padding={1}>
-      <Wrapper>
-        <Typography variant="h1" gutterBottom>
-          h1. Heading
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="h2" gutterBottom>
-          h2. Heading
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="h3" gutterBottom>
-          h3. Heading
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="h4" gutterBottom>
-          h4. Heading
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="h5" gutterBottom>
-          h5. Heading
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="h6" gutterBottom>
-          h6. Heading
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="subtitle1" gutterBottom>
-          subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis
-          tenetur
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="subtitle2" gutterBottom>
-          subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis
-          tenetur
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="body1" gutterBottom>
-          body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
-          unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate
-          numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="body2" gutterBottom>
-          body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
-          unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate
-          numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="button" display="block" gutterBottom>
-          button text
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="caption" display="block" gutterBottom>
-          caption text
-        </Typography>
-      </Wrapper>
-      <Wrapper>
-        <Typography variant="overline" display="block" gutterBottom>
-          overline text
-        </Typography>
-      </Wrapper>
-    </Stack>
-  );
+export const TypographyCatalog: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <Stack gap={1} padding={1}>
+        <Wrapper>
+          <Typography variant="h1" gutterBottom>
+            h1. Heading
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="h2" gutterBottom>
+            h2. Heading
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="h3" gutterBottom>
+            h3. Heading
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="h4" gutterBottom>
+            h4. Heading
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="h5" gutterBottom>
+            h5. Heading
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="h6" gutterBottom>
+            h6. Heading
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="subtitle1" gutterBottom>
+            subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis
+            tenetur
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="subtitle2" gutterBottom>
+            subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis
+            tenetur
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="body1" gutterBottom>
+            body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+            unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate
+            numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="body2" gutterBottom>
+            body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+            unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate
+            numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="button" display="block" gutterBottom>
+            button text
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="caption" display="block" gutterBottom>
+            caption text
+          </Typography>
+        </Wrapper>
+        <Wrapper>
+          <Typography variant="overline" display="block" gutterBottom>
+            overline text
+          </Typography>
+        </Wrapper>
+      </Stack>
+    );
+  },
+
+  parameters: { colorScheme: "light" },
 };
-TypographyCatalog.parameters = { colorScheme: "light" };

--- a/packages/studio-base/src/theme/index.stories.tsx
+++ b/packages/studio-base/src/theme/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box, Typography, useTheme } from "@mui/material";
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 import { ReactNode } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -12,130 +12,132 @@ export default {
   title: "Theme",
 };
 
-export const Palette: StoryFn = (): JSX.Element => {
-  const theme = useTheme();
-  return (
-    <Stack
-      fullHeight
-      fullWidth
-      flexWrap="wrap"
-      padding={2}
-      gap={6}
-      style={{ backgroundColor: theme.palette.background.paper }}
-    >
-      <Stack direction="row" gap={6}>
-        <Stack gap={1}>
-          <Typography variant="overline">Palette</Typography>
-          <Stack direction="row" alignItems="center" gap={1}>
-            {["dark", "main", "light"].map((variant) => (
-              <Box
-                display="flex"
-                key={variant}
-                width={32}
-                alignItems="center"
-                justifyContent="center"
-              >
-                {variant}
-              </Box>
-            ))}
-          </Stack>
-          {["primary", "secondary", "error", "warning", "info", "success"].map((color) => (
-            <Stack key={color} direction="row" alignItems="center" gap={1}>
+export const Palette: StoryObj = {
+  render: function Story() {
+    const theme = useTheme();
+    return (
+      <Stack
+        fullHeight
+        fullWidth
+        flexWrap="wrap"
+        padding={2}
+        gap={6}
+        style={{ backgroundColor: theme.palette.background.paper }}
+      >
+        <Stack direction="row" gap={6}>
+          <Stack gap={1}>
+            <Typography variant="overline">Palette</Typography>
+            <Stack direction="row" alignItems="center" gap={1}>
               {["dark", "main", "light"].map((variant) => (
                 <Box
                   display="flex"
-                  key={`${color}.${variant}`}
+                  key={variant}
+                  width={32}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  {variant}
+                </Box>
+              ))}
+            </Stack>
+            {["primary", "secondary", "error", "warning", "info", "success"].map((color) => (
+              <Stack key={color} direction="row" alignItems="center" gap={1}>
+                {["dark", "main", "light"].map((variant) => (
+                  <Box
+                    display="flex"
+                    key={`${color}.${variant}`}
+                    width={32}
+                    height={32}
+                    bgcolor={`${color}.${variant}`}
+                    color={`${color}.contrastText`}
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    Aa
+                  </Box>
+                ))}
+                {color}
+              </Stack>
+            ))}
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="overline">Action</Typography>
+            {["hover", "focus", "selected", "disabled", "active"].map((color) => (
+              <Stack direction="row" key={color} alignItems="center" gap={1}>
+                <Box
+                  display="flex"
                   width={32}
                   height={32}
-                  bgcolor={`${color}.${variant}`}
-                  color={`${color}.contrastText`}
+                  bgcolor={`action.${color}`}
                   alignItems="center"
                   justifyContent="center"
                 >
                   Aa
                 </Box>
-              ))}
-              {color}
-            </Stack>
-          ))}
+                {color}
+              </Stack>
+            ))}
+          </Stack>
+
+          <Stack gap={1}>
+            <Typography variant="overline">Background</Typography>
+            {Object.keys(theme.palette.background).map((bgcolor) => (
+              <Stack key={bgcolor} direction="row" alignItems="center" gap={1}>
+                <Box
+                  display="flex"
+                  width={32}
+                  height={32}
+                  bgcolor={`background.${bgcolor}`}
+                  alignItems="center"
+                  justifyContent="center"
+                  border="1px solid"
+                  borderColor="divider"
+                >
+                  Aa
+                </Box>
+                <Box
+                  display="flex"
+                  width={32}
+                  height={32}
+                  bgcolor={`background.${bgcolor}`}
+                  alignItems="center"
+                  justifyContent="center"
+                  boxShadow={8}
+                >
+                  Aa
+                </Box>
+                {bgcolor}
+              </Stack>
+            ))}
+          </Stack>
         </Stack>
 
         <Stack gap={1}>
-          <Typography variant="overline">Action</Typography>
-          {["hover", "focus", "selected", "disabled", "active"].map((color) => (
-            <Stack direction="row" key={color} alignItems="center" gap={1}>
-              <Box
-                display="flex"
-                width={32}
-                height={32}
-                bgcolor={`action.${color}`}
-                alignItems="center"
-                justifyContent="center"
-              >
-                Aa
-              </Box>
-              {color}
-            </Stack>
-          ))}
-        </Stack>
-
-        <Stack gap={1}>
-          <Typography variant="overline">Background</Typography>
-          {Object.keys(theme.palette.background).map((bgcolor) => (
-            <Stack key={bgcolor} direction="row" alignItems="center" gap={1}>
-              <Box
-                display="flex"
-                width={32}
-                height={32}
-                bgcolor={`background.${bgcolor}`}
-                alignItems="center"
-                justifyContent="center"
-                border="1px solid"
-                borderColor="divider"
-              >
-                Aa
-              </Box>
-              <Box
-                display="flex"
-                width={32}
-                height={32}
-                bgcolor={`background.${bgcolor}`}
-                alignItems="center"
-                justifyContent="center"
-                boxShadow={8}
-              >
-                Aa
-              </Box>
-              {bgcolor}
-            </Stack>
-          ))}
+          <Typography variant="overline">Grey (with Divider border)</Typography>
+          <Stack gap={1} direction="row" alignItems="center">
+            {Object.keys(theme.palette.grey).map((key) => (
+              <Stack key={key} alignItems="center" gap={1}>
+                <Box
+                  display="flex"
+                  width={32}
+                  height={32}
+                  bgcolor={`grey.${key}`}
+                  alignItems="center"
+                  justifyContent="center"
+                  border="1px solid"
+                  borderColor="divider"
+                >
+                  Aa
+                </Box>
+                {key}
+              </Stack>
+            ))}
+          </Stack>
         </Stack>
       </Stack>
-
-      <Stack gap={1}>
-        <Typography variant="overline">Grey (with Divider border)</Typography>
-        <Stack gap={1} direction="row" alignItems="center">
-          {Object.keys(theme.palette.grey).map((key) => (
-            <Stack key={key} alignItems="center" gap={1}>
-              <Box
-                display="flex"
-                width={32}
-                height={32}
-                bgcolor={`grey.${key}`}
-                alignItems="center"
-                justifyContent="center"
-                border="1px solid"
-                borderColor="divider"
-              >
-                Aa
-              </Box>
-              {key}
-            </Stack>
-          ))}
-        </Stack>
-      </Stack>
-    </Stack>
-  );
+    );
+  },
 };
 
 function Wrapper({ children }: { children: ReactNode }): JSX.Element {

--- a/packages/studio-base/src/theme/index.stories.tsx
+++ b/packages/studio-base/src/theme/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box, Typography, useTheme } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 import { ReactNode } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -11,7 +12,7 @@ export default {
   title: "Theme",
 };
 
-export function Palette(): JSX.Element {
+export const Palette: StoryFn = (): JSX.Element => {
   const theme = useTheme();
   return (
     <Stack
@@ -135,13 +136,13 @@ export function Palette(): JSX.Element {
       </Stack>
     </Stack>
   );
-}
+};
 
 function Wrapper({ children }: { children: ReactNode }): JSX.Element {
   return <Box sx={{ border: "1px dotted", borderColor: "info.main" }}>{children}</Box>;
 }
 
-export function TypographyCatalog(): JSX.Element {
+export const TypographyCatalog: StoryFn = (): JSX.Element => {
   return (
     <Stack gap={1} padding={1}>
       <Wrapper>
@@ -217,5 +218,5 @@ export function TypographyCatalog(): JSX.Element {
       </Wrapper>
     </Stack>
   );
-}
+};
 TypographyCatalog.parameters = { colorScheme: "light" };

--- a/packages/studio-base/src/theme/muiComponents.stories.tsx
+++ b/packages/studio-base/src/theme/muiComponents.stories.tsx
@@ -16,6 +16,7 @@ import {
   TextField,
   useTheme,
 } from "@mui/material";
+import { StoryObj } from "@storybook/react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 
@@ -346,12 +347,12 @@ function FormElements(): JSX.Element {
   );
 }
 
-export const FormElementsDark = {
+export const FormElementsDark: StoryObj = {
   render: FormElements,
   parameters: { colorScheme: "dark" },
 };
 
-export const FormElementsLight = {
+export const FormElementsLight: StoryObj = {
   render: FormElements,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/theme/muiComponents.stories.tsx
+++ b/packages/studio-base/src/theme/muiComponents.stories.tsx
@@ -347,11 +347,11 @@ function FormElements(): JSX.Element {
 }
 
 export const FormElementsDark = {
-  render: (): JSX.Element => FormElements(),
+  render: function Story(): JSX.Element FormElements(),
   parameters: { colorScheme: "dark" },
 };
 
 export const FormElementsLight = {
-  render: (): JSX.Element => FormElements(),
+  render: function Story(): JSX.Element FormElements(),
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-base/src/theme/muiComponents.stories.tsx
+++ b/packages/studio-base/src/theme/muiComponents.stories.tsx
@@ -346,8 +346,12 @@ function FormElements(): JSX.Element {
   );
 }
 
-export const FormElementsDark = (): JSX.Element => FormElements();
-FormElementsDark.parameters = { colorScheme: "dark" };
+export const FormElementsDark = {
+  render: (): JSX.Element => FormElements(),
+  parameters: { colorScheme: "dark" },
+};
 
-export const FormElementsLight = (): JSX.Element => FormElements();
-FormElementsLight.parameters = { colorScheme: "light" };
+export const FormElementsLight = {
+  render: (): JSX.Element => FormElements(),
+  parameters: { colorScheme: "light" },
+};

--- a/packages/studio-base/src/theme/muiComponents.stories.tsx
+++ b/packages/studio-base/src/theme/muiComponents.stories.tsx
@@ -347,11 +347,11 @@ function FormElements(): JSX.Element {
 }
 
 export const FormElementsDark = {
-  render: function Story(): JSX.Element FormElements(),
+  render: FormElements,
   parameters: { colorScheme: "dark" },
 };
 
 export const FormElementsLight = {
-  render: function Story(): JSX.Element FormElements(),
+  render: FormElements,
   parameters: { colorScheme: "light" },
 };

--- a/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
+++ b/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj, StoryFn } from "@storybook/react";
 
 import FileInfoDisplay from "./FileInfoDisplay";
 import StorybookDecorator from "./StorybookDecorator";
@@ -21,6 +21,7 @@ export default {
 export const Bag: StoryFn = (): JSX.Element => {
   return <FileInfoDisplay fileStats={{ name: "name.bag", size: 0 }} />;
 };
+
 export const Mcap: StoryFn = (): JSX.Element => {
   return <FileInfoDisplay fileStats={{ name: "name.mcap", size: 0 }} />;
 };
@@ -36,12 +37,15 @@ export const LongName: StoryFn = (): JSX.Element => {
   );
 };
 
-export const ErrorStory: StoryFn = (): JSX.Element => {
-  return (
-    <FileInfoDisplay fileStats={{ name: "name", size: 0 }} error={new Error("Example error")} />
-  );
+export const ErrorStory: StoryObj = {
+  render: function Story(): JSX.Element {
+    return (
+      <FileInfoDisplay fileStats={{ name: "name", size: 0 }} error={new Error("Example error")} />
+    );
+  },
+
+  name: "Error",
 };
-ErrorStory.storyName = "Error";
 
 export const Details: StoryFn = (): JSX.Element => {
   return (

--- a/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
+++ b/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
@@ -19,19 +19,19 @@ export default {
 };
 
 export const Bag: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <FileInfoDisplay fileStats={{ name: "name.bag", size: 0 }} />;
   },
 };
 
 export const Mcap: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <FileInfoDisplay fileStats={{ name: "name.mcap", size: 0 }} />;
   },
 };
 
 export const LongName: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <FileInfoDisplay
         fileStats={{
@@ -44,7 +44,7 @@ export const LongName: StoryObj = {
 };
 
 export const ErrorStory: StoryObj = {
-  render: function Story(): JSX.Element {
+  render: function Story() {
     return (
       <FileInfoDisplay fileStats={{ name: "name", size: 0 }} error={new Error("Example error")} />
     );
@@ -54,7 +54,7 @@ export const ErrorStory: StoryObj = {
 };
 
 export const Details: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return (
       <FileInfoDisplay
         fileStats={{ name: "name.mcap", size: 0 }}

--- a/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
+++ b/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj, StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import FileInfoDisplay from "./FileInfoDisplay";
 import StorybookDecorator from "./StorybookDecorator";
@@ -18,23 +18,29 @@ export default {
   },
 };
 
-export const Bag: StoryFn = (): JSX.Element => {
-  return <FileInfoDisplay fileStats={{ name: "name.bag", size: 0 }} />;
+export const Bag: StoryObj = {
+  render: (): JSX.Element => {
+    return <FileInfoDisplay fileStats={{ name: "name.bag", size: 0 }} />;
+  },
 };
 
-export const Mcap: StoryFn = (): JSX.Element => {
-  return <FileInfoDisplay fileStats={{ name: "name.mcap", size: 0 }} />;
+export const Mcap: StoryObj = {
+  render: (): JSX.Element => {
+    return <FileInfoDisplay fileStats={{ name: "name.mcap", size: 0 }} />;
+  },
 };
 
-export const LongName: StoryFn = (): JSX.Element => {
-  return (
-    <FileInfoDisplay
-      fileStats={{
-        name: "a_really_long_file_name_that_wraps_a_really_long_file_name_that_wraps_a_really_long_file_name_that_wraps.mcap",
-        size: 0,
-      }}
-    />
-  );
+export const LongName: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <FileInfoDisplay
+        fileStats={{
+          name: "a_really_long_file_name_that_wraps_a_really_long_file_name_that_wraps_a_really_long_file_name_that_wraps.mcap",
+          size: 0,
+        }}
+      />
+    );
+  },
 };
 
 export const ErrorStory: StoryObj = {
@@ -47,24 +53,26 @@ export const ErrorStory: StoryObj = {
   name: "Error",
 };
 
-export const Details: StoryFn = (): JSX.Element => {
-  return (
-    <FileInfoDisplay
-      fileStats={{ name: "name.mcap", size: 0 }}
-      fileInfo={{
-        fileType: "file type",
-        numChunks: 1,
-        numAttachments: 2,
-        totalMessages: 3n,
-        startTime: { sec: 0, nsec: 1 },
-        endTime: { sec: 1, nsec: 2 },
-        topics: [
-          { topic: "foo", schemaName: "Foo", numMessages: 100n, numConnections: 1 },
-          { topic: "bar", schemaName: "Bar", numMessages: 1_000_000n, numConnections: 2 },
-          { topic: "baz", schemaName: "Baz", numMessages: undefined, numConnections: 0 },
-        ],
-        compressionTypes: new Set(["zstd"]),
-      }}
-    />
-  );
+export const Details: StoryObj = {
+  render: (): JSX.Element => {
+    return (
+      <FileInfoDisplay
+        fileStats={{ name: "name.mcap", size: 0 }}
+        fileInfo={{
+          fileType: "file type",
+          numChunks: 1,
+          numAttachments: 2,
+          totalMessages: 3n,
+          startTime: { sec: 0, nsec: 1 },
+          endTime: { sec: 1, nsec: 2 },
+          topics: [
+            { topic: "foo", schemaName: "Foo", numMessages: 100n, numConnections: 1 },
+            { topic: "bar", schemaName: "Bar", numMessages: 1_000_000n, numConnections: 2 },
+            { topic: "baz", schemaName: "Baz", numMessages: undefined, numConnections: 0 },
+          ],
+          compressionTypes: new Set(["zstd"]),
+        }}
+      />
+    );
+  },
 };

--- a/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
+++ b/packages/studio-desktop/src/quicklook/FileInfoDisplay.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import FileInfoDisplay from "./FileInfoDisplay";
 import StorybookDecorator from "./StorybookDecorator";
 
@@ -16,14 +18,14 @@ export default {
   },
 };
 
-export function Bag(): JSX.Element {
+export const Bag: StoryFn = (): JSX.Element => {
   return <FileInfoDisplay fileStats={{ name: "name.bag", size: 0 }} />;
-}
-export function Mcap(): JSX.Element {
+};
+export const Mcap: StoryFn = (): JSX.Element => {
   return <FileInfoDisplay fileStats={{ name: "name.mcap", size: 0 }} />;
-}
+};
 
-export function LongName(): JSX.Element {
+export const LongName: StoryFn = (): JSX.Element => {
   return (
     <FileInfoDisplay
       fileStats={{
@@ -32,16 +34,16 @@ export function LongName(): JSX.Element {
       }}
     />
   );
-}
+};
 
-ErrorStory.storyName = "Error";
-export function ErrorStory(): JSX.Element {
+export const ErrorStory: StoryFn = (): JSX.Element => {
   return (
     <FileInfoDisplay fileStats={{ name: "name", size: 0 }} error={new Error("Example error")} />
   );
-}
+};
+ErrorStory.storyName = "Error";
 
-export function Details(): JSX.Element {
+export const Details: StoryFn = (): JSX.Element => {
   return (
     <FileInfoDisplay
       fileStats={{ name: "name.mcap", size: 0 }}
@@ -61,4 +63,4 @@ export function Details(): JSX.Element {
       }}
     />
   );
-}
+};

--- a/packages/studio-web/package.json
+++ b/packages/studio-web/package.json
@@ -11,6 +11,7 @@
     "@mui/icons-material": "5.11.16",
     "@mui/material": "5.12.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
+    "@storybook/react": "7.0.4",
     "@types/copy-webpack-plugin": "10.1.0",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "11.0.0",

--- a/packages/studio-web/src/VersionBanner.stories.tsx
+++ b/packages/studio-web/src/VersionBanner.stories.tsx
@@ -12,13 +12,13 @@ export default {
 };
 
 export const OldChrome: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <VersionBanner isChrome currentVersion={42} isDismissable />;
   },
 };
 
 export const UnsupportedBrowser: StoryObj = {
-  render: (): JSX.Element => {
+  render: () => {
     return <VersionBanner isChrome={false} currentVersion={42} isDismissable />;
   },
 };

--- a/packages/studio-web/src/VersionBanner.stories.tsx
+++ b/packages/studio-web/src/VersionBanner.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { StoryFn } from "@storybook/react";
+
 import VersionBanner from "./VersionBanner";
 
 export default {

--- a/packages/studio-web/src/VersionBanner.stories.tsx
+++ b/packages/studio-web/src/VersionBanner.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn } from "@storybook/react";
+import { StoryObj } from "@storybook/react";
 
 import VersionBanner from "./VersionBanner";
 
@@ -11,10 +11,14 @@ export default {
   component: VersionBanner,
 };
 
-export const OldChrome: StoryFn = (): JSX.Element => {
-  return <VersionBanner isChrome currentVersion={42} isDismissable />;
+export const OldChrome: StoryObj = {
+  render: (): JSX.Element => {
+    return <VersionBanner isChrome currentVersion={42} isDismissable />;
+  },
 };
 
-export const UnsupportedBrowser: StoryFn = (): JSX.Element => {
-  return <VersionBanner isChrome={false} currentVersion={42} isDismissable />;
+export const UnsupportedBrowser: StoryObj = {
+  render: (): JSX.Element => {
+    return <VersionBanner isChrome={false} currentVersion={42} isDismissable />;
+  },
 };

--- a/packages/studio-web/src/VersionBanner.stories.tsx
+++ b/packages/studio-web/src/VersionBanner.stories.tsx
@@ -9,10 +9,10 @@ export default {
   component: VersionBanner,
 };
 
-export function OldChrome(): JSX.Element {
+export const OldChrome: StoryFn = (): JSX.Element => {
   return <VersionBanner isChrome currentVersion={42} isDismissable />;
-}
+};
 
-export function UnsupportedBrowser(): JSX.Element {
+export const UnsupportedBrowser: StoryFn = (): JSX.Element => {
   return <VersionBanner isChrome={false} currentVersion={42} isDismissable />;
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,6 +2749,7 @@ __metadata:
     "@mui/icons-material": 5.11.16
     "@mui/material": 5.12.0
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
+    "@storybook/react": 7.0.4
     "@types/copy-webpack-plugin": 10.1.0
     clean-webpack-plugin: 4.0.0
     copy-webpack-plugin: 11.0.0
@@ -4496,12 +4497,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:7.0.4, @storybook/client-logger@npm:^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+"@storybook/client-logger@npm:7.0.4":
   version: 7.0.4
   resolution: "@storybook/client-logger@npm:7.0.4"
   dependencies:
     "@storybook/global": ^5.0.0
   checksum: 608d9aa75509fcd5780103681acca88c7808ab8c435a1685a99f9465c1ec7ac1f3a94d4403392a8bfa5e574a3d4e7e71d48e26e69b070e2c1262e8c0c6c9b054
+  languageName: node
+  linkType: hard
+
+"@storybook/client-logger@npm:^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0":
+  version: 7.0.6
+  resolution: "@storybook/client-logger@npm:7.0.6"
+  dependencies:
+    "@storybook/global": ^5.0.0
+  checksum: 44aba82da1281cab536d6d75497f0fd775fda40175c1acdca6ab446412147462298d9834e20aa485c40d02ec5ac5e93dde213d906ac8e2194bf334bf5affe01a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Convert all stories to modern [CSF3](https://storybook.js.org/blog/storybook-csf3-is-here/) syntax.
Used `npx storybook@latest migrate csf-2-to-3`, and a lot of regex, and some manual editing.