### PR TITLE
dependabot-fix: run constraints --fix before install

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -53,13 +53,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
 
+      - run: yarn constraints --fix
       - run: yarn install --mode skip-build
         env:
           # yarn runs in immutable mode "by default" in CI -- turning this off requires an
           # undocumented env var
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
-      - run: yarn constraints --fix
       - run: yarn dedupe
 
       - name: Commit yarn.lock


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Follow-up to #5817 / #5820 
Not sure yet why the `yarn dedupe` wasn't working properly (https://github.com/foxglove/studio/pull/5816/commits/c25412c30e3e301fbf96027439f4353cf54e3a85). Trying to run install _after_ constraints --fix.