### PR TITLE
Fix i18n initialization in benchmark

### DIFF
--- a/benchmark/src/Root.tsx
+++ b/benchmark/src/Root.tsx
@@ -2,15 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
-import {
-  App,
-  AppSetting,
-  IDataSourceFactory,
-  LaunchPreferenceValue,
-  initI18n,
-} from "@foxglove/studio-base";
+import { App, IDataSourceFactory, AppSetting, LaunchPreferenceValue } from "@foxglove/studio-base";
 
 import { McapLocalBenchmarkDataSourceFactory, SyntheticDataSourceFactory } from "./dataSources";
 import { LAYOUTS } from "./layouts";
@@ -20,14 +14,9 @@ import {
   TransformPlayer,
   TransformPreloadingPlayer,
 } from "./players";
-import { MemoryAppConfiguration, PredefinedLayoutStorage } from "./services";
+import { PredefinedLayoutStorage, MemoryAppConfiguration } from "./services";
 
 export function Root(): JSX.Element {
-  useEffect(() => {
-    // Need to init i18n stuff here because we skip the normal startup code path.
-    initI18n().catch(console.error);
-  }, []);
-
   const [appConfiguration] = useState(
     () =>
       new MemoryAppConfiguration({

--- a/benchmark/src/Root.tsx
+++ b/benchmark/src/Root.tsx
@@ -2,9 +2,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { App, IDataSourceFactory, AppSetting, LaunchPreferenceValue } from "@foxglove/studio-base";
+import {
+  App,
+  AppSetting,
+  IDataSourceFactory,
+  LaunchPreferenceValue,
+  initI18n,
+} from "@foxglove/studio-base";
 
 import { McapLocalBenchmarkDataSourceFactory, SyntheticDataSourceFactory } from "./dataSources";
 import { LAYOUTS } from "./layouts";
@@ -14,9 +20,14 @@ import {
   TransformPlayer,
   TransformPreloadingPlayer,
 } from "./players";
-import { PredefinedLayoutStorage, MemoryAppConfiguration } from "./services";
+import { MemoryAppConfiguration, PredefinedLayoutStorage } from "./services";
 
 export function Root(): JSX.Element {
+  useEffect(() => {
+    // Need to init i18n stuff here because we skip the normal startup code path.
+    initI18n().catch(console.error);
+  }, []);
+
   const [appConfiguration] = useState(
     () =>
       new MemoryAppConfiguration({

--- a/benchmark/src/index.tsx
+++ b/benchmark/src/index.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import ReactDOM from "react-dom";
 
 import Logger from "@foxglove/log";
+import { initI18n } from "@foxglove/studio-base";
 
 const log = Logger.getLogger(__filename);
 log.debug("initializing");
@@ -32,6 +33,8 @@ async function main() {
   overwriteFetch();
   // consider moving waitForFonts into App to display an app loading screen
   await waitForFonts();
+
+  await initI18n();
 
   const { Root } = await import("./Root");
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix the benchmark by stabilizing the `useTranslation` hook. The i18n library requires a setup call which we were skipping in the benchmark setup. This caused `useTranslation` to return a new, _not-ready_ value on every render.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
