### PR TITLE
[3D Image] Add message converter support for 2D annotations

### DIFF
--- a/packages/den/collection/TwoKeyMap.test.ts
+++ b/packages/den/collection/TwoKeyMap.test.ts
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { TwoKeyMap } from "./TwoKeyMap";
+
+describe("TwoKeyMap", () => {
+  it("supports basic operations", () => {
+    const map = new TwoKeyMap<string, string, number>();
+
+    map.set("a", "a", 1);
+    expect(map.get("a", "a")).toBe(1);
+    expect(map.get("a", "b")).toBe(undefined);
+    expect(map.get("b", "a")).toBe(undefined);
+    expect([...map.values()]).toEqual([1]);
+
+    map.set("a", "b", 2);
+    expect(map.get("a", "a")).toBe(1);
+    expect(map.get("a", "b")).toBe(2);
+    expect(map.get("a", "c")).toBe(undefined);
+    expect([...map.values()]).toEqual([1, 2]);
+
+    map.delete("a", "a");
+    expect(map.get("a", "a")).toBe(undefined);
+    expect(map.get("a", "b")).toBe(2);
+    expect([...map.values()]).toEqual([2]);
+
+    map.deleteAll("a");
+    expect(map.get("a", "a")).toBe(undefined);
+    expect(map.get("a", "b")).toBe(undefined);
+    expect([...map.values()]).toEqual([]);
+
+    map.set("a", "a", 1);
+    map.set("a", "b", 2);
+    map.set("x", "y", 3);
+    map.set("x", "z", 4);
+    expect([...map.values()]).toEqual([1, 2, 3, 4]);
+
+    map.deleteAll("a");
+    expect([...map.values()]).toEqual([3, 4]);
+
+    map.clear();
+    expect([...map.values()]).toEqual([]);
+  });
+});

--- a/packages/den/collection/TwoKeyMap.ts
+++ b/packages/den/collection/TwoKeyMap.ts
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * A Map that organizes values by two levels of keys, i.e. a wrapper around Map<K1, Map<K2, V>>.
+ */
+export class TwoKeyMap<K1, K2, V> {
+  #map = new Map<K1, Map<K2, V>>();
+
+  public get(key1: K1, key2: K2): V | undefined {
+    return this.#map.get(key1)?.get(key2);
+  }
+
+  public set(key1: K1, key2: K2, value: V): void {
+    let map2 = this.#map.get(key1);
+    if (map2 == undefined) {
+      map2 = new Map<K2, V>();
+      this.#map.set(key1, map2);
+    }
+    map2.set(key2, value);
+  }
+
+  public delete(key1: K1, key2: K2): void {
+    const map2 = this.#map.get(key1);
+    if (map2 != undefined) {
+      map2.delete(key2);
+      if (map2.size === 0) {
+        this.#map.delete(key1);
+      }
+    }
+  }
+
+  public deleteAll(key1: K1): void {
+    this.#map.delete(key1);
+  }
+
+  public clear(): void {
+    this.#map.clear();
+  }
+
+  /**
+   * Iterate over all values. This may not be in the original insertion order, since keys may have
+   * been added to the two levels of maps in different orders.
+   */
+  public *values(): Iterable<V> {
+    for (const map2 of this.#map.values()) {
+      yield* map2.values();
+    }
+  }
+}

--- a/packages/den/collection/index.ts
+++ b/packages/den/collection/index.ts
@@ -8,3 +8,4 @@ export * from "./binarySearch";
 export * from "./minIndexBy";
 export * from "./MultiMap";
 export * from "./VecQueue";
