### PR TITLE
Update target to es2022

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
     "paths": {

--- a/benchmark/src/tsconfig.json
+++ b/benchmark/src/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
     "paths": {

--- a/desktop/preload/tsconfig.json
+++ b/desktop/preload/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "rootDir": "../../",
     "noEmit": true,
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "es2022"],
     "useUnknownInCatchVariables": false
   }
 }

--- a/desktop/quicklook/tsconfig.json
+++ b/desktop/quicklook/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "../../",
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020"]
+    "lib": ["dom", "dom.iterable", "es2022"]
   }
 }

--- a/desktop/renderer/tsconfig.json
+++ b/desktop/renderer/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react-jsx",
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "paths": {
       "@foxglove/studio-base/*": ["../../packages/studio-base/src/*"]
     }

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["*.ts", "common/**/*", "integration-test/**/*.ts", "../package.json"],
   "compilerOptions": {
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "es2022"],
     "module": "commonjs",
     "noEmit": true
   }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/preset-typescript": "7.21.4",
     "@foxglove/eslint-plugin": "0.21.2",
     "@foxglove/eslint-plugin-studio": "workspace:*",
-    "@foxglove/tsconfig": "1.1.0",
+    "@foxglove/tsconfig": "2.0.0",
     "@octokit/rest": "19.0.7",
     "@storybook/addon-actions": "7.0.4",
     "@storybook/addon-essentials": "7.0.4",

--- a/packages/den/tsconfig.json
+++ b/packages/den/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "./dist",
-    "lib": ["DOM", "ES2020"]
+    "lib": ["DOM", "es2022"]
   }
 }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "lib": ["dom", "es2020"]
+    "lib": ["dom", "es2022"]
   }
 }

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/lib.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/lib.ts
@@ -127,6 +127,11 @@ const libDts = new Map(
   }),
 );
 
+/**
+ * Each top-level type definition file (such as lib.es2022.d.ts) is a lightweight wrapper that
+ * references other .d.ts files. To produce the complete definitions we manually resolve these
+ * references.
+ */
 function resolveReferences(originalSrc: string): string {
   return originalSrc.replace(/\/\/\/ <reference lib="(.+)" \/>/g, (_, name: string) => {
     const src = libDts.get(name);

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/lib.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/lib.ts
@@ -47,6 +47,19 @@ import lib_es2020_promise from "typescript/lib/lib.es2020.promise.d.ts?raw";
 import lib_es2020_sharedmemory from "typescript/lib/lib.es2020.sharedmemory.d.ts?raw";
 import lib_es2020_string from "typescript/lib/lib.es2020.string.d.ts?raw";
 import lib_es2020_symbol_wellknown from "typescript/lib/lib.es2020.symbol.wellknown.d.ts?raw";
+import lib_es2021_dts from "typescript/lib/lib.es2021.d.ts?raw";
+import lib_es2021_intl from "typescript/lib/lib.es2021.intl.d.ts?raw";
+import lib_es2021_promise from "typescript/lib/lib.es2021.promise.d.ts?raw";
+import lib_es2021_string from "typescript/lib/lib.es2021.string.d.ts?raw";
+import lib_es2021_weakref from "typescript/lib/lib.es2021.weakref.d.ts?raw";
+import lib_es2022_array from "typescript/lib/lib.es2022.array.d.ts?raw";
+import lib_es2022_dts from "typescript/lib/lib.es2022.d.ts?raw";
+import lib_es2022_error from "typescript/lib/lib.es2022.error.d.ts?raw";
+import lib_es2022_intl from "typescript/lib/lib.es2022.intl.d.ts?raw";
+import lib_es2022_object from "typescript/lib/lib.es2022.object.d.ts?raw";
+import lib_es2022_regexp from "typescript/lib/lib.es2022.regexp.d.ts?raw";
+import lib_es2022_sharedmemory from "typescript/lib/lib.es2022.sharedmemory.d.ts?raw";
+import lib_es2022_string from "typescript/lib/lib.es2022.string.d.ts?raw";
 import lib_es5_dts from "typescript/lib/lib.es5.d.ts?raw";
 
 export const lib_filename = "lib.d.ts";
@@ -66,6 +79,9 @@ const libDts = new Map(
     es2017: lib_es2017_dts,
     es2018: lib_es2018_dts,
     es2019: lib_es2019_dts,
+    es2020: lib_es2020_dts,
+    es2021: lib_es2021_dts,
+    es2022: lib_es2022_dts,
 
     "es2015.core": lib_es2015_core,
     "es2015.collection": lib_es2015_collection,
@@ -97,6 +113,17 @@ const libDts = new Map(
     "es2020.string": lib_es2020_string,
     "es2020.symbol.wellknown": lib_es2020_symbol_wellknown,
     "es2020.intl": lib_es2020_intl,
+    "es2021.intl": lib_es2021_intl,
+    "es2021.promise": lib_es2021_promise,
+    "es2021.string": lib_es2021_string,
+    "es2021.weakref": lib_es2021_weakref,
+    "es2022.array": lib_es2022_array,
+    "es2022.error": lib_es2022_error,
+    "es2022.intl": lib_es2022_intl,
+    "es2022.object": lib_es2022_object,
+    "es2022.regexp": lib_es2022_regexp,
+    "es2022.sharedmemory": lib_es2022_sharedmemory,
+    "es2022.string": lib_es2022_string,
   }),
 );
 
@@ -115,5 +142,5 @@ function resolveReferences(originalSrc: string): string {
   });
 }
 
