### PR TITLE
Update picker to work in image mode

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
@@ -8,6 +8,7 @@
 // - jfaust https://github.com/jfaust
 
 import * as THREE from "three";
+import { assert } from "ts-essentials";
 
 import type { Renderable } from "./Renderable";
 
@@ -29,6 +30,9 @@ export type PickedRenderable = {
 
 export type PickerOptions = {
   debug?: boolean;
+  // Disable the setting of the projection matrix in the picking pass.
+  // Use this if you are setting the projection matrix of the camera manually
+  disableSetViewOffset?: boolean;
 };
 
 /**
@@ -87,26 +91,17 @@ export class Picker {
   ): number {
     // Use the onAfterRender callback to actually render geometry for picking
     this.emptyScene.onAfterRender = this.handleAfterRender;
+
     this.camera = camera;
-    const hw = (PIXEL_WIDTH / 2) | 0;
-    const pixelRatio = this.gl.getPixelRatio();
-    const xi = Math.max(0, x * pixelRatio - hw);
-    const yi = Math.max(0, y * pixelRatio - hw);
-    const w = this.gl.domElement.width;
-    const h = this.gl.domElement.height;
-    // Set the projection matrix to only look at the pixels we are interested in
-    camera.setViewOffset(w, h, xi, yi, PIXEL_WIDTH, PIXEL_WIDTH);
-    const currRenderTarget = this.gl.getRenderTarget();
-    const currAlpha = this.gl.getClearAlpha();
-    this.gl.getClearColor(this.currClearColor);
-    this.gl.setRenderTarget(this.pickingTarget);
-    this.gl.setClearColor(WHITE_COLOR, 1);
-    this.gl.clear();
+    const { xInView, yInView } = this.#updateCameraForPickAndGetPickCoordsInView(x, y, options);
+
+    const originalRenderState = this.#prepareGLRendererForPick();
+
     this.gl.render(this.emptyScene, camera);
-    this.gl.readRenderTargetPixels(this.pickingTarget, hw, hw, 1, 1, this.pixelBuffer);
-    this.gl.setRenderTarget(currRenderTarget);
-    this.gl.setClearColor(this.currClearColor, currAlpha);
-    camera.clearViewOffset();
+    this.gl.readRenderTargetPixels(this.pickingTarget, xInView, yInView, 1, 1, this.pixelBuffer);
+
+    this.#cleanUpGlRendererFromPick(originalRenderState);
+    this.#resetCameraFromPick(options);
 
     const val =
       (this.pixelBuffer[0]! << 24) +
@@ -129,27 +124,17 @@ export class Picker {
     options: PickerOptions = {},
   ): number {
     this.emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
-    this.camera = camera;
 
-    const hw = (PIXEL_WIDTH / 2) | 0;
-    const pixelRatio = this.gl.getPixelRatio();
-    const xi = Math.max(0, x * pixelRatio - hw);
-    const yi = Math.max(0, y * pixelRatio - hw);
-    const w = this.gl.domElement.width;
-    const h = this.gl.domElement.height;
-    // Set the projection matrix to only look at the pixels we are interested in
-    camera.setViewOffset(w, h, xi, yi, PIXEL_WIDTH, PIXEL_WIDTH);
-    const currRenderTarget = this.gl.getRenderTarget();
-    const currAlpha = this.gl.getClearAlpha();
-    this.gl.getClearColor(this.currClearColor);
-    this.gl.setRenderTarget(this.pickingTarget);
-    this.gl.setClearColor(WHITE_COLOR, 1);
-    this.gl.clear();
-    this.gl.render(this.emptyScene, camera);
-    this.gl.readRenderTargetPixels(this.pickingTarget, hw, hw, 1, 1, this.pixelBuffer);
-    this.gl.setRenderTarget(currRenderTarget);
-    this.gl.setClearColor(this.currClearColor, currAlpha);
-    camera.clearViewOffset();
+    this.camera = camera;
+    const { xInView, yInView } = this.#updateCameraForPickAndGetPickCoordsInView(x, y, options);
+
+    const originalRenderState = this.#prepareGLRendererForPick();
+
+    this.gl.render(this.emptyScene, this.camera);
+    this.gl.readRenderTargetPixels(this.pickingTarget, xInView, yInView, 1, 1, this.pixelBuffer);
+
+    this.#cleanUpGlRendererFromPick(originalRenderState);
+    this.#resetCameraFromPick(options);
 
     if (options.debug === true) {
       this.pickInstanceDebugRender(camera, renderable);
@@ -161,6 +146,65 @@ export class Picker {
       (this.pixelBuffer[2]! << 8) +
       this.pixelBuffer[3]!
     );
+  }
+
+  #updateCameraForPickAndGetPickCoordsInView(
+    x: number,
+    y: number,
+    options: PickerOptions,
+  ): { xInView: number; yInView: number } {
+    assert(this.camera, "camera must be set before updating for pick");
+    const w = this.gl.domElement.width;
+    const h = this.gl.domElement.height;
+    const pixelRatio = this.gl.getPixelRatio();
+
+    if (options.disableSetViewOffset !== true) {
+      const hw = PIXEL_WIDTH / 2;
+      const xi = Math.max(0, x * pixelRatio - hw);
+      const yi = Math.max(0, y * pixelRatio - hw);
+      // Set the projection matrix to only look at the pixels we are interested in
+      this.camera.setViewOffset(w, h, xi, yi, PIXEL_WIDTH, PIXEL_WIDTH);
+      return { xInView: hw, yInView: hw };
+    } else {
+      if (this.pickingTarget.width !== w || this.pickingTarget.height !== h) {
+        this.pickingTarget.setSize(w, h);
+      }
+      const xi = Math.max(0, x * pixelRatio);
+      // Flip y coordinate to match WebGL coordinate system
+      const yi = Math.max(0, h - y * pixelRatio);
+      return { xInView: xi, yInView: yi };
+    }
+  }
+
+  #resetCameraFromPick(options: PickerOptions): void {
+    assert(this.camera, "camera must be set before resetting from pick");
+    if (options.disableSetViewOffset !== true) {
+      this.camera.clearViewOffset();
+    }
+  }
+
+  #prepareGLRendererForPick(): {
+    originalRenderTarget: THREE.WebGLRenderTarget | ReactNull;
+    originalAlpha: number;
+  } {
+    const originalRenderTarget = this.gl.getRenderTarget();
+    const originalAlpha = this.gl.getClearAlpha();
+    this.gl.getClearColor(this.currClearColor);
+    this.gl.setRenderTarget(this.pickingTarget);
+    this.gl.setClearColor(WHITE_COLOR, 1);
+    this.gl.clear();
+    return { originalRenderTarget, originalAlpha };
+  }
+
+  #cleanUpGlRendererFromPick({
+    originalRenderTarget,
+    originalAlpha,
+  }: {
+    originalRenderTarget: THREE.WebGLRenderTarget | ReactNull;
+    originalAlpha: number;
+  }): void {
+    this.gl.setRenderTarget(originalRenderTarget);
+    this.gl.setClearColor(this.currClearColor, originalAlpha);
   }
 
   public pickDebugRender(camera: THREE.OrthographicCamera | THREE.PerspectiveCamera): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
@@ -30,8 +30,10 @@ export type PickedRenderable = {
 
 export type PickerOptions = {
   debug?: boolean;
-  // Disable the setting of the projection matrix in the picking pass.
-  // Use this if you are setting the projection matrix of the camera manually
+  /**
+   * Disable the setting of the projection matrix in the picking pass.
+   * Use this if you are setting the projection matrix of the camera manually elsewhere
+   */
   disableSetViewOffset?: boolean;
 };
 
