### PR TITLE
Fix chrome ResizeObserver error

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
@@ -41,7 +41,7 @@ export type InputEvents = {
 export class Input extends EventEmitter<InputEvents> {
   private readonly canvas: HTMLCanvasElement;
   public canvasSize: THREE.Vector2;
-  private resizeObserver: ResizeObserver;
+  private readonly resizeObserver: ResizeObserver;
   private startClientPos?: THREE.Vector2;
   private cursorCoords = new THREE.Vector2();
   private worldSpaceCursorCoords?: THREE.Vector3;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import EventEmitter from "eventemitter3";
+import { debounce } from "lodash";
 import * as THREE from "three";
 import { Key } from "ts-key-enum";
 
@@ -57,7 +58,10 @@ export class Input extends EventEmitter<InputEvents> {
     this.canvas = canvas;
     this.canvasSize = new THREE.Vector2(canvas.width, canvas.height);
 
-    this.resizeObserver = new ResizeObserver(this.onResize);
+    // Calling the resize observer too often causes Chrome to throw an exception
+    // so we debounce it.
+    const debouncedOnResize = debounce(this.onResize);
+    this.resizeObserver = new ResizeObserver(debouncedOnResize);
     this.resizeObserver.observe(parentEl);
 
     canvas.addEventListener("mousedown", this.onMouseDown);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Calling the `ResizeObserver` more often than chrome can service it results in a ResizeObserver loop limit exceeded, so we need to debounce it.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