-const resolvedDts = resolveReferences(lib_es2020_dts);
+const resolvedDts = resolveReferences(lib_es2022_dts);
 export const lib_dts = `${resolvedDts}\n\n${lib_logger}`;

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/utils.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/utils.ts
@@ -89,6 +89,6 @@ function flattenDiagnosticMessageText(
 // https://www.typescriptlang.org/docs/handbook/compiler-options.html
 export const baseCompilerOptions = {
   strict: true,
-  target: ts.ScriptTarget.ES2020,
+  target: ts.ScriptTarget.ES2022,
   module: ts.ModuleKind.CommonJS,
 };

--- a/packages/studio-base/tsconfig.json
+++ b/packages/studio-base/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "baseUrl": "./src",
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "declarationMap": false,
     "sourceMap": false,
     "paths": {

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -218,7 +218,7 @@ export function makeConfig(
 
       minimizer: [
         new ESBuildMinifyPlugin({
-          target: "es2020",
+          target: "es2022",
           minify: true,
         }),
       ],

--- a/packages/studio-desktop/src/preload/tsconfig.json
+++ b/packages/studio-desktop/src/preload/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "rootDir": "../../",
     "noEmit": true,
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "es2022"],
     "useUnknownInCatchVariables": false
   }
 }

--- a/packages/studio-desktop/src/quicklook/tsconfig.json
+++ b/packages/studio-desktop/src/quicklook/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "../../",
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020"]
+    "lib": ["dom", "dom.iterable", "es2022"]
   }
 }

--- a/packages/studio-desktop/src/renderer/tsconfig.json
+++ b/packages/studio-desktop/src/renderer/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react-jsx",
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "paths": {
       "@foxglove/studio-base/*": ["../../../studio-base/src/*"]
     }

--- a/packages/studio-desktop/src/webpackMainConfig.ts
+++ b/packages/studio-desktop/src/webpackMainConfig.ts
@@ -70,7 +70,7 @@ export const webpackMainConfig =
         removeAvailableModules: true,
         minimizer: [
           new ESBuildMinifyPlugin({
-            target: "es2020",
+            target: "es2022",
             minify: true,
           }),
         ],

--- a/packages/studio-desktop/src/webpackPreloadConfig.ts
+++ b/packages/studio-desktop/src/webpackPreloadConfig.ts
@@ -53,7 +53,7 @@ export const webpackPreloadConfig =
         removeAvailableModules: true,
         minimizer: [
           new ESBuildMinifyPlugin({
-            target: "es2020",
+            target: "es2022",
             minify: true,
           }),
         ],

--- a/packages/studio-desktop/src/webpackQuicklookConfig.ts
+++ b/packages/studio-desktop/src/webpackQuicklookConfig.ts
@@ -67,7 +67,7 @@ export const webpackQuicklookConfig =
         removeAvailableModules: true,
         minimizer: [
           new ESBuildMinifyPlugin({
-            target: "es2020",
+            target: "es2022",
             minify: true,
           }),
         ],

--- a/packages/studio-desktop/src/webpackRendererConfig.ts
+++ b/packages/studio-desktop/src/webpackRendererConfig.ts
@@ -52,7 +52,7 @@ export const webpackRendererConfig =
         removeAvailableModules: true,
         minimizer: [
           new ESBuildMinifyPlugin({
-            target: "es2020",
+            target: "es2022",
             minify: true,
           }),
         ],

--- a/packages/studio-desktop/tsconfig.json
+++ b/packages/studio-desktop/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["**/*"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "noEmit": true,
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,

--- a/packages/studio-web/tsconfig.json
+++ b/packages/studio-web/tsconfig.json
@@ -3,7 +3,7 @@
   "include": ["**/*"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "noEmit": true,
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -7,6 +7,6 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "noEmit": true,
-    "lib": ["es2020"]
+    "lib": ["es2022"]
   }
 }

--- a/packages/typescript-transformers/tsconfig.json
+++ b/packages/typescript-transformers/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "lib": ["dom", "es2020"]
+    "lib": ["dom", "es2022"]
   }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -20,7 +20,7 @@
   "include": ["**/*", "**/.storybook/**/*"],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": ["dom", "dom.iterable", "es2022"],
     "paths": {
       "@foxglove/studio-base/*": ["./packages/studio-base/src/*"]
     }

--- a/web/src/tsconfig.json
+++ b/web/src/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "es2022", "webworker"],
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,10 +2783,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/tsconfig@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@foxglove/tsconfig@npm:1.1.0"
-  checksum: 18070d0f6a5bf540c04c5cab3c8ba223aee259d2ca628c78616d37c84e3d193069842901944019caf49fced1943b97cb6772aa7d9b6fe246842ce146386b85a6
+"@foxglove/tsconfig@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@foxglove/tsconfig@npm:2.0.0"
+  checksum: c6d581ff4e6e75e4c22d909a51f377b6f9b296805234009ca6950f86c76bbefc5f4f95eef92e24ede3134cb411c0d08e73d484a30c448d8e248414dcc98c1400
   languageName: node
   linkType: hard
 
@@ -11599,7 +11599,7 @@ __metadata:
     "@babel/preset-typescript": 7.21.4
     "@foxglove/eslint-plugin": 0.21.2
     "@foxglove/eslint-plugin-studio": "workspace:*"
-    "@foxglove/tsconfig": 1.1.0
+    "@foxglove/tsconfig": 2.0.0
     "@octokit/rest": 19.0.7
     "@storybook/addon-actions": 7.0.4
     "@storybook/addon-essentials": 7.0.4


### PR DESCRIPTION
**User-Facing Changes**
Updated TypeScript type definitions available in the User Scripts panel.

**Description**
Upgrade whole build to use `es2022` target, which enables native support for [private fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) rather than transpiling them into WeakMaps.
Relates to FG-3018