### PR TITLE
Rework the TimeBasedChart downsample code organization

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { RpcScales } from "@foxglove/studio-base/components/Chart/types";
+
+import { downsampleScatter, downsampleTimeseries } from "./downsample";
+import { ChartDatasets } from "./types";
+
+type DatasetBounds = {
+  x: { min?: number; max?: number };
+  y: { min?: number; max?: number };
+};
+
+type UpdateParams = {
+  datasets?: ChartDatasets;
+  width?: number;
+  height?: number;
+  datasetBounds?: DatasetBounds;
+  scales?: RpcScales;
+};
+
+/**
+ * Track a dataset, some bounds, a viewport to perform downsampling
+ */
+export class Downsampler {
+  #datasets: ChartDatasets = [];
+  #width = 0;
+  #height = 0;
+  #datasetBounds?: DatasetBounds;
+  #scales?: RpcScales;
+
+  /**
+   * Update internal state for next downsample
+   */
+  public update(opt: UpdateParams): void {
+    this.#datasets = opt.datasets ?? this.#datasets;
+    this.#width = opt.width ?? this.#width;
+    this.#height = opt.height ?? this.#height;
+    this.#datasetBounds = opt.datasetBounds ?? this.#datasetBounds;
+    this.#scales = opt.scales ?? this.#scales;
+  }
+
+  /**
+   * Perform a downsample with the latest state
+   */
+  public downsample(): ChartDatasets {
+    const currentScales = this.#scales;
+    let bounds:
+      | {
+          width: number;
+          height: number;
+          x: { min: number; max: number };
+          y: { min: number; max: number };
+        }
+      | undefined = undefined;
+    if (currentScales?.x && currentScales.y) {
+      bounds = {
+        width: this.#width,
+        height: this.#height,
+        x: {
+          min: currentScales.x.min,
+          max: currentScales.x.max,
+        },
+        y: {
+          min: currentScales.y.min,
+          max: currentScales.y.max,
+        },
+      };
+    }
+
+    const dataBounds = this.#datasetBounds;
+    if (!dataBounds) {
+      return [];
+    }
+
+    // if we don't have bounds (chart not initialized) but do have dataset bounds
+    // then setup bounds as x/y min/max around the dataset values rather than the scales
+    if (
+      !bounds &&
+      dataBounds.x.min != undefined &&
+      dataBounds.x.max != undefined &&
+      dataBounds.y.min != undefined &&
+      dataBounds.y.max != undefined
+    ) {
+      bounds = {
+        width: this.#width,
+        height: this.#height,
+        x: {
+          min: dataBounds.x.min,
+          max: dataBounds.x.max,
+        },
+        y: {
+          min: dataBounds.y.min,
+          max: dataBounds.y.max,
+        },
+      };
+    }
+
+    // If we don't have any bounds - we assume the component is still initializing and return no data
+    // The other alternative is to return the full data set. This leads to rendering full fidelity data
+    // which causes render pauses and blank charts for large data sets.
+    if (!bounds) {
+      return [];
+    }
+
+    return this.#datasets.map((dataset) => {
+      if (!bounds) {
+        return dataset;
+      }
+
+      const downsampled =
+        dataset.showLine !== true
+          ? downsampleScatter(dataset, bounds)
+          : downsampleTimeseries(dataset, bounds);
+      // NaN item values create gaps in the line
+      const undefinedToNanData = downsampled.data.map((item) => {
+        if (item == undefined || isNaN(item.x) || isNaN(item.y)) {
+          return { x: NaN, y: NaN, value: NaN };
+        }
+        return item;
+      });
+
+      return { ...downsampled, data: undefinedToNanData };
+    });
+  }
+}

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -24,7 +24,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useMountedState, useThrottle } from "react-use";
+import { useMountedState } from "react-use";
 import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
@@ -45,12 +45,12 @@ import {
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+import { Downsampler } from "./Downsampler";
 import HoverBar from "./HoverBar";
 import TimeBasedChartTooltipContent, {
   TimeBasedChartTooltipData,
 } from "./TimeBasedChartTooltipContent";
 import { VerticalBarWrapper } from "./VerticalBarWrapper";
-import { downsampleScatter, downsampleTimeseries } from "./downsample";
 
 const log = Logger.getLogger(__filename);
 
@@ -231,20 +231,6 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
     return { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
   }, [datasets]);
-
-  // avoid re-doing a downsample on every scale change, instead mark the downsample as dirty
-  // with a debounce and if downsampling hasn't happened after some time, trigger a downsample via state update
-  const [invalidateDownsample, setDownsampleFlush] = useState({});
-  const queueDownsampleInvalidate = useDebouncedCallback(
-    () => {
-      setDownsampleFlush({});
-    },
-    100,
-    // maxWait equal to debounce timeout makes the debounce act like a throttle
-    // Without a maxWait - invocations of the debounced invalidate reset the countdown
-    // resulting in no invalidation when scales are constantly changing (playback)
-    { leading: false, maxWait: 100 },
-  );
 
   const onResetZoom = () => {
     setHasUserPannedOrZoomed(false);
@@ -524,89 +510,6 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     } as ScaleOptions;
   }, [datasetBounds.y, yAxes, theme.palette]);
 