+export * from "./TwoKeyMap";

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -28,7 +28,7 @@ type BuilderRenderStateInput = {
   currentFrame: MessageEvent<unknown>[] | undefined;
   globalVariables: GlobalVariables;
   hoverValue: HoverValue | undefined;
-  messageConverters?: RegisterMessageConverterArgs<unknown>[];
+  messageConverters?: readonly RegisterMessageConverterArgs<unknown>[];
   playerState: PlayerState | undefined;
   sharedPanelState: Record<string, unknown> | undefined;
   sortedTopics: readonly PlayerTopic[];

--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -26,7 +26,7 @@ export type ExtensionCatalog = {
 
   installedExtensions: undefined | ExtensionInfo[];
   installedPanels: undefined | Record<string, RegisteredPanel>;
-  installedMessageConverters: undefined | RegisterMessageConverterArgs<unknown>[];
+  installedMessageConverters: undefined | readonly RegisterMessageConverterArgs<unknown>[];
 };
 
 export const ExtensionCatalogContext = createContext<undefined | StoreApi<ExtensionCatalog>>(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -6,6 +6,7 @@ import { t } from "i18next";
 import { Immutable } from "immer";
 import * as THREE from "three";
 
+import { TwoKeyMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas";
 import { MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
@@ -21,6 +22,9 @@ import { SettingsTreeEntry } from "../../../SettingsManager";
 import { IMAGE_ANNOTATIONS_DATATYPES } from "../../../foxglove";
 import { IMAGE_MARKER_ARRAY_DATATYPES, IMAGE_MARKER_DATATYPES } from "../../../ros";
 import { topicIsConvertibleToSchema } from "../../../topicIsConvertibleToSchema";
+
+type TopicName = string & { __brand: "TopicName" };
+type SchemaName = string & { __brand: "SchemaName" };
 
 interface ImageAnnotationsContext {
   initialScale: number;
@@ -68,7 +72,11 @@ function subscriptionMatches(
 export class ImageAnnotations extends THREE.Object3D {
   #context: ImageAnnotationsContext;
 
-  #renderablesByTopicAndSchemaName = new Map<string, Map<string, RenderableTopicAnnotations>>();
+  #renderablesByTopicAndSchemaName = new TwoKeyMap<
+    TopicName,
+    SchemaName,
+    RenderableTopicAnnotations
+  >();
   #cameraModel?: PinholeCameraModel;
 
   #scale: number;
@@ -88,10 +96,8 @@ export class ImageAnnotations extends THREE.Object3D {
   }
 
   public dispose(): void {
-    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
-      for (const renderable of renderables.values()) {
-        renderable.dispose();
-      }
+    for (const renderable of this.#renderablesByTopicAndSchemaName.values()) {
+      renderable.dispose();
     }
     this.children.length = 0;
     this.#renderablesByTopicAndSchemaName.clear();
@@ -99,11 +105,9 @@ export class ImageAnnotations extends THREE.Object3D {
 
   /** Called when seeking or a new data source is loaded.  */
   public removeAllRenderables(): void {
-    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
-      for (const renderable of renderables.values()) {
-        renderable.dispose();
-        this.remove(renderable);
-      }
+    for (const renderable of this.#renderablesByTopicAndSchemaName.values()) {
+      renderable.dispose();
+      this.remove(renderable);
     }
     this.#renderablesByTopicAndSchemaName.clear();
   }
@@ -118,21 +122,17 @@ export class ImageAnnotations extends THREE.Object3D {
     this.#canvasWidth = canvasWidth;
     this.#canvasHeight = canvasHeight;
     this.#pixelRatio = pixelRatio;
-    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
-      for (const renderable of renderables.values()) {
-        renderable.setScale(scale, canvasWidth, canvasHeight, pixelRatio);
-        renderable.update();
-      }
+    for (const renderable of this.#renderablesByTopicAndSchemaName.values()) {
+      renderable.setScale(scale, canvasWidth, canvasHeight, pixelRatio);
+      renderable.update();
     }
   }
 
   public updateCameraModel(cameraModel: PinholeCameraModel): void {
     this.#cameraModel = cameraModel;
-    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
-      for (const renderable of renderables.values()) {
-        renderable.setCameraModel(cameraModel);
-        renderable.update();
-      }
+    for (const renderable of this.#renderablesByTopicAndSchemaName.values()) {
+      renderable.setCameraModel(cameraModel);
+      renderable.update();
     }
   }
 
@@ -144,17 +144,19 @@ export class ImageAnnotations extends THREE.Object3D {
       return;
     }
 
-    let topicRenderables = this.#renderablesByTopicAndSchemaName.get(messageEvent.topic);
-    if (!topicRenderables) {
-      topicRenderables = new Map<string, RenderableTopicAnnotations>();
-      this.#renderablesByTopicAndSchemaName.set(messageEvent.topic, topicRenderables);
-    }
-    let renderable = topicRenderables.get(messageEvent.schemaName);
+    let renderable = this.#renderablesByTopicAndSchemaName.get(
+      messageEvent.topic as TopicName,
+      messageEvent.schemaName as SchemaName,
+    );
     if (!renderable) {
       renderable = new RenderableTopicAnnotations();
       renderable.setScale(this.#scale, this.#canvasWidth, this.#canvasHeight, this.#pixelRatio);
       renderable.setCameraModel(this.#cameraModel);
-      topicRenderables.set(messageEvent.schemaName, renderable);
+      this.#renderablesByTopicAndSchemaName.set(
+        messageEvent.topic as TopicName,
+        messageEvent.schemaName as SchemaName,
+        renderable,
+      );
       this.add(renderable);
     }
 
@@ -202,9 +204,10 @@ export class ImageAnnotations extends THREE.Object3D {
         draft.annotations.push(subscription);
       }
     });
-    const renderable = this.#renderablesByTopicAndSchemaName
-      .get(topic.name)
-      ?.get(convertTo ?? topic.schemaName);
+    const renderable = this.#renderablesByTopicAndSchemaName.get(
+      topic.name as TopicName,
+      (convertTo ?? topic.schemaName) as SchemaName,
+    );
     if (renderable) {
       renderable.visible = visible;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -16,7 +16,7 @@ import {
 } from "@foxglove/studio-base/types/Messages";
 
 import { RenderableTopicAnnotations } from "./RenderableTopicAnnotations";
-import { ImageModeConfig } from "../../../IRenderer";
+import { ImageAnnotationSubscription, ImageModeConfig } from "../../../IRenderer";
 import { SettingsTreeEntry } from "../../../SettingsManager";
 import { IMAGE_ANNOTATIONS_DATATYPES } from "../../../foxglove";
 import { IMAGE_MARKER_ARRAY_DATATYPES, IMAGE_MARKER_DATATYPES } from "../../../ros";
@@ -37,10 +37,30 @@ interface ImageAnnotationsContext {
   ): void;
 }
 
+const ALL_SUPPORTED_SCHEMAS = new Set([
+  ...IMAGE_ANNOTATIONS_DATATYPES,
+  ...IMAGE_MARKER_DATATYPES,
+  ...IMAGE_MARKER_ARRAY_DATATYPES,
+]);
+
 /**
  * Match everything up to the last `/` in a topic name, e.g. match `/a/b` in `/a/b/c`.
  */
 const TOPIC_PREFIX_REGEX = /^.+\/(?=.)/;
+
+/**
+ * Determine whether `subscription`, an entry in {@link ImageModeConfig.annotations}, is the entry
+ * that should correspond to `topic` with conversion to `convertTo`.
+ */
+function subscriptionMatches(
+  topic: Topic,
+  subscription: ImageAnnotationSubscription,
+  convertTo: string | undefined,
+): boolean {
+  return (
+    subscription.topic === topic.name && subscription.schemaName === (convertTo ?? topic.schemaName)
+  );
+}
 
 /**
  * This class handles settings and rendering for ImageAnnotations/ImageMarkers.
@@ -48,8 +68,7 @@ const TOPIC_PREFIX_REGEX = /^.+\/(?=.)/;
 export class ImageAnnotations extends THREE.Object3D {
   #context: ImageAnnotationsContext;
 
-  /** FG-3065: support multiple converters per message */
-  #renderablesByTopic = new Map<string, RenderableTopicAnnotations>();
+  #renderablesByTopicAndSchemaName = new Map<string, Map<string, RenderableTopicAnnotations>>();
   #cameraModel?: PinholeCameraModel;
 
   #scale: number;
@@ -65,32 +84,28 @@ export class ImageAnnotations extends THREE.Object3D {
     this.#canvasHeight = context.initialCanvasHeight;
     this.#pixelRatio = context.initialPixelRatio;
 
-    this.#context.addSchemaSubscriptions(
-      IMAGE_ANNOTATIONS_DATATYPES,
-      this.#handleMessage.bind(this),
-    );
-    this.#context.addSchemaSubscriptions(IMAGE_MARKER_DATATYPES, this.#handleMessage.bind(this));
-    this.#context.addSchemaSubscriptions(
-      IMAGE_MARKER_ARRAY_DATATYPES,
-      this.#handleMessage.bind(this),
-    );
+    this.#context.addSchemaSubscriptions(ALL_SUPPORTED_SCHEMAS, this.#handleMessage.bind(this));
   }
 
   public dispose(): void {
-    for (const renderable of this.#renderablesByTopic.values()) {
-      renderable.dispose();
+    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
+      for (const renderable of renderables.values()) {
+        renderable.dispose();
+      }
     }
     this.children.length = 0;
-    this.#renderablesByTopic.clear();
+    this.#renderablesByTopicAndSchemaName.clear();
   }
 
   /** Called when seeking or a new data source is loaded.  */
   public removeAllRenderables(): void {
-    for (const renderable of this.#renderablesByTopic.values()) {
-      renderable.dispose();
-      this.remove(renderable);
+    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
+      for (const renderable of renderables.values()) {
+        renderable.dispose();
+        this.remove(renderable);
+      }
     }
-    this.#renderablesByTopic.clear();
+    this.#renderablesByTopicAndSchemaName.clear();
   }
 
   public updateScale(
@@ -103,17 +118,21 @@ export class ImageAnnotations extends THREE.Object3D {
     this.#canvasWidth = canvasWidth;
     this.#canvasHeight = canvasHeight;
     this.#pixelRatio = pixelRatio;
-    for (const renderable of this.#renderablesByTopic.values()) {
-      renderable.setScale(scale, canvasWidth, canvasHeight, pixelRatio);
-      renderable.update();
+    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
+      for (const renderable of renderables.values()) {
+        renderable.setScale(scale, canvasWidth, canvasHeight, pixelRatio);
+        renderable.update();
+      }
     }
   }
 
   public updateCameraModel(cameraModel: PinholeCameraModel): void {
     this.#cameraModel = cameraModel;
-    for (const renderable of this.#renderablesByTopic.values()) {
-      renderable.setCameraModel(cameraModel);
-      renderable.update();
+    for (const renderables of this.#renderablesByTopicAndSchemaName.values()) {
+      for (const renderable of renderables.values()) {
+        renderable.setCameraModel(cameraModel);
+        renderable.update();
+      }
     }
   }
 
@@ -125,12 +144,17 @@ export class ImageAnnotations extends THREE.Object3D {
       return;
     }
 
-    let renderable = this.#renderablesByTopic.get(messageEvent.topic);
+    let topicRenderables = this.#renderablesByTopicAndSchemaName.get(messageEvent.topic);
+    if (!topicRenderables) {
+      topicRenderables = new Map<string, RenderableTopicAnnotations>();
+      this.#renderablesByTopicAndSchemaName.set(messageEvent.topic, topicRenderables);
+    }
+    let renderable = topicRenderables.get(messageEvent.schemaName);
     if (!renderable) {
       renderable = new RenderableTopicAnnotations();
       renderable.setScale(this.#scale, this.#canvasWidth, this.#canvasHeight, this.#pixelRatio);
       renderable.setCameraModel(this.#cameraModel);
-      this.#renderablesByTopic.set(messageEvent.topic, renderable);
+      topicRenderables.set(messageEvent.schemaName, renderable);
       this.add(renderable);
     }
 
@@ -138,7 +162,11 @@ export class ImageAnnotations extends THREE.Object3D {
     renderable.update();
   }
 
-  #handleSettingsAction(topic: Topic, action: SettingsTreeAction): void {
+  #handleSettingsAction(
+    topic: Topic,
+    convertTo: string | undefined,
+    action: SettingsTreeAction,
+  ): void {
     if (action.action !== "update" || action.payload.path.length < 2) {
       return;
     }
@@ -148,31 +176,35 @@ export class ImageAnnotations extends THREE.Object3D {
       action.payload.path[2] === "visible" &&
       typeof value === "boolean"
     ) {
-      this.#handleTopicVisibilityChange(topic, value);
+      this.#handleTopicVisibilityChange(topic, convertTo, value);
     }
     this.#context.updateSettingsTree();
   }
 
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  #handleTopicVisibilityChange(topic: Topic, visible: boolean): void {
+  #handleTopicVisibilityChange(
+    topic: Topic,
+    convertTo: string | undefined,
+    visible: boolean, // eslint-disable-line @foxglove/no-boolean-parameters
+  ): void {
     this.#context.updateConfig((draft) => {
       draft.annotations ??= [];
-      // FG-3065: support topic.convertTo
-      let subscription = draft.annotations.find(
-        (sub) => sub.topic === topic.name && sub.schemaName === topic.schemaName,
+      let subscription = draft.annotations.find((sub) =>
+        subscriptionMatches(topic, sub, convertTo),
       );
       if (subscription) {
         subscription.settings.visible = visible;
       } else {
         subscription = {
           topic: topic.name,
-          schemaName: topic.schemaName,
+          schemaName: convertTo ?? topic.schemaName,
           settings: { visible },
         };
         draft.annotations.push(subscription);
       }
     });
-    const renderable = this.#renderablesByTopic.get(topic.name);
+    const renderable = this.#renderablesByTopicAndSchemaName
+      .get(topic.name)
+      ?.get(convertTo ?? topic.schemaName);
     if (renderable) {
       renderable.visible = visible;
     }
@@ -193,12 +225,7 @@ export class ImageAnnotations extends THREE.Object3D {
 
     const annotationTopics = this.#context
       .topics()
-      .filter(
-        (topic) =>
-          topicIsConvertibleToSchema(topic, IMAGE_ANNOTATIONS_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, IMAGE_MARKER_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, IMAGE_MARKER_ARRAY_DATATYPES),
-      );
+      .filter((topic) => topicIsConvertibleToSchema(topic, ALL_SUPPORTED_SCHEMAS));
 
     // Sort annotation topics with prefixes matching the image topic to the top.
     if (config.imageTopic) {
@@ -213,22 +240,31 @@ export class ImageAnnotations extends THREE.Object3D {
     }
 
     let i = 0;
-    for (const topic of annotationTopics) {
-      // FG-3065: support topic.convertTo
-      const settings = config.annotations?.find(
-        (sub) => sub.topic === topic.name && sub.schemaName === topic.schemaName,
+    const addEntry = (topic: Topic, convertTo: string | undefined) => {
+      const schemaName = convertTo ?? topic.schemaName;
+      if (!ALL_SUPPORTED_SCHEMAS.has(schemaName)) {
+        return;
+      }
+      const settings = config.annotations?.find((sub) =>
+        subscriptionMatches(topic, sub, convertTo),
       )?.settings;
       entries.push({
         // When building the tree, we just use a numeric index in the path. Inside the handler, this
-        // part of the path is ignored, and instead we pass in the `topic` directly so the handler
-        // knows which value to update in the config.
+        // part of the path is ignored, and instead we pass in the `topic` and `convertTo` directly
+        // so the handler knows which value to update in the config.
         path: ["imageAnnotations", `${i++}`],
         node: {
           label: topic.name,
           visible: settings?.visible ?? false,
-          handler: this.#handleSettingsAction.bind(this, topic),
+          handler: this.#handleSettingsAction.bind(this, topic, convertTo),
         },
       });
+    };
+    for (const topic of annotationTopics) {
+      addEntry(topic, undefined);
+      for (const convertTo of topic.convertibleTo ?? []) {
+        addEntry(topic, convertTo);
+      }
     }
     return entries;
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -19,66 +19,72 @@ export default {
   title: "panels/ThreeDeeRender/Images/Annotations",
   component: ImagePanel,
 };
+function makeImageAndCalibration(width: number, height: number) {
+  const fx = 500;
+  const fy = 500;
+  const cx = width / 2;
+  const cy = height / 2;
+  const calibrationMessage: MessageEvent<Partial<CameraCalibration>> = {
+    topic: "calibration",
+    receiveTime: { sec: 0, nsec: 0 },
+    message: {
+      timestamp: { sec: 0, nsec: 0 },
+      frame_id: "cam",
+      height,
+      width,
+      distortion_model: "rational_polynomial",
+      D: [],
+      K: [fx, 0, cx, 0, fy, cy, 0, 0, 1],
+      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+      P: [fx, 0, cx, 0, 0, fy, cy, 0, 0, 0, 1, 0],
+    },
+    schemaName: "foxglove.CameraCalibration",
+    sizeInBytes: 0,
+  };
+
+  const imageData = new Uint8Array(width * height * 3);
+  for (let i = 0, r = 0; r < height; r++) {
+    for (let c = 0; c < width; c++) {
+      if (r === 0 || r === height - 1 || c === 0 || c === width - 1) {
+        imageData[i++] = 150;
+        imageData[i++] = 150;
+        imageData[i++] = 255;
+      } else {
+        imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
+        imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
+        imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
+      }
+    }
+  }
+
+  const cameraMessage: MessageEvent<Partial<RawImage>> = {
+    topic: "camera",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      timestamp: { sec: 0, nsec: 0 },
+      frame_id: "cam",
+      width,
+      height,
+      encoding: "rgb8",
+      data: imageData,
+    },
+    schemaName: "foxglove.RawImage",
+    sizeInBytes: 0,
+  };
+
+  return { calibrationMessage, cameraMessage };
+}
 
 export const Annotations: StoryObj = {
   parameters: { colorScheme: "light" },
   render: function Story() {
     const width = 60;
     const height = 45;
-    const fx = 500;
-    const fy = 500;
-    const cx = width / 2;
-    const cy = height / 2;
-    const calibrationMessage: MessageEvent<Partial<CameraCalibration>> = {
-      topic: "calibration",
-      receiveTime: { sec: 0, nsec: 0 },
-      message: {
-        timestamp: { sec: 0, nsec: 0 },
-        frame_id: "cam",
-        height,
-        width,
-        distortion_model: "rational_polynomial",
-        D: [],
-        K: [fx, 0, cx, 0, fy, cy, 0, 0, 1],
-        R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
-        P: [fx, 0, cx, 0, 0, fy, cy, 0, 0, 0, 1, 0],
-      },
-      schemaName: "foxglove.CameraCalibration",
-      sizeInBytes: 0,
-    };
 
-    const imageData = new Uint8Array(width * height * 3);
-    for (let i = 0, r = 0; r < height; r++) {
-      for (let c = 0; c < width; c++) {
-        if (r === 0 || r === height - 1 || c === 0 || c === width - 1) {
-          imageData[i++] = 150;
-          imageData[i++] = 150;
-          imageData[i++] = 255;
-        } else {
-          imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
-          imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
-          imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
-        }
-      }
-    }
-
-    const cameraMessage: MessageEvent<Partial<RawImage>> = {
-      topic: "camera",
-      receiveTime: { sec: 10, nsec: 0 },
-      message: {
-        timestamp: { sec: 0, nsec: 0 },
-        frame_id: "cam",
-        width,
-        height,
-        encoding: "rgb8",
-        data: imageData,
-      },
-      schemaName: "foxglove.RawImage",
-      sizeInBytes: 0,
-    };
+    const { calibrationMessage, cameraMessage } = makeImageAndCalibration(width, height);
 
     const annotationsMessage: MessageEvent<Partial<ImageAnnotations>> = {
-      topic: "camera",
+      topic: "annotations",
       receiveTime: { sec: 10, nsec: 0 },
       message: {
         points: [
@@ -257,6 +263,190 @@ export const Annotations: StoryObj = {
                 {
                   topic: "annotations",
                   schemaName: "foxglove.ImageAnnotations",
+                  settings: { visible: true },
+                },
+              ],
+            },
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+};
+
+export const MessageConverterSupport: StoryObj = {
+  parameters: { colorScheme: "light" },
+  render: function Story() {
+    const width = 60;
+    const height = 45;
+
+    const { calibrationMessage, cameraMessage } = makeImageAndCalibration(width, height);
+
+    const annotationsMessage: MessageEvent<Partial<ImageAnnotations>> = {
+      topic: "annotations",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        points: [
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.POINTS,
+            points: [
+              { x: 10 + 0, y: 10 + 0 },
+              { x: 10 + 0, y: 10 + 8 },
+              { x: 10 + 2, y: 10 + 6 },
+              { x: 10 + 5, y: 10 + 2 },
+            ],
+            outline_color: { r: 0, g: 0, b: 0, a: 1 },
+            outline_colors: [
+              { r: 1, g: 0, b: 0, a: 1 },
+              { r: 0, g: 1, b: 0, a: 1 },
+              { r: 0, g: 0, b: 1, a: 1 },
+              { r: 0, g: 1, b: 1, a: 1 },
+            ],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 1,
+          },
+        ],
+      },
+      schemaName: "foxglove.ImageAnnotations",
+      sizeInBytes: 0,
+    };
+
+    const customAnnotationsMessage: MessageEvent<Partial<unknown>> = {
+      topic: "custom_annotations",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: { foo: "bar" },
+      schemaName: "MyCustomSchema",
+      sizeInBytes: 0,
+    };
+
+    const fixture: Fixture = {
+      topics: [
+        { name: "calibration", schemaName: "foxglove.CameraCalibration" },
+        { name: "camera", schemaName: "foxglove.RawImage" },
+        { name: "annotations", schemaName: "foxglove.ImageAnnotations" },
+        { name: "custom_annotations", schemaName: "MyCustomSchema" },
+      ],
+      frame: {
+        calibration: [calibrationMessage],
+        camera: [cameraMessage],
+        annotations: [annotationsMessage],
+        custom_annotations: [customAnnotationsMessage],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+      messageConverters: [
+        // both original and converted schemas are supported
+        {
+          fromSchemaName: "foxglove.ImageAnnotations",
+          toSchemaName: "foxglove_msgs/ImageAnnotations",
+          converter: (_msg): Partial<ImageAnnotations> => ({
+            points: [
+              {
+                timestamp: { sec: 0, nsec: 0 },
+                type: PointsAnnotationType.LINE_LOOP,
+                points: [
+                  { x: 20 + 0, y: 10 + 0 },
+                  { x: 20 + 0, y: 10 + 8 },
+                  { x: 20 + 2, y: 10 + 6 },
+                  { x: 20 + 5, y: 10 + 2 },
+                ],
+                outline_color: { r: 1, g: 1, b: 0, a: 1 },
+                outline_colors: [],
+                fill_color: { r: 0, g: 1, b: 1, a: 0 },
+                thickness: 1,
+              },
+            ],
+          }),
+        },
+        // original schema is not supported, but two converters are supported
+        {
+          fromSchemaName: "MyCustomSchema",
+          toSchemaName: "foxglove_msgs/ImageAnnotations",
+          converter: (_msg): Partial<ImageAnnotations> => ({
+            points: [
+              {
+                timestamp: { sec: 0, nsec: 0 },
+                type: PointsAnnotationType.LINE_LIST,
+                points: [
+                  { x: 30 + 0, y: 10 + 0 },
+                  { x: 30 + 0, y: 10 + 8 },
+                  { x: 30 + 2, y: 10 + 6 },
+                  { x: 30 + 5, y: 10 + 2 },
+                ],
+                outline_color: { r: 0, g: 0, b: 0, a: 1 },
+                outline_colors: [
+                  // 1 color per point
+                  { r: 1, g: 0, b: 0, a: 1 },
+                  { r: 0, g: 1, b: 0, a: 1 },
+                  { r: 0, g: 0, b: 1, a: 1 },
+                  { r: 0, g: 1, b: 1, a: 1 },
+                ],
+                fill_color: { r: 0, g: 0, b: 0, a: 0 },
+                thickness: 2,
+              },
+            ],
+          }),
+        },
+        {
+          fromSchemaName: "MyCustomSchema",
+          toSchemaName: "foxglove_msgs/msg/ImageAnnotations",
+          converter: (_msg): Partial<ImageAnnotations> => ({
+            points: [
+              {
+                timestamp: { sec: 0, nsec: 0 },
+                type: PointsAnnotationType.LINE_STRIP,
+                points: [
+                  { x: 40 + 0, y: 10 + 0 },
+                  { x: 40 + 0, y: 10 + 8 },
+                  { x: 40 + 2, y: 10 + 6 },
+                  { x: 40 + 5, y: 10 + 2 },
+                ],
+                outline_color: { r: 1, g: 1, b: 1, a: 1 },
+                outline_colors: [],
+                fill_color: { r: 0, g: 0, b: 0, a: 0 },
+                thickness: 2,
+              },
+            ],
+          }),
+        },
+        // unrelated converter should not be shown
+        {
+          fromSchemaName: "MyCustomSchema",
+          toSchemaName: "foxglove.SceneUpdate",
+          converter: (msg) => msg,
+        },
+      ],
+    };
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <ImagePanel
+          overrideConfig={{
+            ...ImagePanel.defaultConfig,
+            imageMode: {
+              calibrationTopic: "calibration",
+              imageTopic: "camera",
+              annotations: [
+                {
+                  topic: "annotations",
+                  schemaName: "foxglove.ImageAnnotations",
+                  settings: { visible: true },
+                },
+                {
+                  topic: "annotations",
+                  schemaName: "foxglove_msgs/ImageAnnotations",
+                  settings: { visible: true },
+                },
+                {
+                  topic: "custom_annotations",
+                  schemaName: "foxglove_msgs/ImageAnnotations",
+                  settings: { visible: true },
+                },
+                {
+                  topic: "custom_annotations",
+                  schemaName: "foxglove_msgs/msg/ImageAnnotations",
                   settings: { visible: true },
                 },
               ],

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -95,6 +95,7 @@ function activateExtension(
 
 export function createExtensionRegistryStore(
   loaders: readonly ExtensionLoader[],
+  mockMessageConverters: readonly RegisterMessageConverterArgs<unknown>[] | undefined,
 ): StoreApi<ExtensionCatalog> {
   return createStore((set, get) => ({
     downloadExtension: async (url: string) => {
@@ -149,7 +150,7 @@ export function createExtensionRegistryStore(
 
     installedPanels: {},
 
-    installedMessageConverters: [],
+    installedMessageConverters: mockMessageConverters ?? [],
 
     uninstallExtension: async (namespace: ExtensionNamespace, id: string) => {
       const namespacedLoader = loaders.find((loader) => loader.namespace === namespace);
@@ -165,8 +166,12 @@ export function createExtensionRegistryStore(
 export default function ExtensionCatalogProvider({
   children,
   loaders,
-}: PropsWithChildren<{ loaders: readonly ExtensionLoader[] }>): JSX.Element {
-  const [store] = useState(createExtensionRegistryStore(loaders));
+  mockMessageConverters,
+}: PropsWithChildren<{
+  loaders: readonly ExtensionLoader[];
+  mockMessageConverters?: readonly RegisterMessageConverterArgs<unknown>[];
+}>): JSX.Element {
+  const [store] = useState(createExtensionRegistryStore(loaders, mockMessageConverters));
 
   // Request an initial refresh on first mount
   const refreshExtensions = store.getState().refreshExtensions;

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -21,7 +21,7 @@ import { useTranslation } from "react-i18next";
 import { Mosaic, MosaicNode, MosaicWindow } from "react-mosaic-component";
 
 import { useShallowMemo } from "@foxglove/hooks";
-import { MessageEvent, SettingsTree } from "@foxglove/studio";
+import { MessageEvent, RegisterMessageConverterArgs, SettingsTree } from "@foxglove/studio";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
@@ -86,6 +86,7 @@ export type Fixture = {
   publish?: (request: PublishPayload) => void;
   setPublishers?: (publisherId: string, advertisements: AdvertiseOptions[]) => void;
   setSubscriptions?: ComponentProps<typeof MockMessagePipelineProvider>["setSubscriptions"];
+  messageConverters?: readonly RegisterMessageConverterArgs<unknown>[];
 };
 
 type UnconnectedProps = {
@@ -190,7 +191,11 @@ function PanelWrapper({
 
   return (
     <>
-      {includeSettings && <SettingsTreeEditor settings={settings} />}
+      {includeSettings && (
+        <div style={{ overflow: "auto" }}>
+          <SettingsTreeEditor settings={settings} />
+        </div>
+      )}
       {children}
     </>
   );
@@ -352,7 +357,10 @@ export default function PanelSetup(props: Props): JSX.Element {
         <TimelineInteractionStateProvider>
           <MockCurrentLayoutProvider onAction={props.onLayoutAction}>
             <PanelStateContextProvider>
-              <ExtensionCatalogProvider loaders={[]}>
+              <ExtensionCatalogProvider
+                loaders={[]}
+                mockMessageConverters={props.fixture?.messageConverters}
+              >
                 <ThemeProvider isDark={theme.palette.mode === "dark"}>
                   <UnconnectedPanelSetup {...props} />
                 </ThemeProvider>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds support for message converters (including multiple converters) for image annotations. If multiple converters are available, or a topic's original schema and converted schema are both supported, multiple entries for the topic will be shown in the settings. They can all be toggled individually.

https://user-images.githubusercontent.com/14237/235260068-a8d6f7d4-051d-4a18-a528-b64b53499531.mov

Relates to FG-1040 / #5791 