### PR TITLE
Improve panel settings text input interactivity

### DIFF
--- a/packages/studio-base/src/components/CurrentLayoutSyncAdapter.tsx
+++ b/packages/studio-base/src/components/CurrentLayoutSyncAdapter.tsx
@@ -3,48 +3,59 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { enqueueSnackbar } from "notistack";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useAsync, useMountedState } from "react-use";
 import { useDebounce } from "use-debounce";
 
 import Logger from "@foxglove/log";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
-import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import {
+  LayoutState,
+  useCurrentLayoutSelector,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 
+type UpdatedLayout = NonNullable<LayoutState["selectedLayout"]>;
+
 const log = Logger.getLogger(__filename);
 
+const EMPTY_UNSAVED_LAYOUTS: Record<LayoutID, UpdatedLayout> = {};
 const SAVE_INTERVAL_MS = 1000;
 
-type UpdateLayoutParams = { id: LayoutID; data: LayoutData };
+const selectCurrentLayout = (state: LayoutState) => state.selectedLayout;
 
 /**
- * Handles batching up layout updates and writing them asynchronously to the
- * layout manager so that they don't interfere with things like react event
- * handlers on settings inputs.
- *
- * @returns a function that can be called to persist an updated layout
+ * Observes changes in the current layout and asynchronously pushes them to the
+ * layout manager.
  */
-export function useLayoutPersistence(): (updatedLayout: UpdateLayoutParams) => void {
-  const persistLayout = useCallback((updatedLayout: UpdateLayoutParams) => {
-    setUnsavedLayouts((old) => ({ ...old, [updatedLayout.id]: updatedLayout }));
-  }, []);
+export function CurrentLayoutSyncAdapter(): ReactNull {
+  const selectedLayout = useCurrentLayoutSelector(selectCurrentLayout);
 
   const layoutManager = useLayoutManager();
 
-  const [unsavedLayouts, setUnsavedLayouts] = useState<Record<LayoutID, UpdateLayoutParams>>({});
+  const [unsavedLayouts, setUnsavedLayouts] = useState(EMPTY_UNSAVED_LAYOUTS);
 
   const isMounted = useMountedState();
 
   const analytics = useAnalytics();
+
+  useEffect(() => {
+    if (selectedLayout?.edited === true) {
+      setUnsavedLayouts((old) => ({
+        ...old,
+        [selectedLayout.id]: selectedLayout,
+      }));
+    }
+  }, [selectedLayout]);
 
   const [debouncedUnsavedLayouts, debouncedUnsavedLayoutActions] = useDebounce(
     unsavedLayouts,
     SAVE_INTERVAL_MS,
   );
 
+  // Flush and clear pending updates on unmount.
   useEffect(() => {
     return () => {
       debouncedUnsavedLayoutActions.flush();
@@ -52,9 +63,11 @@ export function useLayoutPersistence(): (updatedLayout: UpdateLayoutParams) => v
     };
   }, [debouncedUnsavedLayoutActions]);
 
+  // Write all pending layout updates to the layout manager. Under the hood this
+  // uses useEffect so it happens after DOM updates are complete.
   useAsync(async () => {
     const unsavedLayoutsSnapshot = { ...debouncedUnsavedLayouts };
-    setUnsavedLayouts({});
+    setUnsavedLayouts(EMPTY_UNSAVED_LAYOUTS);
 
     for (const params of Object.values(unsavedLayoutsSnapshot)) {
       try {
@@ -73,5 +86,5 @@ export function useLayoutPersistence(): (updatedLayout: UpdateLayoutParams) => v
     void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
   }, [analytics, debouncedUnsavedLayouts, isMounted, layoutManager]);
 
-  return persistLayout;
+  return ReactNull;
 }

--- a/packages/studio-base/src/components/SyncAdapters.tsx
+++ b/packages/studio-base/src/components/SyncAdapters.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { CurrentLayoutSyncAdapter } from "@foxglove/studio-base/components/CurrentLayoutSyncAdapter";
 import { URLStateSyncAdapter } from "@foxglove/studio-base/components/URLStateSyncAdapter";
 import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 
@@ -11,6 +12,7 @@ export function SyncAdapters(): JSX.Element {
     <>
       {...syncAdapters}
       <URLStateSyncAdapter />
+      <CurrentLayoutSyncAdapter />
     </>
   );
 }

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -37,6 +37,7 @@ export type LayoutState = Readonly<{
         loading?: boolean;
         data: LayoutData | undefined;
         name?: string;
+        edited?: boolean;
       }
     | undefined;
 }>;

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -8,6 +8,7 @@ import { SnackbarProvider } from "notistack";
 import { useEffect } from "react";
 
 import { Condvar } from "@foxglove/den/async";
+import { CurrentLayoutSyncAdapter } from "@foxglove/studio-base/components/CurrentLayoutSyncAdapter";
 import {
   CurrentLayoutActions,
   LayoutState,
@@ -101,7 +102,10 @@ function renderTest({
           <SnackbarProvider>
             <LayoutManagerContext.Provider value={mockLayoutManager}>
               <UserProfileStorageContext.Provider value={mockUserProfile}>
-                <CurrentLayoutProvider>{children}</CurrentLayoutProvider>
+                <CurrentLayoutProvider>
+                  {children}
+                  <CurrentLayoutSyncAdapter />
+                </CurrentLayoutProvider>
               </UserProfileStorageContext.Provider>
             </LayoutManagerContext.Provider>
           </SnackbarProvider>
@@ -288,13 +292,21 @@ describe("CurrentLayoutProvider", () => {
     };
 
     expect(mockLayoutManager.updateLayout.mock.calls).toEqual([
-      [{ id: "example", data: newState, name: "Test layout" }],
+      [{ id: "example", data: newState, name: "Test layout", edited: true, loading: false }],
     ]);
     expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
       { selectedLayout: undefined },
       { selectedLayout: { loading: true, id: "example", data: undefined } },
       { selectedLayout: { loading: false, id: "example", data: TEST_LAYOUT, name: "Test layout" } },
-      { selectedLayout: { loading: false, id: "example", data: newState, name: "Test layout" } },
+      {
+        selectedLayout: {
+          loading: false,
+          id: "example",
+          data: newState,
+          name: "Test layout",
+          edited: true,
+        },
+      },
     ]);
     (console.warn as jest.Mock).mockClear();
   });

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -8,7 +8,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getNodeAtPath } from "react-mosaic-component";
 import { useAsync, useAsyncFn, useMountedState } from "react-use";
 import shallowequal from "shallowequal";
-import { useDebounce } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
 
 import { useShallowMemo } from "@foxglove/hooks";
@@ -28,7 +27,6 @@ import {
   EndDragPayload,
   MoveTabPayload,
   PanelsActions,
-  LayoutData,
   SaveConfigsPayload,
   SplitPanelPayload,
   StartDragPayload,
@@ -41,15 +39,14 @@ import panelsReducer from "@foxglove/studio-base/providers/CurrentLayoutProvider
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutManagerEventTypes } from "@foxglove/studio-base/services/ILayoutManager";
 import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
-import { PanelConfig, UserNodes, PlaybackConfig } from "@foxglove/studio-base/types/panels";
+import { PanelConfig, PlaybackConfig, UserNodes } from "@foxglove/studio-base/types/panels";
 import { windowAppURLState } from "@foxglove/studio-base/util/appURLState";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import { IncompatibleLayoutVersionAlert } from "./IncompatibleLayoutVersionAlert";
+import { useLayoutPersistence } from "./useLayoutPersistence";
 
 const log = Logger.getLogger(__filename);
-
-const SAVE_INTERVAL_MS = 1000;
 
 export const MAX_SUPPORTED_LAYOUT_VERSION = 1;
 
@@ -115,6 +112,8 @@ export default function CurrentLayoutProvider({
     [],
   );
 
+  const persistLayout = useLayoutPersistence();
+
   const [, setSelectedLayoutId] = useAsyncFn(
     async (
       id: LayoutID | undefined,
@@ -169,9 +168,6 @@ export default function CurrentLayoutProvider({
     [enqueueSnackbar, isMounted, layoutManager, setLayoutState, setUserProfile],
   );
 
-  type UpdateLayoutParams = { id: LayoutID; data: LayoutData };
-  const [unsavedLayouts, setUnsavedLayouts] = useState<Record<LayoutID, UpdateLayoutParams>>({});
-
   // When the user performs an action, we immediately setLayoutState to update the UI. Saving back
   // to the LayoutManager is debounced.
   const performAction = useCallback(
@@ -202,37 +198,10 @@ export default function CurrentLayoutProvider({
       // debounced params are set in the proper order, we invoke setLayoutState at the end.
       setLayoutState({ selectedLayout: { ...newLayout, loading: false } });
 
-      // store the layout for saving
-      setUnsavedLayouts((old) => ({ ...old, [newLayout.id]: newLayout }));
+      persistLayout(newLayout);
     },
-    [setLayoutState],
+    [persistLayout, setLayoutState],
   );
-
-  const [debouncedUnsavedLayouts, debouncedUnsavedLayoutActions] = useDebounce(
-    unsavedLayouts,
-    SAVE_INTERVAL_MS,
-  );
-
-  useAsync(async () => {
-    const unsavedLayoutsSnapshot = { ...debouncedUnsavedLayouts };
-    setUnsavedLayouts({});
-
-    for (const params of Object.values(unsavedLayoutsSnapshot)) {
-      try {
-        await layoutManager.updateLayout(params);
-      } catch (error) {
-        log.error(error);
-        if (isMounted()) {
-          enqueueSnackbar(`Your changes could not be saved. ${error.toString()}`, {
-            variant: "error",
-            key: "CurrentLayoutProvider.throttledSave",
-          });
-        }
-      }
-    }
-
-    await analytics.logEvent(AppEvent.LAYOUT_UPDATE);
-  }, [analytics, debouncedUnsavedLayouts, enqueueSnackbar, isMounted, layoutManager]);
 
   // Changes to the layout storage from external user actions (such as resetting a layout to a
   // previous saved state) need to trigger setLayoutState.
@@ -256,10 +225,8 @@ export default function CurrentLayoutProvider({
     layoutManager.on("change", listener);
     return () => {
       layoutManager.off("change", listener);
-      debouncedUnsavedLayoutActions.flush();
-      debouncedUnsavedLayoutActions.cancel();
     };
-  }, [debouncedUnsavedLayoutActions, layoutManager, setLayoutState]);
+  }, [layoutManager, setLayoutState]);
 
   // Make sure our layout still exists after changes. If not deselect it.
   useEffect(() => {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getNodeAtPath } from "react-mosaic-component";
 import { useAsync, useAsyncFn, useMountedState } from "react-use";
 import shallowequal from "shallowequal";
+import { useDebounce } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
 
 import { useShallowMemo } from "@foxglove/hooks";
@@ -173,7 +174,6 @@ export default function CurrentLayoutProvider({
 
   // When the user performs an action, we immediately setLayoutState to update the UI. Saving back
   // to the LayoutManager is debounced.
-  const debouncedSaveTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
   const performAction = useCallback(
     (action: PanelsActions) => {
       if (
@@ -200,32 +200,36 @@ export default function CurrentLayoutProvider({
       // store the layout for saving
       unsavedLayoutsRef.current.set(newLayout.id, newLayout);
 
-      debouncedSaveTimeout.current ??= setTimeout(() => {
-        const layoutsToSave = [...unsavedLayoutsRef.current.values()];
-        unsavedLayoutsRef.current.clear();
-
-        debouncedSaveTimeout.current = undefined;
-        for (const params of layoutsToSave) {
-          void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
-          layoutManager.updateLayout(params).catch((error) => {
-            log.error(error);
-            if (isMounted()) {
-              enqueueSnackbar(`Your changes could not be saved. ${error.toString()}`, {
-                variant: "error",
-                key: "CurrentLayoutProvider.throttledSave",
-              });
-            }
-          });
-        }
-      }, SAVE_INTERVAL_MS);
-
       // Some actions like CHANGE_PANEL_LAYOUT will cause further downstream effects to update panel
       // configs (i.e. set default configs). These result in calls to performAction. To ensure the
       // debounced params are set in the proper order, we invoke setLayoutState at the end.
       setLayoutState({ selectedLayout: { ...newLayout, loading: false } });
     },
-    [analytics, enqueueSnackbar, isMounted, layoutManager, setLayoutState],
+    [setLayoutState],
   );
+
+  const [debouncedLayoutState, debouncedLayoutStateActions] = useDebounce(
+    layoutState,
+    SAVE_INTERVAL_MS,
+  );
+
+  useEffect(() => {
+    const layoutsToSave = [...unsavedLayoutsRef.current.values()];
+    unsavedLayoutsRef.current.clear();
+
+    for (const params of layoutsToSave) {
+      void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+      layoutManager.updateLayout(params).catch((error) => {
+        log.error(error);
+        if (isMounted()) {
+          enqueueSnackbar(`Your changes could not be saved. ${error.toString()}`, {
+            variant: "error",
+            key: "CurrentLayoutProvider.throttledSave",
+          });
+        }
+      });
+    }
+  }, [analytics, enqueueSnackbar, isMounted, layoutManager, debouncedLayoutState]);
 
   // Changes to the layout storage from external user actions (such as resetting a layout to a
   // previous saved state) need to trigger setLayoutState.
@@ -249,11 +253,9 @@ export default function CurrentLayoutProvider({
     layoutManager.on("change", listener);
     return () => {
       layoutManager.off("change", listener);
-      if (debouncedSaveTimeout.current) {
-        clearTimeout(debouncedSaveTimeout.current);
-      }
+      debouncedLayoutStateActions.cancel();
     };
-  }, [layoutManager, setLayoutState]);
+  }, [debouncedLayoutStateActions, layoutManager, setLayoutState]);
 
   // Make sure our layout still exists after changes. If not deselect it.
   useEffect(() => {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -44,15 +44,14 @@ import { windowAppURLState } from "@foxglove/studio-base/util/appURLState";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import { IncompatibleLayoutVersionAlert } from "./IncompatibleLayoutVersionAlert";
-import { useLayoutPersistence } from "./useLayoutPersistence";
 
 const log = Logger.getLogger(__filename);
 
 export const MAX_SUPPORTED_LAYOUT_VERSION = 1;
 
 /**
- * Concrete implementation of CurrentLayoutContext.Provider which handles automatically saving and
- * restoring the current layout from LayoutStorage.
+ * Concrete implementation of CurrentLayoutContext.Provider which handles
+ * automatically restoring the current layout from LayoutStorage.
  */
 export default function CurrentLayoutProvider({
   children,
@@ -112,8 +111,6 @@ export default function CurrentLayoutProvider({
     [],
   );
 
-  const persistLayout = useLayoutPersistence();
-
   const [, setSelectedLayoutId] = useAsyncFn(
     async (
       id: LayoutID | undefined,
@@ -168,8 +165,6 @@ export default function CurrentLayoutProvider({
     [enqueueSnackbar, isMounted, layoutManager, setLayoutState, setUserProfile],
   );
 
-  // When the user performs an action, we immediately setLayoutState to update the UI. Saving back
-  // to the LayoutManager is debounced.
   const performAction = useCallback(
     (action: PanelsActions) => {
       if (
@@ -181,26 +176,24 @@ export default function CurrentLayoutProvider({
       const oldData = layoutStateRef.current.selectedLayout.data;
       const newData = panelsReducer(oldData, action);
 
-      // the panel state did not change, so no need to perform layout state updates or layout manager updates
+      // The panel state did not change, so no need to perform layout state
+      // updates or layout manager updates.
       if (isEqual(oldData, newData)) {
         log.warn("Panel action resulted in identical config:", action);
         return;
       }
 
-      const newLayout = {
-        id: layoutStateRef.current.selectedLayout.id,
-        data: newData,
-        name: layoutStateRef.current.selectedLayout.name,
-      };
-
-      // Some actions like CHANGE_PANEL_LAYOUT will cause further downstream effects to update panel
-      // configs (i.e. set default configs). These result in calls to performAction. To ensure the
-      // debounced params are set in the proper order, we invoke setLayoutState at the end.
-      setLayoutState({ selectedLayout: { ...newLayout, loading: false } });
-
-      persistLayout(newLayout);
+      setLayoutState({
+        selectedLayout: {
+          id: layoutStateRef.current.selectedLayout.id,
+          data: newData,
+          loading: false,
+          name: layoutStateRef.current.selectedLayout.name,
+          edited: true,
+        },
+      });
     },
-    [persistLayout, setLayoutState],
+    [setLayoutState],
   );
 
   // Changes to the layout storage from external user actions (such as resetting a layout to a

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -170,7 +170,7 @@ export default function CurrentLayoutProvider({
   );
 
   type UpdateLayoutParams = { id: LayoutID; data: LayoutData };
-  const unsavedLayoutsRef = useRef(new Map<LayoutID, UpdateLayoutParams>());
+  const [unsavedLayouts, setUnsavedLayouts] = useState<Record<LayoutID, UpdateLayoutParams>>({});
 
   // When the user performs an action, we immediately setLayoutState to update the UI. Saving back
   // to the LayoutManager is debounced.
@@ -197,29 +197,30 @@ export default function CurrentLayoutProvider({
         name: layoutStateRef.current.selectedLayout.name,
       };
 
-      // store the layout for saving
-      unsavedLayoutsRef.current.set(newLayout.id, newLayout);
-
       // Some actions like CHANGE_PANEL_LAYOUT will cause further downstream effects to update panel
       // configs (i.e. set default configs). These result in calls to performAction. To ensure the
       // debounced params are set in the proper order, we invoke setLayoutState at the end.
       setLayoutState({ selectedLayout: { ...newLayout, loading: false } });
+
+      // store the layout for saving
+      setUnsavedLayouts((old) => ({ ...old, [newLayout.id]: newLayout }));
     },
     [setLayoutState],
   );
 
-  const [debouncedLayoutState, debouncedLayoutStateActions] = useDebounce(
-    layoutState,
+  const [debouncedUnsavedLayouts, debouncedUnsavedLayoutActions] = useDebounce(
+    unsavedLayouts,
     SAVE_INTERVAL_MS,
   );
 
-  useEffect(() => {
-    const layoutsToSave = [...unsavedLayoutsRef.current.values()];
-    unsavedLayoutsRef.current.clear();
+  useAsync(async () => {
+    const unsavedLayoutsSnapshot = { ...debouncedUnsavedLayouts };
+    setUnsavedLayouts({});
 
-    for (const params of layoutsToSave) {
-      void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
-      layoutManager.updateLayout(params).catch((error) => {
+    for (const params of Object.values(unsavedLayoutsSnapshot)) {
+      try {
+        await layoutManager.updateLayout(params);
+      } catch (error) {
         log.error(error);
         if (isMounted()) {
           enqueueSnackbar(`Your changes could not be saved. ${error.toString()}`, {
@@ -227,9 +228,11 @@ export default function CurrentLayoutProvider({
             key: "CurrentLayoutProvider.throttledSave",
           });
         }
-      });
+      }
     }
-  }, [analytics, enqueueSnackbar, isMounted, layoutManager, debouncedLayoutState]);
+
+    await analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+  }, [analytics, debouncedUnsavedLayouts, enqueueSnackbar, isMounted, layoutManager]);
 
   // Changes to the layout storage from external user actions (such as resetting a layout to a
   // previous saved state) need to trigger setLayoutState.
@@ -253,9 +256,10 @@ export default function CurrentLayoutProvider({
     layoutManager.on("change", listener);
     return () => {
       layoutManager.off("change", listener);
-      debouncedLayoutStateActions.cancel();
+      debouncedUnsavedLayoutActions.flush();
+      debouncedUnsavedLayoutActions.cancel();
     };
-  }, [debouncedLayoutStateActions, layoutManager, setLayoutState]);
+  }, [debouncedUnsavedLayoutActions, layoutManager, setLayoutState]);
 
   // Make sure our layout still exists after changes. If not deselect it.
   useEffect(() => {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/useLayoutPersistence.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/useLayoutPersistence.ts
@@ -70,7 +70,7 @@ export function useLayoutPersistence(): (updatedLayout: UpdateLayoutParams) => v
       }
     }
 
-    await analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+    void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
   }, [analytics, debouncedUnsavedLayouts, isMounted, layoutManager]);
 
   return persistLayout;

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/useLayoutPersistence.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/useLayoutPersistence.ts
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { enqueueSnackbar } from "notistack";
+import { useCallback, useEffect, useState } from "react";
+import { useAsync, useMountedState } from "react-use";
+import { useDebounce } from "use-debounce";
+
+import Logger from "@foxglove/log";
+import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
+
+const log = Logger.getLogger(__filename);
+
+const SAVE_INTERVAL_MS = 1000;
+
+type UpdateLayoutParams = { id: LayoutID; data: LayoutData };
+
+/**
+ * Handles batching up layout updates and writing them asynchronously to the
+ * layout manager so that they don't interfere with things like react event
+ * handlers on settings inputs.
+ *
+ * @returns a function that can be called to persist an updated layout
+ */
+export function useLayoutPersistence(): (updatedLayout: UpdateLayoutParams) => void {
+  const persistLayout = useCallback((updatedLayout: UpdateLayoutParams) => {
+    setUnsavedLayouts((old) => ({ ...old, [updatedLayout.id]: updatedLayout }));
+  }, []);
+
+  const layoutManager = useLayoutManager();
+
+  const [unsavedLayouts, setUnsavedLayouts] = useState<Record<LayoutID, UpdateLayoutParams>>({});
+
+  const isMounted = useMountedState();
+
+  const analytics = useAnalytics();
+
+  const [debouncedUnsavedLayouts, debouncedUnsavedLayoutActions] = useDebounce(
+    unsavedLayouts,
+    SAVE_INTERVAL_MS,
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedUnsavedLayoutActions.flush();
+      debouncedUnsavedLayoutActions.cancel();
+    };
+  }, [debouncedUnsavedLayoutActions]);
+
+  useAsync(async () => {
+    const unsavedLayoutsSnapshot = { ...debouncedUnsavedLayouts };
+    setUnsavedLayouts({});
+
+    for (const params of Object.values(unsavedLayoutsSnapshot)) {
+      try {
+        await layoutManager.updateLayout(params);
+      } catch (error) {
+        log.error(error);
+        if (isMounted()) {
+          enqueueSnackbar(`Your changes could not be saved. ${error.toString()}`, {
+            variant: "error",
+            key: "CurrentLayoutProvider.throttledSave",
+          });
+        }
+      }
+    }
+
+    await analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+  }, [analytics, debouncedUnsavedLayouts, isMounted, layoutManager]);
+
+  return persistLayout;
+}


### PR DESCRIPTION
**User-Facing Changes**
Improve panel settings text inputs interactivity.

**Description**
Our existing layout persistence code debounces layout writes but the debounce can happen at arbitrary times during the react event cycle and seems to occasionally delay the update enough to lose keystrokes. 

This moves the updates into a separate sync adapter that pushes the updates downstream to always happen in a `useEffect` (in the form of a `useAsync`) seems to fix it.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