-  const datasetBoundsRef = useRef(datasetBounds);
-  datasetBoundsRef.current = datasetBounds;
-  const downsampleDatasets = useCallback(
-    (fullDatasets: typeof datasets) => {
-      const currentScales = currentScalesRef.current;
-      let bounds:
-        | {
-            width: number;
-            height: number;
-            x: { min: number; max: number };
-            y: { min: number; max: number };
-          }
-        | undefined = undefined;
-      if (currentScales?.x && currentScales.y) {
-        bounds = {
-          width,
-          height,
-          x: {
-            min: currentScales.x.min,
-            max: currentScales.x.max,
-          },
-          y: {
-            min: currentScales.y.min,
-            max: currentScales.y.max,
-          },
-        };
-      }
-
-      const dataBounds = datasetBoundsRef.current;
-
-      // if we don't have bounds (chart not initialized) but do have dataset bounds
-      // then setup bounds as x/y min/max around the dataset values rather than the scales
-      if (
-        !bounds &&
-        dataBounds.x.min != undefined &&
-        dataBounds.x.max != undefined &&
-        dataBounds.y.min != undefined &&
-        dataBounds.y.max != undefined
-      ) {
-        bounds = {
-          width,
-          height,
-          x: {
-            min: dataBounds.x.min,
-            max: dataBounds.x.max,
-          },
-          y: {
-            min: dataBounds.y.min,
-            max: dataBounds.y.max,
-          },
-        };
-      }
-
-      // If we don't have any bounds - we assume the component is still initializing and return no data
-      // The other alternative is to return the full data set. This leads to rendering full fidelity data
-      // which causes render pauses and blank charts for large data sets.
-      if (!bounds) {
-        return [];
-      }
-
-      return fullDatasets.map((dataset) => {
-        if (!bounds) {
-          return dataset;
-        }
-
-        const downsampled =
-          dataset.showLine !== true
-            ? downsampleScatter(dataset, bounds)
-            : downsampleTimeseries(dataset, bounds);
-        // NaN item values create gaps in the line
-        const undefinedToNanData = downsampled.data.map((item) => {
-          if (item == undefined || isNaN(item.x) || isNaN(item.y)) {
-            return { x: NaN, y: NaN, value: NaN };
-          }
-          return item;
-        });
-
-        return { ...downsampled, data: undefinedToNanData };
-      });
-    },
-    [height, width],
-  );
-
   // remove datasets that should be hidden
   const visibleDatasets = useMemo(() => {
     return filterMap(datasets, (dataset) => {
@@ -618,16 +521,45 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     });
   }, [datasets, linesToHide]);
 
-  // throttle the downsampleDatasets callback since this is an input to the downsampledData memo
-  // avoids doing a downsample if the callback changes rapidly
-  const throttledDownsample = useThrottle(() => downsampleDatasets, 100);
+  const [downsampler] = useState(() => new Downsampler());
 
-  // downsample datasets with the latest downsample function
-  const downsampledDatasets = useMemo(() => {
-    void invalidateDownsample;
+  // Set the initial downsampler state and downsample the initial dataset
+  const [downsampledDatasets, setDownsampledDatasets] = useState<typeof datasets>(() => {
+    downsampler.update({
+      width,
+      height,
+      datasets: visibleDatasets,
+      datasetBounds,
+      scales: currentScalesRef.current,
+    });
+    return downsampler.downsample();
+  });
 
-    return throttledDownsample(visibleDatasets);
-  }, [invalidateDownsample, throttledDownsample, visibleDatasets]);
+  // Stable callback to run the downsampler and update the latest copy of the downsampled datasets
+  const applyDownsample = useCallback(() => {
+    setDownsampledDatasets(downsampler.downsample());
+  }, [downsampler]);
+
+  // Debounce calls to invoke the downsampler
+  const queueDownsample = useDebouncedCallback(
+    applyDownsample,
+    100,
+    // maxWait equal to debounce timeout makes the debounce act like a throttle
+    // Without a maxWait - invocations of the debounced invalidate reset the countdown
+    // resulting in no invalidation when scales are constantly changing (playback)
+    { leading: false, maxWait: 100 },
+  );
+
+  // Updates to the dataset bounds do not need to queue a downsample
+  useEffect(() => {
+    downsampler.update({ datasetBounds });
+  }, [datasetBounds, downsampler]);
+
+  // Updates to the viewport or the datasets queue a downsample
+  useEffect(() => {
+    downsampler.update({ width, height, datasets: visibleDatasets });
+    queueDownsample();
+  }, [downsampler, height, width, visibleDatasets, queueDownsample]);
 
   const downsampledData = useMemo(() => {
     return {
@@ -689,7 +621,9 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
       currentScalesRef.current = scales;
 
-      queueDownsampleInvalidate();
+      // Scales updated which indicates we might need to adjust the downsampling
+      downsampler.update({ scales });
+      queueDownsample();
 
       // chart indicated we got a scales update, we may need to update global bounds
       if (!isSynced || !scales.x) {
@@ -752,7 +686,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         };
       });
     },
-    [componentId, isMounted, isSynced, queueDownsampleInvalidate, setGlobalBounds],
+    [componentId, downsampler, isMounted, isSynced, queueDownsample, setGlobalBounds],
   );
 
   useEffect(() => log.debug(`<TimeBasedChart> (datasetId=${datasetId})`), [datasetId]);


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Rather than having two layers of throttle and debounce, this change moves uses one layer of throttle and a Downsampler class to manage the state for the downsample. useEffects update the Downsampler instance with the latest state information and the debounced callback triggers a downsample which updates the state variable with the downsampled dataset.