### PR TITLE
Check version stamp on layouts and warn if too new

### DIFF
--- a/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
@@ -10,6 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
+
 import { MosaicNode, MosaicPath } from "react-mosaic-component";
 
 import { VariableValue } from "@foxglove/studio";
@@ -24,14 +25,19 @@ import {
 } from "@foxglove/studio-base/types/panels";
 
 export type LayoutData = {
-  layout?: MosaicNode<string>;
   // We store config for each panel in an object keyed by the panel id.
   configById: SavedProps;
+  layout?: MosaicNode<string>;
+  globalVariables: GlobalVariables;
+  playbackConfig: PlaybackConfig;
+  userNodes: UserNodes;
   /** @deprecated renamed to configById */
   savedProps?: SavedProps;
-  globalVariables: GlobalVariables;
-  userNodes: UserNodes;
-  playbackConfig: PlaybackConfig;
+  /**
+   * Optional version number. Set this to prevent older incompatible versions of
+   * studio trying to load and possibly corrupt the layout.
+   */
+  version?: number;
 };
 
 export type ConfigsPayload = {

--- a/packages/studio-base/src/i18n/en/incompatibleLayoutVersion.ts
+++ b/packages/studio-base/src/i18n/en/incompatibleLayoutVersion.ts
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const incompatibleLayoutVersion = {
+  title: "Incompatible layout version",
+  text: "This layout was created with a newer version of Foxglove Studio. Please update to the latest version at ",
+};

--- a/packages/studio-base/src/i18n/en/incompatibleLayoutVersion.ts
+++ b/packages/studio-base/src/i18n/en/incompatibleLayoutVersion.ts
@@ -4,5 +4,8 @@
 
 export const incompatibleLayoutVersion = {
   title: "Incompatible layout version",
-  text: "This layout was created with a newer version of Foxglove Studio. Please update to the latest version at ",
+  desktopText:
+    "This layout was created with a newer version of Foxglove Studio. Please update to the latest version at ",
+  webText:
+    "This layout was created with a newer version of Foxglove Studio. Please refresh your browser.",
 };

--- a/packages/studio-base/src/i18n/en/index.ts
+++ b/packages/studio-base/src/i18n/en/index.ts
@@ -2,15 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export * from "./appSettings";
-export * from "./general";
-export * from "./panels";
 export * from "./addPanel";
-export * from "./panelSettings";
-export * from "./log";
-export * from "./plot";
+export * from "./appBar";
+export * from "./appSettings";
 export * from "./dataSourceInfo";
+export * from "./general";
+export * from "./incompatibleLayoutVersion";
+export * from "./log";
 export * from "./openDialog";
+export * from "./panels";
+export * from "./panelSettings";
+export * from "./plot";
 export * from "./settingsEditor";
 export * from "./threeDee";
-export * from "./appBar";

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.stories.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.stories.tsx
@@ -15,3 +15,9 @@ export default {
 };
 
 export const Default: StoryObj = {};
+
+export const Desktop: StoryObj = {
+  args: {
+    isDesktop: true,
+  },
+};

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.stories.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.stories.tsx
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryObj } from "@storybook/react";
+
+import { IncompatibleLayoutVersionAlert } from "./IncompatibleLayoutVersionAlert";
+
+export default {
+  title: "components/IncompatibleLayoutVersionAlert",
+  component: IncompatibleLayoutVersionAlert,
+  parameters: {
+    colorScheme: "light",
+  },
+};
+
+export const Default: StoryObj = {};

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.tsx
@@ -13,25 +13,33 @@ import {
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
 type Props = {
+  isDesktop?: boolean;
   onClose: () => void;
 };
 
 export function IncompatibleLayoutVersionAlert(props: Props): JSX.Element {
-  const { onClose } = props;
+  const { isDesktop, onClose } = props;
   const { t } = useTranslation("incompatibleLayoutVersion");
+
+  const showDesktopText = isDesktop ?? isDesktopApp();
 
   return (
     <Dialog open onClose={onClose}>
       <DialogTitle>{t("title")}</DialogTitle>
       <DialogContent>
-        <DialogContentText>
-          {t("text")}
-          <Link target="_blank" href="https://foxglove.dev/download">
-            https://foxglove.dev/download
-          </Link>
-          .
-        </DialogContentText>
+        {showDesktopText && (
+          <DialogContentText>
+            {t("desktopText")}
+            <Link target="_blank" href="https://foxglove.dev/download">
+              https://foxglove.dev/download
+            </Link>
+            .
+          </DialogContentText>
+        )}
+        {!showDesktopText && <DialogContentText>{t("webText")}</DialogContentText>}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} variant="contained">

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.tsx
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Link,
+} from "@mui/material";
+
+type Props = {
+  onClose: () => void;
+};
+
+export function IncompatibleLayoutVersionAlert(props: Props): JSX.Element {
+  const { onClose } = props;
+
+  return (
+    <Dialog open onClose={onClose}>
+      <DialogTitle>Incompatible layout version</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This layout was created with a newer version of Foxglove Studio. Please update to the{" "}
+          <Link target="_blank" href="https://foxglove.dev/download">
+            latest version
+          </Link>
+          .
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/IncompatibleLayoutVersionAlert.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   Link,
 } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 type Props = {
   onClose: () => void;
@@ -18,15 +19,16 @@ type Props = {
 
 export function IncompatibleLayoutVersionAlert(props: Props): JSX.Element {
   const { onClose } = props;
+  const { t } = useTranslation("incompatibleLayoutVersion");
 
   return (
     <Dialog open onClose={onClose}>
-      <DialogTitle>Incompatible layout version</DialogTitle>
+      <DialogTitle>{t("title")}</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          This layout was created with a newer version of Foxglove Studio. Please update to the{" "}
+          {t("text")}
           <Link target="_blank" href="https://foxglove.dev/download">
-            latest version
+            https://foxglove.dev/download
           </Link>
           .
         </DialogContentText>

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -153,6 +153,43 @@ describe("CurrentLayoutProvider", () => {
     (console.warn as jest.Mock).mockClear();
   });
 
+  it("refuses to load an incompatible layout", async () => {
+    const expectedState: LayoutData = {
+      configById: { "Foo!bar": { setting: 1 } },
+      globalVariables: { var: "hello" },
+      layout: "Foo!bar",
+      playbackConfig: { speed: 0.1 },
+      userNodes: { node1: { name: "node", sourceCode: "node()" } },
+      version: 2,
+    };
+
+    const condvar = new Condvar();
+    const layoutStorageGetCalledWait = condvar.wait();
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      condvar.notifyAll();
+      return {
+        id: "example",
+        name: "Example layout",
+        baseline: { updatedAt: new Date(10).toISOString(), data: expectedState },
+      };
+    });
+
+    const mockUserProfile = makeMockUserProfile();
+    mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: "example" });
+
+    const { all } = renderTest({ mockLayoutManager, mockUserProfile });
+    await act(async () => await layoutStorageGetCalledWait);
+
+    expect(mockLayoutManager.getLayout.mock.calls).toEqual([["example"], ["example"]]);
+    expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
+      { selectedLayout: undefined },
+      { selectedLayout: { loading: true, id: "example", data: undefined } },
+      { selectedLayout: undefined },
+    ]);
+    (console.warn as jest.Mock).mockClear();
+  });
+
   it("saves new layout selection into UserProfile", async () => {
     const mockLayoutManager = makeMockLayoutManager();
     const newLayout: Partial<LayoutData> = {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -20,7 +20,9 @@ import {
   UserProfileStorage,
   UserProfileStorageContext,
 } from "@foxglove/studio-base/context/UserProfileStorageContext";
-import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider";
+import CurrentLayoutProvider, {
+  MAX_SUPPORTED_LAYOUT_VERSION,
+} from "@foxglove/studio-base/providers/CurrentLayoutProvider";
 import { ILayoutManager } from "@foxglove/studio-base/services/ILayoutManager";
 import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 
@@ -160,7 +162,7 @@ describe("CurrentLayoutProvider", () => {
       layout: "Foo!bar",
       playbackConfig: { speed: 0.1 },
       userNodes: { node1: { name: "node", sourceCode: "node()" } },
-      version: 2,
+      version: MAX_SUPPORTED_LAYOUT_VERSION + 1,
     };
 
     const condvar = new Condvar();

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -50,7 +50,7 @@ const log = Logger.getLogger(__filename);
 
 const SAVE_INTERVAL_MS = 1000;
 
-const MAX_SUPPORTED_LAYOUT_VERSION = 1;
+export const MAX_SUPPORTED_LAYOUT_VERSION = 1;
 
 /**
  * Concrete implementation of CurrentLayoutContext.Provider which handles automatically saving and

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import { difference, isEqual } from "lodash";
 import { useSnackbar } from "notistack";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -43,9 +44,13 @@ import { PanelConfig, UserNodes, PlaybackConfig } from "@foxglove/studio-base/ty
 import { windowAppURLState } from "@foxglove/studio-base/util/appURLState";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
+import { IncompatibleLayoutVersionAlert } from "./IncompatibleLayoutVersionAlert";
+
 const log = Logger.getLogger(__filename);
 
 const SAVE_INTERVAL_MS = 1000;
+
+const MAX_SUPPORTED_LAYOUT_VERSION = 1;
 
 /**
  * Concrete implementation of CurrentLayoutContext.Provider which handles automatically saving and
@@ -74,6 +79,7 @@ export default function CurrentLayoutProvider({
     selectedLayout: undefined,
   });
   const layoutStateRef = useRef(layoutState);
+  const [incompatibleLayoutVersionError, setIncompatibleLayoutVersionError] = useState(false);
   const setLayoutState = useCallback((newState: LayoutState) => {
     setLayoutStateInternal(newState);
 
@@ -120,9 +126,16 @@ export default function CurrentLayoutProvider({
       try {
         setLayoutState({ selectedLayout: { id, loading: true, data: undefined } });
         const layout = await layoutManager.getLayout(id);
+        const layoutVersion = layout?.baseline.data.version;
+        if (layoutVersion != undefined && layoutVersion > MAX_SUPPORTED_LAYOUT_VERSION) {
+          setIncompatibleLayoutVersionError(true);
+          setLayoutState({ selectedLayout: undefined });
+          return;
+        }
         if (!isMounted()) {
           return;
         }
+        setIncompatibleLayoutVersionError(false);
         if (layout == undefined) {
           setLayoutState({ selectedLayout: undefined });
         } else {
@@ -148,6 +161,7 @@ export default function CurrentLayoutProvider({
         enqueueSnackbar(`The layout could not be loaded. ${error.toString()}`, {
           variant: "error",
         });
+        setIncompatibleLayoutVersionError(false);
         setLayoutState({ selectedLayout: undefined });
       }
     },
@@ -368,5 +382,12 @@ export default function CurrentLayoutProvider({
     actions,
   });
 
-  return <CurrentLayoutContext.Provider value={value}>{children}</CurrentLayoutContext.Provider>;
+  return (
+    <CurrentLayoutContext.Provider value={value}>
+      {children}
+      {incompatibleLayoutVersionError && (
+        <IncompatibleLayoutVersionAlert onClose={() => setIncompatibleLayoutVersionError(false)} />
+      )}
+    </CurrentLayoutContext.Provider>
+  );
 }


### PR DESCRIPTION
**User-Facing Changes**
Warn users when trying to load layouts created by newer, incompatible versions of studio.

**Description**
Adds a version stamp to layout data and displays an error dialog to the user when trying to load a layout created by a more recent version of studio with an incompatible layout format.

We want to deploy this now so that by the time we do need to do incompatible migrations to layouts the versions of the app in use will handle it gracefully.

<img width="645" alt="Screenshot 2023-04-26 at 11 07 36 AM" src="https://user-images.githubusercontent.com/93935560/234467800-50ba63cb-ab83-48ef-9a3e-cd1395effaa3.png">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
