### PR TITLE
publish panel: Add debounce to avoid frequent publisher changes

### DIFF
--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -15,6 +15,7 @@ import { Button, Typography, styled as muiStyled, OutlinedInput } from "@mui/mat
 import { produce } from "immer";
 import { set } from "lodash";
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useDebounce } from "use-debounce";
 
 import { useRethrow } from "@foxglove/hooks";
 import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
@@ -137,9 +138,11 @@ function Publish(props: Props) {
     saveConfig,
   } = props;
 
+  const [debouncedTopicName] = useDebounce(topicName, 500);
+
   const publish = usePublisher({
     name: "Publish",
-    topic: topicName,
+    topic: debouncedTopicName,
     schemaName: datatype,
     datatypes,
   });


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When typing the topic name in the publish panel, lots of intermediate publishers are being registered with the underlying player before the user has finished typing the desired topic name. This PR adds a debounce which, depending on the user's typing speed, avoids intermediate publishers from being created. 



