### PR TITLE
Skip current frame accumulation for non-timebased plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
@@ -74,12 +74,16 @@ export function usePlotPanelMessageData(params: Params): Immutable<PlotDataByPat
   const restore = useCallback(
     (previous?: TaggedPlotDataByPath): TaggedPlotDataByPath => {
       if (!previous) {
-        return { tag: new Date().toISOString(), data: {} };
+        // If we're showing single frames, we don't want to accumulate chunks of messages
+        // across multiple frames, so we put everything into a single restore tag and
+        // each new frame replaces the old one.
+        const tag = showSingleCurrentMessage ? "single" : new Date().toISOString();
+        return { tag, data: {} };
       }
 
       return { ...previous, data: pick(previous.data, allPaths) };
     },
-    [allPaths],
+    [allPaths, showSingleCurrentMessage],
   );
 
   const addMessages = useCallback(


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with timeline scrubbing on non-time based plots.

**Description**
The logic we added in #5694 for accumulating currentFrame messages across multiple `useMessageReducer` invocations assumes we're plotting by time. For plots with non-time based X axes this is incorrect and we should only include the most recent frame in the data.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
Fixes #5862
