### PR TITLE
Fix urdf collada mesh color being overwritten

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -725,8 +725,10 @@ function createRenderable(
       return new RenderableSphere(name, marker, undefined, renderer);
     }
     case "mesh": {
-      // Use embedded materials only when no override material is defined in the URDF
-      const embedded = !visual.material ? EmbeddedMaterialUsage.Use : EmbeddedMaterialUsage.Ignore;
+      const isCollada = visual.geometry.filename.toLowerCase().endsWith(".dae");
+      // Use embedded materials if the mesh is a Collada file or if no material is defined in the URDF
+      const embedded =
+        isCollada || !visual.material ? EmbeddedMaterialUsage.Use : EmbeddedMaterialUsage.Ignore;
       const marker = createMeshMarker(frameId, pose, embedded, visual.geometry, baseUrl, color);
       return new RenderableMeshResource(name, marker, undefined, renderer);
     }


### PR DESCRIPTION
**User-Facing Changes**
- Fix Collada meshes being displayed with wrong color

**Description**
Collada mesh materials were ignored if the URDF visual had a an optional material specified. In Rviz, the optional material is only used if the mesh itself does not contain texture information. This PR makes sure that for collada files, embedded mesh materials are always used. To my knowledge, Collada is the only mesh file type used for URDFs which contains texture information.