### PR TITLE
Remember playback loop setting across refreshes

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
@@ -29,6 +29,7 @@ import {
 } from "@foxglove/studio-base/players/types";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import { makeMockEvents } from "@foxglove/studio-base/test/mocks/makeMockEvents";
 
 import PlaybackControls from "./index";
@@ -109,11 +110,13 @@ export default {
   decorators: [
     (Wrapped: StoryFn): JSX.Element => (
       <AppConfigurationContext.Provider value={mockAppConfiguration}>
-        <MockCurrentLayoutProvider>
-          <EventsProvider>
-            <Wrapped />
-          </EventsProvider>
-        </MockCurrentLayoutProvider>
+        <WorkspaceContextProvider>
+          <MockCurrentLayoutProvider>
+            <EventsProvider>
+              <Wrapped />
+            </EventsProvider>
+          </MockCurrentLayoutProvider>
+        </WorkspaceContextProvider>
       </AppConfigurationContext.Provider>
     ),
   ],

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -43,6 +43,11 @@ import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpee
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { EventsStore, useEvents } from "@foxglove/studio-base/context/EventsContext";
+import {
+  useWorkspaceActions,
+  useWorkspaceStore,
+  WorkspaceContextStore,
+} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { Player, PlayerPresence } from "@foxglove/studio-base/players/types";
 
@@ -70,6 +75,7 @@ const useStyles = makeStyles()((theme) => ({
 
 const selectPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
 const selectEventsSupported = (store: EventsStore) => store.eventsSupported;
+const selectPlaybackRepeat = (store: WorkspaceContextStore) => store.playbackControls.repeat;
 
 export default function PlaybackControls(props: {
   play: NonNullable<Player["startPlayback"]>;
@@ -84,14 +90,18 @@ export default function PlaybackControls(props: {
   const [enableNewTopNav = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
 
   const { classes } = useStyles();
-  const [repeat, setRepeat] = useState(false);
+  const repeat = useWorkspaceStore(selectPlaybackRepeat);
   const [createEventDialogOpen, setCreateEventDialogOpen] = useState(false);
   const { currentUser } = useCurrentUser();
   const eventsSupported = useEvents(selectEventsSupported);
 
+  const {
+    playbackControlActions: { setRepeat },
+  } = useWorkspaceActions();
+
   const toggleRepeat = useCallback(() => {
     setRepeat((old) => !old);
-  }, []);
+  }, [setRepeat]);
 
   const togglePlayPause = useCallback(() => {
     if (isPlaying) {

--- a/packages/studio-base/src/context/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/WorkspaceContext.ts
@@ -45,6 +45,9 @@ export type WorkspaceContextStore = DeepReadonly<{
   leftSidebarSize: undefined | number;
   rightSidebarItem: undefined | RightSidebarItemKey;
   rightSidebarSize: undefined | number;
+  playbackControls: {
+    repeat: boolean;
+  };
   prefsDialogState: {
     initialTab: undefined | AppSettingsTab;
     open: boolean;
@@ -86,6 +89,9 @@ export type WorkspaceActions = {
   openAccountSettings: () => void;
   openPanelSettings: () => void;
   openLayoutBrowser: () => void;
+  playbackControlActions: {
+    setRepeat: Dispatch<SetStateAction<boolean>>;
+  };
   prefsDialogActions: {
     close: () => void;
     open: (initialTab?: AppSettingsTab) => void;
@@ -151,6 +157,15 @@ export function useWorkspaceActions(): WorkspaceActions {
           : set({ sidebarItem: "panel-settings" }),
 
       openLayoutBrowser: () => set({ sidebarItem: "layouts" }),
+
+      playbackControlActions: {
+        setRepeat: (setter: SetStateAction<boolean>) => {
+          set((oldValue) => {
+            const repeat = setterValue(setter, oldValue.playbackControls.repeat);
+            return { playbackControls: { repeat } };
+          });
+        },
+      },
 
       prefsDialogActions: {
         close: () => set({ prefsDialogState: { open: false, initialTab: undefined } }),

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -26,6 +26,9 @@ function createWorkspaceContextStore(
           leftSidebarItem: "panel-settings",
           leftSidebarOpen: true,
           leftSidebarSize: undefined,
+          playbackControls: {
+            repeat: false,
+          },
           prefsDialogState: {
             initialTab: undefined,
             open: false,


### PR DESCRIPTION
**User-Facing Changes**
Persist playback controls loop control state across refreshes.

**Description**
Move the playback controls repeat/loop state into the workspace store, where it is automatically persisted.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
