### PR TITLE
Fix memory leak with accumulated condvar callbacks in UserNodePlayer

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -385,6 +385,10 @@ export default class UserNodePlayer implements Player {
 
       // Prune the node registration cache so it doesn't grow forever.
       // We add one to the count so we don't have to recompile nodes if users undo/redo node changes.
+
+      // fixme - but if a user removes a user node and the keys length decreases this randomly un-cached some other userNode?
+      // why?
+
       const maxNodeRegistrationCacheCount = Object.keys(userNodes).length + 1;
       state.nodeRegistrationCache.splice(maxNodeRegistrationCacheCount);
       // This code causes us to reset workers twice because the seeking resets the workers too
@@ -403,6 +407,10 @@ export default class UserNodePlayer implements Player {
   ): Promise<NodeRegistration> {
     for (const cacheEntry of state.nodeRegistrationCache) {
       if (nodeId === cacheEntry.nodeId && isEqual(userNode, cacheEntry.userNode)) {
+        // fixme
+        // the node is already registered so the intent is to avoid transforming unchanged code again
+        // but the message build processor closed over the already terminated signal
+
         return cacheEntry.result;
       }
     }
@@ -425,7 +433,11 @@ export default class UserNodePlayer implements Player {
     const { inputTopics, outputTopic, transpiledCode, projectCode, outputDatatype } = nodeData;
 
     let rpc: Rpc | undefined;
+
+    // This signals that we have terminated the node registration and we should bail any message
+    // processing that is in-flight.
     const terminateCondvar = new Condvar();
+    const terminateSignal = terminateCondvar.wait();
 
     // problemKey is a unique identifier for each userspace node so we can manage problems from
     // a specific node. A node may have a problem that may later clear. Using the key we can add/remove
@@ -433,8 +445,6 @@ export default class UserNodePlayer implements Player {
     const problemKey = `node-id-${nodeId}`;
     const buildMessageProcessor = (): NodeRegistration["processMessage"] => {
       return async (msgEvent: MessageEvent<unknown>, globalVariables: GlobalVariables) => {
-        const terminateSignal = terminateCondvar.wait();
-
         // Register the node within a web worker to be executed.
         if (!rpc) {
           rpc = this._unusedNodeRuntimeWorkers.pop();
@@ -573,7 +583,19 @@ export default class UserNodePlayer implements Player {
       };
     };
 
+    // fixme - is this meant to signal that we are done with this node registration or that we want
+    // to terminate the specific message build but keep the registration around?
+    //
+    // The use of the cache makes it seem like we maybe wanted to keep the registration around?
     const terminate = () => {
+      // Removed the cached registration once terminated
+      const existingCacheIdx = state.nodeRegistrationCache.findIndex(
+        (nodeRegistration) => nodeRegistration.nodeId === nodeId,
+      );
+      if (existingCacheIdx >= 0) {
+        state.nodeRegistrationCache.splice(existingCacheIdx, 1);
+      }
+
       this._problemStore.delete(problemKey);
       terminateCondvar.notifyAll();
       if (rpc) {
@@ -659,9 +681,11 @@ export default class UserNodePlayer implements Player {
       return;
     }
 
+    // teardown and cleanup any existing node registrations
     for (const nodeRegistration of state.nodeRegistrations) {
       nodeRegistration.terminate();
     }
+    state.nodeRegistrations = [];
 
     const rosLib = await this._getRosLib(state);
     const typesLib = await this._getTypesLib(state);


### PR DESCRIPTION


**User-Facing Changes**
Improve memory use for user scripts

**Description**
UserNodePlayer message handling uses a Condvar to signal when the node should terminate (maybe due to code changes in other nodes or itself). The message processing logic calls `.wait()` on this condvar for every message to process and races the returned signal against the RPC call to process. During normal runtime (with no changes to user scripts), nothing notifies all of these signals and they continue to pile up in the callback queue of the condvar.

This change updates the logic to create one signal during the node registration for use by the message processor callback. This signal is re-created on terminate.