@@ -159,7 +161,7 @@ export class Picker {
     const pixelRatio = this.gl.getPixelRatio();
 
     if (options.disableSetViewOffset !== true) {
-      const hw = PIXEL_WIDTH / 2;
+      const hw = (PIXEL_WIDTH / 2) | 0;
       const xi = Math.max(0, x * pixelRatio - hw);
       const yi = Math.max(0, y * pixelRatio - hw);
       // Set the projection matrix to only look at the pixels we are interested in

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1136,7 +1136,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       cursorCoords.x,
       cursorCoords.y,
       this.cameraHandler.getActiveCamera(),
-      { debug: this.debugPicking },
+      { debug: this.debugPicking, disableSetViewOffset: this.interfaceMode === "image" },
     );
     if (objectId === -1) {
       return undefined;
@@ -1169,7 +1169,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
         cursorCoords.y,
         this.cameraHandler.getActiveCamera(),
         renderable,
-        { debug: this.debugPicking },
+        { debug: this.debugPicking, disableSetViewOffset: this.interfaceMode === "image" },
       );
       instanceIndex = instanceIndex === -1 ? undefined : instanceIndex;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -26,7 +26,7 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/projections";
 import { makePose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 
-import { ImageModelCamera } from "./ImageModelCamera";
+import { ImageModeCamera } from "./ImageModeCamera";
 import { ImageAnnotations } from "./annotations/ImageAnnotations";
 import type { IRenderer } from "../../IRenderer";
 import { PartialMessageEvent, SceneExtension } from "../../SceneExtension";
@@ -58,7 +58,7 @@ const IMAGE_TOPIC_DIFFERENT_FRAME = "IMAGE_TOPIC_DIFFERENT_FRAME";
 const CAMERA_MODEL = "CameraModel";
 
 export class ImageMode extends SceneExtension<ImageRenderable> implements ICameraHandler {
-  private camera: ImageModelCamera;
+  private camera: ImageModeCamera;
   private cameraModel:
     | {
         model: PinholeCameraModel;
@@ -76,7 +76,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   public constructor(renderer: IRenderer, canvasSize: THREE.Vector2) {
     super("foxglove.ImageMode", renderer);
 
-    this.camera = new ImageModelCamera();
+    this.camera = new ImageModeCamera();
 
     /**
      * By default the camera is facing down the -y axis with -z up,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -371,6 +371,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
       renderable.userData.cameraInfo = this.cameraModel.info;
       renderable.setCameraModel(this.cameraModel.model);
     }
+    renderable.name = topic;
     renderable.setImage(image);
     renderable.update();
   };
@@ -389,7 +390,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     // we don't have settings for images yet
     const userSettings = { ...IMAGE_RENDERABLE_DEFAULT_SETTINGS };
 
-    renderable = new ImageRenderable("imageMode-image", this.renderer, {
+    renderable = new ImageRenderable(topicName, this.renderer, {
       receiveTime,
       messageTime: image ? toNanoSec("header" in image ? image.header.stamp : image.timestamp) : 0n,
       frameId: this.renderer.normalizeFrameId(frameId),

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -11,7 +11,7 @@ const DEFAULT_CAMERA_STATE = {
   far: 1000,
 };
 
-export class ImageModelCamera extends THREE.PerspectiveCamera {
+export class ImageModeCamera extends THREE.PerspectiveCamera {
   private model?: PinholeCameraModel;
   private cameraState = DEFAULT_CAMERA_STATE;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
+import { screen, userEvent } from "@storybook/testing-library";
 
 import { CompressedImage, RawImage } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
@@ -334,6 +335,20 @@ export const ImageModeResizeHandled: StoryObj = {
     await delay(30);
     parentEl.style.width = "50%";
     canvas.dispatchEvent(new Event("resize"));
+    await delay(30);
+  },
+};
+
+export const ImageModePick: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  parameters: { colorScheme: "light" },
+
+  play: async () => {
+    const canvas = document.querySelector("canvas")!;
+    const inspectObjects = screen.getByRole("button", { name: /inspect objects/i });
+    userEvent.click(inspectObjects);
+    await delay(30);
+    userEvent.click(canvas, { clientX: 500, clientY: 500 });
     await delay(30);
   },
 };


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- none (experimental)

**Description**
Now in ImageMode the picker does not use a smaller render target. Previously the `setViewOffset` was overriding the manually set projection matrix in the camera. The setViewOffset was used to render only a subset of the view from the camera, which improves performance when picking. From observation it looks like this makes the `clickHandler` in ImageMode take two times longer when picking (up from ~50ms to ~100ms) for the same size windows. I think this difference will be negligible for users when picking. If it does become a problem we can revisit the manual setting of the camera matrix in image mode. 


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
FG-3096
<!-- add relevant metric tracking for experimental / new features -->
