### PR TITLE
Modify the Storybook workflow for TurboSnap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           storybookBuildDir: storybook-static
           autoAcceptChanges: main
           exitOnceUploaded: true
+          onlychanged: true
 
   integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           storybookBuildDir: storybook-static
           autoAcceptChanges: main
           exitOnceUploaded: true
-          onlychanged: true
+          onlyChanged: true
 
   integration:
     runs-on: ${{ matrix.os }}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -30,7 +30,9 @@ const storybookConfig: StorybookConfig = {
       {
         allowUnusedVariables: true,
         version: "0.0.0-storybook",
-        storybookConfigPath: `${path.resolve(__dirname)}/tsconfig.json`,
+        // We are only setting the configFile from Storybook as it is required to properly resolve
+        // some assumptions made while traversing the dependency tree in Chromatic.
+        tsconfigPath: `${path.resolve(__dirname)}/tsconfig.json`,
       },
     );
     return {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,30 +5,14 @@
 /* eslint-disable filenames/match-exported */
 
 import { StorybookConfig } from "@storybook/react-webpack5";
-import fs from "fs";
 import path from "path";
 import { Configuration } from "webpack";
 
 import { makeConfig } from "@foxglove/studio-base/webpack";
 
-const STORY_SUFFIX = /\.stories\.tsx?$/;
-/** Workaround for https://github.com/storybookjs/storybook/issues/19446 */
-function* findStories(dir: string): Iterable<string> {
-  for (const child of fs.readdirSync(dir, { withFileTypes: true })) {
-    const childPath = path.join(dir, child.name);
-    if (child.isDirectory()) {
-      if (child.name === "node_modules" || child.name === ".git") {
-        continue;
-      }
-      yield* findStories(childPath);
-    } else if (STORY_SUFFIX.test(child.name)) {
-      yield childPath;
-    }
-  }
-}
-
 const storybookConfig: StorybookConfig = {
-  stories: [...findStories(path.join(__dirname, ".."))],
+  // stories: [...findStories(path.join(__dirname, ".."))],
+  stories: ["../packages/**/!(node_modules)**/*.stories.tsx"],
   addons: ["@storybook/addon-essentials", "@storybook/addon-actions"],
   framework: {
     name: "@storybook/react-webpack5",
@@ -43,12 +27,15 @@ const storybookConfig: StorybookConfig = {
     const studioWebpackConfig = makeConfig(
       undefined,
       { mode: config.mode },
-      { allowUnusedVariables: true, version: "0.0.0-storybook" },
+      {
+        allowUnusedVariables: true,
+        version: "0.0.0-storybook",
+        storybookConfigPath: `${path.resolve(__dirname)}/tsconfig.json`,
+      },
     );
     return {
       ...config,
       // context is required for ForkTsCheckerWebpackPlugin to find .storybook/tsconfig.json
-      context: path.resolve(__dirname),
       optimization: {
         ...config.optimization,
         minimize: false, // disabling minification improves build performance

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,7 +11,7 @@ import { Configuration } from "webpack";
 import { makeConfig } from "@foxglove/studio-base/webpack";
 
 const storybookConfig: StorybookConfig = {
-  // stories: [...findStories(path.join(__dirname, ".."))],
+  // Workaround for https://github.com/storybookjs/storybook/issues/19446
   stories: ["../packages/**/!(node_modules)**/*.stories.tsx"],
   addons: ["@storybook/addon-essentials", "@storybook/addon-actions"],
   framework: {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "package:e2e": "yarn && yarn clean && yarn desktop:build:prod && yarn package",
     "release:bump-nightly-version": "node -r ts-node/register ./ci/bump-nightly-version.ts",
     "storybook": "storybook dev --port 9009 --config-dir .storybook",
-    "storybook:build": "storybook build --config-dir .storybook",
+    "storybook:build": "storybook build --config-dir .storybook --webpack-stats-json",
     "version:all": "yarn workspaces foreach version"
   },
   "workspaces": {

--- a/packages/studio-base/src/components/AppBar/UserMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/UserMenu.tsx
@@ -7,6 +7,7 @@ import { useSnackbar } from "notistack";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
 
+// Comment
 import Logger from "@foxglove/log";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";

--- a/packages/studio-base/src/components/AppBar/UserMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/UserMenu.tsx
@@ -7,7 +7,6 @@ import { useSnackbar } from "notistack";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
 
-// Comment
 import Logger from "@foxglove/log";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -37,8 +37,8 @@ type Options = {
   allowUnusedVariables?: boolean;
   /** Specify the app version. */
   version: string;
-  /** Specify the Storybook config path for Type checking */
-  storybookConfigPath?: string;
+  /** Specify the path to the tsconfig.json file for ForkTsCheckerWebpackPlugin. If unset, the plugin defaults to finding the config file in the webpack `context` directory. */
+  tsconfigPath?: string;
 };
 
 // Create a partial webpack configuration required to build app using webpack.
@@ -51,11 +51,7 @@ export function makeConfig(
   const isDev = argv.mode === "development";
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
 
-  const {
-    allowUnusedVariables = isDev && isServe,
-    version,
-    storybookConfigPath = undefined,
-  } = options;
+  const { allowUnusedVariables = isDev && isServe, version, tsconfigPath } = options;
 
   return {
     resolve: {
@@ -224,7 +220,7 @@ export function makeConfig(
 
       minimizer: [
         new ESBuildMinifyPlugin({
-          target: "es2020",
+          target: "es2022",
           minify: true,
         }),
       ],
@@ -268,9 +264,7 @@ export function makeConfig(
               jsx: isDev ? "react-jsxdev" : "react-jsx",
             },
           },
-          // We are only setting the configFile from Storybook as it is required to properly resolve
-          // some assumptions made while traversing the dependency tree in Chromatic.
-          configFile: storybookConfigPath,
+          configFile: tsconfigPath,
         },
       }),
     ],

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -254,9 +254,7 @@ export function makeConfig(
       }),
       new ForkTsCheckerWebpackPlugin({
         typescript: {
-          // Note: configFile should not be overridden, it needs to differ between web, desktop,
-          // etc. so that files specific to each build (not just shared files) are also
-          // type-checked. The default behavior is to find it from the webpack `context` directory.
+          configFile: tsconfigPath,
           configOverwrite: {
             compilerOptions: {
               noUnusedLocals: !allowUnusedVariables,
@@ -264,7 +262,6 @@ export function makeConfig(
               jsx: isDev ? "react-jsxdev" : "react-jsx",
             },
           },
-          configFile: tsconfigPath,
         },
       }),
     ],

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -37,6 +37,8 @@ type Options = {
   allowUnusedVariables?: boolean;
   /** Specify the app version. */
   version: string;
+  /** Specify the Storybook config path for Type checking */
+  storybookConfigPath?: string;
 };
 
 // Create a partial webpack configuration required to build app using webpack.
@@ -49,7 +51,11 @@ export function makeConfig(
   const isDev = argv.mode === "development";
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
 
-  const { allowUnusedVariables = isDev && isServe, version } = options;
+  const {
+    allowUnusedVariables = isDev && isServe,
+    version,
+    storybookConfigPath = undefined,
+  } = options;
 
   return {
     resolve: {
@@ -218,7 +224,7 @@ export function makeConfig(
 
       minimizer: [
         new ESBuildMinifyPlugin({
-          target: "es2022",
+          target: "es2020",
           minify: true,
         }),
       ],
@@ -262,6 +268,9 @@ export function makeConfig(
               jsx: isDev ? "react-jsxdev" : "react-jsx",
             },
           },
+          // We are only setting the configFile from Storybook as it is required to properly resolve
+          // some assumptions made while traversing the dependency tree in Chromatic.
+          configFile: storybookConfigPath,
         },
       }),
     ],


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
The changes here primarily affect internal contributing users.
The changes enable using TurboSnap with Chromatic, a visual regression tool.

TurboSnap will optimize Chromatic build times and reduce the number of snapshots used per triggered build.

**Description**

Adding the `--webpack-stats-json` flag to the Storybook build script enables the generation of a Webpack stats file, which Chromatic needs to trace the Webpack dependency tree.

Adding `onlyChanged: true` to the Chromatic CI job enables TurboSnap.

The main reason for removing the `context` definition in the Webpack configuration for Storybook is that it affected some internal assumptions made by Storybook in generating the stats file.

This affects the relative path for the `moduleName` that Chromatic looks for to resolve dependencies and find the relevant story changes.

Modifying the `makeConfig` should only affect the Storybook process and leave the application Webpack build process unchanged.

<!-- link relevant GitHub issues -->
https://github.com/storybookjs/storybook/issues/19446#issuecomment-1276067149

I also removed the `findStories` function related to the open Storybook issue above in favor of optimizing the stories glob pattern to exclude `node_modules``.`

This speeds up the Storybook build time as well.

The trace now works correctly as well.

```
ℹ Traced 1 changed file to 3 affected story files:

— packages/studio-base/src/components/AppBar/UserMenu.tsx [changed]
  ∟ packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
    ∟ [story index]

— packages/studio-base/src/components/AppBar/UserMenu.tsx [changed]
  ∟ packages/studio-base/src/components/AppBar/index.tsx + 4 modules
    ∟ packages/studio-base/src/Workspace.stories.tsx + 24 modules
      ∟ [story index]

— packages/studio-base/src/components/AppBar/UserMenu.tsx [changed]
  ∟ packages/studio-base/src/components/AppBar/index.tsx + 4 modules
    ∟ packages/studio-base/src/components/AppBar/UserMenu.stories.tsx [duplicate]
      ∟ [story index]

— packages/studio-base/src/components/AppBar/UserMenu.tsx [changed]
  ∟ packages/studio-base/src/components/AppBar/index.tsx + 4 modules
    ∟ packages/studio-base/src/components/AppBar/index.stories.tsx
      ∟ [story index]
```

<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
