### PR TITLE
Fix incorrect placeholder text for `PosesInFrame` Axis Scale

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -37,7 +37,6 @@ import {
   fieldLineWidth,
   fieldScaleVec3,
   fieldSize,
-  PRECISION_DISTANCE,
 } from "../settings";
 import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
 import { makePose, Pose } from "../transforms";
@@ -173,7 +172,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
       };
       switch (displayType) {
         case "axis":
-          fields["axisScale"] = fieldSize("Scale", axisScale, PRECISION_DISTANCE);
+          fields["axisScale"] = fieldSize("Scale", axisScale, DEFAULT_AXIS_SCALE);
           break;
         case "arrow":
           fields["arrowScale"] = fieldScaleVec3("Scale", arrowScale);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix incorrect placeholder text for `PosesInFrame` Axis Scale

**Description**
Incorrect variable used for axis scale


<!-- link relevant GitHub issues -->
Fixes: #5755
FG-2911

<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
