### PR TITLE
Allow long user scripts error messages to wrap

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -168,7 +168,6 @@ overrides:
       - "packages/studio-base/src/components/TextHighlight.tsx"
       - "packages/studio-base/src/panels/Image/components/Toolbar.tsx"
       - "packages/studio-base/src/panels/Image/components/ZoomMenu.tsx"
-      - "packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx"
       - "packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx"
       - "packages/studio-base/src/panels/NodePlayground/Sidebar.tsx"
       - "packages/studio-base/src/panels/NodePlayground/index.tsx"

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
@@ -9,10 +9,10 @@ import WarningIcon from "@mui/icons-material/Warning";
 import { List, ListItem, ListItemIcon, ListItemText, Typography } from "@mui/material";
 import { invert } from "lodash";
 import { ReactElement } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Diagnostic, DiagnosticSeverity } from "@foxglove/studio-base/players/UserNodePlayer/types";
-import { makeStyles } from "tss-react/mui";
 
 const severityIcons = {
   Hint: <HelpIcon fontSize="small" />,

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
@@ -6,19 +6,13 @@ import ErrorIcon from "@mui/icons-material/Error";
 import HelpIcon from "@mui/icons-material/Help";
 import InfoIcon from "@mui/icons-material/Info";
 import WarningIcon from "@mui/icons-material/Warning";
-import {
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
-  Typography,
-  styled as muiStyled,
-} from "@mui/material";
+import { List, ListItem, ListItemIcon, ListItemText, Typography } from "@mui/material";
 import { invert } from "lodash";
 import { ReactElement } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Diagnostic, DiagnosticSeverity } from "@foxglove/studio-base/players/UserNodePlayer/types";
+import { makeStyles } from "tss-react/mui";
 
 const severityIcons = {
   Hint: <HelpIcon fontSize="small" />,
@@ -31,21 +25,27 @@ type Props = {
   diagnostics: readonly Diagnostic[];
 };
 
-const StyledListItem = muiStyled(ListItem)(({ theme }) => ({
-  paddingTop: 0,
-  paddingBottom: 0,
-
-  ".MuiListItemText-root": {
+const useStyles = makeStyles()((theme) => ({
+  listItem: {
+    paddingTop: 0,
+    paddingBottom: 0,
+    marginBlock: theme.spacing(0.5),
+  },
+  listItemText: {
     display: "flex",
     flexDirection: "row",
+    margin: 0,
     gap: theme.spacing(1),
   },
-  ".MuiListItemIcon-root": {
+  listItemIcon: {
+    alignSelf: "flex-start",
     minWidth: theme.spacing(3),
   },
 }));
 
 const DiagnosticsSection = ({ diagnostics }: Props): ReactElement => {
+  const { classes } = useStyles();
+
   if (diagnostics.length === 0) {
     return (
       <Stack gap={0.5} padding={2}>
@@ -70,20 +70,19 @@ const DiagnosticsSection = ({ diagnostics }: Props): ReactElement => {
             : "";
 
         return (
-          <StyledListItem key={`${message}_${i}`}>
-            <ListItemIcon>{severityIcons[severityLabel]}</ListItemIcon>
+          <ListItem key={`${message}_${i}`} className={classes.listItem}>
+            <ListItemIcon className={classes.listItemIcon}>
+              {severityIcons[severityLabel]}
+            </ListItemIcon>
             <ListItemText
+              className={classes.listItemText}
               primary={message}
-              primaryTypographyProps={{
-                noWrap: true,
-              }}
               secondary={`${source} ${errorLoc}`}
               secondaryTypographyProps={{
                 color: "text.secondary",
-                noWrap: true,
               }}
             />
-          </StyledListItem>
+          </ListItem>
         );
       })}
     </List>

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -499,6 +499,16 @@ export const BottomBarErrorsOpen: StoryObj = {
         userNodeDiagnostics: {
           nodeId1: [
             {
+              message: Array(10).fill("Long error that might wrap.").join(" "),
+              severity: 8,
+              source: "Typescript",
+              startLineNumber: 0,
+              startColumn: 6,
+              endLineNumber: 72,
+              endColumn: 20,
+              code: 2304,
+            },
+            {
               message: `Type '"bad number"' is not assignable to type 'number[]'.`,
               severity: 8,
               source: "Typescript",


### PR DESCRIPTION
**User-Facing Changes**
Improve formatting of error messages in the user script panel.

**Description**
Allow long error messages in the user script panel to wrap so they can be read.

<img width="740" alt="Screenshot 2023-04-21 at 10 11 11 AM" src="https://user-images.githubusercontent.com/93935560/233531754-36b11138-23d1-4a2c-8725-7346ff0cdcd8.png">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

Fixes #5770
