### PR TITLE
Use ES private fields instead of TS private accessibility modifier

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -28,6 +28,7 @@ settings:
 rules:
   "@foxglove/license-header": error
   "@foxglove/studio/link-target": error
+  "@foxglove/studio/prefer-hash-private": error
 
   tss-unused-classes/unused-classes: error
 

--- a/benchmark/src/BenchmarkStats.ts
+++ b/benchmark/src/BenchmarkStats.ts
@@ -17,18 +17,18 @@ type RecordFrameTimesFn = (frameTimes: Sample[]) => void;
 class BenchmarkStats {
   private static instance: BenchmarkStats | undefined;
 
-  private frameTimesMs: Sample[] = [];
+  #frameTimesMs: Sample[] = [];
 
   private constructor() {}
 
   public recordFrameTime(durationMs: number): void {
-    this.frameTimesMs.push({
+    this.#frameTimesMs.push({
       stamp: Date.now() / 1_000,
       value: durationMs,
     });
 
-    if (this.frameTimesMs.length >= 100) {
-      const values = this.frameTimesMs.map((sample) => sample.value);
+    if (this.#frameTimesMs.length >= 100) {
+      const values = this.#frameTimesMs.map((sample) => sample.value);
       const totalFrameMs = values.reduce((a, b) => a + b, 0);
       const avgFrameMs = totalFrameMs / values.length;
 
@@ -42,9 +42,9 @@ class BenchmarkStats {
       );
 
       const record = (window as { recordFrameTimes?: RecordFrameTimesFn }).recordFrameTimes;
-      record?.(this.frameTimesMs);
+      record?.(this.#frameTimesMs);
 
-      this.frameTimesMs.length = 0;
+      this.#frameTimesMs.length = 0;
     }
   }
 

--- a/benchmark/src/dataSources/SyntheticDataSourceFactory.ts
+++ b/benchmark/src/dataSources/SyntheticDataSourceFactory.ts
@@ -18,15 +18,15 @@ class SyntheticDataSourceFactory implements IDataSourceFactory {
   public displayName = "Synthetic";
   public iconName: IDataSourceFactory["iconName"] = "FileASPX";
 
-  private newFn: PlayerConstructor;
+  #newFn: PlayerConstructor;
 
   public constructor(id: string, newFn: PlayerConstructor) {
     this.id = id;
-    this.newFn = newFn;
+    this.#newFn = newFn;
   }
 
   public initialize(_args: DataSourceFactoryInitializeArgs): Player | undefined {
-    return new this.newFn();
+    return new this.#newFn();
   }
 }
 

--- a/benchmark/src/players/BenchmarkPlayer.ts
+++ b/benchmark/src/players/BenchmarkPlayer.ts
@@ -37,7 +37,7 @@ class BenchmarkPlayer implements Player {
   #blockLoader?: BlockLoader;
   #problemManager = new PlayerProblemManager();
 
-  public constructor(name: string, source: BenchmarkPlayer["source"]) {
+  public constructor(name: string, source: IIterableSource) {
     this.#name = name;
     this.#source = source;
   }

--- a/benchmark/src/players/BenchmarkPlayer.ts
+++ b/benchmark/src/players/BenchmarkPlayer.ts
@@ -30,27 +30,27 @@ const MAX_BLOCKS = 400;
 const CAPABILITIES: string[] = [PlayerCapabilities.playbackControl];
 
 class BenchmarkPlayer implements Player {
-  private source: IIterableSource;
-  private name: string;
-  private listener?: (state: PlayerState) => Promise<void>;
-  private subscriptions: SubscribePayload[] = [];
-  private _blockLoader?: BlockLoader;
-  private _problemManager = new PlayerProblemManager();
+  #source: IIterableSource;
+  #name: string;
+  #listener?: (state: PlayerState) => Promise<void>;
+  #subscriptions: SubscribePayload[] = [];
+  #blockLoader?: BlockLoader;
+  #problemManager = new PlayerProblemManager();
 
   public constructor(name: string, source: BenchmarkPlayer["source"]) {
-    this.name = name;
-    this.source = source;
+    this.#name = name;
+    this.#source = source;
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {
-    this.listener = listener;
-    void this.run();
+    this.#listener = listener;
+    void this.#run();
   }
   public close(): void {
     //throw new Error("Method not implemented.");
   }
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this.subscriptions = subscriptions;
+    this.#subscriptions = subscriptions;
   }
   public setPublishers(_publishers: AdvertiseOptions[]): void {
     //throw new Error("Method not implemented.");
@@ -68,8 +68,8 @@ class BenchmarkPlayer implements Player {
     throw new Error("Method not implemented.");
   }
 
-  private async run() {
-    const listener = this.listener;
+  async #run() {
+    const listener = this.#listener;
     if (!listener) {
       throw new Error("Invariant: listener is not set");
     }
@@ -79,14 +79,14 @@ class BenchmarkPlayer implements Player {
     await listener({
       profile: undefined,
       presence: PlayerPresence.INITIALIZING,
-      name: this.name + "\ninitializing source",
-      playerId: this.name,
+      name: this.#name + "\ninitializing source",
+      playerId: this.#name,
       capabilities: CAPABILITIES,
       progress: {},
     });
 
     // initialize
-    const result = await this.source.initialize();
+    const result = await this.#source.initialize();
 
     const { start: startTime, end: endTime, topicStats, datatypes, topics } = result;
 
@@ -104,8 +104,8 @@ class BenchmarkPlayer implements Player {
       await listener({
         profile: undefined,
         presence: PlayerPresence.INITIALIZING,
-        name: this.name + "\ngetting messages",
-        playerId: this.name,
+        name: this.#name + "\ngetting messages",
+        playerId: this.#name,
         capabilities: CAPABILITIES,
         progress: {},
         activeData: {
@@ -122,25 +122,25 @@ class BenchmarkPlayer implements Player {
           datatypes,
         },
       });
-    } while (this.subscriptions.length === 0);
+    } while (this.#subscriptions.length === 0);
 
     // Get all messages for our subscriptions
-    const subscribeTopics = this.subscriptions.map((sub) => sub.topic);
+    const subscribeTopics = this.#subscriptions.map((sub) => sub.topic);
     const topicsForPreload = new Set(
-      filterMap(this.subscriptions, (sub) => (sub.preloadType === "full" ? sub.topic : undefined)),
+      filterMap(this.#subscriptions, (sub) => (sub.preloadType === "full" ? sub.topic : undefined)),
     );
-    const iterator = this.source.messageIterator({
+    const iterator = this.#source.messageIterator({
       topics: subscribeTopics,
     });
     try {
-      this._blockLoader = new BlockLoader({
+      this.#blockLoader = new BlockLoader({
         cacheSizeBytes: DEFAULT_CACHE_SIZE_BYTES,
-        source: this.source,
+        source: this.#source,
         start: startTime,
         end: endTime,
         maxBlocks: MAX_BLOCKS,
         minBlockDurationNs: MIN_MEM_CACHE_BLOCK_SIZE_NS,
-        problemManager: this._problemManager,
+        problemManager: this.#problemManager,
       });
     } catch (err) {
       log.error(err);
@@ -148,14 +148,14 @@ class BenchmarkPlayer implements Player {
       const startStr = toRFC3339String(startTime);
       const endStr = toRFC3339String(endTime);
 
-      this._problemManager.addProblem("block-loader", {
+      this.#problemManager.addProblem("block-loader", {
         severity: "warn",
         message: "Failed to initialize message preloading",
         tip: `The start (${startStr}) and end (${endStr}) of your data is too far apart.`,
         error: err,
       });
     }
-    this._blockLoader?.setTopics(topicsForPreload);
+    this.#blockLoader?.setTopics(topicsForPreload);
 
     const msgEvents: MessageEvent<unknown>[] = [];
     const frameMs: number[] = [];
@@ -175,14 +175,14 @@ class BenchmarkPlayer implements Player {
 
     log.info("Preloading messages");
     performance.mark("preloading-start");
-    await this._blockLoader?.startLoading({
+    await this.#blockLoader?.startLoading({
       progress: (progress: Progress) => {
         progressForListener = progress;
         if (
           progress.fullyLoadedFractionRanges?.length === 1 &&
           progress.fullyLoadedFractionRanges[0]!.end === 1
         ) {
-          void this._blockLoader?.stopLoading();
+          void this.#blockLoader?.stopLoading();
         }
       },
     });
@@ -201,8 +201,8 @@ class BenchmarkPlayer implements Player {
       await listener({
         profile: undefined,
         presence: PlayerPresence.PRESENT,
-        name: this.name,
-        playerId: this.name,
+        name: this.#name,
+        playerId: this.#name,
         capabilities: CAPABILITIES,
         progress: progressForListener,
         activeData: {
@@ -250,8 +250,8 @@ class BenchmarkPlayer implements Player {
         await listener({
           profile: undefined,
           presence: PlayerPresence.PRESENT,
-          name: this.name,
-          playerId: this.name,
+          name: this.#name,
+          playerId: this.#name,
           capabilities: CAPABILITIES,
           progress: progressForListener,
           activeData: {

--- a/benchmark/src/players/PointcloudPlayer.ts
+++ b/benchmark/src/players/PointcloudPlayer.ts
@@ -109,13 +109,13 @@ function makePointCloud(stamp: rostime.Time): FoxglovePointCloud {
 }
 
 class PointcloudPlayer implements Player {
-  private name: string = "pointcloud";
-  private startTime: Time = rostime.fromDate(new Date());
-  private listener?: (state: PlayerState) => Promise<void>;
-  private datatypes: RosDatatypes = new Map();
+  #name: string = "pointcloud";
+  #startTime: Time = rostime.fromDate(new Date());
+  #listener?: (state: PlayerState) => Promise<void>;
+  #datatypes: RosDatatypes = new Map();
 
   public constructor() {
-    this.datatypes.set("Time", {
+    this.#datatypes.set("Time", {
       definitions: [
         {
           name: "sec",
@@ -128,7 +128,7 @@ class PointcloudPlayer implements Player {
       ],
     });
 
-    this.datatypes.set("foxglove.PointCloud", {
+    this.#datatypes.set("foxglove.PointCloud", {
       name: "foxglove.PointCloud",
       definitions: [
         {
@@ -150,8 +150,8 @@ class PointcloudPlayer implements Player {
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {
-    this.listener = listener;
-    void this.run();
+    this.#listener = listener;
+    void this.#run();
   }
   public close(): void {
     // no-op
@@ -173,8 +173,8 @@ class PointcloudPlayer implements Player {
     throw new Error("Method not implemented.");
   }
 
-  private async run() {
-    const listener = this.listener;
+  async #run() {
+    const listener = this.#listener;
     if (!listener) {
       throw new Error("Invariant: listener is not set");
     }
@@ -184,8 +184,8 @@ class PointcloudPlayer implements Player {
     await listener({
       profile: undefined,
       presence: PlayerPresence.PRESENT,
-      name: this.name,
-      playerId: this.name,
+      name: this.#name,
+      playerId: this.#name,
       capabilities: CAPABILITIES,
       progress: {},
       urlState: {
@@ -237,22 +237,22 @@ class PointcloudPlayer implements Player {
       await listener({
         profile: undefined,
         presence: PlayerPresence.PRESENT,
-        name: this.name,
-        playerId: this.name,
+        name: this.#name,
+        playerId: this.#name,
         capabilities: CAPABILITIES,
         progress: {},
         activeData: {
           messages,
           totalBytesReceived: 0,
           currentTime: now,
-          startTime: this.startTime,
+          startTime: this.#startTime,
           isPlaying: true,
           speed: 1,
           lastSeekTime: 1,
           endTime: now,
           topics,
           topicStats,
-          datatypes: this.datatypes,
+          datatypes: this.#datatypes,
         },
       });
 

--- a/benchmark/src/players/SinewavePlayer.ts
+++ b/benchmark/src/players/SinewavePlayer.ts
@@ -26,13 +26,13 @@ const log = Log.getLogger(__filename);
 const CAPABILITIES: string[] = [];
 
 class SinewavePlayer implements Player {
-  private name: string = "sinewave";
-  private startTime: Time = rostime.fromDate(new Date());
-  private listener?: (state: PlayerState) => Promise<void>;
-  private datatypes: RosDatatypes = new Map();
+  #name: string = "sinewave";
+  #startTime: Time = rostime.fromDate(new Date());
+  #listener?: (state: PlayerState) => Promise<void>;
+  #datatypes: RosDatatypes = new Map();
 
   public constructor() {
-    this.datatypes.set("Sinewave", {
+    this.#datatypes.set("Sinewave", {
       name: "Sinewave",
       definitions: [
         {
@@ -44,8 +44,8 @@ class SinewavePlayer implements Player {
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {
-    this.listener = listener;
-    void this.run();
+    this.#listener = listener;
+    void this.#run();
   }
   public close(): void {
     // no-op
@@ -67,8 +67,8 @@ class SinewavePlayer implements Player {
     throw new Error("Method not implemented.");
   }
 
-  private async run() {
-    const listener = this.listener;
+  async #run() {
+    const listener = this.#listener;
     if (!listener) {
       throw new Error("Invariant: listener is not set");
     }
@@ -78,8 +78,8 @@ class SinewavePlayer implements Player {
     await listener({
       profile: undefined,
       presence: PlayerPresence.PRESENT,
-      name: this.name,
-      playerId: this.name,
+      name: this.#name,
+      playerId: this.#name,
       capabilities: CAPABILITIES,
       progress: {},
       urlState: {
@@ -131,22 +131,22 @@ class SinewavePlayer implements Player {
       await listener({
         profile: undefined,
         presence: PlayerPresence.PRESENT,
-        name: this.name,
-        playerId: this.name,
+        name: this.#name,
+        playerId: this.#name,
         capabilities: CAPABILITIES,
         progress: {},
         activeData: {
           messages,
           totalBytesReceived: 0,
           currentTime: now,
-          startTime: this.startTime,
+          startTime: this.#startTime,
           isPlaying: true,
           speed: 1,
           lastSeekTime: 1,
           endTime: now,
           topics,
           topicStats,
-          datatypes: this.datatypes,
+          datatypes: this.#datatypes,
         },
       });
 

--- a/benchmark/src/players/TransformPlayer.ts
+++ b/benchmark/src/players/TransformPlayer.ts
@@ -30,19 +30,19 @@ const TRANSFORMS_PER_TICK = 50;
 const CAPABILITIES: string[] = [];
 
 class TransformPlayer implements Player {
-  private name: string = "transform";
-  private listener?: (state: PlayerState) => Promise<void>;
-  private datatypes: RosDatatypes = new Map();
+  #name: string = "transform";
+  #listener?: (state: PlayerState) => Promise<void>;
+  #datatypes: RosDatatypes = new Map();
 
   public constructor() {
-    this.datatypes.set("Time", {
+    this.#datatypes.set("Time", {
       definitions: [
         { name: "sec", type: "uint32" },
         { name: "nsec", type: "uint32" },
       ],
     });
 
-    this.datatypes.set("foxglove.FrameTransform", {
+    this.#datatypes.set("foxglove.FrameTransform", {
       name: "foxglove.FrameTransform",
       definitions: [
         { name: "timestamp", type: "Time", isComplex: true },
@@ -55,8 +55,8 @@ class TransformPlayer implements Player {
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {
-    this.listener = listener;
-    void this.run();
+    this.#listener = listener;
+    void this.#run();
   }
   public close(): void {
     // no-op
@@ -78,8 +78,8 @@ class TransformPlayer implements Player {
     throw new Error("Method not implemented.");
   }
 
-  private async run() {
-    const listener = this.listener;
+  async #run() {
+    const listener = this.#listener;
     if (!listener) {
       throw new Error("Invariant: listener is not set");
     }
@@ -89,12 +89,12 @@ class TransformPlayer implements Player {
     await listener({
       profile: undefined,
       presence: PlayerPresence.PRESENT,
-      name: this.name,
-      playerId: this.name,
+      name: this.#name,
+      playerId: this.#name,
       capabilities: CAPABILITIES,
       progress: {},
       urlState: {
-        sourceId: this.name,
+        sourceId: this.#name,
       },
     });
 
@@ -156,8 +156,8 @@ class TransformPlayer implements Player {
       await listener({
         profile: undefined,
         presence: PlayerPresence.PRESENT,
-        name: this.name,
-        playerId: this.name,
+        name: this.#name,
+        playerId: this.#name,
         capabilities: CAPABILITIES,
         progress: {},
         activeData: {
@@ -171,7 +171,7 @@ class TransformPlayer implements Player {
           endTime: timestamp,
           topics,
           topicStats,
-          datatypes: this.datatypes,
+          datatypes: this.#datatypes,
         },
       });
 

--- a/benchmark/src/players/TransformPreloadingPlayer.ts
+++ b/benchmark/src/players/TransformPreloadingPlayer.ts
@@ -29,23 +29,23 @@ const log = Log.getLogger(__filename);
 const CAPABILITIES: string[] = [PlayerCapabilities.playbackControl];
 
 class TransformPreloadingPlayer implements Player {
-  private name: string = "transformpreloading";
-  private listener?: (state: PlayerState) => Promise<void>;
-  private datatypes: RosDatatypes = new Map();
-  private startTime: Time;
-  private endTime: Time;
-  private topicStats: Map<string, TopicStats>;
-  private topics: Topic[];
+  #name: string = "transformpreloading";
+  #listener?: (state: PlayerState) => Promise<void>;
+  #datatypes: RosDatatypes = new Map();
+  #startTime: Time;
+  #endTime: Time;
+  #topicStats: Map<string, TopicStats>;
+  #topics: Topic[];
 
   public constructor() {
-    this.datatypes.set("Time", {
+    this.#datatypes.set("Time", {
       definitions: [
         { name: "sec", type: "uint32" },
         { name: "nsec", type: "uint32" },
       ],
     });
 
-    this.datatypes.set("foxglove.FrameTransform", {
+    this.#datatypes.set("foxglove.FrameTransform", {
       name: "foxglove.FrameTransform",
       definitions: [
         { name: "timestamp", type: "Time", isComplex: true },
@@ -55,10 +55,10 @@ class TransformPreloadingPlayer implements Player {
         { name: "rotation", type: "Quaternion", isComplex: true },
       ],
     });
-    this.startTime = { sec: 0, nsec: 0 };
-    this.endTime = { sec: 600, nsec: 0 };
+    this.#startTime = { sec: 0, nsec: 0 };
+    this.#endTime = { sec: 600, nsec: 0 };
 
-    this.topicStats = new Map([
+    this.#topicStats = new Map([
       [
         "/100hz",
         {
@@ -77,7 +77,7 @@ class TransformPreloadingPlayer implements Player {
       ],
     ]);
 
-    this.topics = [
+    this.#topics = [
       {
         name: "/100hz",
         schemaName: "foxglove.FrameTransform",
@@ -90,8 +90,8 @@ class TransformPreloadingPlayer implements Player {
   }
 
   public setListener(listener: (state: PlayerState) => Promise<void>): void {
-    this.listener = listener;
-    void this.run();
+    this.#listener = listener;
+    void this.#run();
   }
   public close(): void {
     // no-op
@@ -115,8 +115,8 @@ class TransformPreloadingPlayer implements Player {
     throw new Error("Method not implemented.");
   }
 
-  private async run() {
-    const listener = this.listener;
+  async #run() {
+    const listener = this.#listener;
     if (!listener) {
       throw new Error("Invariant: listener is not set");
     }
@@ -126,34 +126,34 @@ class TransformPreloadingPlayer implements Player {
     await listener({
       profile: undefined,
       presence: PlayerPresence.PRESENT,
-      name: this.name,
-      playerId: this.name,
+      name: this.#name,
+      playerId: this.#name,
       capabilities: CAPABILITIES,
       progress: {},
       urlState: {
-        sourceId: this.name,
+        sourceId: this.#name,
       },
     });
 
     await listener({
       profile: undefined,
       presence: PlayerPresence.INITIALIZING,
-      name: this.name + "\ngetting messages",
-      playerId: this.name,
+      name: this.#name + "\ngetting messages",
+      playerId: this.#name,
       capabilities: CAPABILITIES,
       progress: {},
       activeData: {
         messages: [],
         totalBytesReceived: 0,
-        currentTime: this.startTime,
-        startTime: this.startTime,
+        currentTime: this.#startTime,
+        startTime: this.#startTime,
         isPlaying: false,
         speed: 1,
         lastSeekTime: 1,
-        endTime: this.endTime,
-        topics: this.topics,
-        topicStats: this.topicStats,
-        datatypes: this.datatypes,
+        endTime: this.#endTime,
+        topics: this.#topics,
+        topicStats: this.#topicStats,
+        datatypes: this.#datatypes,
       },
     });
 
@@ -162,7 +162,7 @@ class TransformPreloadingPlayer implements Player {
     const msgs100Hz = getTfMessages({
       topic: "/100hz",
       startSeconds: 0,
-      endSeconds: this.endTime.sec,
+      endSeconds: this.#endTime.sec,
       tfParams: {
         axis: "x",
         parent: "base_link",
@@ -173,7 +173,7 @@ class TransformPreloadingPlayer implements Player {
     const msgs150Hz = getTfMessages({
       topic: "/150hz",
       startSeconds: 0,
-      endSeconds: this.endTime.sec,
+      endSeconds: this.#endTime.sec,
       tfParams: { axis: "z", parent: "100hz", frequencyHz: 150, translation: { x: 0, y: 0, z: 1 } },
     });
 
@@ -225,22 +225,22 @@ class TransformPreloadingPlayer implements Player {
         await listener({
           profile: undefined,
           presence: PlayerPresence.PRESENT,
-          name: this.name,
-          playerId: this.name,
+          name: this.#name,
+          playerId: this.#name,
           capabilities: CAPABILITIES,
           progress: progressForListener,
           activeData: {
             messages: [seekToMessage],
             totalBytesReceived: 1,
-            startTime: this.startTime,
-            endTime: this.endTime,
+            startTime: this.#startTime,
+            endTime: this.#endTime,
             currentTime: seekToMessage.receiveTime,
             isPlaying: false,
             speed: 1,
             lastSeekTime: Date.now(),
-            topics: this.topics,
-            topicStats: this.topicStats,
-            datatypes: this.datatypes,
+            topics: this.#topics,
+            topicStats: this.#topicStats,
+            datatypes: this.#datatypes,
           },
         });
         const endFrame = performance.now();
@@ -269,22 +269,22 @@ class TransformPreloadingPlayer implements Player {
         await listener({
           profile: undefined,
           presence: PlayerPresence.PRESENT,
-          name: this.name,
-          playerId: this.name,
+          name: this.#name,
+          playerId: this.#name,
           capabilities: CAPABILITIES,
           progress: progressForListener,
           activeData: {
             messages: [seekToMessage],
             totalBytesReceived: 1,
-            startTime: this.startTime,
-            endTime: this.endTime,
+            startTime: this.#startTime,
+            endTime: this.#endTime,
             currentTime: seekToMessage.receiveTime,
             isPlaying: false,
             speed: 1,
             lastSeekTime: Date.now(),
-            topics: this.topics,
-            topicStats: this.topicStats,
-            datatypes: this.datatypes,
+            topics: this.#topics,
+            topicStats: this.#topicStats,
+            datatypes: this.#datatypes,
           },
         });
         const endFrame = performance.now();

--- a/benchmark/src/services/MemoryAppConfiguration.tsx
+++ b/benchmark/src/services/MemoryAppConfiguration.tsx
@@ -11,24 +11,24 @@ import { IAppConfiguration, ChangeHandler, AppConfigurationValue } from "@foxglo
  * Configuration does not survive any reload nor is it persisted.
  */
 export class MemoryAppConfiguration implements IAppConfiguration {
-  private values = new Map<string, AppConfigurationValue>();
+  #values = new Map<string, AppConfigurationValue>();
 
-  private changeListeners = new Map<string, Set<ChangeHandler>>();
+  #changeListeners = new Map<string, Set<ChangeHandler>>();
 
   public constructor({ defaults }: { defaults?: { [key: string]: AppConfigurationValue } }) {
     if (defaults) {
       for (const [key, value] of Object.entries(defaults)) {
-        this.values.set(key, value);
+        this.#values.set(key, value);
       }
     }
   }
 
   public get(key: string): AppConfigurationValue {
-    return this.values.get(key);
+    return this.#values.get(key);
   }
   public async set(key: string, value: AppConfigurationValue): Promise<void> {
-    this.values.set(key, value);
-    const listeners = this.changeListeners.get(key);
+    this.#values.set(key, value);
+    const listeners = this.#changeListeners.get(key);
     if (listeners) {
       // Copy the list of listeners to protect against mutation during iteration
       [...listeners].forEach((listener) => listener(value));
@@ -36,16 +36,16 @@ export class MemoryAppConfiguration implements IAppConfiguration {
   }
 
   public addChangeListener(key: string, cb: ChangeHandler): void {
-    let listeners = this.changeListeners.get(key);
+    let listeners = this.#changeListeners.get(key);
     if (!listeners) {
       listeners = new Set();
-      this.changeListeners.set(key, listeners);
+      this.#changeListeners.set(key, listeners);
     }
     listeners.add(cb);
   }
 
   public removeChangeListener(key: string, cb: ChangeHandler): void {
-    const listeners = this.changeListeners.get(key);
+    const listeners = this.#changeListeners.get(key);
     listeners?.delete(cb);
   }
 }

--- a/benchmark/src/services/PredefinedLayoutStorage.tsx
+++ b/benchmark/src/services/PredefinedLayoutStorage.tsx
@@ -9,22 +9,22 @@ import { Layout, LayoutID, ILayoutStorage } from "@foxglove/studio-base";
  * catalog of layouts. Adding, updating, or removing layouts is not supported.
  */
 class PredefinedLayoutStorage implements ILayoutStorage {
-  private layouts: Map<string, Layout>;
+  #layouts: Map<string, Layout>;
 
   public constructor(layouts: Map<string, Layout>) {
-    this.layouts = layouts;
+    this.#layouts = layouts;
   }
 
   public async list(_namespace: string): Promise<readonly Layout[]> {
-    return Array.from(this.layouts.values());
+    return Array.from(this.#layouts.values());
   }
 
   public async get(_namespace: string, id: LayoutID): Promise<Layout | undefined> {
-    return this.layouts.get(id);
+    return this.#layouts.get(id);
   }
 
   public async put(_namespace: string, layout: Layout): Promise<Layout> {
-    if (!this.layouts.get(layout.id)) {
+    if (!this.#layouts.get(layout.id)) {
       throw new Error("Benchmark app only allows updating existing layouts.");
     }
     return layout;

--- a/eslint-test.ts
+++ b/eslint-test.ts
@@ -29,5 +29,18 @@
 // @ts-expect-error unused function
 function useEffectOnce() {} // eslint-disable-line id-denylist, @typescript-eslint/no-unused-vars
 
+class Foo {
+  private bar = 1; // eslint-disable-line @foxglove/studio/prefer-hash-private
+  // eslint-disable-next-line @foxglove/studio/prefer-hash-private
+  private foo() {
+    this.bar = 2;
+  }
+  public asdf() {
+    this.foo();
+    void this.bar;
+  }
+}
+void Foo;
+
 // keep isolatedModules happy
 export default {};

--- a/packages/den/async/Condvar.ts
+++ b/packages/den/async/Condvar.ts
@@ -12,7 +12,7 @@
  * See: https://en.wikipedia.org/wiki/Monitor_(synchronization)#Condition_variables_2
  */
 class Condvar {
-  private waitQueue: Array<() => void> = [];
+  #waitQueue: Array<() => void> = [];
 
   /**
    * Wait on a notification.
@@ -25,7 +25,7 @@ class Condvar {
    */
   public async wait(): Promise<void> {
     await new Promise<void>((resolve) => {
-      this.waitQueue.push(resolve);
+      this.#waitQueue.push(resolve);
     });
   }
 
@@ -33,7 +33,7 @@ class Condvar {
    * Notify one wait.
    */
   public notifyOne(): void {
-    const item = this.waitQueue.shift();
+    const item = this.#waitQueue.shift();
     item?.();
   }
 
@@ -41,10 +41,10 @@ class Condvar {
    * Notify all waiting.
    */
   public notifyAll(): void {
-    for (const item of this.waitQueue) {
+    for (const item of this.#waitQueue) {
       item();
     }
-    this.waitQueue.length = 0;
+    this.#waitQueue.length = 0;
   }
 }
 

--- a/packages/den/async/LazilyInitialized.ts
+++ b/packages/den/async/LazilyInitialized.ts
@@ -9,18 +9,18 @@
 export default class LazilyInitialized<T> {
   // The promise and compute function are held separately so the function can be garbage collected
   // when it is no longer needed.
-  private state: { promise: Promise<T> } | { promise?: undefined; compute: () => Promise<T> };
+  #state: { promise: Promise<T> } | { promise?: undefined; compute: () => Promise<T> };
 
   public constructor(compute: () => Promise<T>) {
-    this.state = { compute };
+    this.#state = { compute };
   }
 
   public async get(): Promise<T> {
-    if (this.state.promise) {
-      return await this.state.promise;
+    if (this.#state.promise) {
+      return await this.#state.promise;
     }
-    const promise = this.state.compute();
-    this.state = { promise };
+    const promise = this.#state.compute();
+    this.#state = { promise };
     return await promise;
   }
 }

--- a/packages/den/async/MutexLocked.ts
+++ b/packages/den/async/MutexLocked.ts
@@ -11,10 +11,10 @@ import { Mutex } from "async-mutex";
  * access to be protected by the mutex.
  */
 export default class MutexLocked<T> {
-  private mutex = new Mutex();
+  #mutex = new Mutex();
   public constructor(private value: T) {}
 
   public async runExclusive<Result>(body: (value: T) => Promise<Result>): Promise<Result> {
-    return await this.mutex.runExclusive(async () => await body(this.value));
+    return await this.#mutex.runExclusive(async () => await body(this.value));
   }
 }

--- a/packages/den/collection/ArrayMap.ts
+++ b/packages/den/collection/ArrayMap.ts
@@ -8,20 +8,20 @@
  * key as an existing entry is a replacement operation.
  */
 export class ArrayMap<K, V> {
-  private _list: [K, V][] = [];
+  #list: [K, V][] = [];
 
   // eslint-disable-next-line no-restricted-syntax
   public get size(): number {
-    return this._list.length;
+    return this.#list.length;
   }
 
   public clear(): void {
-    this._list.length = 0;
+    this.#list.length = 0;
   }
 
   /** Retrieve the key/value tuple at the given index, if it exists. */
   public at(index: number): [K, V] | undefined {
-    return this._list[index];
+    return this.#list[index];
   }
 
   /**
@@ -31,33 +31,33 @@ export class ArrayMap<K, V> {
   public set(key: K, value: V): void {
     const index = this.binarySearch(key);
     if (index >= 0) {
-      this._list[index]![1] = value;
+      this.#list[index]![1] = value;
     } else {
       const greaterThanIndex = ~index;
       const newEntry: [K, V] = [key, value];
-      if (greaterThanIndex >= this._list.length) {
-        this._list.push(newEntry);
+      if (greaterThanIndex >= this.#list.length) {
+        this.#list.push(newEntry);
       } else {
-        this._list.splice(greaterThanIndex, 0, newEntry);
+        this.#list.splice(greaterThanIndex, 0, newEntry);
       }
     }
   }
 
   /** Removes the first element and returns it, if available. */
   public shift(): [K, V] | undefined {
-    return this._list.shift();
+    return this.#list.shift();
   }
 
   /** Removes the last element and returns it, if available. */
   public pop(): [K, V] | undefined {
-    return this._list.pop();
+    return this.#list.pop();
   }
 
   /** Removes the element with the given key, if it exists */
   public remove(key: K): void {
     const index = this.binarySearch(key);
     if (index >= 0) {
-      this._list.splice(index, 1);
+      this.#list.splice(index, 1);
     }
   }
 
@@ -65,34 +65,34 @@ export class ArrayMap<K, V> {
   public removeAfter(key: K): void {
     const index = this.binarySearch(key);
     const greaterThanIndex = index >= 0 ? index + 1 : ~index;
-    this._list.length = greaterThanIndex;
+    this.#list.length = greaterThanIndex;
   }
 
   /** Removes all elements with keys less than the given key. */
   public removeBefore(key: K): void {
     const index = this.binarySearch(key);
     const lessThanIndex = index >= 0 ? index : ~index;
-    this._list.splice(0, lessThanIndex);
+    this.#list.splice(0, lessThanIndex);
   }
 
   /** Access the first key/value tuple in the list, without modifying the list. */
   public minEntry(): [K, V] | undefined {
-    return this._list[0];
+    return this.#list[0];
   }
 
   /** Access the last key/value tuple in the list, without modifying the list. */
   public maxEntry(): [K, V] | undefined {
-    return this._list[this._list.length - 1];
+    return this.#list[this.#list.length - 1];
   }
 
   /** Access the first key in the list, without modifying the list. */
   public minKey(): K | undefined {
-    return this._list[0]?.[0];
+    return this.#list[0]?.[0];
   }
 
   /** Access the last key in the list, without modifying the list. */
   public maxKey(): K | undefined {
-    return this._list[this._list.length - 1]?.[0];
+    return this.#list[this.#list.length - 1]?.[0];
   }
 
   /**
@@ -108,7 +108,7 @@ export class ArrayMap<K, V> {
    * plus 1.
    */
   public binarySearch(key: K): number {
-    const list = this._list;
+    const list = this.#list;
     if (list.length === 0) {
       return -1;
     }

--- a/packages/den/collection/VecQueue.ts
+++ b/packages/den/collection/VecQueue.ts
@@ -9,9 +9,9 @@
  * `dequeue` removes items from the front of the queue
  */
 export class VecQueue<T> {
-  private readPos = 0;
-  private writePos = 0;
-  private buffer: Array<T | undefined> = new Array(4);
+  #readPos = 0;
+  #writePos = 0;
+  #buffer: Array<T | undefined> = new Array(4);
 
   /**
    * Add an item at the end of the queue. If the queue is full the underlying buffer is grown.
@@ -21,24 +21,24 @@ export class VecQueue<T> {
     // When the write position is past the buffer end, we need to take one of two actions:
     // 1. If read position is at 0, we grow the array and write to the end
     // 2. Otherwise, we wrap write to the front and continue writing
-    if (this.writePos >= this.buffer.length) {
+    if (this.#writePos >= this.#buffer.length) {
       // Read head is at the start, we will write at the end
-      if (this.readPos === 0) {
-        this.addCapacity();
+      if (this.#readPos === 0) {
+        this.#addCapacity();
       } else {
-        this.writePos = this.writePos % this.buffer.length;
+        this.#writePos = this.#writePos % this.#buffer.length;
       }
     }
 
     // Read is only 1 away from write, so once the item is written our write head would be at the read head
     // we can't allow that so we need to add capacity
-    if (this.readPos - this.writePos === 1) {
-      this.addCapacity();
+    if (this.#readPos - this.#writePos === 1) {
+      this.#addCapacity();
     }
 
     // write to position and increment
-    this.buffer[this.writePos] = item;
-    this.writePos++;
+    this.#buffer[this.#writePos] = item;
+    this.#writePos++;
   }
 
   /**
@@ -46,19 +46,19 @@ export class VecQueue<T> {
    * @returns the first item in the queue or undefined if the queue is empty
    */
   public dequeue(): T | undefined {
-    if (this.readPos === this.writePos) {
+    if (this.#readPos === this.#writePos) {
       return undefined;
     }
 
     // Read position may have incremented from a previous read
     // and we need to maybe wrap it to our size
-    if (this.readPos >= this.buffer.length) {
-      this.readPos = this.readPos % this.buffer.length;
+    if (this.#readPos >= this.#buffer.length) {
+      this.#readPos = this.#readPos % this.#buffer.length;
     }
 
-    const item = this.buffer[this.readPos];
-    this.buffer[this.readPos] = undefined;
-    this.readPos += 1;
+    const item = this.#buffer[this.#readPos];
+    this.#buffer[this.#readPos] = undefined;
+    this.#readPos += 1;
     return item;
   }
 
@@ -66,59 +66,59 @@ export class VecQueue<T> {
    * @returns the number of items in the queue
    */
   public size(): number {
-    if (this.writePos >= this.readPos) {
-      return this.writePos - this.readPos;
+    if (this.#writePos >= this.#readPos) {
+      return this.#writePos - this.#readPos;
     }
 
-    return this.buffer.length - this.readPos + this.writePos;
+    return this.#buffer.length - this.#readPos + this.#writePos;
   }
 
   /**
    * @returns the capacity of the underlying circular buffer
    */
   public capacity(): number {
-    return this.buffer.length;
+    return this.#buffer.length;
   }
 
   /**
    * Clear the queue.
    */
   public clear(): void {
-    this.buffer.length = 0;
-    this.writePos = 0;
-    this.readPos = 0;
+    this.#buffer.length = 0;
+    this.#writePos = 0;
+    this.#readPos = 0;
   }
 
-  private addCapacity() {
-    const oldLen = this.buffer.length;
-    this.buffer.length = this.buffer.length * 2;
+  #addCapacity() {
+    const oldLen = this.#buffer.length;
+    this.#buffer.length = this.#buffer.length * 2;
 
     // if the read head is before write, then there's no change to index management and write can continue at end
     // if the read head is ahead of write, then we can un-wrap the write bytes
-    if (this.readPos <= this.writePos) {
+    if (this.#readPos <= this.#writePos) {
       return;
     }
 
-    const newLen = this.buffer.length;
+    const newLen = this.#buffer.length;
 
     // if writePos is past half it is cheaper to move the read elements
-    if (this.writePos >= oldLen / 2) {
-      const oldCount = oldLen - this.readPos;
+    if (this.#writePos >= oldLen / 2) {
+      const oldCount = oldLen - this.#readPos;
       // move the read elements to the end giving us the most room to write
       const offset = newLen - oldCount;
       for (let i = 0; i < oldCount; ++i) {
-        this.buffer[offset + i] = this.buffer[this.readPos + i];
-        this.buffer[this.readPos + i] = undefined;
+        this.#buffer[offset + i] = this.#buffer[this.#readPos + i];
+        this.#buffer[this.#readPos + i] = undefined;
       }
-      this.readPos = offset;
+      this.#readPos = offset;
     } else {
       // copy all the elements from start to writePos - 1 to the end of the extended buffer
-      for (let i = 0; i < this.writePos; ++i) {
-        this.buffer[oldLen + i] = this.buffer[i];
-        this.buffer[i] = undefined;
+      for (let i = 0; i < this.#writePos; ++i) {
+        this.#buffer[oldLen + i] = this.#buffer[i];
+        this.#buffer[i] = undefined;
       }
 
-      this.writePos = oldLen + this.writePos;
+      this.#writePos = oldLen + this.#writePos;
     }
   }
 }

--- a/packages/eslint-plugin-studio/index.js
+++ b/packages/eslint-plugin-studio/index.js
@@ -5,5 +5,6 @@
 module.exports = {
   rules: {
     "link-target": require("./link-target"),
+    "prefer-hash-private": require("./prefer-hash-private"),
   },
 };

--- a/packages/eslint-plugin-studio/prefer-hash-private.js
+++ b/packages/eslint-plugin-studio/prefer-hash-private.js
@@ -2,8 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-const { findVariable } = require("@eslint-community/eslint-utils");
-
 /**
  * @param {import("estree").Node} node
  */
@@ -73,31 +71,6 @@ module.exports = {
             infoByClass.set(cls, info);
           }
           info.privates.add(node);
-
-          // const scope = context.getScope();
-          // const v = findVariable(context.getScope(), node.key.name);
-          // console.log(`scope for ${node.key.name} is:`, scope);
-          // console.log(`fn scope:`, scope.childScopes[1]);
-          // console.log(`findVariable returned`, v);
-          // const variable = scope.set.get(node.key.name);
-          // if (!variable) {
-          //   throw new Error(`Couldn't find scope variable named ${node.key.name}`);
-          // }
-
-          // const newName = "#" + node.key.name.replace(/^_/, "");
-
-          // context.report({
-          //   node,
-          //   message: "Use `#` language feature instead of `private` accessibility modifier",
-          //   suggest: [
-          //     {
-          //       desc: `Rename to ${newName}`,
-          //       fix: (fixer) => {
-          //         return variable.references.map((ref) => fixer.replaceText(ref.identifier, newName));
-          //       },
-          //     },
-          //   ],
-          // });
         },
 
       [`ClassDeclaration:exit`]: (node) => {

--- a/packages/eslint-plugin-studio/prefer-hash-private.js
+++ b/packages/eslint-plugin-studio/prefer-hash-private.js
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+const { findVariable } = require("@eslint-community/eslint-utils");
+
+/**
+ * @param {import("estree").Node} node
+ */
+function getEnclosingClass(node) {
+  for (let current = node; current; current = current.parent) {
+    if (current.type === "ClassDeclaration") {
+      return current;
+    } else if (current.type === "FunctionDeclaration") {
+      return undefined;
+    } else if (
+      current.type === "FunctionExpression" &&
+      current.parent?.parent?.type !== "ClassBody"
+    ) {
+      return undefined;
+    }
+  }
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    fixable: "code",
+  },
+  create: (context) => {
+    /** @type {Map<import("estree").ClassDeclaration, { privates: Set<import("estree").Identifier>, memberReferences: Map<string, import("estree").Identifier[]> }>} */
+    const infoByClass = new Map();
+    return {
+      [`MemberExpression:has(ThisExpression.object) > Identifier.property`]: (
+        /** @type {import("estree").Identifier} */ node,
+      ) => {
+        const cls = getEnclosingClass(node);
+        if (!cls) {
+          return;
+        }
+        let info = infoByClass.get(cls);
+        if (!info) {
+          info = { privates: new Set(), memberReferences: new Map() };
+          infoByClass.set(cls, info);
+        }
+        let refs = info.memberReferences.get(node.name);
+        if (!refs) {
+          refs = [];
+          info.memberReferences.set(node.name, refs);
+        }
+        refs.push(node);
+      },
+      [`:matches(PropertyDefinition, MethodDefinition)[accessibility="private"] > Identifier.key`]:
+        (
+          /** @type {import("estree").PropertyDefinition | import("estree").MethodDefinition} */
+          node,
+        ) => {
+          // debugger;
+          const cls = getEnclosingClass(node);
+          if (!cls) {
+            throw new Error("No class around private definition??");
+          }
+
+          let info = infoByClass.get(cls);
+          if (!info) {
+            info = { privates: new Set(), memberReferences: new Map() };
+            infoByClass.set(cls, info);
+          }
+          info.privates.add(node);
+
+          // const scope = context.getScope();
+          // const v = findVariable(context.getScope(), node.key.name);
+          // console.log(`scope for ${node.key.name} is:`, scope);
+          // console.log(`fn scope:`, scope.childScopes[1]);
+          // console.log(`findVariable returned`, v);
+          // const variable = scope.set.get(node.key.name);
+          // if (!variable) {
+          //   throw new Error(`Couldn't find scope variable named ${node.key.name}`);
+          // }
+
+          // const newName = "#" + node.key.name.replace(/^_/, "");
+
+          // context.report({
+          //   node,
+          //   message: "Use `#` language feature instead of `private` accessibility modifier",
+          //   suggest: [
+          //     {
+          //       desc: `Rename to ${newName}`,
+          //       fix: (fixer) => {
+          //         return variable.references.map((ref) => fixer.replaceText(ref.identifier, newName));
+          //       },
+          //     },
+          //   ],
+          // });
+        },
+
+      [`ClassDeclaration:exit`]: (node) => {
+        const info = infoByClass.get(node);
+        if (!info) {
+          return;
+        }
+
+        for (const privateIdentifier of info.privates) {
+          const refs = info.memberReferences.get(privateIdentifier.name);
+          if (!refs) {
+            continue;
+          }
+
+          const newName = "#" + privateIdentifier.name.replace(/^_/, "");
+          context.report({
+            node: privateIdentifier,
+            message: `Prefer \`${newName}\` language feature over \`private ${privateIdentifier.name}\` accessibility modifier`,
+            *fix(fixer) {
+              const privateToken = context
+                .getSourceCode()
+                .getTokens(privateIdentifier.parent)
+                .find((token) => token.type === "Keyword" && token.value === "private");
+              if (privateToken) {
+                yield fixer.removeRange([privateToken.range[0], privateToken.range[1] + 1]);
+              }
+              yield fixer.replaceText(privateIdentifier, newName);
+              for (const ref of refs) {
+                yield fixer.replaceText(ref, newName);
+              }
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-studio/prefer-hash-private.js
+++ b/packages/eslint-plugin-studio/prefer-hash-private.js
@@ -35,6 +35,10 @@ module.exports = {
       [`MemberExpression:has(ThisExpression.object) > Identifier.property`]: (
         /** @type {import("estree").Identifier} */ node,
       ) => {
+        if (node.parent.object.type !== "ThisExpression") {
+          // We'd prefer the selector to use `:has(> ThisExpression.object)`, but ESQuery doesn't support that syntax.
+          return;
+        }
         const cls = getEnclosingClass(node);
         if (!cls) {
           return;

--- a/packages/eslint-plugin-studio/prefer-hash-private.js
+++ b/packages/eslint-plugin-studio/prefer-hash-private.js
@@ -36,6 +36,7 @@ module.exports = {
         /** @type {import("estree").Identifier} */ node,
       ) => {
         if (node.parent.object.type !== "ThisExpression") {
+          // Avoid treating `this.foo.bar` as a reference to `private bar`.
           // We'd prefer the selector to use `:has(> ThisExpression.object)`, but ESQuery doesn't support that syntax.
           return;
         }

--- a/packages/eslint-plugin-studio/prefer-hash-private.js
+++ b/packages/eslint-plugin-studio/prefer-hash-private.js
@@ -25,6 +25,7 @@ module.exports = {
   meta: {
     type: "problem",
     fixable: "code",
+    hasSuggestions: true,
   },
   create: (context) => {
     /** @type {Map<import("estree").ClassDeclaration, { privates: Set<import("estree").Identifier>, memberReferences: Map<string, import("estree").Identifier[]> }>} */
@@ -59,7 +60,6 @@ module.exports = {
           /** @type {import("estree").PropertyDefinition | import("estree").MethodDefinition} */
           node,
         ) => {
-          // debugger;
           const cls = getEnclosingClass(node);
           if (!cls) {
             throw new Error("No class around private definition??");
@@ -89,19 +89,24 @@ module.exports = {
           context.report({
             node: privateIdentifier,
             message: `Prefer \`${newName}\` language feature over \`private ${privateIdentifier.name}\` accessibility modifier`,
-            *fix(fixer) {
-              const privateToken = context
-                .getSourceCode()
-                .getTokens(privateIdentifier.parent)
-                .find((token) => token.type === "Keyword" && token.value === "private");
-              if (privateToken) {
-                yield fixer.removeRange([privateToken.range[0], privateToken.range[1] + 1]);
-              }
-              yield fixer.replaceText(privateIdentifier, newName);
-              for (const ref of refs) {
-                yield fixer.replaceText(ref, newName);
-              }
-            },
+            suggest: [
+              {
+                desc: `Rename to ${newName}`,
+                *fix(fixer) {
+                  const privateToken = context
+                    .getSourceCode()
+                    .getTokens(privateIdentifier.parent)
+                    .find((token) => token.type === "Keyword" && token.value === "private");
+                  if (privateToken) {
+                    yield fixer.removeRange([privateToken.range[0], privateToken.range[1] + 1]);
+                  }
+                  yield fixer.replaceText(privateIdentifier, newName);
+                  for (const ref of refs) {
+                    yield fixer.replaceText(ref, newName);
+                  }
+                },
+              },
+            ],
           });
         }
       },

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -13,18 +13,18 @@ class Logger {
   // default logger has an empty name
   public static default = new Logger("");
 
-  private _name: string;
+  #name: string;
 
   // all new loggers are created from the default logger
   private constructor(name: string) {
-    this._name = name;
+    this.#name = name;
     this.setLevel("debug");
     channels.set(name, this);
   }
 
   // fully qualified name for the logger
   public name(): string {
-    return this._name;
+    return this.#name;
   }
 
   /**
@@ -101,7 +101,7 @@ class Logger {
   // create a new logger under this logger's namespace
   public getLogger(name: string): Logger {
     const shortName = name.replace(/^.+\.(asar|webpack)[\\/\\]/, "").replace(/^(\.\.\/)+/, "");
-    const channelName = this._name.length > 0 ? `${this._name}.${shortName}` : shortName;
+    const channelName = this.#name.length > 0 ? `${this.#name}.${shortName}` : shortName;
     const existing = channels.get(channelName);
     if (existing) {
       return existing;

--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -24,15 +24,15 @@ import {
 
 // ts-prune-ignore-next
 export default class FakePlayer implements Player {
-  private listener?: (arg0: PlayerState) => Promise<void>;
+  #listener?: (arg0: PlayerState) => Promise<void>;
   public playerId: string = "test";
   public subscriptions: SubscribePayload[] = [];
   public publishers: AdvertiseOptions[] | undefined;
-  private _capabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
-  private _profile: string | undefined;
+  #capabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
+  #profile: string | undefined;
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this.listener = listener;
+    this.#listener = listener;
   }
 
   public async emit({
@@ -44,15 +44,15 @@ export default class FakePlayer implements Player {
     presence?: PlayerPresence;
     progress?: PlayerState["progress"];
   } = {}): Promise<void> {
-    if (!this.listener) {
+    if (!this.#listener) {
       return undefined;
     }
 
-    return await this.listener({
+    return await this.#listener({
       playerId: this.playerId,
       presence: presence ?? PlayerPresence.PRESENT,
-      capabilities: this._capabilities,
-      profile: this._profile,
+      capabilities: this.#capabilities,
+      profile: this.#profile,
       progress: progress ?? {},
       activeData,
     });
@@ -85,10 +85,10 @@ export default class FakePlayer implements Player {
   public setCapabilities = (
     capabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][],
   ): void => {
-    this._capabilities = capabilities;
+    this.#capabilities = capabilities;
   };
   public setProfile = (profile: string | undefined): void => {
-    this._profile = profile;
+    this.#profile = profile;
   };
   public startPlayback = (): void => {
     // no-op

--- a/packages/studio-base/src/dataSources/RemoteDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RemoteDataSourceFactory.tsx
@@ -59,7 +59,7 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
         label: "Remote file URL",
         placeholder: "https://example.com/file.bag",
         validate: (newValue: string): Error | undefined => {
-          return this.validateUrl(newValue);
+          return this.#validateUrl(newValue);
         },
       },
     ],
@@ -99,7 +99,7 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
     });
   }
 
-  private validateUrl(newValue: string): Error | undefined {
+  #validateUrl(newValue: string): Error | undefined {
     try {
       const url = new URL(newValue);
       const extension = path.extname(url.pathname);

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.worker.ts
@@ -26,13 +26,13 @@ type RenderState = {
 };
 
 class ImageCanvasWorker {
-  private readonly _renderStates: Record<string, RenderState> = {};
+  readonly #renderStates: Record<string, RenderState> = {};
 
   public constructor(rpc: Rpc) {
     setupWorker(rpc);
 
     rpc.receive("initialize", async ({ id, canvas }: { id: string; canvas: OffscreenCanvas }) => {
-      this._renderStates[id] = {
+      this.#renderStates[id] = {
         canvas,
         hitmap: new OffscreenCanvas(canvas.width, canvas.height),
         markers: [],
@@ -40,7 +40,7 @@ class ImageCanvasWorker {
     });
 
     rpc.receive("mouseMove", async ({ id, x, y }: { id: string; x: number; y: number }) => {
-      const state = this._renderStates[id];
+      const state = this.#renderStates[id];
       if (!state) {
         return undefined;
       }
@@ -70,7 +70,7 @@ class ImageCanvasWorker {
       (args: RenderArgs & { id: string }): Promise<RenderDimensions | undefined> => {
         const { id, geometry, imageMessage, rawMarkerData, options } = args;
 
-        const render = this._renderStates[id];
+        const render = this.#renderStates[id];
         if (!render) {
           return Promise.resolve(undefined);
         }

--- a/packages/studio-base/src/panels/Image/lib/HitmapRenderContext.ts
+++ b/packages/studio-base/src/panels/Image/lib/HitmapRenderContext.ts
@@ -9,27 +9,27 @@ import { indexToIDColor } from "./util";
  * to a separate hitmap context.
  */
 export class HitmapRenderContext {
-  private _currentMarkerIndex: number = 0;
-  private readonly _hctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | undefined;
+  #currentMarkerIndex: number = 0;
+  readonly #hctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | undefined;
 
   public constructor(
     private readonly _ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
     private readonly _hitmapCanvas: HTMLCanvasElement | OffscreenCanvas | undefined,
   ) {
-    this._hctx = this._hitmapCanvas?.getContext("2d") ?? undefined;
-    if (this._hctx) {
-      this._hctx.imageSmoothingEnabled = false;
-      this._hctx.clearRect(0, 0, this._ctx.canvas.width, this._ctx.canvas.height);
+    this.#hctx = this._hitmapCanvas?.getContext("2d") ?? undefined;
+    if (this.#hctx) {
+      this.#hctx.imageSmoothingEnabled = false;
+      this.#hctx.clearRect(0, 0, this._ctx.canvas.width, this._ctx.canvas.height);
     }
   }
 
   public startMarker(): void {
-    if (this._hctx) {
-      const colorString = indexToIDColor(this._currentMarkerIndex);
-      this._hctx.fillStyle = `#${colorString}ff`;
-      this._hctx.strokeStyle = `#${colorString}ff`;
+    if (this.#hctx) {
+      const colorString = indexToIDColor(this.#currentMarkerIndex);
+      this.#hctx.fillStyle = `#${colorString}ff`;
+      this.#hctx.strokeStyle = `#${colorString}ff`;
     }
-    this._currentMarkerIndex++;
+    this.#currentMarkerIndex++;
   }
 
   // eslint-disable-next-line no-restricted-syntax
@@ -40,8 +40,8 @@ export class HitmapRenderContext {
   // eslint-disable-next-line no-restricted-syntax
   public set lineWidth(width: number) {
     this._ctx.lineWidth = width;
-    if (this._hctx) {
-      this._hctx.lineWidth = width;
+    if (this.#hctx) {
+      this.#hctx.lineWidth = width;
     }
   }
 
@@ -63,8 +63,8 @@ export class HitmapRenderContext {
   // eslint-disable-next-line no-restricted-syntax
   public set font(font: string) {
     this._ctx.font = font;
-    if (this._hctx) {
-      this._hctx.font = font;
+    if (this.#hctx) {
+      this.#hctx.font = font;
     }
   }
 
@@ -86,8 +86,8 @@ export class HitmapRenderContext {
   // eslint-disable-next-line no-restricted-syntax
   public set textBaseline(baseline: CanvasRenderingContext2D["textBaseline"]) {
     this._ctx.textBaseline = baseline;
-    if (this._hctx) {
-      this._hctx.textBaseline = baseline;
+    if (this.#hctx) {
+      this.#hctx.textBaseline = baseline;
     }
   }
 
@@ -101,22 +101,22 @@ export class HitmapRenderContext {
     counterclockwise?: boolean,
   ): void {
     this._ctx.arc(x, y, radius, startAngle, endAngle, counterclockwise);
-    this._hctx?.arc(x, y, radius, startAngle, endAngle, counterclockwise);
+    this.#hctx?.arc(x, y, radius, startAngle, endAngle, counterclockwise);
   }
 
   public beginPath(): void {
     this._ctx.beginPath();
-    this._hctx?.beginPath();
+    this.#hctx?.beginPath();
   }
 
   public clearRect(x: number, y: number, w: number, h: number): void {
     this._ctx.clearRect(x, y, w, h);
-    this._hctx?.clearRect(x, y, w, h);
+    this.#hctx?.clearRect(x, y, w, h);
   }
 
   public closePath(): void {
     this._ctx.closePath();
-    this._hctx?.closePath();
+    this.#hctx?.closePath();
   }
 
   public drawImage(image: CanvasImageSource, dx: number, dy: number): void {
@@ -126,17 +126,17 @@ export class HitmapRenderContext {
 
   public fill(): void {
     this._ctx.fill();
-    this._hctx?.fill();
+    this.#hctx?.fill();
   }
 
   public fillRect(x: number, y: number, w: number, h: number): void {
     this._ctx.fillRect(x, y, w, h);
-    this._hctx?.fillRect(x, y, w, h);
+    this.#hctx?.fillRect(x, y, w, h);
   }
 
   public fillText(text: string, x: number, y: number): void {
     this._ctx.fillText(text, x, y);
-    this._hctx?.fillText(text, x, y);
+    this.#hctx?.fillText(text, x, y);
   }
 
   public getTransform(): DOMMatrix {
@@ -145,7 +145,7 @@ export class HitmapRenderContext {
 
   public lineTo(x: number, y: number): void {
     this._ctx.lineTo(x, y);
-    this._hctx?.lineTo(x, y);
+    this.#hctx?.lineTo(x, y);
   }
 
   public measureText(text: string): TextMetrics {
@@ -154,42 +154,42 @@ export class HitmapRenderContext {
 
   public moveTo(x: number, y: number): void {
     this._ctx.moveTo(x, y);
-    this._hctx?.moveTo(x, y);
+    this.#hctx?.moveTo(x, y);
   }
 
   public restore(): void {
     this._ctx.restore();
-    this._hctx?.restore();
+    this.#hctx?.restore();
   }
 
   public rotate(angle: number): void {
     const rads = (angle * Math.PI) / 180;
     this._ctx.rotate(rads);
-    this._hctx?.rotate(rads);
+    this.#hctx?.rotate(rads);
   }
 
   public save(): void {
     this._ctx.save();
-    this._hctx?.save();
+    this.#hctx?.save();
   }
 
   public scale(x: number, y: number): void {
     this._ctx.scale(x, y);
-    this._hctx?.scale(x, y);
+    this.#hctx?.scale(x, y);
   }
 
   public stroke(): void {
     this._ctx.stroke();
-    this._hctx?.stroke();
+    this.#hctx?.stroke();
   }
 
   public strokeRect(x: number, y: number, w: number, h: number): void {
     this._ctx.strokeRect(x, y, w, h);
-    this._hctx?.strokeRect(x, y, w, h);
+    this.#hctx?.strokeRect(x, y, w, h);
   }
 
   public translate(x: number, y: number): void {
     this._ctx.translate(x, y);
-    this._hctx?.translate(x, y);
+    this.#hctx?.translate(x, y);
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicBufferGeometry.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicBufferGeometry.ts
@@ -22,17 +22,17 @@ interface ArrayConstructor {
 export class DynamicBufferGeometry extends THREE.BufferGeometry {
   public override attributes: { [name: string]: THREE.BufferAttribute } = {};
 
-  private _attributeConstructors = new Map<string, ArrayConstructor>();
-  private _usage: THREE.Usage;
-  private _itemCapacity = 0;
+  #attributeConstructors = new Map<string, ArrayConstructor>();
+  #usage: THREE.Usage;
+  #itemCapacity = 0;
 
   public constructor(usage: THREE.Usage = THREE.DynamicDrawUsage) {
     super();
-    this._usage = usage;
+    this.#usage = usage;
   }
 
   public setUsage(usage: THREE.Usage): void {
-    this._usage = usage;
+    this.#usage = usage;
     for (const attribute of Object.values(this.attributes)) {
       attribute.setUsage(usage);
     }
@@ -45,17 +45,17 @@ export class DynamicBufferGeometry extends THREE.BufferGeometry {
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     normalized?: boolean,
   ): THREE.BufferGeometry {
-    const data = new arrayConstructor(this._itemCapacity * itemSize);
+    const data = new arrayConstructor(this.#itemCapacity * itemSize);
     const attribute = new THREE.BufferAttribute(data, itemSize, normalized);
-    attribute.setUsage(this._usage);
-    this._attributeConstructors.set(name, arrayConstructor);
+    attribute.setUsage(this.#usage);
+    this.#attributeConstructors.set(name, arrayConstructor);
     return this.setAttribute(name, attribute);
   }
 
   public resize(itemCount: number): void {
     this.setDrawRange(0, itemCount);
 
-    if (itemCount <= this._itemCapacity) {
+    if (itemCount <= this.#itemCapacity) {
       for (const attribute of Object.values(this.attributes)) {
         attribute.count = itemCount;
       }
@@ -63,7 +63,7 @@ export class DynamicBufferGeometry extends THREE.BufferGeometry {
     }
 
     for (const [attributeName, attribute] of Object.entries(this.attributes)) {
-      const dataConstructor = this._attributeConstructors.get(attributeName);
+      const dataConstructor = this.#attributeConstructors.get(attributeName);
       if (!dataConstructor) {
         throw new Error(
           `DynamicBufferGeometry resize(${itemCount}) failed, missing data constructor for attribute "${attributeName}". Attributes must be created using createAttribute().`,
@@ -71,10 +71,10 @@ export class DynamicBufferGeometry extends THREE.BufferGeometry {
       }
       const data = new dataConstructor(itemCount * attribute.itemSize);
       const newAttrib = new THREE.BufferAttribute(data, attribute.itemSize, attribute.normalized);
-      newAttrib.setUsage(this._usage);
+      newAttrib.setUsage(this.#usage);
       this.setAttribute(attributeName, newAttrib);
     }
 
-    this._itemCapacity = itemCount;
+    this.#itemCapacity = itemCount;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
@@ -19,13 +19,13 @@ export class DynamicInstancedMesh<
   TMaterial extends THREE.Material | THREE.Material[] = THREE.Material | THREE.Material[],
 > extends THREE.InstancedMesh<TGeometry, TMaterial> {
   // Total size of the buffer attributes, which can be larger than .count (instances in use)
-  private _capacity: number;
+  #capacity: number;
 
   public constructor(geometry: TGeometry, material: TMaterial, initialCapacity = INITIAL_CAPACITY) {
     super(geometry, material, 0);
 
-    this._capacity = initialCapacity;
-    this._resize();
+    this.#capacity = initialCapacity;
+    this.#resize();
   }
 
   public set(
@@ -35,7 +35,7 @@ export class DynamicInstancedMesh<
     defaultColor: ColorRGBA,
   ): void {
     const count = points.length;
-    this._setCount(count);
+    this.#setCount(count);
 
     const colorArray = this.instanceColor!.array as Uint8ClampedArray;
     for (let i = 0; i < count; i++) {
@@ -56,26 +56,26 @@ export class DynamicInstancedMesh<
     }
   }
 
-  private _setCount(count: number) {
-    while (count >= this._capacity) {
-      this._expand();
+  #setCount(count: number) {
+    while (count >= this.#capacity) {
+      this.#expand();
     }
     this.count = count;
     this.instanceMatrix.count = count;
     this.instanceColor!.count = count;
   }
 
-  private _expand() {
-    this._capacity = this._capacity + Math.trunc(this._capacity / 2) + 16;
-    this._resize();
+  #expand() {
+    this.#capacity = this.#capacity + Math.trunc(this.#capacity / 2) + 16;
+    this.#resize();
   }
 
-  private _resize() {
+  #resize() {
     const oldMatrixArray = this.instanceMatrix.array as Float32Array;
     const oldColorArray = this.instanceColor?.array as Uint8ClampedArray | undefined;
 
-    const newMatrixArray = new Float32Array(this._capacity * 16);
-    const newColorArray = new Uint8ClampedArray(this._capacity * 3);
+    const newMatrixArray = new Float32Array(this.#capacity * 16);
+    const newColorArray = new Uint8ClampedArray(this.#capacity * 3);
 
     if (oldMatrixArray.length > 0) {
       newMatrixArray.set(oldMatrixArray);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
@@ -39,14 +39,14 @@ export type InputEvents = {
 };
 
 export class Input extends EventEmitter<InputEvents> {
-  private readonly canvas: HTMLCanvasElement;
+  readonly #canvas: HTMLCanvasElement;
   /** Size in CSS pixels */
   public canvasSize: THREE.Vector2;
-  private readonly resizeObserver: ResizeObserver;
-  private startClientPos?: THREE.Vector2;
-  private cursorCoords = new THREE.Vector2();
-  private worldSpaceCursorCoords?: THREE.Vector3;
-  private raycaster = new THREE.Raycaster();
+  readonly #resizeObserver: ResizeObserver;
+  #startClientPos?: THREE.Vector2;
+  #cursorCoords = new THREE.Vector2();
+  #worldSpaceCursorCoords?: THREE.Vector3;
+  #raycaster = new THREE.Raycaster();
 
   public constructor(canvas: HTMLCanvasElement, private getCamera: () => THREE.Camera) {
     super();
@@ -56,19 +56,19 @@ export class Input extends EventEmitter<InputEvents> {
       throw new Error("<canvas> must be parented to a DOM element");
     }
 
-    this.canvas = canvas;
+    this.#canvas = canvas;
     this.canvasSize = new THREE.Vector2();
-    this.onResize([]);
+    this.#onResize([]);
 
     // Calling the resize observer too often causes Chrome to throw an exception
     // so we debounce it.
-    const debouncedOnResize = debounce(this.onResize);
-    this.resizeObserver = new ResizeObserver(debouncedOnResize);
-    this.resizeObserver.observe(parentEl);
+    const debouncedOnResize = debounce(this.#onResize);
+    this.#resizeObserver = new ResizeObserver(debouncedOnResize);
+    this.#resizeObserver.observe(parentEl);
 
-    canvas.addEventListener("mousedown", this.onMouseDown);
-    canvas.addEventListener("mousemove", this.onMouseMove);
-    canvas.addEventListener("mouseup", this.onMouseUp);
+    canvas.addEventListener("mousedown", this.#onMouseDown);
+    canvas.addEventListener("mousemove", this.#onMouseMove);
+    canvas.addEventListener("mouseup", this.#onMouseUp);
     canvas.addEventListener("click", this.onClick);
     canvas.addEventListener("touchstart", this.onTouchStart, { passive: false });
     canvas.addEventListener("touchend", this.onTouchEnd, { passive: false });
@@ -77,14 +77,14 @@ export class Input extends EventEmitter<InputEvents> {
   }
 
   public dispose(): void {
-    const canvas = this.canvas;
+    const canvas = this.#canvas;
 
     this.removeAllListeners();
-    this.resizeObserver.disconnect();
+    this.#resizeObserver.disconnect();
 
-    canvas.removeEventListener("mousedown", this.onMouseDown);
-    canvas.removeEventListener("mousemove", this.onMouseMove);
-    canvas.removeEventListener("mouseup", this.onMouseUp);
+    canvas.removeEventListener("mousedown", this.#onMouseDown);
+    canvas.removeEventListener("mousemove", this.#onMouseMove);
+    canvas.removeEventListener("mouseup", this.#onMouseUp);
     canvas.removeEventListener("click", this.onClick);
     canvas.removeEventListener("touchstart", this.onTouchStart);
     canvas.removeEventListener("touchend", this.onTouchEnd);
@@ -92,9 +92,9 @@ export class Input extends EventEmitter<InputEvents> {
     canvas.removeEventListener("touchcancel", this.onTouchCancel);
   }
 
-  private onResize = (_entries: ResizeObserverEntry[]): void => {
-    if (this.canvas.parentElement) {
-      const newSize = innerSize(this.canvas.parentElement);
+  #onResize = (_entries: ResizeObserverEntry[]): void => {
+    if (this.#canvas.parentElement) {
+      const newSize = innerSize(this.#canvas.parentElement);
       if (isNaN(newSize.width) || isNaN(newSize.height)) {
         return;
       }
@@ -106,42 +106,42 @@ export class Input extends EventEmitter<InputEvents> {
     }
   };
 
-  private onMouseDown = (event: MouseEvent): void => {
-    this.startClientPos = new THREE.Vector2(event.offsetX, event.offsetY);
-    this.updateCursorCoords(event);
-    this.emit("mousedown", this.cursorCoords, this.worldSpaceCursorCoords, event);
+  #onMouseDown = (event: MouseEvent): void => {
+    this.#startClientPos = new THREE.Vector2(event.offsetX, event.offsetY);
+    this.#updateCursorCoords(event);
+    this.emit("mousedown", this.#cursorCoords, this.#worldSpaceCursorCoords, event);
   };
 
-  private onMouseMove = (event: MouseEvent): void => {
-    this.updateCursorCoords(event);
-    this.emit("mousemove", this.cursorCoords, this.worldSpaceCursorCoords, event);
+  #onMouseMove = (event: MouseEvent): void => {
+    this.#updateCursorCoords(event);
+    this.emit("mousemove", this.#cursorCoords, this.#worldSpaceCursorCoords, event);
   };
 
-  private onMouseUp = (event: MouseEvent): void => {
-    this.updateCursorCoords(event);
-    this.emit("mouseup", this.cursorCoords, this.worldSpaceCursorCoords, event);
+  #onMouseUp = (event: MouseEvent): void => {
+    this.#updateCursorCoords(event);
+    this.emit("mouseup", this.#cursorCoords, this.#worldSpaceCursorCoords, event);
   };
 
   private onClick = (event: MouseEvent): void => {
-    if (!this.startClientPos) {
+    if (!this.#startClientPos) {
       return;
     }
 
-    const dist = this.startClientPos.distanceTo(tempVec2.set(event.offsetX, event.offsetY));
-    this.startClientPos = undefined;
+    const dist = this.#startClientPos.distanceTo(tempVec2.set(event.offsetX, event.offsetY));
+    this.#startClientPos = undefined;
 
     if (dist > MAX_DIST) {
       return;
     }
 
-    this.updateCursorCoords(event);
-    this.emit("click", this.cursorCoords, this.worldSpaceCursorCoords, event);
+    this.#updateCursorCoords(event);
+    this.emit("click", this.#cursorCoords, this.#worldSpaceCursorCoords, event);
   };
 
   private onTouchStart = (event: TouchEvent): void => {
     const touch = event.touches[0];
     if (touch) {
-      this.startClientPos = new THREE.Vector2(touch.clientX, touch.clientY);
+      this.#startClientPos = new THREE.Vector2(touch.clientX, touch.clientY);
     }
     event.preventDefault();
   };
@@ -158,11 +158,11 @@ export class Input extends EventEmitter<InputEvents> {
     event.preventDefault();
   };
 
-  private updateCursorCoords(event: MouseEvent): void {
-    this.cursorCoords.x = event.offsetX;
-    this.cursorCoords.y = event.offsetY;
+  #updateCursorCoords(event: MouseEvent): void {
+    this.#cursorCoords.x = event.offsetX;
+    this.#cursorCoords.y = event.offsetY;
 
-    this.raycaster.setFromCamera(
+    this.#raycaster.setFromCamera(
       // Cursor position in NDC
       tempVec2.set(
         (event.offsetX / this.canvasSize.width) * 2 - 1,
@@ -170,10 +170,10 @@ export class Input extends EventEmitter<InputEvents> {
       ),
       this.getCamera(),
     );
-    this.worldSpaceCursorCoords =
-      this.raycaster.ray.intersectPlane(
+    this.#worldSpaceCursorCoords =
+      this.#raycaster.ray.intersectPlane(
         XY_PLANE,
-        this.worldSpaceCursorCoords ?? new THREE.Vector3(),
+        this.#worldSpaceCursorCoords ?? new THREE.Vector3(),
       ) ?? undefined;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Input.ts
@@ -69,11 +69,11 @@ export class Input extends EventEmitter<InputEvents> {
     canvas.addEventListener("mousedown", this.#onMouseDown);
     canvas.addEventListener("mousemove", this.#onMouseMove);
     canvas.addEventListener("mouseup", this.#onMouseUp);
-    canvas.addEventListener("click", this.onClick);
-    canvas.addEventListener("touchstart", this.onTouchStart, { passive: false });
-    canvas.addEventListener("touchend", this.onTouchEnd, { passive: false });
-    canvas.addEventListener("touchmove", this.onTouchMove, { passive: false });
-    canvas.addEventListener("touchcancel", this.onTouchCancel, { passive: false });
+    canvas.addEventListener("click", this.#onClick);
+    canvas.addEventListener("touchstart", this.#onTouchStart, { passive: false });
+    canvas.addEventListener("touchend", this.#onTouchEnd, { passive: false });
+    canvas.addEventListener("touchmove", this.#onTouchMove, { passive: false });
+    canvas.addEventListener("touchcancel", this.#onTouchCancel, { passive: false });
   }
 
   public dispose(): void {
@@ -85,11 +85,11 @@ export class Input extends EventEmitter<InputEvents> {
     canvas.removeEventListener("mousedown", this.#onMouseDown);
     canvas.removeEventListener("mousemove", this.#onMouseMove);
     canvas.removeEventListener("mouseup", this.#onMouseUp);
-    canvas.removeEventListener("click", this.onClick);
-    canvas.removeEventListener("touchstart", this.onTouchStart);
-    canvas.removeEventListener("touchend", this.onTouchEnd);
-    canvas.removeEventListener("touchmove", this.onTouchMove);
-    canvas.removeEventListener("touchcancel", this.onTouchCancel);
+    canvas.removeEventListener("click", this.#onClick);
+    canvas.removeEventListener("touchstart", this.#onTouchStart);
+    canvas.removeEventListener("touchend", this.#onTouchEnd);
+    canvas.removeEventListener("touchmove", this.#onTouchMove);
+    canvas.removeEventListener("touchcancel", this.#onTouchCancel);
   }
 
   #onResize = (_entries: ResizeObserverEntry[]): void => {
@@ -122,7 +122,7 @@ export class Input extends EventEmitter<InputEvents> {
     this.emit("mouseup", this.#cursorCoords, this.#worldSpaceCursorCoords, event);
   };
 
-  private onClick = (event: MouseEvent): void => {
+  #onClick = (event: MouseEvent): void => {
     if (!this.#startClientPos) {
       return;
     }
@@ -138,7 +138,7 @@ export class Input extends EventEmitter<InputEvents> {
     this.emit("click", this.#cursorCoords, this.#worldSpaceCursorCoords, event);
   };
 
-  private onTouchStart = (event: TouchEvent): void => {
+  #onTouchStart = (event: TouchEvent): void => {
     const touch = event.touches[0];
     if (touch) {
       this.#startClientPos = new THREE.Vector2(touch.clientX, touch.clientY);
@@ -146,15 +146,15 @@ export class Input extends EventEmitter<InputEvents> {
     event.preventDefault();
   };
 
-  private onTouchEnd = (event: TouchEvent): void => {
+  #onTouchEnd = (event: TouchEvent): void => {
     event.preventDefault();
   };
 
-  private onTouchMove = (event: TouchEvent): void => {
+  #onTouchMove = (event: TouchEvent): void => {
     event.preventDefault();
   };
 
-  private onTouchCancel = (event: TouchEvent): void => {
+  #onTouchCancel = (event: TouchEvent): void => {
     event.preventDefault();
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/LayerErrors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/LayerErrors.ts
@@ -94,12 +94,12 @@ export class LayerErrors extends EventEmitter<LayerErrorEvents> {
   }
 
   public hasError(path: Path, errorId: string): boolean {
-    const node = this._getNode(path);
+    const node = this.#getNode(path);
     return node?.errorsById?.has(errorId) === true;
   }
 
   public remove(path: Path, errorId: string): void {
-    const node = this._getNode(path);
+    const node = this.#getNode(path);
     if (node?.errorsById?.has(errorId) === true) {
       node.errorsById.delete(errorId);
       this.emit("remove", path, errorId);
@@ -112,7 +112,7 @@ export class LayerErrors extends EventEmitter<LayerErrorEvents> {
   }
 
   public clearPath(path: Path): void {
-    const node = this._getNode(path);
+    const node = this.#getNode(path);
     if (!node) {
       return;
     }
@@ -139,7 +139,7 @@ export class LayerErrors extends EventEmitter<LayerErrorEvents> {
     this.clearPath([]);
   }
 
-  private _getNode(path: Path): NodeError | undefined {
+  #getNode(path: Path): NodeError | undefined {
     let node: NodeError | undefined = this.errors;
     for (const segment of path) {
       node = node.children?.get(segment);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -42,14 +42,14 @@ const DAE_MIME_TYPES = ["model/vnd.collada+xml"];
 const OBJ_MIME_TYPES = ["model/obj", "text/prs.wavefront-obj"];
 
 export class ModelCache {
-  private _textDecoder = new TextDecoder();
-  private _models = new Map<string, Promise<LoadedModel | undefined>>();
-  private _edgeMaterial: THREE.Material;
+  #textDecoder = new TextDecoder();
+  #models = new Map<string, Promise<LoadedModel | undefined>>();
+  #edgeMaterial: THREE.Material;
 
-  private _dracoLoader?: DRACOLoader;
+  #dracoLoader?: DRACOLoader;
 
   public constructor(public readonly options: ModelCacheOptions) {
-    this._edgeMaterial = options.edgeMaterial;
+    this.#edgeMaterial = options.edgeMaterial;
   }
 
   public async load(
@@ -57,23 +57,23 @@ export class ModelCache {
     opts: LoadModelOptions,
     reportError: ErrorCallback,
   ): Promise<LoadedModel | undefined> {
-    let promise = this._models.get(url);
+    let promise = this.#models.get(url);
     if (promise) {
       return await promise;
     }
 
-    promise = this._loadModel(url, opts, reportError)
-      .then((model) => addEdges(model, this._edgeMaterial))
+    promise = this.#loadModel(url, opts, reportError)
+      .then((model) => addEdges(model, this.#edgeMaterial))
       .catch(async (err) => {
         reportError(err as Error);
         return undefined;
       });
 
-    this._models.set(url, promise);
+    this.#models.set(url, promise);
     return await promise;
   }
 
-  private async _loadModel(
+  async #loadModel(
     url: string,
     options: LoadModelOptions,
     reportError: ErrorCallback,
@@ -100,30 +100,30 @@ export class ModelCache {
       /\.glb$/i.test(url) ||
       /\.gltf$/i.test(url)
     ) {
-      return await this.loadGltf(url, reportError);
+      return await this.#loadGltf(url, reportError);
     }
 
     // Check if this is a STL file based on content-type or file extension
     if (STL_MIME_TYPES.includes(contentType) || /\.stl$/i.test(url)) {
-      return this.loadSTL(url, buffer, this.options.meshUpAxis);
+      return this.#loadSTL(url, buffer, this.options.meshUpAxis);
     }
 
     // Check if this is a COLLADA file based on content-type or file extension
     if (DAE_MIME_TYPES.includes(contentType) || /\.dae$/i.test(url)) {
-      const text = this._textDecoder.decode(buffer);
-      return await this.loadCollada(url, text, this.options.ignoreColladaUpAxis, reportError);
+      const text = this.#textDecoder.decode(buffer);
+      return await this.#loadCollada(url, text, this.options.ignoreColladaUpAxis, reportError);
     }
 
     // Check if this is an OBJ file based on content-type or file extension
     if (OBJ_MIME_TYPES.includes(contentType) || /\.obj$/i.test(url)) {
-      const text = this._textDecoder.decode(buffer);
-      return await this.loadOBJ(url, text, this.options.meshUpAxis, reportError);
+      const text = this.#textDecoder.decode(buffer);
+      return await this.#loadOBJ(url, text, this.options.meshUpAxis, reportError);
     }
 
     throw new Error(`Unknown ${buffer.byteLength} byte mesh (content-type: "${contentType}")`);
   }
 
-  private async loadGltf(url: string, reportError: ErrorCallback): Promise<LoadedModel> {
+  async #loadGltf(url: string, reportError: ErrorCallback): Promise<LoadedModel> {
     const onError = (assetUrl: string) => {
       const originalUrl = unrewriteUrl(assetUrl);
       log.error(`Failed to load GLTF asset "${originalUrl}" for "${url}"`);
@@ -134,7 +134,7 @@ export class ModelCache {
     manager.setURLModifier(rewriteUrl);
     const gltfLoader = new GLTFLoader(manager);
     gltfLoader.setMeshoptDecoder(MeshoptDecoder);
-    gltfLoader.setDRACOLoader(this.getDracoLoader(manager));
+    gltfLoader.setDRACOLoader(this.#getDracoLoader(manager));
 
     manager.itemStart(url);
     const gltf = await gltfLoader.loadAsync(url);
@@ -147,7 +147,7 @@ export class ModelCache {
     return gltf.scene;
   }
 
-  private loadSTL(url: string, buffer: ArrayBuffer, meshUpAxis: MeshUpAxis): LoadedModel {
+  #loadSTL(url: string, buffer: ArrayBuffer, meshUpAxis: MeshUpAxis): LoadedModel {
     // STL files do not reference any external assets, no LoadingManager needed
     const stlLoader = new STLLoader();
     const bufferGeometry = stlLoader.parse(buffer);
@@ -172,7 +172,7 @@ export class ModelCache {
     return group;
   }
 
-  private async loadCollada(
+  async #loadCollada(
     url: string,
     text: string,
     // eslint-disable-next-line @foxglove/no-boolean-parameters
@@ -212,7 +212,7 @@ export class ModelCache {
     return fixDaeMaterials(dae.scene);
   }
 
-  private async loadOBJ(
+  async #loadOBJ(
     url: string,
     text: string,
     meshUpAxis: MeshUpAxis,
@@ -242,8 +242,8 @@ export class ModelCache {
   }
 
   // singleton dracoloader
-  private getDracoLoader(manager: THREE.LoadingManager): DRACOLoader {
-    let dracoLoader = this._dracoLoader;
+  #getDracoLoader(manager: THREE.LoadingManager): DRACOLoader {
+    let dracoLoader = this.#dracoLoader;
     if (!dracoLoader) {
       dracoLoader = new DRACOLoader(manager);
       // Hack in a replacement function to load assets from the webpack bundle
@@ -260,7 +260,7 @@ export class ModelCache {
           );
         }
       };
-      this._dracoLoader = dracoLoader;
+      this.#dracoLoader = dracoLoader;
     }
 
     dracoLoader.manager = manager;
@@ -269,8 +269,8 @@ export class ModelCache {
 
   public dispose(): void {
     // DRACOLoader is only loader that needs to be disposed because it uses a webworker
-    this._dracoLoader?.dispose();
-    this._dracoLoader = undefined;
+    this.#dracoLoader?.dispose();
+    this.#dracoLoader = undefined;
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
@@ -49,40 +49,40 @@ export type PickerOptions = {
  * shader used for picking.
  */
 export class Picker {
-  private gl: THREE.WebGLRenderer;
-  private scene: THREE.Scene;
-  private camera?: Camera;
-  private materialCache = new Map<number, THREE.ShaderMaterial>();
-  private emptyScene: THREE.Scene;
-  private pixelBuffer: Uint8Array;
-  private currClearColor = new THREE.Color();
-  private pickingTarget: THREE.WebGLRenderTarget;
-  private isDebugPass = false;
+  #gl: THREE.WebGLRenderer;
+  #scene: THREE.Scene;
+  #camera?: Camera;
+  #materialCache = new Map<number, THREE.ShaderMaterial>();
+  #emptyScene: THREE.Scene;
+  #pixelBuffer: Uint8Array;
+  #currClearColor = new THREE.Color();
+  #pickingTarget: THREE.WebGLRenderTarget;
+  #isDebugPass = false;
 
   public constructor(gl: THREE.WebGLRenderer, scene: THREE.Scene) {
-    this.gl = gl;
-    this.scene = scene;
+    this.#gl = gl;
+    this.#scene = scene;
 
     // This is the PIXEL_WIDTH x PIXEL_WIDTH render target we use to do the picking
-    this.pickingTarget = new THREE.WebGLRenderTarget(PIXEL_WIDTH, PIXEL_WIDTH, {
+    this.#pickingTarget = new THREE.WebGLRenderTarget(PIXEL_WIDTH, PIXEL_WIDTH, {
       minFilter: THREE.NearestFilter,
       magFilter: THREE.NearestFilter,
       format: THREE.RGBAFormat, // stores objectIds as uint32
       encoding: THREE.LinearEncoding,
       generateMipmaps: false,
     });
-    this.pixelBuffer = new Uint8Array(4);
+    this.#pixelBuffer = new Uint8Array(4);
     // We need to be inside of .render in order to call renderBufferDirect in
     // renderList() so create an empty scene
-    this.emptyScene = new THREE.Scene();
+    this.#emptyScene = new THREE.Scene();
   }
 
   public dispose(): void {
-    for (const material of this.materialCache.values()) {
+    for (const material of this.#materialCache.values()) {
       material.dispose();
     }
-    this.materialCache.clear();
-    this.pickingTarget.dispose();
+    this.#materialCache.clear();
+    this.#pickingTarget.dispose();
   }
 
   public pick(
@@ -92,24 +92,24 @@ export class Picker {
     options: PickerOptions = {},
   ): number {
     // Use the onAfterRender callback to actually render geometry for picking
-    this.emptyScene.onAfterRender = this.handleAfterRender;
+    this.#emptyScene.onAfterRender = this.#handleAfterRender;
 
-    this.camera = camera;
+    this.#camera = camera;
     const { xInView, yInView } = this.#updateCameraForPickAndGetPickCoordsInView(x, y, options);
 
     const originalRenderState = this.#prepareGLRendererForPick();
 
-    this.gl.render(this.emptyScene, camera);
-    this.gl.readRenderTargetPixels(this.pickingTarget, xInView, yInView, 1, 1, this.pixelBuffer);
+    this.#gl.render(this.#emptyScene, camera);
+    this.#gl.readRenderTargetPixels(this.#pickingTarget, xInView, yInView, 1, 1, this.#pixelBuffer);
 
     this.#cleanUpGlRendererFromPick(originalRenderState);
     this.#resetCameraFromPick(options);
 
     const val =
-      (this.pixelBuffer[0]! << 24) +
-      (this.pixelBuffer[1]! << 16) +
-      (this.pixelBuffer[2]! << 8) +
-      this.pixelBuffer[3]!;
+      (this.#pixelBuffer[0]! << 24) +
+      (this.#pixelBuffer[1]! << 16) +
+      (this.#pixelBuffer[2]! << 8) +
+      this.#pixelBuffer[3]!;
 
     if (options.debug === true) {
       this.pickDebugRender(camera);
@@ -125,15 +125,15 @@ export class Picker {
     renderable: Renderable,
     options: PickerOptions = {},
   ): number {
-    this.emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
+    this.#emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
 
-    this.camera = camera;
+    this.#camera = camera;
     const { xInView, yInView } = this.#updateCameraForPickAndGetPickCoordsInView(x, y, options);
 
     const originalRenderState = this.#prepareGLRendererForPick();
 
-    this.gl.render(this.emptyScene, this.camera);
-    this.gl.readRenderTargetPixels(this.pickingTarget, xInView, yInView, 1, 1, this.pixelBuffer);
+    this.#gl.render(this.#emptyScene, this.#camera);
+    this.#gl.readRenderTargetPixels(this.#pickingTarget, xInView, yInView, 1, 1, this.#pixelBuffer);
 
     this.#cleanUpGlRendererFromPick(originalRenderState);
     this.#resetCameraFromPick(options);
@@ -143,10 +143,10 @@ export class Picker {
     }
 
     return (
-      (this.pixelBuffer[0]! << 24) +
-      (this.pixelBuffer[1]! << 16) +
-      (this.pixelBuffer[2]! << 8) +
-      this.pixelBuffer[3]!
+      (this.#pixelBuffer[0]! << 24) +
+      (this.#pixelBuffer[1]! << 16) +
+      (this.#pixelBuffer[2]! << 8) +
+      this.#pixelBuffer[3]!
     );
   }
 
@@ -155,21 +155,21 @@ export class Picker {
     y: number,
     options: PickerOptions,
   ): { xInView: number; yInView: number } {
-    assert(this.camera, "camera must be set before updating for pick");
-    const w = this.gl.domElement.width;
-    const h = this.gl.domElement.height;
-    const pixelRatio = this.gl.getPixelRatio();
+    assert(this.#camera, "camera must be set before updating for pick");
+    const w = this.#gl.domElement.width;
+    const h = this.#gl.domElement.height;
+    const pixelRatio = this.#gl.getPixelRatio();
 
     if (options.disableSetViewOffset !== true) {
       const hw = (PIXEL_WIDTH / 2) | 0;
       const xi = Math.max(0, x * pixelRatio - hw);
       const yi = Math.max(0, y * pixelRatio - hw);
       // Set the projection matrix to only look at the pixels we are interested in
-      this.camera.setViewOffset(w, h, xi, yi, PIXEL_WIDTH, PIXEL_WIDTH);
+      this.#camera.setViewOffset(w, h, xi, yi, PIXEL_WIDTH, PIXEL_WIDTH);
       return { xInView: hw, yInView: hw };
     } else {
-      if (this.pickingTarget.width !== w || this.pickingTarget.height !== h) {
-        this.pickingTarget.setSize(w, h);
+      if (this.#pickingTarget.width !== w || this.#pickingTarget.height !== h) {
+        this.#pickingTarget.setSize(w, h);
       }
       const xi = Math.max(0, x * pixelRatio);
       // Flip y coordinate to match WebGL coordinate system
@@ -179,9 +179,9 @@ export class Picker {
   }
 
   #resetCameraFromPick(options: PickerOptions): void {
-    assert(this.camera, "camera must be set before resetting from pick");
+    assert(this.#camera, "camera must be set before resetting from pick");
     if (options.disableSetViewOffset !== true) {
-      this.camera.clearViewOffset();
+      this.#camera.clearViewOffset();
     }
   }
 
@@ -189,12 +189,12 @@ export class Picker {
     originalRenderTarget: THREE.WebGLRenderTarget | ReactNull;
     originalAlpha: number;
   } {
-    const originalRenderTarget = this.gl.getRenderTarget();
-    const originalAlpha = this.gl.getClearAlpha();
-    this.gl.getClearColor(this.currClearColor);
-    this.gl.setRenderTarget(this.pickingTarget);
-    this.gl.setClearColor(WHITE_COLOR, 1);
-    this.gl.clear();
+    const originalRenderTarget = this.#gl.getRenderTarget();
+    const originalAlpha = this.#gl.getClearAlpha();
+    this.#gl.getClearColor(this.#currClearColor);
+    this.#gl.setRenderTarget(this.#pickingTarget);
+    this.#gl.setClearColor(WHITE_COLOR, 1);
+    this.#gl.clear();
     return { originalRenderTarget, originalAlpha };
   }
 
@@ -205,44 +205,44 @@ export class Picker {
     originalRenderTarget: THREE.WebGLRenderTarget | ReactNull;
     originalAlpha: number;
   }): void {
-    this.gl.setRenderTarget(originalRenderTarget);
-    this.gl.setClearColor(this.currClearColor, originalAlpha);
+    this.#gl.setRenderTarget(originalRenderTarget);
+    this.#gl.setClearColor(this.#currClearColor, originalAlpha);
   }
 
   public pickDebugRender(camera: THREE.OrthographicCamera | THREE.PerspectiveCamera): void {
-    this.isDebugPass = true;
-    this.emptyScene.onAfterRender = this.handleAfterRender;
-    const currAlpha = this.gl.getClearAlpha();
-    this.gl.getClearColor(this.currClearColor);
-    this.gl.setClearColor(WHITE_COLOR, 1);
-    this.gl.clear();
-    this.gl.render(this.emptyScene, camera);
-    this.gl.setClearColor(this.currClearColor, currAlpha);
-    this.isDebugPass = false;
+    this.#isDebugPass = true;
+    this.#emptyScene.onAfterRender = this.#handleAfterRender;
+    const currAlpha = this.#gl.getClearAlpha();
+    this.#gl.getClearColor(this.#currClearColor);
+    this.#gl.setClearColor(WHITE_COLOR, 1);
+    this.#gl.clear();
+    this.#gl.render(this.#emptyScene, camera);
+    this.#gl.setClearColor(this.#currClearColor, currAlpha);
+    this.#isDebugPass = false;
   }
 
   public pickInstanceDebugRender(
     camera: THREE.OrthographicCamera | THREE.PerspectiveCamera,
     renderable: Renderable,
   ): void {
-    this.isDebugPass = true;
-    this.emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
-    const currAlpha = this.gl.getClearAlpha();
-    this.gl.getClearColor(this.currClearColor);
-    this.gl.setClearColor(WHITE_COLOR, 1);
-    this.gl.clear();
-    this.gl.render(this.emptyScene, camera);
-    this.gl.setClearColor(this.currClearColor, currAlpha);
-    this.isDebugPass = false;
+    this.#isDebugPass = true;
+    this.#emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
+    const currAlpha = this.#gl.getClearAlpha();
+    this.#gl.getClearColor(this.#currClearColor);
+    this.#gl.setClearColor(WHITE_COLOR, 1);
+    this.#gl.clear();
+    this.#gl.render(this.#emptyScene, camera);
+    this.#gl.setClearColor(this.#currClearColor, currAlpha);
+    this.#isDebugPass = false;
   }
 
-  private handleAfterRender = (): void => {
+  #handleAfterRender = (): void => {
     // This is the magic, these render lists are still filled with valid data.
     // So we can submit them again for picking and save lots of work!
-    const renderList = this.gl.renderLists.get(this.scene, 0);
-    renderList.opaque.forEach(this.processItem);
-    renderList.transmissive.forEach(this.processItem);
-    renderList.transparent.forEach(this.processItem);
+    const renderList = this.#gl.renderLists.get(this.#scene, 0);
+    renderList.opaque.forEach(this.#processItem);
+    renderList.transmissive.forEach(this.#processItem);
+    renderList.transparent.forEach(this.#processItem);
   };
 
   private makeHandleInstanceAfterRender(renderable: Renderable): () => void {
@@ -265,18 +265,18 @@ export class Picker {
             z: 0,
             group: ReactNull,
           };
-          this.processInstancedItem(renderItem);
+          this.#processInstancedItem(renderItem);
         }
       });
     };
   }
 
-  private processItem = (renderItem: THREE.RenderItem): void => {
-    if (!this.camera) {
+  #processItem = (renderItem: THREE.RenderItem): void => {
+    if (!this.#camera) {
       return;
     }
     const object = renderItem.object;
-    const objId = this.isDebugPass ? hashInt(object.id) : object.id;
+    const objId = this.#isDebugPass ? hashInt(object.id) : object.id;
     const material = renderItem.material;
     const geometry = renderItem.geometry;
     if (
@@ -292,17 +292,17 @@ export class Picker {
     const pickingMaterial = renderItem.object.userData.pickingMaterial as
       | THREE.ShaderMaterial
       | undefined;
-    const renderMaterial = pickingMaterial ?? this.renderMaterial(sprite, sizeAttenuation);
+    const renderMaterial = pickingMaterial ?? this.#renderMaterial(sprite, sizeAttenuation);
     if (sprite === 1) {
       renderMaterial.uniforms.rotation = { value: (material as THREE.SpriteMaterial).rotation };
       renderMaterial.uniforms.center = { value: (object as THREE.Sprite).center };
     }
     setObjectId(renderMaterial, objId);
-    this.gl.renderBufferDirect(this.camera, NullScene, geometry, renderMaterial, object, ReactNull);
+    this.#gl.renderBufferDirect(this.#camera, NullScene, geometry, renderMaterial, object, ReactNull);
   };
 
-  private processInstancedItem = (renderItem: THREE.RenderItem): void => {
-    if (!this.camera) {
+  #processInstancedItem = (renderItem: THREE.RenderItem): void => {
+    if (!this.#camera) {
       return;
     }
     const object = renderItem.object;
@@ -317,13 +317,13 @@ export class Picker {
     const instancePickingMaterial = renderItem.object.userData.instancePickingMaterial as
       | THREE.ShaderMaterial
       | undefined;
-    const renderMaterial = instancePickingMaterial ?? this.instanceRenderMaterial();
-    this.gl.renderBufferDirect(this.camera, NullScene, geometry, renderMaterial, object, ReactNull);
+    const renderMaterial = instancePickingMaterial ?? this.#instanceRenderMaterial();
+    this.#gl.renderBufferDirect(this.#camera, NullScene, geometry, renderMaterial, object, ReactNull);
   };
 
-  private renderMaterial(sprite: 0 | 1, sizeAttenuation: 0 | 1): THREE.ShaderMaterial {
+  #renderMaterial(sprite: 0 | 1, sizeAttenuation: 0 | 1): THREE.ShaderMaterial {
     const index = (sprite << 0) | (sizeAttenuation << 1);
-    let renderMaterial = this.materialCache.get(index);
+    let renderMaterial = this.#materialCache.get(index);
     if (renderMaterial) {
       return renderMaterial;
     }
@@ -346,13 +346,13 @@ export class Picker {
       side: THREE.DoubleSide,
       uniforms: { objectId: { value: [NaN, NaN, NaN, NaN] } },
     });
-    this.materialCache.set(index, renderMaterial);
+    this.#materialCache.set(index, renderMaterial);
     return renderMaterial;
   }
 
-  private instanceRenderMaterial(): THREE.ShaderMaterial {
+  #instanceRenderMaterial(): THREE.ShaderMaterial {
     const index = -1; // special materialCache index used for the instanced picking material
-    let renderMaterial = this.materialCache.get(index);
+    let renderMaterial = this.#materialCache.get(index);
     if (renderMaterial) {
       return renderMaterial;
     }
@@ -382,7 +382,7 @@ export class Picker {
       side: THREE.DoubleSide,
       uniforms: { objectId: { value: [NaN, NaN, NaN, NaN] } },
     });
-    this.materialCache.set(index, renderMaterial);
+    this.#materialCache.set(index, renderMaterial);
     return renderMaterial;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
@@ -125,7 +125,7 @@ export class Picker {
     renderable: Renderable,
     options: PickerOptions = {},
   ): number {
-    this.#emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
+    this.#emptyScene.onAfterRender = this.#makeHandleInstanceAfterRender(renderable);
 
     this.#camera = camera;
     const { xInView, yInView } = this.#updateCameraForPickAndGetPickCoordsInView(x, y, options);
@@ -226,7 +226,7 @@ export class Picker {
     renderable: Renderable,
   ): void {
     this.#isDebugPass = true;
-    this.#emptyScene.onAfterRender = this.makeHandleInstanceAfterRender(renderable);
+    this.#emptyScene.onAfterRender = this.#makeHandleInstanceAfterRender(renderable);
     const currAlpha = this.#gl.getClearAlpha();
     this.#gl.getClearColor(this.#currClearColor);
     this.#gl.setClearColor(WHITE_COLOR, 1);
@@ -245,7 +245,7 @@ export class Picker {
     renderList.transparent.forEach(this.#processItem);
   };
 
-  private makeHandleInstanceAfterRender(renderable: Renderable): () => void {
+  #makeHandleInstanceAfterRender(renderable: Renderable): () => void {
     return (): void => {
       // Note that no attempt is made to define a sensible sort order. Since the
       // instanced picking pass should only be rendering opaque pixels, the

--- a/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Picker.ts
@@ -298,7 +298,14 @@ export class Picker {
       renderMaterial.uniforms.center = { value: (object as THREE.Sprite).center };
     }
     setObjectId(renderMaterial, objId);
-    this.#gl.renderBufferDirect(this.#camera, NullScene, geometry, renderMaterial, object, ReactNull);
+    this.#gl.renderBufferDirect(
+      this.#camera,
+      NullScene,
+      geometry,
+      renderMaterial,
+      object,
+      ReactNull,
+    );
   };
 
   #processInstancedItem = (renderItem: THREE.RenderItem): void => {
@@ -318,7 +325,14 @@ export class Picker {
       | THREE.ShaderMaterial
       | undefined;
     const renderMaterial = instancePickingMaterial ?? this.#instanceRenderMaterial();
-    this.#gl.renderBufferDirect(this.#camera, NullScene, geometry, renderMaterial, object, ReactNull);
+    this.#gl.renderBufferDirect(
+      this.#camera,
+      NullScene,
+      geometry,
+      renderMaterial,
+      object,
+      ReactNull,
+    );
   };
 
   #renderMaterial(sprite: 0 | 1, sizeAttenuation: 0 | 1): THREE.ShaderMaterial {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -226,9 +226,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   #prevResolution = new THREE.Vector2();
   #pickingEnabled = false;
-  private _animationFrame?: number;
-  private _cameraSyncError: undefined | string;
-  private _devicePixelRatioMediaQuery?: MediaQueryList;
+  #animationFrame?: number;
+  #cameraSyncError: undefined | string;
+  #devicePixelRatioMediaQuery?: MediaQueryList;
 
   public constructor(
     canvas: HTMLCanvasElement,
@@ -322,22 +322,22 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     // Internal handlers for TF messages to update the transform tree
     this.addSchemaSubscriptions(FRAME_TRANSFORM_DATATYPES, {
-      handler: this.handleFrameTransform,
+      handler: this.#handleFrameTransform,
       shouldSubscribe: () => true,
       preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addSchemaSubscriptions(FRAME_TRANSFORMS_DATATYPES, {
-      handler: this.handleFrameTransforms,
+      handler: this.#handleFrameTransforms,
       shouldSubscribe: () => true,
       preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addSchemaSubscriptions(TF_DATATYPES, {
-      handler: this.handleTFMessage,
+      handler: this.#handleTFMessage,
       shouldSubscribe: () => true,
       preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addSchemaSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
-      handler: this.handleTransformStamped,
+      handler: this.#handleTransformStamped,
       shouldSubscribe: () => true,
       preload: config.scene.transforms?.enablePreloading ?? true,
     });
@@ -346,33 +346,33 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     switch (interfaceMode) {
       case "image":
         this.cameraHandler = new ImageMode(this, this.input.canvasSize);
-        this.addSceneExtension(this.cameraHandler);
+        this.#addSceneExtension(this.cameraHandler);
         break;
       case "3d":
         this.cameraHandler = new CameraStateSettings(this, this.#canvas, aspect);
-        this.addSceneExtension(this.cameraHandler);
-        this.addSceneExtension(new PublishSettings(this));
-        this.addSceneExtension(new Images(this));
-        this.addSceneExtension(new Cameras(this));
+        this.#addSceneExtension(this.cameraHandler);
+        this.#addSceneExtension(new PublishSettings(this));
+        this.#addSceneExtension(new Images(this));
+        this.#addSceneExtension(new Cameras(this));
         break;
     }
 
-    this.addSceneExtension(new SceneSettings(this));
-    this.addSceneExtension(new FrameAxes(this, { visible: interfaceMode === "3d" }));
-    this.addSceneExtension(new Grids(this));
-    this.addSceneExtension(new Markers(this));
-    this.addSceneExtension(new FoxgloveSceneEntities(this));
-    this.addSceneExtension(new FoxgloveGrid(this));
-    this.addSceneExtension(new LaserScans(this));
-    this.addSceneExtension(new OccupancyGrids(this));
-    this.addSceneExtension(new PointClouds(this));
-    this.addSceneExtension(new Polygons(this));
-    this.addSceneExtension(new Poses(this));
-    this.addSceneExtension(new PoseArrays(this));
-    this.addSceneExtension(new Urdfs(this));
-    this.addSceneExtension(new VelodyneScans(this));
-    this.addSceneExtension(this.measurementTool);
-    this.addSceneExtension(this.publishClickTool);
+    this.#addSceneExtension(new SceneSettings(this));
+    this.#addSceneExtension(new FrameAxes(this, { visible: interfaceMode === "3d" }));
+    this.#addSceneExtension(new Grids(this));
+    this.#addSceneExtension(new Markers(this));
+    this.#addSceneExtension(new FoxgloveSceneEntities(this));
+    this.#addSceneExtension(new FoxgloveGrid(this));
+    this.#addSceneExtension(new LaserScans(this));
+    this.#addSceneExtension(new OccupancyGrids(this));
+    this.#addSceneExtension(new PointClouds(this));
+    this.#addSceneExtension(new Polygons(this));
+    this.#addSceneExtension(new Poses(this));
+    this.#addSceneExtension(new PoseArrays(this));
+    this.#addSceneExtension(new Urdfs(this));
+    this.#addSceneExtension(new VelodyneScans(this));
+    this.#addSceneExtension(this.measurementTool);
+    this.#addSceneExtension(this.publishClickTool);
 
     this.#watchDevicePixelRatio();
 
@@ -380,24 +380,24 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.animationFrame();
   }
 
-  private _onDevicePixelRatioChange = () => {
+  #onDevicePixelRatioChange = () => {
     log.debug(`devicePixelRatio changed to ${window.devicePixelRatio}`);
     this.#resizeHandler(this.input.canvasSize);
     this.#watchDevicePixelRatio();
   };
 
   #watchDevicePixelRatio() {
-    this._devicePixelRatioMediaQuery = window.matchMedia(
+    this.#devicePixelRatioMediaQuery = window.matchMedia(
       `(resolution: ${window.devicePixelRatio}dppx)`,
     );
-    this._devicePixelRatioMediaQuery.addEventListener("change", this._onDevicePixelRatioChange, {
+    this.#devicePixelRatioMediaQuery.addEventListener("change", this.#onDevicePixelRatioChange, {
       once: true,
     });
   }
 
   public dispose(): void {
     log.warn(`Disposing renderer`);
-    this._devicePixelRatioMediaQuery?.removeEventListener("change", this._onDevicePixelRatioChange);
+    this.#devicePixelRatioMediaQuery?.removeEventListener("change", this.#onDevicePixelRatioChange);
     this.removeAllListeners();
 
     this.settings.removeAllListeners();
@@ -418,11 +418,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   }
 
   public cameraSyncError(): undefined | string {
-    return this._cameraSyncError;
+    return this.#cameraSyncError;
   }
 
   public setCameraSyncError(error: undefined | string): void {
-    this._cameraSyncError = error;
+    this.#cameraSyncError = error;
     // Updates the settings tree for camera state settings to account for any changes in the config.
     this.cameraHandler.updateSettingsTree();
   }
@@ -482,7 +482,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  private _allFramesCursor: {
+  #allFramesCursor: {
     // index represents where the last read message is in allFrames
     index: number;
     cursorTimeReached?: Time;
@@ -492,7 +492,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   };
 
   #resetAllFramesCursor() {
-    this._allFramesCursor = {
+    this.#allFramesCursor = {
       index: -1,
       cursorTimeReached: undefined,
     };
@@ -505,7 +505,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
    */
   public handleAllFramesMessages(allFrames?: readonly MessageEvent<unknown>[]): boolean {
     const currentTime = fromNanoSec(this.currentTime);
-    const allFramesCursor = this._allFramesCursor;
+    const allFramesCursor = this.#allFramesCursor;
     // index always indicates last read-in message
     let cursor = allFramesCursor.index;
     let cursorTimeReached = allFramesCursor.cursorTimeReached;
@@ -557,11 +557,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       return false;
     }
 
-    this._allFramesCursor = { index: cursor, cursorTimeReached };
+    this.#allFramesCursor = { index: cursor, cursorTimeReached };
     return true;
   }
 
-  private addSceneExtension(extension: SceneExtension): void {
+  #addSceneExtension(extension: SceneExtension): void {
     if (this.sceneExtensions.has(extension.extensionId)) {
       throw new Error(`Attempted to add duplicate extensionId "${extension.extensionId}"`);
     }
@@ -656,14 +656,14 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
         label: `${i18next.t("threeDee:customLayers")}${layerCount > 0 ? ` (${layerCount})` : ""}`,
         children: this.settings.tree()["layers"]?.children,
         actions: Array.from(this.#customLayerActions.values()).map((entry) => entry.action),
-        handler: this.handleCustomLayersAction,
+        handler: this.#handleCustomLayersAction,
       },
     };
 
     this.settings.setNodesForKey(RENDERER_ID, [topics, customLayers]);
   }
 
-  private defaultFrameId(): string | undefined {
+  #defaultFrameId(): string | undefined {
     const allFrames = this.transformTree.frames();
     if (allFrames.size === 0) {
       return undefined;
@@ -867,7 +867,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  private addFrameTransform(transform: FrameTransform): void {
+  #addFrameTransform(transform: FrameTransform): void {
     const parentId = transform.parent_frame_id;
     const childId = transform.child_frame_id;
     const stamp = toNanoSec(transform.timestamp);
@@ -877,7 +877,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.addTransform(parentId, childId, stamp, t, q);
   }
 
-  private addTransformMessage(tf: TransformStamped): void {
+  #addTransformMessage(tf: TransformStamped): void {
     const normalizedParentId = this.normalizeFrameId(tf.header.frame_id);
     const normalizedChildId = this.normalizeFrameId(tf.child_frame_id);
     const stamp = toNanoSec(tf.header.stamp);
@@ -943,20 +943,20 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   // Callback handlers
 
   public animationFrame = (): void => {
-    this._animationFrame = undefined;
-    this.frameHandler(this.currentTime);
+    this.#animationFrame = undefined;
+    this.#frameHandler(this.currentTime);
   };
 
   public queueAnimationFrame(): void {
-    if (this._animationFrame == undefined) {
-      this._animationFrame = requestAnimationFrame(this.animationFrame);
+    if (this.#animationFrame == undefined) {
+      this.#animationFrame = requestAnimationFrame(this.animationFrame);
     }
   }
 
-  private frameHandler = (currentTime: bigint): void => {
+  #frameHandler = (currentTime: bigint): void => {
     this.currentTime = currentTime;
-    this._updateFrames();
-    this._updateResolution();
+    this.#updateFrames();
+    this.#updateResolution();
 
     this.gl.clear();
     this.emit("startFrame", currentTime, this);
@@ -1038,36 +1038,36 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.emit("renderablesClicked", selections, cursorCoords, this);
   };
 
-  private handleFrameTransform = ({ message }: MessageEvent<DeepPartial<FrameTransform>>): void => {
+  #handleFrameTransform = ({ message }: MessageEvent<DeepPartial<FrameTransform>>): void => {
     // foxglove.FrameTransform - Ingest this single transform into our TF tree
     const transform = normalizeFrameTransform(message);
-    this.addFrameTransform(transform);
+    this.#addFrameTransform(transform);
   };
 
-  private handleFrameTransforms = ({
+  #handleFrameTransforms = ({
     message,
   }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
     // foxglove.FrameTransforms - Ingest the list of transforms into our TF tree
     const frameTransforms = normalizeFrameTransforms(message);
     for (const transform of frameTransforms.transforms) {
-      this.addFrameTransform(transform);
+      this.#addFrameTransform(transform);
     }
   };
 
-  private handleTFMessage = ({ message }: MessageEvent<DeepPartial<TFMessage>>): void => {
+  #handleTFMessage = ({ message }: MessageEvent<DeepPartial<TFMessage>>): void => {
     // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
     const tfMessage = normalizeTFMessage(message);
     for (const tf of tfMessage.transforms) {
-      this.addTransformMessage(tf);
+      this.#addTransformMessage(tf);
     }
   };
 
-  private handleTransformStamped = ({
+  #handleTransformStamped = ({
     message,
   }: MessageEvent<DeepPartial<TransformStamped>>): void => {
     // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
     const tf = normalizeTransformStamped(message);
-    this.addTransformMessage(tf);
+    this.#addTransformMessage(tf);
   };
 
   #handleTopicsAction = (action: SettingsTreeAction): void => {
@@ -1100,7 +1100,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   };
 
-  private handleCustomLayersAction = (action: SettingsTreeAction): void => {
+  #handleCustomLayersAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
     if (action.action !== "perform-node-action" || path.length !== 1 || path[0] !== "layers") {
       return;
@@ -1180,7 +1180,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   /** Tracks the number of frames so we can recompute the defaultFrameId when frames are added. */
   #lastTransformFrameCount = 0;
 
-  private _updateFrames(): void {
+  #updateFrames(): void {
     if (
       this.followFrameId != undefined &&
       this.renderFrameId !== this.followFrameId &&
@@ -1195,7 +1195,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     ) {
       // No valid renderFrameId set, or new frames have been added, fall back to selecting the
       // heuristically most valid frame (if any frames are present)
-      this.renderFrameId = this.defaultFrameId();
+      this.renderFrameId = this.#defaultFrameId();
       this.#lastTransformFrameCount = this.transformTree.frames().size;
 
       if (this.renderFrameId == undefined) {
@@ -1252,7 +1252,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.settings.errors.clearPath(FOLLOW_TF_PATH);
   }
 
-  private _updateResolution(): void {
+  #updateResolution(): void {
     const resolution = this.input.canvasSize;
     if (this.#prevResolution.equals(resolution)) {
       return;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1044,9 +1044,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.#addFrameTransform(transform);
   };
 
-  #handleFrameTransforms = ({
-    message,
-  }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
+  #handleFrameTransforms = ({ message }: MessageEvent<DeepPartial<FrameTransforms>>): void => {
     // foxglove.FrameTransforms - Ingest the list of transforms into our TF tree
     const frameTransforms = normalizeFrameTransforms(message);
     for (const transform of frameTransforms.transforms) {
@@ -1062,9 +1060,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   };
 
-  #handleTransformStamped = ({
-    message,
-  }: MessageEvent<DeepPartial<TransformStamped>>): void => {
+  #handleTransformStamped = ({ message }: MessageEvent<DeepPartial<TransformStamped>>): void => {
     // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
     const tf = normalizeTransformStamped(message);
     this.#addTransformMessage(tf);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -169,7 +169,7 @@ Object.defineProperty(LabelMaterial.prototype, "fragmentShaderKey", {
  */
 export class Renderer extends EventEmitter<RendererEvents> implements IRenderer {
   public readonly interfaceMode: InterfaceMode;
-  private canvas: HTMLCanvasElement;
+  #canvas: HTMLCanvasElement;
   public readonly gl: THREE.WebGLRenderer;
   public maxLod = DetailLevel.High;
   public debugPicking = false;
@@ -190,10 +190,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   // topicName -> RendererSubscription[]
   public topicHandlers = new Map<string, RendererSubscription[]>();
   // layerId -> { action, handler }
-  private customLayerActions = new Map<string, CustomLayerAction>();
-  private scene: THREE.Scene;
-  private dirLight: THREE.DirectionalLight;
-  private hemiLight: THREE.HemisphereLight;
+  #customLayerActions = new Map<string, CustomLayerAction>();
+  #scene: THREE.Scene;
+  #dirLight: THREE.DirectionalLight;
+  #hemiLight: THREE.HemisphereLight;
   public input: Input;
   public readonly outlineMaterial = new THREE.LineBasicMaterial({ dithering: true });
   public readonly instancedOutlineMaterial = new InstancedLineMaterial({ dithering: true });
@@ -208,9 +208,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   // stripping any leading "/" prefix. See `normalizeFrameId()` for details.
   public ros = false;
 
-  private picker: Picker;
-  private selectionBackdrop: ScreenOverlay;
-  private selectedRenderable: PickedRenderable | undefined;
+  #picker: Picker;
+  #selectionBackdrop: ScreenOverlay;
+  #selectedRenderable: PickedRenderable | undefined;
   public colorScheme: "dark" | "light" = "light";
   public modelCache: ModelCache;
   public transformTree = new TransformTree();
@@ -224,8 +224,8 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   public markerPool = new MarkerPool(this);
   public sharedGeometry = new SharedGeometry();
 
-  private _prevResolution = new THREE.Vector2();
-  private _pickingEnabled = false;
+  #prevResolution = new THREE.Vector2();
+  #pickingEnabled = false;
   private _animationFrame?: number;
   private _cameraSyncError: undefined | string;
   private _devicePixelRatioMediaQuery?: MediaQueryList;
@@ -240,7 +240,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     THREE.Object3D.DEFAULT_UP = new THREE.Vector3(0, 0, 1);
 
     this.interfaceMode = interfaceMode;
-    this.canvas = canvas;
+    this.#canvas = canvas;
     this.config = config;
 
     this.settings = new SettingsManager(baseSettingsTree(this.interfaceMode));
@@ -282,34 +282,34 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       edgeMaterial: this.outlineMaterial,
     });
 
-    this.scene = new THREE.Scene();
+    this.#scene = new THREE.Scene();
 
-    this.dirLight = new THREE.DirectionalLight();
-    this.dirLight.position.set(1, 1, 1);
-    this.dirLight.castShadow = true;
-    this.dirLight.layers.enableAll();
+    this.#dirLight = new THREE.DirectionalLight();
+    this.#dirLight.position.set(1, 1, 1);
+    this.#dirLight.castShadow = true;
+    this.#dirLight.layers.enableAll();
 
-    this.dirLight.shadow.mapSize.width = 2048;
-    this.dirLight.shadow.mapSize.height = 2048;
-    this.dirLight.shadow.camera.near = 0.5;
-    this.dirLight.shadow.camera.far = 500;
-    this.dirLight.shadow.bias = -0.00001;
+    this.#dirLight.shadow.mapSize.width = 2048;
+    this.#dirLight.shadow.mapSize.height = 2048;
+    this.#dirLight.shadow.camera.near = 0.5;
+    this.#dirLight.shadow.camera.far = 500;
+    this.#dirLight.shadow.bias = -0.00001;
 
-    this.hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, 0.5);
-    this.hemiLight.layers.enableAll();
+    this.#hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, 0.5);
+    this.#hemiLight.layers.enableAll();
 
-    this.scene.add(this.dirLight);
-    this.scene.add(this.hemiLight);
+    this.#scene.add(this.#dirLight);
+    this.#scene.add(this.#hemiLight);
 
     this.input = new Input(canvas, () => this.cameraHandler.getActiveCamera());
-    this.input.on("resize", (size) => this.resizeHandler(size));
-    this.input.on("click", (cursorCoords) => this.clickHandler(cursorCoords));
+    this.input.on("resize", (size) => this.#resizeHandler(size));
+    this.input.on("click", (cursorCoords) => this.#clickHandler(cursorCoords));
 
-    this.picker = new Picker(this.gl, this.scene);
+    this.#picker = new Picker(this.gl, this.#scene);
 
-    this.selectionBackdrop = new ScreenOverlay(this);
-    this.selectionBackdrop.visible = false;
-    this.scene.add(this.selectionBackdrop);
+    this.#selectionBackdrop = new ScreenOverlay(this);
+    this.#selectionBackdrop.visible = false;
+    this.#scene.add(this.#selectionBackdrop);
 
     this.followFrameId = config.followTf;
 
@@ -349,7 +349,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
         this.addSceneExtension(this.cameraHandler);
         break;
       case "3d":
-        this.cameraHandler = new CameraStateSettings(this, this.canvas, aspect);
+        this.cameraHandler = new CameraStateSettings(this, this.#canvas, aspect);
         this.addSceneExtension(this.cameraHandler);
         this.addSceneExtension(new PublishSettings(this));
         this.addSceneExtension(new Images(this));
@@ -374,7 +374,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.addSceneExtension(this.measurementTool);
     this.addSceneExtension(this.publishClickTool);
 
-    this._watchDevicePixelRatio();
+    this.#watchDevicePixelRatio();
 
     this.setCameraState(config.cameraState);
     this.animationFrame();
@@ -382,11 +382,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   private _onDevicePixelRatioChange = () => {
     log.debug(`devicePixelRatio changed to ${window.devicePixelRatio}`);
-    this.resizeHandler(this.input.canvasSize);
-    this._watchDevicePixelRatio();
+    this.#resizeHandler(this.input.canvasSize);
+    this.#watchDevicePixelRatio();
   };
 
-  private _watchDevicePixelRatio() {
+  #watchDevicePixelRatio() {
     this._devicePixelRatioMediaQuery = window.matchMedia(
       `(resolution: ${window.devicePixelRatio}dppx)`,
     );
@@ -412,7 +412,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     this.labelPool.dispose();
     this.markerPool.dispose();
-    this.picker.dispose();
+    this.#picker.dispose();
     this.input.dispose();
     this.gl.dispose();
   }
@@ -473,7 +473,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       this.transformTree.clear();
     }
     if (resetAllFramesCursor === true) {
-      this._resetAllFramesCursor();
+      this.#resetAllFramesCursor();
     }
     this.settings.errors.clear();
 
@@ -491,7 +491,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     cursorTimeReached: undefined,
   };
 
-  private _resetAllFramesCursor() {
+  #resetAllFramesCursor() {
     this._allFramesCursor = {
       index: -1,
       cursorTimeReached: undefined,
@@ -513,7 +513,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     if (!allFrames || allFrames.length === 0) {
       // when tf preloading is disabled
       if (cursor > -1) {
-        this._resetAllFramesCursor();
+        this.#resetAllFramesCursor();
       }
       return false;
     }
@@ -566,7 +566,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       throw new Error(`Attempted to add duplicate extensionId "${extension.extensionId}"`);
     }
     this.sceneExtensions.set(extension.extensionId, extension);
-    this.scene.add(extension);
+    this.#scene.add(extension);
   }
 
   public updateConfig(updateHandler: (draft: RendererConfig) => void): void {
@@ -630,7 +630,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       label: options.label,
       icon: options.icon,
     };
-    this.customLayerActions.set(options.layerId, { action, handler });
+    this.#customLayerActions.set(options.layerId, { action, handler });
 
     // "Topics" settings tree node
     const topics: SettingsTreeEntry = {
@@ -644,7 +644,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
           { id: "hide-all", type: "action", label: i18next.t("threeDee:hideAll") },
         ],
         children: this.settings.tree()["topics"]?.children,
-        handler: this.handleTopicsAction,
+        handler: this.#handleTopicsAction,
       },
     };
 
@@ -655,7 +655,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       node: {
         label: `${i18next.t("threeDee:customLayers")}${layerCount > 0 ? ` (${layerCount})` : ""}`,
         children: this.settings.tree()["layers"]?.children,
-        actions: Array.from(this.customLayerActions.values()).map((entry) => entry.action),
+        actions: Array.from(this.#customLayerActions.values()).map((entry) => entry.action),
         handler: this.handleCustomLayersAction,
       },
     };
@@ -698,7 +698,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   /** Enable or disable object selection mode */
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   public setPickingEnabled(enabled: boolean): void {
-    this._pickingEnabled = enabled;
+    this.#pickingEnabled = enabled;
     if (!enabled) {
       this.setSelectedRenderable(undefined);
     }
@@ -720,14 +720,14 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       this.outlineMaterial.needsUpdate = true;
       this.instancedOutlineMaterial.color.set(DARK_OUTLINE);
       this.instancedOutlineMaterial.needsUpdate = true;
-      this.selectionBackdrop.setColor(DARK_BACKDROP, 0.8);
+      this.#selectionBackdrop.setColor(DARK_BACKDROP, 0.8);
     } else {
       this.gl.setClearColor(bgColor ?? LIGHT_BACKDROP);
       this.outlineMaterial.color.set(LIGHT_OUTLINE);
       this.outlineMaterial.needsUpdate = true;
       this.instancedOutlineMaterial.color.set(LIGHT_OUTLINE);
       this.instancedOutlineMaterial.needsUpdate = true;
-      this.selectionBackdrop.setColor(LIGHT_BACKDROP, 0.8);
+      this.#selectionBackdrop.setColor(LIGHT_BACKDROP, 0.8);
     }
   }
 
@@ -778,18 +778,18 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   }
 
   public setSelectedRenderable(selection: PickedRenderable | undefined): void {
-    if (this.selectedRenderable === selection) {
+    if (this.#selectedRenderable === selection) {
       return;
     }
 
-    const prevSelected = this.selectedRenderable;
+    const prevSelected = this.#selectedRenderable;
     if (prevSelected) {
       // Deselect the previously selected renderable
       deselectObject(prevSelected.renderable);
       log.debug(`Deselected ${prevSelected.renderable.id} (${prevSelected.renderable.name})`);
     }
 
-    this.selectedRenderable = selection;
+    this.#selectedRenderable = selection;
 
     if (selection) {
       // Select the newly selected renderable
@@ -963,7 +963,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     const camera = this.cameraHandler.getActiveCamera();
     camera.layers.set(LAYER_DEFAULT);
-    this.selectionBackdrop.visible = this.selectedRenderable != undefined;
+    this.#selectionBackdrop.visible = this.#selectedRenderable != undefined;
 
     // use the FALLBACK_FRAME_ID if renderFrame is undefined and there are no options for transforms
     const renderFrameId = this.renderFrameId ?? CoordinateFrame.FALLBACK_FRAME_ID;
@@ -973,13 +973,13 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       sceneExtension.startFrame(currentTime, renderFrameId, fixedFrameId);
     }
 
-    this.gl.render(this.scene, camera);
+    this.gl.render(this.#scene, camera);
 
-    if (this.selectedRenderable) {
+    if (this.#selectedRenderable) {
       this.gl.clearDepth();
       camera.layers.set(LAYER_SELECTED);
-      this.selectionBackdrop.visible = false;
-      this.gl.render(this.scene, camera);
+      this.#selectionBackdrop.visible = false;
+      this.gl.render(this.#scene, camera);
     }
 
     this.emit("endFrame", currentTime, this);
@@ -987,7 +987,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.gl.info.reset();
   };
 
-  private resizeHandler = (size: THREE.Vector2): void => {
+  #resizeHandler = (size: THREE.Vector2): void => {
     this.gl.setPixelRatio(window.devicePixelRatio);
     this.gl.setSize(size.width, size.height);
     this.cameraHandler.handleResize(size.width, size.height, window.devicePixelRatio);
@@ -997,8 +997,8 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.animationFrame();
   };
 
-  private clickHandler = (cursorCoords: THREE.Vector2): void => {
-    if (!this._pickingEnabled) {
+  #clickHandler = (cursorCoords: THREE.Vector2): void => {
+    if (!this.#pickingEnabled) {
       this.setSelectedRenderable(undefined);
       return;
     }
@@ -1018,12 +1018,12 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     const selections: PickedRenderable[] = [];
     let curSelection: PickedRenderable | undefined;
     while (
-      (curSelection = this._pickSingleObject(cursorCoords)) &&
+      (curSelection = this.#pickSingleObject(cursorCoords)) &&
       selections.length < MAX_SELECTIONS
     ) {
       selections.push(curSelection);
       curSelection.renderable.visible = false;
-      this.gl.render(this.scene, camera);
+      this.gl.render(this.#scene, camera);
     }
 
     // Put everything back to normal and render one last frame
@@ -1070,7 +1070,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.addTransformMessage(tf);
   };
 
-  private handleTopicsAction = (action: SettingsTreeAction): void => {
+  #handleTopicsAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
     if (action.action !== "perform-node-action" || path.length !== 1 || path[0] !== "topics") {
       return;
@@ -1112,7 +1112,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     const layerId = actionId.slice(0, -37);
     const instanceId = actionId.slice(-36);
 
-    const entry = this.customLayerActions.get(layerId);
+    const entry = this.#customLayerActions.get(layerId);
     if (!entry) {
       throw new Error(`No custom layer action found for "${layerId}"`);
     }
@@ -1129,10 +1129,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.updateCustomLayersCount();
   };
 
-  private _pickSingleObject(cursorCoords: THREE.Vector2): PickedRenderable | undefined {
+  #pickSingleObject(cursorCoords: THREE.Vector2): PickedRenderable | undefined {
     // Render a single pixel using a fragment shader that writes object IDs as
     // colors, then read the value of that single pixel back
-    const objectId = this.picker.pick(
+    const objectId = this.#picker.pick(
       cursorCoords.x,
       cursorCoords.y,
       this.cameraHandler.getActiveCamera(),
@@ -1143,7 +1143,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
 
     // Traverse the scene looking for this objectId
-    const pickedObject = this.scene.getObjectById(objectId);
+    const pickedObject = this.#scene.getObjectById(objectId);
 
     // Find the highest ancestor of the picked object that is a Renderable
     let renderable: Renderable | undefined;
@@ -1164,7 +1164,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     let instanceIndex: number | undefined;
     if (renderable.pickableInstances) {
-      instanceIndex = this.picker.pickInstance(
+      instanceIndex = this.#picker.pickInstance(
         cursorCoords.x,
         cursorCoords.y,
         this.cameraHandler.getActiveCamera(),
@@ -1178,7 +1178,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   }
 
   /** Tracks the number of frames so we can recompute the defaultFrameId when frames are added. */
-  private _lastTransformFrameCount = 0;
+  #lastTransformFrameCount = 0;
 
   private _updateFrames(): void {
     if (
@@ -1190,13 +1190,13 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       this.renderFrameId = this.followFrameId;
     } else if (
       this.renderFrameId == undefined ||
-      this.transformTree.frames().size !== this._lastTransformFrameCount ||
+      this.transformTree.frames().size !== this.#lastTransformFrameCount ||
       !this.transformTree.hasFrame(this.renderFrameId)
     ) {
       // No valid renderFrameId set, or new frames have been added, fall back to selecting the
       // heuristically most valid frame (if any frames are present)
       this.renderFrameId = this.defaultFrameId();
-      this._lastTransformFrameCount = this.transformTree.frames().size;
+      this.#lastTransformFrameCount = this.transformTree.frames().size;
 
       if (this.renderFrameId == undefined) {
         if (this.followFrameId != undefined) {
@@ -1254,12 +1254,12 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   private _updateResolution(): void {
     const resolution = this.input.canvasSize;
-    if (this._prevResolution.equals(resolution)) {
+    if (this.#prevResolution.equals(resolution)) {
       return;
     }
-    this._prevResolution.copy(resolution);
+    this.#prevResolution.copy(resolution);
 
-    this.scene.traverse((object) => {
+    this.#scene.traverse((object) => {
       if ((object as Partial<THREE.Mesh>).material) {
         const mesh = object as THREE.Mesh;
         const material = mesh.material as Partial<LineMaterial>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ScreenOverlay.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ScreenOverlay.ts
@@ -9,12 +9,12 @@ import type { IRenderer } from "./IRenderer";
 type vec4 = [number, number, number, number];
 
 export class ScreenOverlay extends THREE.Object3D {
-  private material: THREE.ShaderMaterial;
+  #material: THREE.ShaderMaterial;
 
   public constructor(renderer: IRenderer) {
     super();
 
-    this.material = new THREE.ShaderMaterial({
+    this.#material = new THREE.ShaderMaterial({
       transparent: true,
       uniforms: { color: { value: [1, 0, 1, 1] } },
       vertexShader: /* glsl */ `
@@ -30,13 +30,13 @@ export class ScreenOverlay extends THREE.Object3D {
     });
 
     const geometry = renderer.sharedGeometry.getGeometry(this.constructor.name, createGeometry);
-    const mesh = new THREE.Mesh(geometry, this.material);
+    const mesh = new THREE.Mesh(geometry, this.#material);
     mesh.frustumCulled = false;
     this.add(mesh);
   }
 
   public setColor(color: THREE.Color, opacity: number): void {
-    const colorUniform = this.material.uniforms.color!.value as vec4;
+    const colorUniform = this.#material.uniforms.color!.value as vec4;
     colorUniform[0] = color.r;
     colorUniform[1] = color.g;
     colorUniform[2] = color.b;

--- a/packages/studio-base/src/panels/ThreeDeeRender/SettingsManager.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SettingsManager.ts
@@ -22,22 +22,22 @@ export type SettingsManagerEvents = {
 export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
   public errors = new LayerErrors();
 
-  private _nodesByKey = new Map<string, SettingsTreeEntry[]>();
-  private _root: SettingsTreeNodeWithActionHandler = { children: {} };
+  #nodesByKey = new Map<string, SettingsTreeEntry[]>();
+  #root: SettingsTreeNodeWithActionHandler = { children: {} };
 
   public constructor(baseTree: SettingsTreeNodes) {
     super();
 
-    this._root = { children: baseTree };
+    this.#root = { children: baseTree };
     this.errors.on("update", this.handleErrorUpdate);
     this.errors.on("remove", this.handleErrorUpdate);
     this.errors.on("clear", this.handleErrorUpdate);
   }
 
   public setNodesForKey(key: string, nodes: SettingsTreeEntry[]): void {
-    this._root = produce(this._root, (draft) => {
+    this.#root = produce(this.#root, (draft) => {
       // Delete all previous nodes for this key
-      const prevNodes = this._nodesByKey.get(key);
+      const prevNodes = this.#nodesByKey.get(key);
       if (prevNodes) {
         for (const { path } of prevNodes) {
           removeNodeAtPath(draft, path);
@@ -54,13 +54,13 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
     });
 
     // Update the map of nodes by key
-    this._nodesByKey.set(key, nodes);
+    this.#nodesByKey.set(key, nodes);
 
     this.emit("update");
   }
 
   public setLabel(path: Path, label: string): void {
-    this._root = produce(this._root, (draft) => {
+    this.#root = produce(this.#root, (draft) => {
       setLabelAtPath(draft, path, label);
     });
 
@@ -68,7 +68,7 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
   }
 
   public clearChildren(path: Path): void {
-    this._root = produce(this._root, (draft) => {
+    this.#root = produce(this.#root, (draft) => {
       clearChildren(draft, path);
     });
 
@@ -76,7 +76,7 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
   }
 
   public tree(): SettingsTreeNodes {
-    return this._root.children!;
+    return this.#root.children!;
   }
 
   public handleAction = (action: SettingsTreeAction): void => {
@@ -84,7 +84,7 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
 
     // Walk the settings tree down to the end of the path, firing any action
     // handlers along the way
-    let curNode = this._root;
+    let curNode = this.#root;
     curNode.handler?.(action);
     for (const segment of path) {
       const nextNode: SettingsTreeNodeWithActionHandler | undefined = curNode.children?.[segment];
@@ -97,7 +97,7 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
   };
 
   public handleErrorUpdate = (path: Path): void => {
-    this._root = produce(this._root, (draft) => {
+    this.#root = produce(this.#root, (draft) => {
       if (path.length === 0) {
         return { ...draft };
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/SharedGeometry.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SharedGeometry.ts
@@ -10,7 +10,7 @@ import * as THREE from "three";
  * singleton geometry.
  */
 export class SharedGeometry {
-  private _geometryMap = new Map<string, THREE.BufferGeometry>();
+  #geometryMap = new Map<string, THREE.BufferGeometry>();
 
   /**
    * Get a geometry from the map, or create it if it doesn't exist.
@@ -20,18 +20,18 @@ export class SharedGeometry {
    * @returns - created geometry if it doesn't exist or the existing geometry from the map
    */
   public getGeometry<T extends THREE.BufferGeometry>(key: string, createGeometry: () => T): T {
-    let geometry = this._geometryMap.get(key);
+    let geometry = this.#geometryMap.get(key);
     if (!geometry) {
       geometry = createGeometry();
-      this._geometryMap.set(key, geometry);
+      this.#geometryMap.set(key, geometry);
     }
     return geometry as T;
   }
   // disposes of all geometries and clears the map
   public dispose(): void {
-    for (const geometry of this._geometryMap.values()) {
+    for (const geometry of this.#geometryMap.values()) {
       geometry.dispose();
     }
-    this._geometryMap.clear();
+    this.#geometryMap.clear();
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
@@ -71,95 +71,95 @@ export function Stats(): JSX.Element {
 // modified to use a maximum value of ~33ms instead of the default 200ms and
 // the FPS panel is removed
 class THREEStats {
-  private mode = 0;
-  private container: HTMLDivElement;
+  #mode = 0;
+  #container: HTMLDivElement;
   public dom: HTMLDivElement;
-  private beginTime: number;
-  private prevTime: number;
-  private msPanel: Panel;
+  #beginTime: number;
+  #prevTime: number;
+  #msPanel: Panel;
   // fpsPanel: Panel;
-  private memPanel: Panel;
+  #memPanel: Panel;
 
   public constructor() {
-    this.container = document.createElement("div");
-    this.container.style.cssText =
+    this.#container = document.createElement("div");
+    this.#container.style.cssText =
       "position:fixed;top:0;left:0;cursor:pointer;opacity:0.9;z-index:10000";
-    this.container.addEventListener(
+    this.#container.addEventListener(
       "click",
       (event) => {
         event.preventDefault();
-        this.showPanel(++this.mode % this.container.children.length);
+        this.showPanel(++this.#mode % this.#container.children.length);
       },
       false,
     );
-    this.dom = this.container;
+    this.dom = this.#container;
 
-    this.beginTime = performance.now();
-    this.prevTime = this.beginTime;
+    this.#beginTime = performance.now();
+    this.#prevTime = this.#beginTime;
 
-    this.msPanel = this.addPanel(new Panel("MS", "#9480ed", "#1e1a2f"));
+    this.#msPanel = this.addPanel(new Panel("MS", "#9480ed", "#1e1a2f"));
     // this.fpsPanel = this.addPanel(new Panel("FPS", "#0ff", "#002"));
-    this.memPanel = this.addPanel(new Panel("MB", "#f08", "#201"));
+    this.#memPanel = this.addPanel(new Panel("MB", "#f08", "#201"));
 
     this.showPanel(0);
   }
 
   public addPanel(panel: Panel) {
-    this.container.appendChild(panel.dom);
+    this.#container.appendChild(panel.dom);
     return panel;
   }
 
   public showPanel(id: number) {
-    for (let i = 0; i < this.container.children.length; i++) {
-      const child = this.container.children[i] as HTMLElement;
+    for (let i = 0; i < this.#container.children.length; i++) {
+      const child = this.#container.children[i] as HTMLElement;
       child.style.display = i === id ? "block" : "none";
     }
 
-    this.mode = id;
+    this.#mode = id;
   }
 
   public begin = () => {
-    this.beginTime = performance.now();
+    this.#beginTime = performance.now();
   };
 
   public end = () => {
     const time = performance.now();
 
-    this.msPanel.update(time - this.beginTime, 1000 / 30);
+    this.#msPanel.update(time - this.#beginTime, 1000 / 30);
 
-    if (time >= this.prevTime + 1000) {
+    if (time >= this.#prevTime + 1000) {
       // this.fpsPanel.update((this.frames * 1000) / (time - this.prevTime), 100);
 
-      this.prevTime = time;
+      this.#prevTime = time;
 
       const memory = (
         performance as unknown as { memory: { usedJSHeapSize: number; jsHeapSizeLimit: number } }
       ).memory;
-      this.memPanel.update(memory.usedJSHeapSize / 1048576, memory.jsHeapSizeLimit / 1048576);
+      this.#memPanel.update(memory.usedJSHeapSize / 1048576, memory.jsHeapSizeLimit / 1048576);
     }
 
     return time;
   };
 
   public update = () => {
-    this.beginTime = this.end();
+    this.#beginTime = this.end();
   };
 }
 
 // Adapted from <https://github.com/mrdoob/stats.js/>. License: MIT.
 class Panel {
   public dom: HTMLCanvasElement;
-  private context: CanvasRenderingContext2D;
-  private min = Infinity;
-  private max = 0;
-  private name: string;
-  private fg: string;
-  private bg: string;
+  #context: CanvasRenderingContext2D;
+  #min = Infinity;
+  #max = 0;
+  #name: string;
+  #fg: string;
+  #bg: string;
 
   public constructor(name: string, fg: string, bg: string) {
-    this.name = name;
-    this.fg = fg;
-    this.bg = bg;
+    this.#name = name;
+    this.#fg = fg;
+    this.#bg = bg;
 
     const PR = Math.round(window.devicePixelRatio);
     const WIDTH = 80 * PR,
@@ -192,7 +192,7 @@ class Panel {
     context.fillRect(GRAPH_X, GRAPH_Y, GRAPH_WIDTH, GRAPH_HEIGHT);
 
     this.dom = canvas;
-    this.context = context;
+    this.#context = context;
   }
 
   public update(value: number, maxValue: number): void {
@@ -205,20 +205,20 @@ class Panel {
       GRAPH_WIDTH = 74 * PR,
       GRAPH_HEIGHT = 30 * PR;
 
-    this.min = Math.min(this.min, value);
-    this.max = Math.max(this.max, value);
+    this.#min = Math.min(this.#min, value);
+    this.#max = Math.max(this.#max, value);
 
-    this.context.fillStyle = this.bg;
-    this.context.globalAlpha = 1;
-    this.context.fillRect(0, 0, WIDTH, GRAPH_Y);
-    this.context.fillStyle = this.fg;
-    this.context.fillText(
-      `${Math.round(value)} ${this.name} (${Math.round(this.min)}-${Math.round(this.max)})`,
+    this.#context.fillStyle = this.#bg;
+    this.#context.globalAlpha = 1;
+    this.#context.fillRect(0, 0, WIDTH, GRAPH_Y);
+    this.#context.fillStyle = this.#fg;
+    this.#context.fillText(
+      `${Math.round(value)} ${this.#name} (${Math.round(this.#min)}-${Math.round(this.#max)})`,
       TEXT_X,
       TEXT_Y,
     );
 
-    this.context.drawImage(
+    this.#context.drawImage(
       this.dom,
       GRAPH_X + PR,
       GRAPH_Y,
@@ -230,11 +230,11 @@ class Panel {
       GRAPH_HEIGHT,
     );
 
-    this.context.fillRect(GRAPH_X + GRAPH_WIDTH - PR, GRAPH_Y, PR, GRAPH_HEIGHT);
+    this.#context.fillRect(GRAPH_X + GRAPH_WIDTH - PR, GRAPH_Y, PR, GRAPH_HEIGHT);
 
-    this.context.fillStyle = this.bg;
-    this.context.globalAlpha = 0.9;
-    this.context.fillRect(
+    this.#context.fillStyle = this.#bg;
+    this.#context.globalAlpha = 0.9;
+    this.#context.fillRect(
       GRAPH_X + GRAPH_WIDTH - PR,
       GRAPH_Y,
       PR,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Axis.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Axis.ts
@@ -27,45 +27,45 @@ const tempMat4 = new THREE.Matrix4();
 const tempVec = new THREE.Vector3();
 
 export class Axis extends THREE.Object3D {
-  private readonly renderer: IRenderer;
-  private shaftMesh: THREE.InstancedMesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
-  private headMesh: THREE.InstancedMesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  readonly #renderer: IRenderer;
+  #shaftMesh: THREE.InstancedMesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  #headMesh: THREE.InstancedMesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
 
   public constructor(name: string, renderer: IRenderer) {
     super();
     this.name = name;
-    this.renderer = renderer;
+    this.#renderer = renderer;
 
     // Create three arrow shafts
-    const shaftGeometry = this.renderer.sharedGeometry.getGeometry(
-      `${this.constructor.name}-shaft-${this.renderer.maxLod}`,
-      () => createShaftGeometry(this.renderer.maxLod),
+    const shaftGeometry = this.#renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-shaft-${this.#renderer.maxLod}`,
+      () => createShaftGeometry(this.#renderer.maxLod),
     );
-    this.shaftMesh = new THREE.InstancedMesh(shaftGeometry, standardMaterial(COLOR_WHITE), 3);
-    this.shaftMesh.castShadow = true;
-    this.shaftMesh.receiveShadow = true;
+    this.#shaftMesh = new THREE.InstancedMesh(shaftGeometry, standardMaterial(COLOR_WHITE), 3);
+    this.#shaftMesh.castShadow = true;
+    this.#shaftMesh.receiveShadow = true;
 
     // Create three arrow heads
-    const headGeometry = this.renderer.sharedGeometry.getGeometry(
-      `${this.constructor.name}-head-${this.renderer.maxLod}`,
-      () => createHeadGeometry(this.renderer.maxLod),
+    const headGeometry = this.#renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-head-${this.#renderer.maxLod}`,
+      () => createHeadGeometry(this.#renderer.maxLod),
     );
 
-    this.headMesh = new THREE.InstancedMesh(headGeometry, standardMaterial(COLOR_WHITE), 3);
-    this.headMesh.castShadow = true;
-    this.headMesh.receiveShadow = true;
+    this.#headMesh = new THREE.InstancedMesh(headGeometry, standardMaterial(COLOR_WHITE), 3);
+    this.#headMesh.castShadow = true;
+    this.#headMesh.receiveShadow = true;
 
-    Axis.UpdateInstances(this.shaftMesh, this.headMesh, 0);
+    Axis.UpdateInstances(this.#shaftMesh, this.#headMesh, 0);
 
-    this.add(this.shaftMesh);
-    this.add(this.headMesh);
+    this.add(this.#shaftMesh);
+    this.add(this.#headMesh);
   }
 
   public dispose(): void {
-    this.shaftMesh.material.dispose();
-    this.shaftMesh.dispose();
-    this.headMesh.material.dispose();
-    this.headMesh.dispose();
+    this.#shaftMesh.material.dispose();
+    this.#shaftMesh.dispose();
+    this.#headMesh.material.dispose();
+    this.#headMesh.dispose();
   }
 
   private static UpdateInstances(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -68,9 +68,9 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
 
     renderer.on("cameraMove", this.#handleCameraMove);
 
-    renderer.settings.errors.on("update", this.handleErrorChange);
-    renderer.settings.errors.on("clear", this.handleErrorChange);
-    renderer.settings.errors.on("remove", this.handleErrorChange);
+    renderer.settings.errors.on("update", this.#handleErrorChange);
+    renderer.settings.errors.on("clear", this.#handleErrorChange);
+    renderer.settings.errors.on("remove", this.#handleErrorChange);
 
     this.#canvas = canvas;
     this.#perspectiveCamera = new THREE.PerspectiveCamera();
@@ -107,15 +107,15 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     // for frame settings
     this.renderer.off("transformTreeUpdated", this.#handleTransformTreeUpdated);
 
-    this.renderer.settings.errors.off("update", this.handleErrorChange);
-    this.renderer.settings.errors.off("clear", this.handleErrorChange);
-    this.renderer.settings.errors.off("remove", this.handleErrorChange);
+    this.renderer.settings.errors.off("update", this.#handleErrorChange);
+    this.renderer.settings.errors.off("clear", this.#handleErrorChange);
+    this.renderer.settings.errors.off("remove", this.#handleErrorChange);
 
     super.dispose();
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    return [this.#cameraSettingsNode(), this.frameSettingsNode()];
+    return [this.#cameraSettingsNode(), this.#frameSettingsNode()];
   }
 
   #cameraSettingsNode(): SettingsTreeEntry {
@@ -198,7 +198,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     };
   }
 
-  private frameSettingsNode(): SettingsTreeEntry {
+  #frameSettingsNode(): SettingsTreeEntry {
     const config = this.renderer.config;
     const handler = this.handleSettingsAction;
 
@@ -391,16 +391,12 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   #handleTransformTreeUpdated = (): void => {
     this.updateSettingsTree();
   };
-  private handleErrorChange = (): void => {
+  #handleErrorChange = (): void => {
     this.updateSettingsTree();
   };
 
   // Redefine follow pose snapshot whenever renderFrame or fixedFrame changes
-  #getUnfollowPoseSnapshot(
-    fixedFrameId: string,
-    renderFrameId: string,
-    currentTime: bigint,
-  ) {
+  #getUnfollowPoseSnapshot(fixedFrameId: string, renderFrameId: string, currentTime: bigint) {
     const transformTree = this.renderer.transformTree;
     if (
       this.#unfollowSnapshotFrameIds?.fixed !== fixedFrameId ||
@@ -486,7 +482,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     this.#perspectiveCamera.fov = cameraState.fovy;
     this.#perspectiveCamera.near = cameraState.near;
     this.#perspectiveCamera.far = cameraState.far;
-    this.#perspectiveCamera.#aspect = this.#aspect;
+    this.#perspectiveCamera.aspect = this.#aspect;
     this.#perspectiveCamera.updateProjectionMatrix();
 
     this.#controls.target.copy(targetOffset);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -37,7 +37,7 @@ const tempEuler = new THREE.Euler();
 const FOLLOW_TF_PATH = ["general", "followTf"];
 export class CameraStateSettings extends SceneExtension implements ICameraHandler {
   // The frameId's of the fixed and render frames used to create the current unfollowPoseSnapshot
-  private unfollowSnapshotFrameIds:
+  #unfollowSnapshotFrameIds:
     | {
         render: UserFrameId;
         fixed: UserFrameId;
@@ -48,64 +48,64 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   // This is used to position and orient the camera from the fixed frame in the render frame
   public unfollowPoseSnapshot: Pose | undefined;
 
-  private controls: OrbitControls;
-  private isUpdatingCameraState = false;
-  private canvas: HTMLCanvasElement;
+  #controls: OrbitControls;
+  #isUpdatingCameraState = false;
+  #canvas: HTMLCanvasElement;
 
   // This group is used to transform the cameras based on the Frame follow mode
   // quaternion is affected in stationary and position-only follow modes
   // both position and quaternion of the group are affected in stationary mode
-  private cameraGroup: THREE.Group;
-  private perspectiveCamera: THREE.PerspectiveCamera;
-  private orthographicCamera: THREE.OrthographicCamera;
-  private aspect: number;
+  #cameraGroup: THREE.Group;
+  #perspectiveCamera: THREE.PerspectiveCamera;
+  #orthographicCamera: THREE.OrthographicCamera;
+  #aspect: number;
 
   public constructor(renderer: IRenderer, canvas: HTMLCanvasElement, aspect: number) {
     super("foxglove.CameraStateSettings", renderer);
 
     // for Frame settings, we need to listen to the transform tree to update settings when new possible display frames are present
-    renderer.on("transformTreeUpdated", this.handleTransformTreeUpdated);
+    renderer.on("transformTreeUpdated", this.#handleTransformTreeUpdated);
 
-    renderer.on("cameraMove", this.handleCameraMove);
+    renderer.on("cameraMove", this.#handleCameraMove);
 
     renderer.settings.errors.on("update", this.handleErrorChange);
     renderer.settings.errors.on("clear", this.handleErrorChange);
     renderer.settings.errors.on("remove", this.handleErrorChange);
 
-    this.canvas = canvas;
-    this.perspectiveCamera = new THREE.PerspectiveCamera();
-    this.orthographicCamera = new THREE.OrthographicCamera();
-    this.cameraGroup = new THREE.Group();
+    this.#canvas = canvas;
+    this.#perspectiveCamera = new THREE.PerspectiveCamera();
+    this.#orthographicCamera = new THREE.OrthographicCamera();
+    this.#cameraGroup = new THREE.Group();
 
-    this.cameraGroup.add(this.perspectiveCamera);
-    this.cameraGroup.add(this.orthographicCamera);
-    this.add(this.cameraGroup);
+    this.#cameraGroup.add(this.#perspectiveCamera);
+    this.#cameraGroup.add(this.#orthographicCamera);
+    this.add(this.#cameraGroup);
 
-    this.controls = new OrbitControls(this.perspectiveCamera, this.canvas);
-    this.controls.screenSpacePanning = false; // only allow panning in the XY plane
-    this.controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
-    this.controls.mouseButtons.RIGHT = THREE.MOUSE.ROTATE;
-    this.controls.touches.ONE = THREE.TOUCH.PAN;
-    this.controls.touches.TWO = THREE.TOUCH.DOLLY_ROTATE;
-    this.controls.addEventListener("change", () => {
-      if (!this.isUpdatingCameraState) {
+    this.#controls = new OrbitControls(this.#perspectiveCamera, this.#canvas);
+    this.#controls.screenSpacePanning = false; // only allow panning in the XY plane
+    this.#controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
+    this.#controls.mouseButtons.RIGHT = THREE.MOUSE.ROTATE;
+    this.#controls.touches.ONE = THREE.TOUCH.PAN;
+    this.#controls.touches.TWO = THREE.TOUCH.DOLLY_ROTATE;
+    this.#controls.addEventListener("change", () => {
+      if (!this.#isUpdatingCameraState) {
         renderer.emit("cameraMove", renderer);
       }
     });
 
     // Make the canvas able to receive keyboard events and setup WASD controls
     canvas.tabIndex = 1000;
-    this.aspect = aspect;
-    this.controls.keys = { LEFT: "KeyA", RIGHT: "KeyD", UP: "KeyW", BOTTOM: "KeyS" };
-    this.controls.listenToKeyEvents(canvas);
+    this.#aspect = aspect;
+    this.#controls.keys = { LEFT: "KeyA", RIGHT: "KeyD", UP: "KeyW", BOTTOM: "KeyS" };
+    this.#controls.listenToKeyEvents(canvas);
   }
 
   public override dispose(): void {
     // for camera settings
-    this.renderer.off("cameraMove", this.handleCameraMove);
+    this.renderer.off("cameraMove", this.#handleCameraMove);
 
     // for frame settings
-    this.renderer.off("transformTreeUpdated", this.handleTransformTreeUpdated);
+    this.renderer.off("transformTreeUpdated", this.#handleTransformTreeUpdated);
 
     this.renderer.settings.errors.off("update", this.handleErrorChange);
     this.renderer.settings.errors.off("clear", this.handleErrorChange);
@@ -115,10 +115,10 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    return [this.cameraSettingsNode(), this.frameSettingsNode()];
+    return [this.#cameraSettingsNode(), this.frameSettingsNode()];
   }
 
-  private cameraSettingsNode(): SettingsTreeEntry {
+  #cameraSettingsNode(): SettingsTreeEntry {
     const config = this.renderer.config;
     const { cameraState: camera } = config;
     const handler = this.handleSettingsAction;
@@ -330,14 +330,14 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
       fixedFrameId === CoordinateFrame.FALLBACK_FRAME_ID ||
       renderFrameId === CoordinateFrame.FALLBACK_FRAME_ID
     ) {
-      this.unfollowSnapshotFrameIds = undefined;
+      this.#unfollowSnapshotFrameIds = undefined;
       this.unfollowPoseSnapshot = undefined;
-      this.cameraGroup.position.set(0, 0, 0);
-      this.cameraGroup.quaternion.set(0, 0, 0, 1);
+      this.#cameraGroup.position.set(0, 0, 0);
+      this.#cameraGroup.quaternion.set(0, 0, 0, 1);
       return;
     }
 
-    const poseSnapshot = this.getUnfollowPoseSnapshot(fixedFrameId, renderFrameId, currentTime);
+    const poseSnapshot = this.#getUnfollowPoseSnapshot(fixedFrameId, renderFrameId, currentTime);
 
     const transformTree = this.renderer.transformTree;
 
@@ -367,16 +367,16 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
       if (followMode === "follow-position") {
         // only make orientation static/stationary in this mode
         // the position still follows the frame
-        this.cameraGroup.position.set(0, 0, 0);
+        this.#cameraGroup.position.set(0, 0, 0);
       } else {
-        this.cameraGroup.position.set(
+        this.#cameraGroup.position.set(
           snapshotInRenderFrame.position.x,
           snapshotInRenderFrame.position.y,
           snapshotInRenderFrame.position.z,
         );
       }
       // this negates the rotation of the changes in renderFrame
-      this.cameraGroup.quaternion.set(
+      this.#cameraGroup.quaternion.set(
         snapshotInRenderFrame.orientation.x,
         snapshotInRenderFrame.orientation.y,
         snapshotInRenderFrame.orientation.z,
@@ -385,10 +385,10 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     }
   }
 
-  private handleCameraMove = (): void => {
+  #handleCameraMove = (): void => {
     this.updateSettingsTree();
   };
-  private handleTransformTreeUpdated = (): void => {
+  #handleTransformTreeUpdated = (): void => {
     this.updateSettingsTree();
   };
   private handleErrorChange = (): void => {
@@ -396,15 +396,15 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   };
 
   // Redefine follow pose snapshot whenever renderFrame or fixedFrame changes
-  private getUnfollowPoseSnapshot(
+  #getUnfollowPoseSnapshot(
     fixedFrameId: string,
     renderFrameId: string,
     currentTime: bigint,
   ) {
     const transformTree = this.renderer.transformTree;
     if (
-      this.unfollowSnapshotFrameIds?.fixed !== fixedFrameId ||
-      this.unfollowSnapshotFrameIds.render !== renderFrameId
+      this.#unfollowSnapshotFrameIds?.fixed !== fixedFrameId ||
+      this.#unfollowSnapshotFrameIds.render !== renderFrameId
     ) {
       this.unfollowPoseSnapshot = makePose();
       // record the pose of the center of the render frame in fixed frame into the snapshot
@@ -417,7 +417,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
         currentTime,
         currentTime,
       );
-      this.unfollowSnapshotFrameIds = {
+      this.#unfollowSnapshotFrameIds = {
         fixed: fixedFrameId,
         render: renderFrameId,
       };
@@ -427,12 +427,12 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
 
   public getActiveCamera(): THREE.PerspectiveCamera | THREE.OrthographicCamera {
     return this.renderer.config.cameraState.perspective
-      ? this.perspectiveCamera
-      : this.orthographicCamera;
+      ? this.#perspectiveCamera
+      : this.#orthographicCamera;
   }
 
   public handleResize(width: number, height: number, _pixelRatio: number): void {
-    this.aspect = width / height;
+    this.#aspect = width / height;
     this.setCameraState(this.renderer.config.cameraState);
   }
 
@@ -440,10 +440,10 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     const config = this.renderer.config;
     return {
       perspective: config.cameraState.perspective,
-      distance: this.controls.getDistance(),
-      phi: THREE.MathUtils.radToDeg(this.controls.getPolarAngle()),
-      thetaOffset: THREE.MathUtils.radToDeg(-this.controls.getAzimuthalAngle()),
-      targetOffset: [this.controls.target.x, this.controls.target.y, this.controls.target.z],
+      distance: this.#controls.getDistance(),
+      phi: THREE.MathUtils.radToDeg(this.#controls.getPolarAngle()),
+      thetaOffset: THREE.MathUtils.radToDeg(-this.#controls.getAzimuthalAngle()),
+      targetOffset: [this.#controls.target.x, this.#controls.target.y, this.#controls.target.z],
       target: config.cameraState.target,
       targetOrientation: config.cameraState.targetOrientation,
       fovy: config.cameraState.fovy,
@@ -453,18 +453,18 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   }
 
   public setCameraState(cameraState: CameraState): void {
-    this.isUpdatingCameraState = true;
-    this._updateCameras(cameraState);
+    this.#isUpdatingCameraState = true;
+    this.#updateCameras(cameraState);
     // only active for follow pose mode because it introduces strange behavior into the other modes
     // due to the fact that they are manipulating the camera after update with the `cameraGroup`
     if (this.renderer.config.followMode === "follow-pose") {
-      this.controls.update();
+      this.#controls.update();
     }
-    this.isUpdatingCameraState = false;
+    this.#isUpdatingCameraState = false;
   }
 
   /** Translate a CameraState to the three.js coordinate system */
-  private _updateCameras(cameraState: CameraState): void {
+  #updateCameras(cameraState: CameraState): void {
     const targetOffset = tempVec3;
     const config = this.renderer.config;
     targetOffset.fromArray(cameraState.targetOffset);
@@ -478,37 +478,37 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
 
     // Convert the camera spherical coordinates (radius, phi, theta) to Cartesian (X, Y, Z)
     tempSpherical.set(cameraState.distance, phi, theta);
-    this.perspectiveCamera.position.setFromSpherical(tempSpherical).applyAxisAngle(UNIT_X, PI_2);
-    this.perspectiveCamera.position.add(targetOffset);
+    this.#perspectiveCamera.position.setFromSpherical(tempSpherical).applyAxisAngle(UNIT_X, PI_2);
+    this.#perspectiveCamera.position.add(targetOffset);
 
     // Convert the camera spherical coordinates (phi, theta) to a quaternion rotation
-    this.perspectiveCamera.quaternion.setFromEuler(tempEuler.set(phi, 0, theta, "ZYX"));
-    this.perspectiveCamera.fov = cameraState.fovy;
-    this.perspectiveCamera.near = cameraState.near;
-    this.perspectiveCamera.far = cameraState.far;
-    this.perspectiveCamera.aspect = this.aspect;
-    this.perspectiveCamera.updateProjectionMatrix();
+    this.#perspectiveCamera.quaternion.setFromEuler(tempEuler.set(phi, 0, theta, "ZYX"));
+    this.#perspectiveCamera.fov = cameraState.fovy;
+    this.#perspectiveCamera.near = cameraState.near;
+    this.#perspectiveCamera.far = cameraState.far;
+    this.#perspectiveCamera.#aspect = this.#aspect;
+    this.#perspectiveCamera.updateProjectionMatrix();
 
-    this.controls.target.copy(targetOffset);
+    this.#controls.target.copy(targetOffset);
 
     if (cameraState.perspective) {
       // Unlock the polar angle (pitch axis)
-      this.controls.minPolarAngle = 0;
-      this.controls.maxPolarAngle = Math.PI;
+      this.#controls.minPolarAngle = 0;
+      this.#controls.maxPolarAngle = Math.PI;
     } else {
       // Lock the polar angle during 2D mode
       const curPolarAngle = THREE.MathUtils.degToRad(config.cameraState.phi);
-      this.controls.minPolarAngle = this.controls.maxPolarAngle = curPolarAngle;
+      this.#controls.minPolarAngle = this.#controls.maxPolarAngle = curPolarAngle;
 
-      this.orthographicCamera.position.set(targetOffset.x, targetOffset.y, cameraState.far / 2);
-      this.orthographicCamera.quaternion.setFromAxisAngle(UNIT_Z, theta);
-      this.orthographicCamera.left = (-cameraState.distance / 2) * this.aspect;
-      this.orthographicCamera.right = (cameraState.distance / 2) * this.aspect;
-      this.orthographicCamera.top = cameraState.distance / 2;
-      this.orthographicCamera.bottom = -cameraState.distance / 2;
-      this.orthographicCamera.near = cameraState.near;
-      this.orthographicCamera.far = cameraState.far;
-      this.orthographicCamera.updateProjectionMatrix();
+      this.#orthographicCamera.position.set(targetOffset.x, targetOffset.y, cameraState.far / 2);
+      this.#orthographicCamera.quaternion.setFromAxisAngle(UNIT_Z, theta);
+      this.#orthographicCamera.left = (-cameraState.distance / 2) * this.#aspect;
+      this.#orthographicCamera.right = (cameraState.distance / 2) * this.#aspect;
+      this.#orthographicCamera.top = cameraState.distance / 2;
+      this.#orthographicCamera.bottom = -cameraState.distance / 2;
+      this.#orthographicCamera.near = cameraState.near;
+      this.#orthographicCamera.far = cameraState.far;
+      this.#orthographicCamera.updateProjectionMatrix();
     }
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
@@ -84,8 +84,8 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
   public constructor(renderer: IRenderer) {
     super("foxglove.Cameras", renderer);
 
-    renderer.addSchemaSubscriptions(ROS_CAMERA_INFO_DATATYPES, this.handleCameraInfo);
-    renderer.addSchemaSubscriptions(CAMERA_CALIBRATION_DATATYPES, this.handleCameraInfo);
+    renderer.addSchemaSubscriptions(ROS_CAMERA_INFO_DATATYPES, this.#handleCameraInfo);
+    renderer.addSchemaSubscriptions(CAMERA_CALIBRATION_DATATYPES, this.#handleCameraInfo);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -142,7 +142,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
         const settings = this.renderer.config.topics[topicName] as
           | Partial<LayerSettingsCameraInfo>
           | undefined;
-        this._updateCameraInfoRenderable(
+        this.#updateCameraInfoRenderable(
           renderable,
           cameraInfo,
           originalMessage,
@@ -153,7 +153,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
     }
   };
 
-  private handleCameraInfo = (
+  #handleCameraInfo = (
     messageEvent: PartialMessageEvent<IncomingCameraInfo | CameraCalibration>,
   ): void => {
     const topic = messageEvent.topic;
@@ -189,7 +189,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    this._updateCameraInfoRenderable(
+    this.#updateCameraInfoRenderable(
       renderable,
       cameraInfo,
       messageEvent.message,
@@ -198,7 +198,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
     );
   };
 
-  private _updateCameraInfoRenderable(
+  #updateCameraInfoRenderable(
     renderable: CameraInfoRenderable,
     cameraInfo: CameraInfo,
     originalMessage: Record<string, RosValue> | undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -162,7 +162,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     pickingMaterial.needsUpdate = true;
   }
 
-  private _getRgbaFieldReaders(out: RgbaFieldReaders, foxgloveGrid: Grid) {
+  #getRgbaFieldReaders(out: RgbaFieldReaders, foxgloveGrid: Grid) {
     const { cell_stride } = foxgloveGrid;
     for (const field of foxgloveGrid.fields) {
       const { name } = field;
@@ -178,7 +178,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     }
   }
 
-  private _getColorByFieldReader(
+  #getColorByFieldReader(
     foxgloveGrid: Grid,
     settings: LayerSettingsFoxgloveGrid,
   ): FieldReader | undefined {
@@ -276,7 +276,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
 
   public updateTexture(foxgloveGrid: Grid, settings: LayerSettingsFoxgloveGrid): void {
     let texture = this.userData.texture;
-    const fieldReader = this._getColorByFieldReader(foxgloveGrid, settings);
+    const fieldReader = this.#getColorByFieldReader(foxgloveGrid, settings);
     if (!fieldReader) {
       return;
     }
@@ -327,7 +327,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
       const rgba = texture.image.data;
       let hasTransparency = false;
       if (settings.colorMode === "rgba-fields") {
-        this._getRgbaFieldReaders(tempRgbaFieldReaders, foxgloveGrid);
+        this.#getRgbaFieldReaders(tempRgbaFieldReaders, foxgloveGrid);
         const { redReader, greenReader, blueReader, alphaReader } = tempRgbaFieldReaders;
         for (let y = 0; y < rows; y++) {
           for (let x = 0; x < cols; x++) {
@@ -385,12 +385,12 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
 }
 
 export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
-  private fieldsByTopic = new Map<string, string[]>();
+  #fieldsByTopic = new Map<string, string[]>();
 
   public constructor(renderer: IRenderer) {
     super("foxglove.Grid", renderer);
 
-    renderer.addSchemaSubscriptions(GRID_DATATYPES, this.handleFoxgloveGrid);
+    renderer.addSchemaSubscriptions(GRID_DATATYPES, this.#handleFoxgloveGrid);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -404,7 +404,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsFoxgloveGrid>;
 
       const node = baseColorModeSettingsNode(
-        this.fieldsByTopic.get(topic.name) ?? [],
+        this.#fieldsByTopic.get(topic.name) ?? [],
         config,
         topic,
         DEFAULT_SETTINGS,
@@ -457,14 +457,14 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     }
   };
 
-  private handleFoxgloveGrid = (messageEvent: PartialMessageEvent<Grid>): void => {
+  #handleFoxgloveGrid = (messageEvent: PartialMessageEvent<Grid>): void => {
     const topic = messageEvent.topic;
     const foxgloveGrid = normalizeFoxgloveGrid(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
     let renderable = this.renderables.get(topic);
 
-    if (!this._validateFoxgloveGrid(foxgloveGrid, messageEvent.topic)) {
+    if (!this.#validateFoxgloveGrid(foxgloveGrid, messageEvent.topic)) {
       if (renderable) {
         renderable.visible = false;
       }
@@ -480,7 +480,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       // only want to autoselect if it's in flatcolor mode (without colorfield) and previously didn't have fields
-      if (settings.colorField == undefined && this.fieldsByTopic.get(topic) == undefined) {
+      if (settings.colorField == undefined && this.#fieldsByTopic.get(topic) == undefined) {
         autoSelectColorField(settings, foxgloveGrid.fields, { supportsPackedRgbModes: false });
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {
@@ -523,14 +523,14 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    let fields = this.fieldsByTopic.get(topic);
+    let fields = this.#fieldsByTopic.get(topic);
     if (!fields || fields.length !== foxgloveGrid.fields.length) {
       fields = foxgloveGrid.fields.map((field) => field.name);
-      this.fieldsByTopic.set(topic, fields);
+      this.#fieldsByTopic.set(topic, fields);
       this.updateSettingsTree();
     }
 
-    this._updateFoxgloveGridRenderable(
+    this.#updateFoxgloveGridRenderable(
       renderable,
       foxgloveGrid,
       receiveTime,
@@ -538,7 +538,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     );
   };
 
-  private _validateFoxgloveGrid(foxgloveGrid: Grid, topic: string): boolean {
+  #validateFoxgloveGrid(foxgloveGrid: Grid, topic: string): boolean {
     const { cell_stride, row_stride, column_count: cols } = foxgloveGrid;
     const rows = foxgloveGrid.data.byteLength / row_stride;
 
@@ -591,7 +591,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
   }
 
   /** @param foxgloveGrid must be validated already */
-  private _updateFoxgloveGridRenderable(
+  #updateFoxgloveGridRenderable(
     renderable: FoxgloveGridRenderable,
     foxgloveGrid: Grid,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -434,7 +434,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     label.setBillboard(true);
     label.setText(text);
     label.setLineHeight(config.scene.transforms?.labelSize ?? DEFAULT_TF_LABEL_SIZE);
-    label.setColor(this.#labelForegroundColor, this.#labelForegroundColor, this.#labelForegroundColor);
+    label.setColor(
+      this.#labelForegroundColor,
+      this.#labelForegroundColor,
+      this.#labelForegroundColor,
+    );
     label.setBackgroundColor(
       this.#labelBackgroundColor.r,
       this.#labelBackgroundColor.g,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -322,11 +322,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     }
   }
 
-  private setLineWidth(width: number): void {
+  #setLineWidth(width: number): void {
     this.#lineMaterial.linewidth = width;
   }
 
-  private setLineColor(color: string): void {
+  #setLineColor(color: string): void {
     stringToRgb(this.#lineMaterial.color, color);
   }
 
@@ -372,7 +372,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       this.saveSetting(["scene", "transforms", setting], value);
 
       if (setting === "editable") {
-        this._updateFrameAxes();
+        this.#updateFrameAxes();
       } else if (setting === "labelSize") {
         const labelSize = value as number | undefined;
         this.#setLabelSize(labelSize ?? DEFAULT_TF_LABEL_SIZE);
@@ -381,10 +381,10 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
         this.#setAxisScale(axisScale ?? DEFAULT_AXIS_SCALE);
       } else if (setting === "lineWidth") {
         const lineWidth = value as number | undefined;
-        this.setLineWidth(lineWidth ?? DEFAULT_LINE_WIDTH_PX);
+        this.#setLineWidth(lineWidth ?? DEFAULT_LINE_WIDTH_PX);
       } else if (setting === "lineColor") {
         const lineColor = value as string | undefined;
-        this.setLineColor(lineColor ?? DEFAULT_LINE_COLOR_STR);
+        this.#setLineColor(lineColor ?? DEFAULT_LINE_COLOR_STR);
       }
     } else {
       this.saveSetting(path, action.payload.value);
@@ -480,7 +480,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     this.#updateFrameAxis(renderable);
   }
 
-  private _updateFrameAxes(): void {
+  #updateFrameAxes(): void {
     for (const renderable of this.renderables.values()) {
       this.#updateFrameAxis(renderable);
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -80,13 +80,13 @@ const tempEuler = new THREE.Euler();
 const tempTfPath: [string, string] = ["transforms", ""];
 
 export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
-  private lineMaterial: LineMaterial;
-  private linePickingMaterial: THREE.ShaderMaterial;
+  #lineMaterial: LineMaterial;
+  #linePickingMaterial: THREE.ShaderMaterial;
 
-  private labelForegroundColor = 1;
-  private labelBackgroundColor = new THREE.Color();
-  private lineGeometry: LineGeometry;
-  private defaultRenderableSettings: LayerSettingsTransform;
+  #labelForegroundColor = 1;
+  #labelBackgroundColor = new THREE.Color();
+  #lineGeometry: LineGeometry;
+  #defaultRenderableSettings: LayerSettingsTransform;
 
   public constructor(
     renderer: IRenderer,
@@ -99,27 +99,27 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       new THREE.Color(),
       this.renderer.config.scene.transforms?.lineColor ?? DEFAULT_LINE_COLOR_STR,
     );
-    this.lineMaterial = new LineMaterial({ linewidth });
-    this.lineMaterial.color = color;
+    this.#lineMaterial = new LineMaterial({ linewidth });
+    this.#lineMaterial.color = color;
 
     const options = { resolution: renderer.input.canvasSize, worldUnits: false };
 
-    this.lineGeometry = this.renderer.sharedGeometry.getGeometry(
+    this.#lineGeometry = this.renderer.sharedGeometry.getGeometry(
       this.constructor.name,
       createLineGeometry,
     );
 
-    this.linePickingMaterial = makeLinePickingMaterial(PICKING_LINE_SIZE, options);
+    this.#linePickingMaterial = makeLinePickingMaterial(PICKING_LINE_SIZE, options);
 
-    renderer.on("transformTreeUpdated", this.handleTransformTreeUpdated);
+    renderer.on("transformTreeUpdated", this.#handleTransformTreeUpdated);
 
-    this.defaultRenderableSettings = { ...DEFAULT_SETTINGS, ...defaultRenderableSettings };
+    this.#defaultRenderableSettings = { ...DEFAULT_SETTINGS, ...defaultRenderableSettings };
   }
 
   public override dispose(): void {
-    this.renderer.off("transformTreeUpdated", this.handleTransformTreeUpdated);
-    this.lineMaterial.dispose();
-    this.linePickingMaterial.dispose();
+    this.renderer.off("transformTreeUpdated", this.#handleTransformTreeUpdated);
+    this.#lineMaterial.dispose();
+    this.#linePickingMaterial.dispose();
     super.dispose();
   }
 
@@ -191,7 +191,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     let order = 1;
     for (const { label, value: frameId } of this.renderer.coordinateFrameList) {
       const frameKey = `frame:${frameId}`;
-      const tfConfig = this.getRenderableSettingsWithDefaults(configTransforms[frameKey] ?? {});
+      const tfConfig = this.#getRenderableSettingsWithDefaults(configTransforms[frameKey] ?? {});
       const frame = this.renderer.transformTree.frame(frameId);
       const fields = buildSettingsFields(frame, this.renderer.currentTime, config);
       tempTfPath[1] = frameKey;
@@ -227,7 +227,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     fixedFrameId: string,
   ): void {
     // Keep the material's `resolution` uniform in sync with the actual canvas size
-    this.lineMaterial.resolution = this.renderer.input.canvasSize;
+    this.#lineMaterial.resolution = this.renderer.input.canvasSize;
 
     // Update all the transforms settings nodes each frame since they contain
     // fields that change when currentTime changes
@@ -288,46 +288,46 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     backgroundColor: THREE.Color | undefined,
   ): void {
     const foreground = colorScheme === "dark" ? 1 : 0;
-    this.labelForegroundColor = foreground;
-    this.labelBackgroundColor.setRGB(1 - foreground, 1 - foreground, 1 - foreground);
+    this.#labelForegroundColor = foreground;
+    this.#labelBackgroundColor.setRGB(1 - foreground, 1 - foreground, 1 - foreground);
     if (backgroundColor) {
-      this.labelForegroundColor =
+      this.#labelForegroundColor =
         getLuminance(backgroundColor.r, backgroundColor.g, backgroundColor.b) > 0.5 ? 0 : 1;
-      this.labelBackgroundColor.copy(backgroundColor);
+      this.#labelBackgroundColor.copy(backgroundColor);
     }
 
     for (const renderable of this.renderables.values()) {
       renderable.userData.label.setColor(
-        this.labelForegroundColor,
-        this.labelForegroundColor,
-        this.labelForegroundColor,
+        this.#labelForegroundColor,
+        this.#labelForegroundColor,
+        this.#labelForegroundColor,
       );
       renderable.userData.label.setBackgroundColor(
-        this.labelBackgroundColor.r,
-        this.labelBackgroundColor.g,
-        this.labelBackgroundColor.b,
+        this.#labelBackgroundColor.r,
+        this.#labelBackgroundColor.g,
+        this.#labelBackgroundColor.b,
       );
     }
   }
 
-  private setLabelSize(size: number): void {
+  #setLabelSize(size: number): void {
     for (const renderable of this.renderables.values()) {
       renderable.userData.label.setLineHeight(size);
     }
   }
 
-  private setAxisScale(scale: number): void {
+  #setAxisScale(scale: number): void {
     for (const renderable of this.renderables.values()) {
       renderable.userData.axis.scale.set(scale, scale, scale);
     }
   }
 
   private setLineWidth(width: number): void {
-    this.lineMaterial.linewidth = width;
+    this.#lineMaterial.linewidth = width;
   }
 
   private setLineColor(color: string): void {
-    stringToRgb(this.lineMaterial.color, color);
+    stringToRgb(this.#lineMaterial.color, color);
   }
 
   public override handleSettingsAction = (action: SettingsTreeAction): void => {
@@ -375,10 +375,10 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
         this._updateFrameAxes();
       } else if (setting === "labelSize") {
         const labelSize = value as number | undefined;
-        this.setLabelSize(labelSize ?? DEFAULT_TF_LABEL_SIZE);
+        this.#setLabelSize(labelSize ?? DEFAULT_TF_LABEL_SIZE);
       } else if (setting === "axisScale") {
         const axisScale = value as number | undefined;
-        this.setAxisScale(axisScale ?? DEFAULT_AXIS_SCALE);
+        this.#setAxisScale(axisScale ?? DEFAULT_AXIS_SCALE);
       } else if (setting === "lineWidth") {
         const lineWidth = value as number | undefined;
         this.setLineWidth(lineWidth ?? DEFAULT_LINE_WIDTH_PX);
@@ -397,27 +397,27 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
         const settings = this.renderer.config.transforms[frameKey] as
           | Partial<LayerSettingsTransform>
           | undefined;
-        renderable.userData.settings = this.getRenderableSettingsWithDefaults(settings ?? {});
+        renderable.userData.settings = this.#getRenderableSettingsWithDefaults(settings ?? {});
 
-        this._updateFrameAxis(renderable);
+        this.#updateFrameAxis(renderable);
       }
     }
   };
 
-  private getRenderableSettingsWithDefaults(
+  #getRenderableSettingsWithDefaults(
     partialDefinedSettings: Partial<LayerSettingsTransform>,
   ): LayerSettingsTransform {
-    return { ...this.defaultRenderableSettings, ...partialDefinedSettings };
+    return { ...this.#defaultRenderableSettings, ...partialDefinedSettings };
   }
 
-  private handleTransformTreeUpdated = (): void => {
+  #handleTransformTreeUpdated = (): void => {
     for (const frameId of this.renderer.transformTree.frames().keys()) {
-      this._addFrameAxis(frameId);
+      this.#addFrameAxis(frameId);
     }
     this.updateSettingsTree();
   };
 
-  private _addFrameAxis(frameId: string): void {
+  #addFrameAxis(frameId: string): void {
     if (this.renderables.has(frameId)) {
       return;
     }
@@ -434,23 +434,23 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     label.setBillboard(true);
     label.setText(text);
     label.setLineHeight(config.scene.transforms?.labelSize ?? DEFAULT_TF_LABEL_SIZE);
-    label.setColor(this.labelForegroundColor, this.labelForegroundColor, this.labelForegroundColor);
+    label.setColor(this.#labelForegroundColor, this.#labelForegroundColor, this.#labelForegroundColor);
     label.setBackgroundColor(
-      this.labelBackgroundColor.r,
-      this.labelBackgroundColor.g,
-      this.labelBackgroundColor.b,
+      this.#labelBackgroundColor.r,
+      this.#labelBackgroundColor.g,
+      this.#labelBackgroundColor.b,
     );
 
     // Set the initial settings from default values merged with any user settings
     const frameKey = `frame:${frameId}`;
     const userSettings = config.transforms[frameKey] as Partial<LayerSettingsTransform> | undefined;
-    const settings = this.getRenderableSettingsWithDefaults(userSettings ?? {});
+    const settings = this.#getRenderableSettingsWithDefaults(userSettings ?? {});
 
     // Parent line
-    const parentLine = new Line2(this.lineGeometry, this.lineMaterial);
+    const parentLine = new Line2(this.#lineGeometry, this.#lineMaterial);
     parentLine.castShadow = true;
     parentLine.receiveShadow = false;
-    parentLine.userData.pickingMaterial = this.linePickingMaterial;
+    parentLine.userData.pickingMaterial = this.#linePickingMaterial;
 
     // Three arrow axis
     const axis = new Axis(frameId, this.renderer);
@@ -477,16 +477,16 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     this.add(renderable);
     this.renderables.set(frameId, renderable);
 
-    this._updateFrameAxis(renderable);
+    this.#updateFrameAxis(renderable);
   }
 
   private _updateFrameAxes(): void {
     for (const renderable of this.renderables.values()) {
-      this._updateFrameAxis(renderable);
+      this.#updateFrameAxis(renderable);
     }
   }
 
-  private _updateFrameAxis(renderable: FrameAxisRenderable): void {
+  #updateFrameAxis(renderable: FrameAxisRenderable): void {
     const frame = this.renderer.transformTree.getOrCreateFrame(renderable.userData.frameId);
 
     // Check if TF editing is disabled

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
@@ -75,21 +75,21 @@ export class Grids extends SceneExtension<GridRenderable> {
       layerId: LAYER_ID,
       label: t("threeDee:addGrid"),
       icon: "Grid",
-      handler: this.handleAddGrid,
+      handler: this.#handleAddGrid,
     });
 
-    renderer.on("transformTreeUpdated", this.handleTransformTreeUpdated);
+    renderer.on("transformTreeUpdated", this.#handleTransformTreeUpdated);
 
     // Load existing grid layers from the config
     for (const [instanceId, entry] of Object.entries(renderer.config.layers)) {
       if (entry?.layerId === LAYER_ID) {
-        this._updateGrid(instanceId, entry as Partial<LayerSettingsGrid>);
+        this.#updateGrid(instanceId, entry as Partial<LayerSettingsGrid>);
       }
     }
   }
 
   public override dispose(): void {
-    this.renderer.off("transformTreeUpdated", this.handleTransformTreeUpdated);
+    this.renderer.off("transformTreeUpdated", this.#handleTransformTreeUpdated);
     super.dispose();
   }
 
@@ -137,7 +137,7 @@ export class Grids extends SceneExtension<GridRenderable> {
 
       // Create renderables for new grid layers
       if (!this.renderables.has(instanceId)) {
-        this._updateGrid(instanceId, config);
+        this.#updateGrid(instanceId, config);
       }
     }
     return entries;
@@ -169,7 +169,7 @@ export class Grids extends SceneExtension<GridRenderable> {
         });
 
         // Remove the renderable
-        this._updateGrid(instanceId, undefined);
+        this.#updateGrid(instanceId, undefined);
 
         // Update the settings tree
         this.updateSettingsTree();
@@ -188,10 +188,10 @@ export class Grids extends SceneExtension<GridRenderable> {
     const settings = this.renderer.config.layers[instanceId] as
       | Partial<LayerSettingsGrid>
       | undefined;
-    this._updateGrid(instanceId, settings);
+    this.#updateGrid(instanceId, settings);
   };
 
-  private handleAddGrid = (instanceId: string): void => {
+  #handleAddGrid = (instanceId: string): void => {
     log.info(`Creating ${LAYER_ID} layer ${instanceId}`);
 
     const config: LayerSettingsGrid = { ...DEFAULT_SETTINGS, instanceId };
@@ -204,17 +204,17 @@ export class Grids extends SceneExtension<GridRenderable> {
     });
 
     // Add a renderable
-    this._updateGrid(instanceId, config);
+    this.#updateGrid(instanceId, config);
 
     // Update the settings tree
     this.updateSettingsTree();
   };
 
-  private handleTransformTreeUpdated = (): void => {
+  #handleTransformTreeUpdated = (): void => {
     this.updateSettingsTree();
   };
 
-  private _updateGrid(instanceId: string, settings: Partial<LayerSettingsGrid> | undefined): void {
+  #updateGrid(instanceId: string, settings: Partial<LayerSettingsGrid> | undefined): void {
     let renderable = this.renderables.get(instanceId);
 
     // Handle deletes
@@ -229,7 +229,7 @@ export class Grids extends SceneExtension<GridRenderable> {
 
     const newSettings = { ...DEFAULT_SETTINGS, ...settings };
     if (!renderable) {
-      renderable = this._createRenderable(instanceId, newSettings);
+      renderable = this.#createRenderable(instanceId, newSettings);
       renderable.userData.pose = xyzrpyToPose(newSettings.position, newSettings.rotation);
     }
 
@@ -258,7 +258,7 @@ export class Grids extends SceneExtension<GridRenderable> {
     }
   }
 
-  private _createRenderable(instanceId: string, settings: LayerSettingsGrid): GridRenderable {
+  #createRenderable(instanceId: string, settings: LayerSettingsGrid): GridRenderable {
     const marker = createMarker(settings);
     const lineListId = `${instanceId}:LINE_LIST`;
     const lineList = new RenderableLineList(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -314,7 +314,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     const value = action.payload.value;
     if (category === "imageMode") {
       this.saveSetting(path, value);
-      this.updateViewAndRenderables();
+      this.#updateViewAndRenderables();
     } else {
       return;
     }
@@ -339,16 +339,14 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     // the camera info by the info topic configured for the image
     const cameraInfo = normalizeCameraInfo(messageEvent.message);
     this.#updateCameraModel(cameraInfo);
-    this.updateViewAndRenderables();
+    this.#updateViewAndRenderables();
   };
 
   #handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
     this.#handleImage(messageEvent, normalizeRosImage(messageEvent.message));
   };
 
-  #handleRosCompressedImage = (
-    messageEvent: PartialMessageEvent<RosCompressedImage>,
-  ): void => {
+  #handleRosCompressedImage = (messageEvent: PartialMessageEvent<RosCompressedImage>): void => {
     this.#handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
   };
 
@@ -459,7 +457,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   /**
    * Updates renderable, frame, and camera to be in sync with current camera model
    */
-  private updateViewAndRenderables(): void {
+  #updateViewAndRenderables(): void {
     const cameraInfo = this.#cameraModel?.info;
     if (!cameraInfo) {
       this.renderer.settings.errors.add(
@@ -508,7 +506,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
         model,
         info: newCameraInfo,
       };
-      this.#annotations.#updateCameraModel(model);
+      this.#annotations.updateCameraModel(model);
     }
   }
 
@@ -540,7 +538,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   }
 
   public setCameraState(): void {
-    this.updateViewAndRenderables();
+    this.#updateViewAndRenderables();
   }
 
   public getCameraState(): undefined {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -58,8 +58,8 @@ const IMAGE_TOPIC_DIFFERENT_FRAME = "IMAGE_TOPIC_DIFFERENT_FRAME";
 const CAMERA_MODEL = "CameraModel";
 
 export class ImageMode extends SceneExtension<ImageRenderable> implements ICameraHandler {
-  private camera: ImageModeCamera;
-  private cameraModel:
+  #camera: ImageModeCamera;
+  #cameraModel:
     | {
         model: PinholeCameraModel;
         info: CameraInfo;
@@ -76,49 +76,49 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   public constructor(renderer: IRenderer, canvasSize: THREE.Vector2) {
     super("foxglove.ImageMode", renderer);
 
-    this.camera = new ImageModeCamera();
+    this.#camera = new ImageModeCamera();
 
     /**
      * By default the camera is facing down the -y axis with -z up,
      * where the image is on the +y axis with +z up.
      * To correct this we rotate the camera 180 degrees around the x axis.
      */
-    this.camera.quaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI);
-    this.camera.setCanvasSize(canvasSize.width, canvasSize.height);
+    this.#camera.quaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI);
+    this.#camera.setCanvasSize(canvasSize.width, canvasSize.height);
 
-    renderer.settings.errors.on("update", this.handleErrorChange);
-    renderer.settings.errors.on("clear", this.handleErrorChange);
-    renderer.settings.errors.on("remove", this.handleErrorChange);
+    renderer.settings.errors.on("update", this.#handleErrorChange);
+    renderer.settings.errors.on("clear", this.#handleErrorChange);
+    renderer.settings.errors.on("remove", this.#handleErrorChange);
 
     renderer.addSchemaSubscriptions(CAMERA_INFO_DATATYPES, {
-      handler: this.handleCameraInfo,
-      shouldSubscribe: this.cameraInfoShouldSubscribe,
+      handler: this.#handleCameraInfo,
+      shouldSubscribe: this.#cameraInfoShouldSubscribe,
     });
     renderer.addSchemaSubscriptions(CAMERA_CALIBRATION_DATATYPES, {
-      handler: this.handleCameraInfo,
-      shouldSubscribe: this.cameraInfoShouldSubscribe,
+      handler: this.#handleCameraInfo,
+      shouldSubscribe: this.#cameraInfoShouldSubscribe,
     });
 
     renderer.addSchemaSubscriptions(ROS_IMAGE_DATATYPES, {
-      handler: this.handleRosRawImage,
-      shouldSubscribe: this.imageShouldSubscribe,
+      handler: this.#handleRosRawImage,
+      shouldSubscribe: this.#imageShouldSubscribe,
     });
     renderer.addSchemaSubscriptions(ROS_COMPRESSED_IMAGE_DATATYPES, {
-      handler: this.handleRosCompressedImage,
-      shouldSubscribe: this.imageShouldSubscribe,
+      handler: this.#handleRosCompressedImage,
+      shouldSubscribe: this.#imageShouldSubscribe,
     });
 
     renderer.addSchemaSubscriptions(RAW_IMAGE_DATATYPES, {
-      handler: this.handleRawImage,
-      shouldSubscribe: this.imageShouldSubscribe,
+      handler: this.#handleRawImage,
+      shouldSubscribe: this.#imageShouldSubscribe,
     });
     renderer.addSchemaSubscriptions(COMPRESSED_IMAGE_DATATYPES, {
-      handler: this.handleCompressedImage,
-      shouldSubscribe: this.imageShouldSubscribe,
+      handler: this.#handleCompressedImage,
+      shouldSubscribe: this.#imageShouldSubscribe,
     });
 
     this.#annotations = new ImageAnnotations({
-      initialScale: this.camera.getEffectiveScale(),
+      initialScale: this.#camera.getEffectiveScale(),
       initialCanvasWidth: canvasSize.width,
       initialCanvasHeight: canvasSize.height,
       initialPixelRatio: renderer.getPixelRatio(),
@@ -138,9 +138,9 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   }
 
   public override dispose(): void {
-    this.renderer.settings.errors.off("update", this.handleErrorChange);
-    this.renderer.settings.errors.off("clear", this.handleErrorChange);
-    this.renderer.settings.errors.off("remove", this.handleErrorChange);
+    this.renderer.settings.errors.off("update", this.#handleErrorChange);
+    this.renderer.settings.errors.off("clear", this.#handleErrorChange);
+    this.renderer.settings.errors.off("remove", this.#handleErrorChange);
     this.#annotations.dispose();
     super.dispose();
   }
@@ -323,53 +323,53 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     this.updateSettingsTree();
   };
 
-  private cameraInfoShouldSubscribe = (topic: string): boolean => {
-    return this.getImageModeSettings().calibrationTopic === topic;
+  #cameraInfoShouldSubscribe = (topic: string): boolean => {
+    return this.#getImageModeSettings().calibrationTopic === topic;
   };
 
-  private imageShouldSubscribe = (topic: string): boolean => {
-    return this.getImageModeSettings().imageTopic === topic;
+  #imageShouldSubscribe = (topic: string): boolean => {
+    return this.#getImageModeSettings().imageTopic === topic;
   };
 
   /** Processes camera info messages and updates state */
-  private handleCameraInfo = (
+  #handleCameraInfo = (
     messageEvent: PartialMessageEvent<CameraInfo> & PartialMessageEvent<CameraCalibration>,
   ): void => {
     // Store the last camera info on each topic, when processing an image message we'll look up
     // the camera info by the info topic configured for the image
     const cameraInfo = normalizeCameraInfo(messageEvent.message);
-    this.updateCameraModel(cameraInfo);
+    this.#updateCameraModel(cameraInfo);
     this.updateViewAndRenderables();
   };
 
-  private handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
-    this.handleImage(messageEvent, normalizeRosImage(messageEvent.message));
+  #handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
+    this.#handleImage(messageEvent, normalizeRosImage(messageEvent.message));
   };
 
-  private handleRosCompressedImage = (
+  #handleRosCompressedImage = (
     messageEvent: PartialMessageEvent<RosCompressedImage>,
   ): void => {
-    this.handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
+    this.#handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
   };
 
-  private handleRawImage = (messageEvent: PartialMessageEvent<RawImage>): void => {
-    this.handleImage(messageEvent, normalizeRawImage(messageEvent.message));
+  #handleRawImage = (messageEvent: PartialMessageEvent<RawImage>): void => {
+    this.#handleImage(messageEvent, normalizeRawImage(messageEvent.message));
   };
 
-  private handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
-    this.handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
+  #handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
+    this.#handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
   };
 
-  private handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
+  #handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
     const topic = messageEvent.topic;
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const frameId = "header" in image ? image.header.frame_id : image.frame_id;
 
     const renderable = this.#getImageRenderable(topic, receiveTime, image, frameId);
 
-    if (this.cameraModel) {
-      renderable.userData.cameraInfo = this.cameraModel.info;
-      renderable.setCameraModel(this.cameraModel.model);
+    if (this.#cameraModel) {
+      renderable.userData.cameraInfo = this.#cameraModel.info;
+      renderable.setCameraModel(this.#cameraModel.model);
     }
     renderable.name = topic;
     renderable.setImage(image);
@@ -415,7 +415,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   }
 
   /** Gets frame from active info or image message if info does not have one*/
-  private getCurrentFrameId(): string | undefined {
+  #getCurrentFrameId(): string | undefined {
     const { imageMode } = this.renderer.config;
     const { calibrationTopic, imageTopic } = imageMode;
 
@@ -423,7 +423,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
       return undefined;
     }
 
-    const selectedCameraInfo = this.cameraModel?.info;
+    const selectedCameraInfo = this.#cameraModel?.info;
     const selectedImage = this.#imageRenderable?.userData.image;
 
     const cameraInfoFrameId = selectedCameraInfo?.header.frame_id;
@@ -449,7 +449,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     return cameraInfoFrameId ?? imageFrameId;
   }
 
-  private getImageModeSettings(): {
+  #getImageModeSettings(): {
     readonly calibrationTopic?: string;
     readonly imageTopic?: string;
   } {
@@ -460,7 +460,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
    * Updates renderable, frame, and camera to be in sync with current camera model
    */
   private updateViewAndRenderables(): void {
-    const cameraInfo = this.cameraModel?.info;
+    const cameraInfo = this.#cameraModel?.info;
     if (!cameraInfo) {
       this.renderer.settings.errors.add(
         CALIBRATION_TOPIC_PATH,
@@ -473,19 +473,19 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     }
 
     // set the render frame id to the camera info's frame id
-    this.renderer.followFrameId = this.getCurrentFrameId();
-    if (this.cameraModel?.model) {
-      this.camera.updateCamera(this.cameraModel.model);
+    this.renderer.followFrameId = this.#getCurrentFrameId();
+    if (this.#cameraModel?.model) {
+      this.#camera.updateCamera(this.#cameraModel.model);
       this.#annotations.updateScale(
-        this.camera.getEffectiveScale(),
+        this.#camera.getEffectiveScale(),
         this.renderer.input.canvasSize.width,
         this.renderer.input.canvasSize.height,
         this.renderer.getPixelRatio(),
       );
       const imageRenderable = this.#imageRenderable;
       if (imageRenderable) {
-        imageRenderable.userData.cameraInfo = this.cameraModel.info;
-        imageRenderable.setCameraModel(this.cameraModel.model);
+        imageRenderable.userData.cameraInfo = this.#cameraModel.info;
+        imageRenderable.setCameraModel(this.#cameraModel.model);
         imageRenderable.update();
       }
     }
@@ -494,21 +494,21 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   /**
    * update this.cameraModel with a new model if the camera info has changed
    */
-  private updateCameraModel(newCameraInfo: CameraInfo) {
+  #updateCameraModel(newCameraInfo: CameraInfo) {
     // If the camera info has not changed, we don't need to make a new model and can return the existing one
-    const currentCameraInfo = this.cameraModel?.info;
+    const currentCameraInfo = this.#cameraModel?.info;
     const dataEqual = cameraInfosEqual(currentCameraInfo, newCameraInfo);
     if (dataEqual && currentCameraInfo != undefined) {
       return;
     }
 
-    const model = this.getPinholeCameraModel(newCameraInfo);
+    const model = this.#getPinholeCameraModel(newCameraInfo);
     if (model) {
-      this.cameraModel = {
+      this.#cameraModel = {
         model,
         info: newCameraInfo,
       };
-      this.#annotations.updateCameraModel(model);
+      this.#annotations.#updateCameraModel(model);
     }
   }
 
@@ -517,13 +517,13 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
    * This function will set a topic error on the image topic if the camera model creation fails.
    * @param cameraInfo - CameraInfo to create model from
    */
-  private getPinholeCameraModel(cameraInfo: CameraInfo): PinholeCameraModel | undefined {
+  #getPinholeCameraModel(cameraInfo: CameraInfo): PinholeCameraModel | undefined {
     let model = undefined;
     try {
       model = new PinholeCameraModel(cameraInfo);
       this.renderer.settings.errors.remove(CALIBRATION_TOPIC_PATH, CAMERA_MODEL);
     } catch (errUnk) {
-      this.cameraModel = undefined;
+      this.#cameraModel = undefined;
       const err = errUnk as Error;
       this.renderer.settings.errors.add(CALIBRATION_TOPIC_PATH, CAMERA_MODEL, err.message);
     }
@@ -531,12 +531,12 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   }
 
   public getActiveCamera(): THREE.PerspectiveCamera | THREE.OrthographicCamera {
-    return this.camera;
+    return this.#camera;
   }
 
   public handleResize(width: number, height: number, pixelRatio: number): void {
-    this.camera.setCanvasSize(width, height);
-    this.#annotations.updateScale(this.camera.getEffectiveScale(), width, height, pixelRatio);
+    this.#camera.setCanvasSize(width, height);
+    this.#annotations.updateScale(this.#camera.getEffectiveScale(), width, height, pixelRatio);
   }
 
   public setCameraState(): void {
@@ -547,7 +547,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     return undefined;
   }
 
-  private handleErrorChange = (): void => {
+  #handleErrorChange = (): void => {
     this.updateSettingsTree();
   };
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -12,22 +12,22 @@ const DEFAULT_CAMERA_STATE = {
 };
 
 export class ImageModeCamera extends THREE.PerspectiveCamera {
-  private model?: PinholeCameraModel;
-  private cameraState = DEFAULT_CAMERA_STATE;
+  #model?: PinholeCameraModel;
+  #cameraState = DEFAULT_CAMERA_STATE;
 
   /** x/y zoom factors derived from image and window aspect ratios */
-  private aspectZoom = new THREE.Vector2();
-  private canvasSize = new THREE.Vector2();
+  #aspectZoom = new THREE.Vector2();
+  #canvasSize = new THREE.Vector2();
 
   public updateCamera(cameraModel: PinholeCameraModel): void {
-    this.model = cameraModel;
-    this.updateProjection();
+    this.#model = cameraModel;
+    this.#updateProjection();
   }
 
-  private updateProjection(): void {
-    this.updateAspectScaledZoom();
+  #updateProjection(): void {
+    this.#updateAspectScaledZoom();
 
-    const projection = this.getProjection();
+    const projection = this.#getProjection();
 
     if (projection) {
       this.projectionMatrix.copy(projection);
@@ -39,8 +39,8 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
    * Get Perspective projection matrix from this.cameraModel.model
    * @returns the projection matrix for the current camera model, or undefined if no camera model is available
    */
-  private getProjection(): THREE.Matrix4 | undefined {
-    const model = this.model;
+  #getProjection(): THREE.Matrix4 | undefined {
+    const model = this.#model;
     if (!model?.P) {
       return;
     }
@@ -55,11 +55,11 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
     const cy = model.P[6];
     const { width, height } = model;
 
-    const zoom = this.aspectZoom;
+    const zoom = this.#aspectZoom;
     const zoomX = zoom.x;
     const zoomY = zoom.y;
-    const near = this.cameraState.near;
-    const far = this.cameraState.far;
+    const near = this.#cameraState.near;
+    const far = this.#cameraState.far;
 
     // prettier-ignore
     const matrix = new THREE.Matrix4()
@@ -75,43 +75,43 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
 
   /** Set canvas size in CSS pixels */
   public setCanvasSize(width: number, height: number): void {
-    this.canvasSize.set(width, height);
-    this.updateProjection();
+    this.#canvasSize.set(width, height);
+    this.#updateProjection();
   }
 
   /** @returns The ratio of CSS pixels per image pixel */
   public getEffectiveScale(): number {
-    if (!this.model) {
+    if (!this.#model) {
       return 1;
     }
     return Math.min(
-      (this.canvasSize.width / this.model.width) * this.aspectZoom.x,
-      (this.canvasSize.height / this.model.height) * this.aspectZoom.y,
+      (this.#canvasSize.width / this.#model.width) * this.#aspectZoom.x,
+      (this.#canvasSize.height / this.#model.height) * this.#aspectZoom.y,
     );
   }
 
   /**
    * Uses the camera model to compute the zoom factors to preserve the aspect ratio of the image.
    */
-  private updateAspectScaledZoom(): void {
-    const model = this.model;
+  #updateAspectScaledZoom(): void {
+    const model = this.#model;
     if (!model?.P) {
       return;
     }
     // Adapted from https://github.com/ros2/rviz/blob/ee44ccde8a7049073fd1901dd36c1fb69110f726/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp#L568
-    this.aspectZoom.set(1.0, 1.0);
+    this.#aspectZoom.set(1.0, 1.0);
 
     const { width: imgWidth, height: imgHeight } = model;
 
     const fx = model.P[0]!;
     const fy = model.P[5]!;
-    const rendererAspect = this.canvasSize.width / this.canvasSize.height;
+    const rendererAspect = this.#canvasSize.width / this.#canvasSize.height;
     const imageAspect = imgWidth / fx / (imgHeight / fy);
     // preserve the aspect ratio
     if (imageAspect > rendererAspect) {
-      this.aspectZoom.y = (this.aspectZoom.y / imageAspect) * rendererAspect;
+      this.#aspectZoom.y = (this.#aspectZoom.y / imageAspect) * rendererAspect;
     } else {
-      this.aspectZoom.x = (this.aspectZoom.x / rendererAspect) * imageAspect;
+      this.#aspectZoom.x = (this.#aspectZoom.x / rendererAspect) * imageAspect;
     }
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -247,9 +247,7 @@ export class Images extends SceneExtension<ImageRenderable> {
     this.#handleImage(messageEvent, normalizeRosImage(messageEvent.message));
   };
 
-  #handleRosCompressedImage = (
-    messageEvent: PartialMessageEvent<RosCompressedImage>,
-  ): void => {
+  #handleRosCompressedImage = (messageEvent: PartialMessageEvent<RosCompressedImage>): void => {
     this.#handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -58,39 +58,39 @@ const CAMERA_MODEL = "CameraModel";
 
 export class Images extends SceneExtension<ImageRenderable> {
   /* All known camera info topics */
-  private cameraInfoTopics = new Set<string>();
+  #cameraInfoTopics = new Set<string>();
 
   /**
    * A bi-directional mapping between cameraInfo topics and image topics. This
    * is used for retrieving an image renderable, which is indexed by image
    * topic, when receiving a camera info message.
    */
-  private cameraInfoToImageTopics = new MultiMap<string, string>();
+  #cameraInfoToImageTopics = new MultiMap<string, string>();
 
   /**
    * Map of camera info topic name -> normalized CameraInfo message
    *
    * This stores the last camera info message on each topic so it can be applied when rendering the image
    */
-  private cameraInfoByTopic = new Map<string, CameraInfo>();
+  #cameraInfoByTopic = new Map<string, CameraInfo>();
 
-  private lastTopics: readonly Topic[] | undefined = undefined;
+  #lastTopics: readonly Topic[] | undefined = undefined;
 
   public constructor(renderer: IRenderer) {
     super("foxglove.Images", renderer);
 
-    renderer.addSchemaSubscriptions(ROS_IMAGE_DATATYPES, this.handleRosRawImage);
-    renderer.addSchemaSubscriptions(ROS_COMPRESSED_IMAGE_DATATYPES, this.handleRosCompressedImage);
+    renderer.addSchemaSubscriptions(ROS_IMAGE_DATATYPES, this.#handleRosRawImage);
+    renderer.addSchemaSubscriptions(ROS_COMPRESSED_IMAGE_DATATYPES, this.#handleRosCompressedImage);
     renderer.addSchemaSubscriptions(CAMERA_INFO_DATATYPES, {
-      handler: this.handleCameraInfo,
-      shouldSubscribe: this.cameraInfoShouldSubscribe,
+      handler: this.#handleCameraInfo,
+      shouldSubscribe: this.#cameraInfoShouldSubscribe,
     });
 
-    renderer.addSchemaSubscriptions(RAW_IMAGE_DATATYPES, this.handleRawImage);
-    renderer.addSchemaSubscriptions(COMPRESSED_IMAGE_DATATYPES, this.handleCompressedImage);
+    renderer.addSchemaSubscriptions(RAW_IMAGE_DATATYPES, this.#handleRawImage);
+    renderer.addSchemaSubscriptions(COMPRESSED_IMAGE_DATATYPES, this.#handleCompressedImage);
     renderer.addSchemaSubscriptions(CAMERA_CALIBRATION_DATATYPES, {
-      handler: this.handleCameraInfo,
-      shouldSubscribe: this.cameraInfoShouldSubscribe,
+      handler: this.#handleCameraInfo,
+      shouldSubscribe: this.#cameraInfoShouldSubscribe,
     });
 
     this._updateCameraInfoTopics();
@@ -100,19 +100,19 @@ export class Images extends SceneExtension<ImageRenderable> {
    * Update cameraInfoTopics cache with latest set of camera info messages
    */
   private _updateCameraInfoTopics() {
-    if (this.renderer.topics === this.lastTopics) {
+    if (this.renderer.topics === this.#lastTopics) {
       return;
     }
 
-    this.lastTopics = this.renderer.topics;
+    this.#lastTopics = this.renderer.topics;
 
-    this.cameraInfoTopics = new Set();
+    this.#cameraInfoTopics = new Set();
     for (const topic of this.renderer.topics ?? []) {
       if (
         topicIsConvertibleToSchema(topic, CAMERA_INFO_DATATYPES) ||
         topicIsConvertibleToSchema(topic, CAMERA_CALIBRATION_DATATYPES)
       ) {
-        this.cameraInfoTopics.add(topic.name);
+        this.#cameraInfoTopics.add(topic.name);
       }
     }
   }
@@ -139,7 +139,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       // Build a list of all matching CameraInfo topics
       const bestCameraInfoOptions: SelectEntry[] = [];
       const otherCameraInfoOptions: SelectEntry[] = [];
-      for (const cameraInfoTopic of this.cameraInfoTopics) {
+      for (const cameraInfoTopic of this.#cameraInfoTopics) {
         if (cameraInfoTopicMatches(imageTopic, cameraInfoTopic)) {
           bestCameraInfoOptions.push({ label: cameraInfoTopic, value: cameraInfoTopic });
         } else {
@@ -191,7 +191,7 @@ export class Images extends SceneExtension<ImageRenderable> {
 
     // Add this camera_info_topic -> image_topic mapping
     if (cameraInfoTopic !== prevCameraInfoTopic && cameraInfoTopic != undefined) {
-      this.cameraInfoToImageTopics.set(cameraInfoTopic, imageTopic);
+      this.#cameraInfoToImageTopics.set(cameraInfoTopic, imageTopic);
     }
 
     const renderable = this.renderables.get(imageTopic);
@@ -204,7 +204,7 @@ export class Images extends SceneExtension<ImageRenderable> {
     // The camera info topic changed for our renderable
     // Remove the previous camera_info_topic -> image_topic mapping
     if (prevCameraInfoTopic != undefined) {
-      this.cameraInfoToImageTopics.delete(prevCameraInfoTopic, imageTopic);
+      this.#cameraInfoToImageTopics.delete(prevCameraInfoTopic, imageTopic);
     }
 
     // apply camera info to new renderable
@@ -213,7 +213,7 @@ export class Images extends SceneExtension<ImageRenderable> {
     }
 
     // Look up the camera info for our image topic
-    const cameraInfo = this.cameraInfoByTopic.get(cameraInfoTopic);
+    const cameraInfo = this.#cameraInfoByTopic.get(cameraInfoTopic);
     if (!cameraInfo) {
       this.renderer.settings.errors.addToTopic(
         imageTopic,
@@ -222,11 +222,11 @@ export class Images extends SceneExtension<ImageRenderable> {
       );
       return;
     }
-    this._recomputeCameraModel(renderable, cameraInfo);
+    this.#recomputeCameraModel(renderable, cameraInfo);
     renderable.update();
   };
 
-  private cameraInfoShouldSubscribe = (cameraInfoTopic: string): boolean => {
+  #cameraInfoShouldSubscribe = (cameraInfoTopic: string): boolean => {
     // Iterate over each topic config and check if it has a cameraInfoTopic setting that matches
     // the cameraInfoTopic we might want to turn on. If it does and the topic is visible, return
     // true so we know to subscribe.
@@ -243,25 +243,25 @@ export class Images extends SceneExtension<ImageRenderable> {
     return false;
   };
 
-  private handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
-    this.handleImage(messageEvent, normalizeRosImage(messageEvent.message));
+  #handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
+    this.#handleImage(messageEvent, normalizeRosImage(messageEvent.message));
   };
 
-  private handleRosCompressedImage = (
+  #handleRosCompressedImage = (
     messageEvent: PartialMessageEvent<RosCompressedImage>,
   ): void => {
-    this.handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
+    this.#handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
   };
 
-  private handleRawImage = (messageEvent: PartialMessageEvent<RawImage>): void => {
-    this.handleImage(messageEvent, normalizeRawImage(messageEvent.message));
+  #handleRawImage = (messageEvent: PartialMessageEvent<RawImage>): void => {
+    this.#handleImage(messageEvent, normalizeRawImage(messageEvent.message));
   };
 
-  private handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
-    this.handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
+  #handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
+    this.#handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
   };
 
-  private handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
+  #handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
     // Ensure the latest list of camera info topics is up to date for autoSelectCameraInfoTopic call below
     this._updateCameraInfoTopics();
 
@@ -269,14 +269,14 @@ export class Images extends SceneExtension<ImageRenderable> {
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const frameId = "header" in image ? image.header.frame_id : image.frame_id;
 
-    const renderable = this._getImageRenderable(imageTopic, receiveTime, image, frameId);
+    const renderable = this.#getImageRenderable(imageTopic, receiveTime, image, frameId);
 
     renderable.setImage(image);
     renderable.userData.receiveTime = receiveTime;
     // Auto-select settings.cameraInfoTopic if it's not already set
     const settings = renderable.userData.settings;
     if (settings.cameraInfoTopic == undefined) {
-      const newCameraInfoTopic = autoSelectCameraInfoTopic(imageTopic, this.cameraInfoTopics);
+      const newCameraInfoTopic = autoSelectCameraInfoTopic(imageTopic, this.#cameraInfoTopics);
       settings.cameraInfoTopic = newCameraInfoTopic;
       renderable.setSettings(settings);
 
@@ -305,10 +305,10 @@ export class Images extends SceneExtension<ImageRenderable> {
     }
 
     assert(settings.cameraInfoTopic != undefined);
-    this.cameraInfoToImageTopics.set(settings.cameraInfoTopic, imageTopic);
+    this.#cameraInfoToImageTopics.set(settings.cameraInfoTopic, imageTopic);
 
     // Look up the camera info for our renderable
-    const cameraInfo = this.cameraInfoByTopic.get(settings.cameraInfoTopic);
+    const cameraInfo = this.#cameraInfoByTopic.get(settings.cameraInfoTopic);
     if (!cameraInfo) {
       this.renderer.settings.errors.addToTopic(
         imageTopic,
@@ -318,21 +318,21 @@ export class Images extends SceneExtension<ImageRenderable> {
       return;
     }
 
-    this._recomputeCameraModel(renderable, cameraInfo);
+    this.#recomputeCameraModel(renderable, cameraInfo);
     renderable.update();
   };
 
-  private handleCameraInfo = (
+  #handleCameraInfo = (
     messageEvent: PartialMessageEvent<CameraInfo> & PartialMessageEvent<CameraCalibration>,
   ): void => {
     // Store the last camera info on each topic, when processing an image message we'll look up
     // the camera info by the info topic configured for the image
     const cameraInfo = normalizeCameraInfo(messageEvent.message);
-    this.cameraInfoByTopic.set(messageEvent.topic, cameraInfo);
+    this.#cameraInfoByTopic.set(messageEvent.topic, cameraInfo);
 
     // Look up any image topics assigned to our camera info topic and determine if we need to update
     // those renderables since we now have a camera info whereas we may not have previously
-    const imageTopics = this.cameraInfoToImageTopics.get(messageEvent.topic) ?? [];
+    const imageTopics = this.#cameraInfoToImageTopics.get(messageEvent.topic) ?? [];
     for (const imageTopic of imageTopics) {
       const renderable = this.renderables.get(imageTopic);
       if (!renderable) {
@@ -346,7 +346,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       }
       this.renderer.settings.errors.removeFromTopic(imageTopic, NO_CAMERA_INFO_ERR);
 
-      this._recomputeCameraModel(renderable, cameraInfo);
+      this.#recomputeCameraModel(renderable, cameraInfo);
       renderable.update();
     }
   };
@@ -359,7 +359,7 @@ export class Images extends SceneExtension<ImageRenderable> {
    *
    * This function will set a topic error on the image topic if the camera model creation fails.
    */
-  private _recomputeCameraModel(renderable: ImageRenderable, newCameraInfo: CameraInfo) {
+  #recomputeCameraModel(renderable: ImageRenderable, newCameraInfo: CameraInfo) {
     // If the camera info has not changed, we don't need to make a new model and can return the existing one
     const dataEqual = cameraInfosEqual(renderable.userData.cameraInfo, newCameraInfo);
     if (dataEqual && renderable.userData.cameraModel != undefined) {
@@ -379,7 +379,7 @@ export class Images extends SceneExtension<ImageRenderable> {
   }
 
   // Get or create an image renderable for the imageTopic
-  private _getImageRenderable(
+  #getImageRenderable(
     imageTopic: string,
     receiveTime: bigint,
     image: AnyImage | undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -93,13 +93,13 @@ export class Images extends SceneExtension<ImageRenderable> {
       shouldSubscribe: this.#cameraInfoShouldSubscribe,
     });
 
-    this._updateCameraInfoTopics();
+    this.#updateCameraInfoTopics();
   }
 
   /**
    * Update cameraInfoTopics cache with latest set of camera info messages
    */
-  private _updateCameraInfoTopics() {
+  #updateCameraInfoTopics() {
     if (this.renderer.topics === this.#lastTopics) {
       return;
     }
@@ -118,7 +118,7 @@ export class Images extends SceneExtension<ImageRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    this._updateCameraInfoTopics();
+    this.#updateCameraInfoTopics();
     const configTopics = this.renderer.config.topics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
@@ -263,7 +263,7 @@ export class Images extends SceneExtension<ImageRenderable> {
 
   #handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
     // Ensure the latest list of camera info topics is up to date for autoSelectCameraInfoTopic call below
-    this._updateCameraInfoTopics();
+    this.#updateCameraInfoTopics();
 
     const imageTopic = messageEvent.topic;
     const receiveTime = toNanoSec(messageEvent.receiveTime);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -152,26 +152,26 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.updateHeaderInfo();
 
     if (this.#geometryNeedsUpdate) {
-      this.rebuildGeometry();
+      this.#rebuildGeometry();
       this.#geometryNeedsUpdate = false;
     }
 
     if (this.#textureNeedsUpdate) {
-      this.updateTexture();
+      this.#updateTexture();
       this.#textureNeedsUpdate = false;
     }
     if (this.#materialNeedsUpdate) {
-      this.updateMaterial();
+      this.#updateMaterial();
       this.#materialNeedsUpdate = false;
     }
 
     if (this.#meshNeedsUpdate && this.userData.texture) {
-      this.updateMesh();
+      this.#updateMesh();
       this.#meshNeedsUpdate = false;
     }
   }
 
-  private rebuildGeometry() {
+  #rebuildGeometry() {
     assert(this.userData.cameraModel, "Camera model must be set before geometry can be updated");
     // Dispose of the current geometry if the settings have changed
     this.userData.geometry?.dispose();
@@ -181,7 +181,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.#meshNeedsUpdate = true;
   }
 
-  private updateTexture(): void {
+  #updateTexture(): void {
     assert(this.userData.image, "Image must be set before texture can be updated or created");
     const image = this.userData.image;
     // Create or update the bitmap texture
@@ -198,13 +198,13 @@ export class ImageRenderable extends Renderable<ImageUserData> {
             this.userData.texture.needsUpdate = true;
           }
 
-          this.removeTopicError(CREATE_BITMAP_ERR);
+          this.#removeTopicError(CREATE_BITMAP_ERR);
           this.#materialNeedsUpdate = true;
           this.update();
           this.renderer.queueAnimationFrame();
         })
         .catch((err) => {
-          this.addTopicError(CREATE_BITMAP_ERR, `createBitmap failed: ${err.message}`);
+          this.#addTopicError(CREATE_BITMAP_ERR, `createBitmap failed: ${err.message}`);
         });
     } else {
       const { width, height } = image;
@@ -225,15 +225,15 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.#materialNeedsUpdate = true;
   }
 
-  private addTopicError(key: string, errorMessage: string) {
+  #addTopicError(key: string, errorMessage: string) {
     this.renderer.settings.errors.add(this.userData.settingsPath, key, errorMessage);
   }
-  private removeTopicError(key: string) {
+  #removeTopicError(key: string) {
     this.renderer.settings.errors.remove(this.userData.settingsPath, key);
   }
-  private updateMaterial(): void {
+  #updateMaterial(): void {
     if (!this.userData.material) {
-      this.initMaterial();
+      this.#initMaterial();
       this.#meshNeedsUpdate = true;
     }
     const material = this.userData.material!;
@@ -263,7 +263,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     material.needsUpdate = true;
   }
 
-  private initMaterial(): void {
+  #initMaterial(): void {
     stringToRgba(tempColor, this.userData.settings.color);
     const transparent = tempColor.a < 1;
     const color = new THREE.Color(tempColor.r, tempColor.g, tempColor.b);
@@ -277,7 +277,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     });
   }
 
-  private updateMesh(): void {
+  #updateMesh(): void {
     assert(this.userData.geometry, "Geometry must be set before mesh can be updated or created");
     assert(this.userData.material, "Material must be set before mesh can be updated or created");
     if (!this.userData.mesh) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -37,8 +37,8 @@ export class Markers extends SceneExtension<TopicMarkers> {
   public constructor(renderer: IRenderer) {
     super("foxglove.Markers", renderer);
 
-    renderer.addSchemaSubscriptions(MARKER_ARRAY_DATATYPES, this.handleMarkerArray);
-    renderer.addSchemaSubscriptions(MARKER_DATATYPES, this.handleMarker);
+    renderer.addSchemaSubscriptions(MARKER_ARRAY_DATATYPES, this.#handleMarkerArray);
+    renderer.addSchemaSubscriptions(MARKER_DATATYPES, this.#handleMarker);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -87,7 +87,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
             icon: "Shapes",
             visible: ns.settings.visible,
             defaultExpansionState: namespaces.length > 1 ? "collapsed" : "expanded",
-            handler: this.handleSettingsActionNamespace,
+            handler: this.#handleSettingsActionNamespace,
           };
           node.children[`ns:${ns.namespace}`] = child;
         }
@@ -130,7 +130,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
     }
   };
 
-  private handleSettingsActionNamespace = (action: SettingsTreeAction): void => {
+  #handleSettingsActionNamespace = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
     if (action.action !== "update" || path.length !== 4) {
       return;
@@ -169,7 +169,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
     this.updateSettingsTree();
   };
 
-  private handleMarkerArray = (messageEvent: PartialMessageEvent<MarkerArray>): void => {
+  #handleMarkerArray = (messageEvent: PartialMessageEvent<MarkerArray>): void => {
     const topic = messageEvent.topic;
     const markerArray = messageEvent.message;
     const receiveTime = toNanoSec(messageEvent.receiveTime);
@@ -177,21 +177,21 @@ export class Markers extends SceneExtension<TopicMarkers> {
     for (const markerMsg of markerArray.markers ?? []) {
       if (markerMsg) {
         const marker = normalizeMarker(markerMsg);
-        this.addMarker(topic, marker, receiveTime);
+        this.#addMarker(topic, marker, receiveTime);
       }
     }
   };
 
-  private handleMarker = (messageEvent: PartialMessageEvent<Marker>): void => {
+  #handleMarker = (messageEvent: PartialMessageEvent<Marker>): void => {
     const topic = messageEvent.topic;
     const marker = normalizeMarker(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
-    this.addMarker(topic, marker, receiveTime);
+    this.#addMarker(topic, marker, receiveTime);
   };
 
-  private addMarker(topic: string, marker: Marker, receiveTime: bigint): void {
-    const topicMarkers = this._getTopicMarkers(topic, marker, receiveTime);
+  #addMarker(topic: string, marker: Marker, receiveTime: bigint): void {
+    const topicMarkers = this.#getTopicMarkers(topic, marker, receiveTime);
     const prevNsCount = topicMarkers.namespaces.size;
     topicMarkers.addMarkerMessage(marker, receiveTime);
 
@@ -207,7 +207,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
       return;
     }
 
-    const topicMarkers = this._getTopicMarkers(topic, firstMarker, receiveTime);
+    const topicMarkers = this.#getTopicMarkers(topic, firstMarker, receiveTime);
     const prevNsCount = topicMarkers.namespaces.size;
     for (const marker of markerArray) {
       topicMarkers.addMarkerMessage(marker, receiveTime);
@@ -219,7 +219,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
     }
   }
 
-  private _getTopicMarkers(topic: string, marker: Marker, receiveTime: bigint): TopicMarkers {
+  #getTopicMarkers(topic: string, marker: Marker, receiveTime: bigint): TopicMarkers {
     let topicMarkers = this.renderables.get(topic);
     if (!topicMarkers) {
       const userSettings = this.renderer.config.topics[topic] as

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
@@ -93,8 +93,8 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
   #point1NeedsUpdate = false;
   #point2NeedsUpdate = false;
 
-  private point1?: THREE.Vector3;
-  private point2?: THREE.Vector3;
+  #point1?: THREE.Vector3;
+  #point2?: THREE.Vector3;
 
   public state: MeasurementState = "idle";
 
@@ -134,7 +134,7 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.add(this.#line);
     this.add(this.#lineOccluded);
     this.add(this.#label);
-    this._setState("idle");
+    this.#setState("idle");
   }
 
   public override dispose(): void {
@@ -147,16 +147,16 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.#lineOccluded.geometry.dispose();
     this.#lineOccluded.material.dispose();
     this.renderer.input.removeListener("click", this.#handleClick);
-    this.renderer.input.removeListener("mousemove", this._handleMouseMove);
+    this.renderer.input.removeListener("mousemove", this.#handleMouseMove);
   }
 
   public startMeasuring(): void {
-    this._setState("place-first-point");
+    this.#setState("place-first-point");
   }
 
   public stopMeasuring(): void {
-    this.point1 = this.point2 = undefined;
-    this._setState("idle");
+    this.#point1 = this.#point2 = undefined;
+    this.#setState("idle");
   }
 
   public override startFrame(
@@ -169,28 +169,28 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.#circleMaterial.uniforms.canvasSize!.value[1] = this.renderer.input.canvasSize.y;
   }
 
-  private _setState(state: MeasurementState): void {
+  #setState(state: MeasurementState): void {
     this.state = state;
     switch (state) {
       case "idle":
         this.renderer.input.removeListener("click", this.#handleClick);
-        this.renderer.input.removeListener("mousemove", this._handleMouseMove);
+        this.renderer.input.removeListener("mousemove", this.#handleMouseMove);
         this.dispatchEvent({ type: "foxglove.measure-end" });
         break;
       case "place-first-point":
-        this.point1 = this.point2 = undefined;
+        this.#point1 = this.#point2 = undefined;
         this.renderer.input.addListener("click", this.#handleClick);
-        this.renderer.input.addListener("mousemove", this._handleMouseMove);
+        this.renderer.input.addListener("mousemove", this.#handleMouseMove);
         this.dispatchEvent({ type: "foxglove.measure-start" });
         break;
       case "place-second-point":
         break;
     }
     this.#updateDistance();
-    this._render();
+    this.#render();
   }
 
-  private _handleMouseMove = (
+  #handleMouseMove = (
     _cursorCoords: THREE.Vector2,
     worldSpaceCursorCoords: THREE.Vector3 | undefined,
     _event: MouseEvent,
@@ -202,21 +202,21 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
       case "idle":
         break;
       case "place-first-point":
-        (this.point1 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
+        (this.#point1 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
         this.#point1NeedsUpdate = true;
         break;
       case "place-second-point":
-        (this.point2 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
+        (this.#point2 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
         this.#point2NeedsUpdate = true;
         this.#updateDistance();
         break;
     }
-    this._render();
+    this.#render();
   };
 
   #updateDistance() {
-    if (this.point1 && this.point2) {
-      this.#label.setText(this.point1.distanceTo(this.point2).toFixed(2));
+    if (this.#point1 && this.#point2) {
+      this.#label.setText(this.#point1.distanceTo(this.#point2).toFixed(2));
     }
   }
 
@@ -232,26 +232,26 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
       case "idle":
         break;
       case "place-first-point":
-        this.point1 = worldSpaceCursorCoords.clone();
+        this.#point1 = worldSpaceCursorCoords.clone();
         this.#point1NeedsUpdate = true;
-        this._setState("place-second-point");
+        this.#setState("place-second-point");
         break;
       case "place-second-point":
-        this.point2 = worldSpaceCursorCoords.clone();
+        this.#point2 = worldSpaceCursorCoords.clone();
         this.#point2NeedsUpdate = true;
-        this._setState("idle");
+        this.#setState("idle");
         break;
     }
-    this._render();
+    this.#render();
   };
 
-  private _render() {
-    if (this.point1) {
+  #render() {
+    if (this.#point1) {
       this.#circle1.visible = true;
-      this.#circle1.position.copy(this.point1);
+      this.#circle1.position.copy(this.#point1);
 
       if (this.#point1NeedsUpdate) {
-        this.#linePositionAttribute.setXYZ(0, this.point1.x, this.point1.y, this.point1.z);
+        this.#linePositionAttribute.setXYZ(0, this.#point1.x, this.#point1.y, this.#point1.z);
         this.#linePositionAttribute.needsUpdate = true;
         this.#lineOccluded.computeLineDistances();
         this.#point1NeedsUpdate = false;
@@ -260,12 +260,12 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
       this.#circle1.visible = false;
     }
 
-    if (this.point2) {
+    if (this.#point2) {
       this.#circle2.visible = true;
-      this.#circle2.position.copy(this.point2);
+      this.#circle2.position.copy(this.#point2);
 
       if (this.#point2NeedsUpdate) {
-        this.#linePositionAttribute.setXYZ(1, this.point2.x, this.point2.y, this.point2.z);
+        this.#linePositionAttribute.setXYZ(1, this.#point2.x, this.#point2.y, this.#point2.z);
         this.#linePositionAttribute.needsUpdate = true;
         this.#lineOccluded.computeLineDistances();
         this.#point2NeedsUpdate = false;
@@ -274,11 +274,11 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
       this.#circle2.visible = false;
     }
 
-    if (this.point1 && this.point2) {
+    if (this.#point1 && this.#point2) {
       this.#line.visible = true;
       this.#lineOccluded.visible = true;
       this.#label.visible = true;
-      this.#label.position.copy(this.point1).lerp(this.point2, 0.5);
+      this.#label.position.copy(this.#point1).lerp(this.#point2, 0.5);
     } else {
       this.#line.visible = false;
       this.#lineOccluded.visible = false;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
@@ -59,17 +59,17 @@ class FixedSizeMeshMaterial extends THREE.ShaderMaterial {
 type MeasurementEvent = { type: "foxglove.measure-start" } | { type: "foxglove.measure-end" };
 
 export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, MeasurementEvent> {
-  private circleGeometry = new THREE.CircleGeometry(5, 16);
-  private circleMaterial = new FixedSizeMeshMaterial({
+  #circleGeometry = new THREE.CircleGeometry(5, 16);
+  #circleMaterial = new FixedSizeMeshMaterial({
     color: 0xff0000,
     depthTest: false,
     depthWrite: false,
   });
-  private circle1 = new THREE.Mesh(this.circleGeometry, this.circleMaterial);
-  private circle2 = new THREE.Mesh(this.circleGeometry, this.circleMaterial);
+  #circle1 = new THREE.Mesh(this.#circleGeometry, this.#circleMaterial);
+  #circle2 = new THREE.Mesh(this.#circleGeometry, this.#circleMaterial);
 
-  private linePositionAttribute = new THREE.Float32BufferAttribute([0, 0, 0, 0, 0, 0], 3);
-  private line = new THREE.Line(
+  #linePositionAttribute = new THREE.Float32BufferAttribute([0, 0, 0, 0, 0, 0], 3);
+  #line = new THREE.Line(
     new THREE.BufferGeometry(),
     new THREE.LineBasicMaterial({ color: 0xff0000 }),
   );
@@ -77,7 +77,7 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
    * A dashed copy of the line drawn with inverse depth test so the line can still be visible when
    * it's occluded
    */
-  private lineOccluded = new THREE.Line(
+  #lineOccluded = new THREE.Line(
     new THREE.BufferGeometry(),
     new THREE.LineDashedMaterial({
       color: 0xff0000,
@@ -88,10 +88,10 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     }),
   );
 
-  private label: Label;
+  #label: Label;
 
-  private point1NeedsUpdate = false;
-  private point2NeedsUpdate = false;
+  #point1NeedsUpdate = false;
+  #point2NeedsUpdate = false;
 
   private point1?: THREE.Vector3;
   private point2?: THREE.Vector3;
@@ -101,52 +101,52 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
   public constructor(renderer: IRenderer) {
     super("foxglove.MeasurementTool", renderer);
 
-    this.line.userData.picking = false;
-    this.lineOccluded.userData.picking = false;
-    this.circle1.userData.picking = false;
-    this.circle2.userData.picking = false;
+    this.#line.userData.picking = false;
+    this.#lineOccluded.userData.picking = false;
+    this.#circle1.userData.picking = false;
+    this.#circle2.userData.picking = false;
 
-    this.label = renderer.labelPool.acquire();
-    this.label.visible = false;
-    this.label.setBillboard(true);
-    this.label.setSizeAttenuation(false);
-    this.label.setLineHeight(12);
-    this.label.setColor(1, 0, 0);
+    this.#label = renderer.labelPool.acquire();
+    this.#label.visible = false;
+    this.#label.setBillboard(true);
+    this.#label.setSizeAttenuation(false);
+    this.#label.setLineHeight(12);
+    this.#label.setColor(1, 0, 0);
 
     // Make the label appear on top of other objects in the scene so it doesn't get clipped/occluded
-    this.label.renderOrder = LATE_RENDER_ORDER;
-    this.label.material.depthTest = false;
-    this.label.material.depthWrite = false;
-    this.label.material.transparent = true;
+    this.#label.renderOrder = LATE_RENDER_ORDER;
+    this.#label.material.depthTest = false;
+    this.#label.material.depthWrite = false;
+    this.#label.material.transparent = true;
 
-    this.lineOccluded.renderOrder = LATE_RENDER_ORDER;
-    this.circle1.renderOrder = LATE_RENDER_ORDER;
-    this.circle2.renderOrder = LATE_RENDER_ORDER;
+    this.#lineOccluded.renderOrder = LATE_RENDER_ORDER;
+    this.#circle1.renderOrder = LATE_RENDER_ORDER;
+    this.#circle2.renderOrder = LATE_RENDER_ORDER;
 
-    this.line.frustumCulled = false;
-    this.lineOccluded.frustumCulled = false;
-    this.line.geometry.setAttribute("position", this.linePositionAttribute);
-    this.lineOccluded.geometry.setAttribute("position", this.linePositionAttribute);
-    this.circle1.visible = false;
-    this.circle2.visible = false;
-    this.add(this.circle1);
-    this.add(this.circle2);
-    this.add(this.line);
-    this.add(this.lineOccluded);
-    this.add(this.label);
+    this.#line.frustumCulled = false;
+    this.#lineOccluded.frustumCulled = false;
+    this.#line.geometry.setAttribute("position", this.#linePositionAttribute);
+    this.#lineOccluded.geometry.setAttribute("position", this.#linePositionAttribute);
+    this.#circle1.visible = false;
+    this.#circle2.visible = false;
+    this.add(this.#circle1);
+    this.add(this.#circle2);
+    this.add(this.#line);
+    this.add(this.#lineOccluded);
+    this.add(this.#label);
     this._setState("idle");
   }
 
   public override dispose(): void {
     super.dispose();
-    this.renderer.labelPool.release(this.label);
-    this.circleGeometry.dispose();
-    this.circleMaterial.dispose();
-    this.line.geometry.dispose();
-    this.line.material.dispose();
-    this.lineOccluded.geometry.dispose();
-    this.lineOccluded.material.dispose();
-    this.renderer.input.removeListener("click", this._handleClick);
+    this.renderer.labelPool.release(this.#label);
+    this.#circleGeometry.dispose();
+    this.#circleMaterial.dispose();
+    this.#line.geometry.dispose();
+    this.#line.material.dispose();
+    this.#lineOccluded.geometry.dispose();
+    this.#lineOccluded.material.dispose();
+    this.renderer.input.removeListener("click", this.#handleClick);
     this.renderer.input.removeListener("mousemove", this._handleMouseMove);
   }
 
@@ -165,28 +165,28 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     fixedFrameId: string,
   ): void {
     super.startFrame(currentTime, renderFrameId, fixedFrameId);
-    this.circleMaterial.uniforms.canvasSize!.value[0] = this.renderer.input.canvasSize.x;
-    this.circleMaterial.uniforms.canvasSize!.value[1] = this.renderer.input.canvasSize.y;
+    this.#circleMaterial.uniforms.canvasSize!.value[0] = this.renderer.input.canvasSize.x;
+    this.#circleMaterial.uniforms.canvasSize!.value[1] = this.renderer.input.canvasSize.y;
   }
 
   private _setState(state: MeasurementState): void {
     this.state = state;
     switch (state) {
       case "idle":
-        this.renderer.input.removeListener("click", this._handleClick);
+        this.renderer.input.removeListener("click", this.#handleClick);
         this.renderer.input.removeListener("mousemove", this._handleMouseMove);
         this.dispatchEvent({ type: "foxglove.measure-end" });
         break;
       case "place-first-point":
         this.point1 = this.point2 = undefined;
-        this.renderer.input.addListener("click", this._handleClick);
+        this.renderer.input.addListener("click", this.#handleClick);
         this.renderer.input.addListener("mousemove", this._handleMouseMove);
         this.dispatchEvent({ type: "foxglove.measure-start" });
         break;
       case "place-second-point":
         break;
     }
-    this._updateDistance();
+    this.#updateDistance();
     this._render();
   }
 
@@ -203,24 +203,24 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
         break;
       case "place-first-point":
         (this.point1 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
-        this.point1NeedsUpdate = true;
+        this.#point1NeedsUpdate = true;
         break;
       case "place-second-point":
         (this.point2 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
-        this.point2NeedsUpdate = true;
-        this._updateDistance();
+        this.#point2NeedsUpdate = true;
+        this.#updateDistance();
         break;
     }
     this._render();
   };
 
-  private _updateDistance() {
+  #updateDistance() {
     if (this.point1 && this.point2) {
-      this.label.setText(this.point1.distanceTo(this.point2).toFixed(2));
+      this.#label.setText(this.point1.distanceTo(this.point2).toFixed(2));
     }
   }
 
-  private _handleClick = (
+  #handleClick = (
     _cursorCoords: THREE.Vector2,
     worldSpaceCursorCoords: THREE.Vector3 | undefined,
     _event: MouseEvent,
@@ -233,12 +233,12 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
         break;
       case "place-first-point":
         this.point1 = worldSpaceCursorCoords.clone();
-        this.point1NeedsUpdate = true;
+        this.#point1NeedsUpdate = true;
         this._setState("place-second-point");
         break;
       case "place-second-point":
         this.point2 = worldSpaceCursorCoords.clone();
-        this.point2NeedsUpdate = true;
+        this.#point2NeedsUpdate = true;
         this._setState("idle");
         break;
     }
@@ -247,42 +247,42 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
 
   private _render() {
     if (this.point1) {
-      this.circle1.visible = true;
-      this.circle1.position.copy(this.point1);
+      this.#circle1.visible = true;
+      this.#circle1.position.copy(this.point1);
 
-      if (this.point1NeedsUpdate) {
-        this.linePositionAttribute.setXYZ(0, this.point1.x, this.point1.y, this.point1.z);
-        this.linePositionAttribute.needsUpdate = true;
-        this.lineOccluded.computeLineDistances();
-        this.point1NeedsUpdate = false;
+      if (this.#point1NeedsUpdate) {
+        this.#linePositionAttribute.setXYZ(0, this.point1.x, this.point1.y, this.point1.z);
+        this.#linePositionAttribute.needsUpdate = true;
+        this.#lineOccluded.computeLineDistances();
+        this.#point1NeedsUpdate = false;
       }
     } else {
-      this.circle1.visible = false;
+      this.#circle1.visible = false;
     }
 
     if (this.point2) {
-      this.circle2.visible = true;
-      this.circle2.position.copy(this.point2);
+      this.#circle2.visible = true;
+      this.#circle2.position.copy(this.point2);
 
-      if (this.point2NeedsUpdate) {
-        this.linePositionAttribute.setXYZ(1, this.point2.x, this.point2.y, this.point2.z);
-        this.linePositionAttribute.needsUpdate = true;
-        this.lineOccluded.computeLineDistances();
-        this.point2NeedsUpdate = false;
+      if (this.#point2NeedsUpdate) {
+        this.#linePositionAttribute.setXYZ(1, this.point2.x, this.point2.y, this.point2.z);
+        this.#linePositionAttribute.needsUpdate = true;
+        this.#lineOccluded.computeLineDistances();
+        this.#point2NeedsUpdate = false;
       }
     } else {
-      this.circle2.visible = false;
+      this.#circle2.visible = false;
     }
 
     if (this.point1 && this.point2) {
-      this.line.visible = true;
-      this.lineOccluded.visible = true;
-      this.label.visible = true;
-      this.label.position.copy(this.point1).lerp(this.point2, 0.5);
+      this.#line.visible = true;
+      this.#lineOccluded.visible = true;
+      this.#label.visible = true;
+      this.#label.position.copy(this.point1).lerp(this.point2, 0.5);
     } else {
-      this.line.visible = false;
-      this.lineOccluded.visible = false;
-      this.label.visible = false;
+      this.#line.visible = false;
+      this.#lineOccluded.visible = false;
+      this.#label.visible = false;
     }
 
     this.renderer.queueAnimationFrame();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -85,7 +85,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
   public constructor(renderer: IRenderer) {
     super("foxglove.OccupancyGrids", renderer);
 
-    renderer.addSchemaSubscriptions(OCCUPANCY_GRID_DATATYPES, this.handleOccupancyGrid);
+    renderer.addSchemaSubscriptions(OCCUPANCY_GRID_DATATYPES, this.#handleOccupancyGrid);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -190,7 +190,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
         renderable.userData.material.needsUpdate = true;
       }
 
-      this._updateOccupancyGridRenderable(
+      this.#updateOccupancyGridRenderable(
         renderable,
         renderable.userData.occupancyGrid,
         renderable.userData.receiveTime,
@@ -198,7 +198,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
     }
   };
 
-  private handleOccupancyGrid = (messageEvent: PartialMessageEvent<OccupancyGrid>): void => {
+  #handleOccupancyGrid = (messageEvent: PartialMessageEvent<OccupancyGrid>): void => {
     const topic = messageEvent.topic;
     const occupancyGrid = normalizeOccupancyGrid(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
@@ -241,10 +241,10 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    this._updateOccupancyGridRenderable(renderable, occupancyGrid, receiveTime);
+    this.#updateOccupancyGridRenderable(renderable, occupancyGrid, receiveTime);
   };
 
-  private _updateOccupancyGridRenderable(
+  #updateOccupancyGridRenderable(
     renderable: OccupancyGridRenderable,
     occupancyGrid: OccupancyGrid,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Polygons.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Polygons.ts
@@ -64,7 +64,7 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
   public constructor(renderer: IRenderer) {
     super("foxglove.Polygons", renderer);
 
-    renderer.addSchemaSubscriptions(POLYGON_STAMPED_DATATYPES, this.handlePolygon);
+    renderer.addSchemaSubscriptions(POLYGON_STAMPED_DATATYPES, this.#handlePolygon);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -113,7 +113,7 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
         | Partial<LayerSettingsPolygon>
         | undefined;
       renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
-      this._updatePolygonRenderable(
+      this.#updatePolygonRenderable(
         renderable,
         renderable.userData.polygonStamped,
         renderable.userData.receiveTime,
@@ -121,7 +121,7 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
     }
   };
 
-  private handlePolygon = (messageEvent: PartialMessageEvent<PolygonStamped>): void => {
+  #handlePolygon = (messageEvent: PartialMessageEvent<PolygonStamped>): void => {
     const topic = messageEvent.topic;
     const polygonStamped = normalizePolygonStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
@@ -150,10 +150,10 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    this._updatePolygonRenderable(renderable, polygonStamped, receiveTime);
+    this.#updatePolygonRenderable(renderable, polygonStamped, receiveTime);
   };
 
-  private _updatePolygonRenderable(
+  #updatePolygonRenderable(
     renderable: PolygonRenderable,
     polygonStamped: PolygonStamped,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -142,9 +142,9 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
   public constructor(renderer: IRenderer) {
     super("foxglove.PoseArrays", renderer);
 
-    renderer.addSchemaSubscriptions(POSE_ARRAY_DATATYPES, this.handlePoseArray);
-    renderer.addSchemaSubscriptions(POSES_IN_FRAME_DATATYPES, this.handlePosesInFrame);
-    renderer.addSchemaSubscriptions(NAV_PATH_DATATYPES, this.handleNavPath);
+    renderer.addSchemaSubscriptions(POSE_ARRAY_DATATYPES, this.#handlePoseArray);
+    renderer.addSchemaSubscriptions(POSES_IN_FRAME_DATATYPES, this.#handlePosesInFrame);
+    renderer.addSchemaSubscriptions(NAV_PATH_DATATYPES, this.#handleNavPath);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -217,7 +217,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
         | Partial<LayerSettingsPoseArray>
         | undefined;
       const defaultType = { type: getDefaultType(this.renderer.topicsByName?.get(topicName)) };
-      this._updatePoseArrayRenderable(
+      this.#updatePoseArrayRenderable(
         renderable,
         renderable.userData.poseArrayMessage,
         renderable.userData.originalMessage,
@@ -227,29 +227,29 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     }
   };
 
-  private handlePoseArray = (messageEvent: PartialMessageEvent<PoseArray>): void => {
+  #handlePoseArray = (messageEvent: PartialMessageEvent<PoseArray>): void => {
     const poseArrayMessage = normalizePoseArray(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
+    this.#addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
   };
 
-  private handleNavPath = (messageEvent: PartialMessageEvent<NavPath>): void => {
+  #handleNavPath = (messageEvent: PartialMessageEvent<NavPath>): void => {
     if (!validateNavPath(messageEvent, this.renderer)) {
       return;
     }
 
     const poseArrayMessage = normalizeNavPathToPoseArray(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
+    this.#addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
   };
 
-  private handlePosesInFrame = (messageEvent: PartialMessageEvent<PosesInFrame>): void => {
+  #handlePosesInFrame = (messageEvent: PartialMessageEvent<PosesInFrame>): void => {
     const poseArrayMessage = normalizePosesInFrameToPoseArray(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
+    this.#addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
   };
 
-  private addPoseArray(
+  #addPoseArray(
     topic: string,
     poseArrayMessage: PoseArray,
     originalMessage: Record<string, RosValue>,
@@ -282,7 +282,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    this._updatePoseArrayRenderable(
+    this.#updatePoseArrayRenderable(
       renderable,
       poseArrayMessage,
       originalMessage,
@@ -291,7 +291,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     );
   }
 
-  private _createAxesToMatchPoses(
+  #createAxesToMatchPoses(
     renderable: PoseArrayRenderable,
     poseArray: PoseArray,
     topic: string,
@@ -323,7 +323,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     }
   }
 
-  private _createArrowsToMatchPoses(
+  #createArrowsToMatchPoses(
     renderable: PoseArrayRenderable,
     poseArray: PoseArray,
     topic: string,
@@ -361,7 +361,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     }
   }
 
-  private _updatePoseArrayRenderable(
+  #updatePoseArrayRenderable(
     renderable: PoseArrayRenderable,
     poseArrayMessage: PoseArray,
     originalMessage: Record<string, RosValue>,
@@ -430,13 +430,13 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     // Update the pose for each pose renderable
     switch (settings.type) {
       case "axis":
-        this._createAxesToMatchPoses(renderable, poseArrayMessage, topic);
+        this.#createAxesToMatchPoses(renderable, poseArrayMessage, topic);
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.axes[i]!, poseArrayMessage.poses[i]!);
         }
         break;
       case "arrow":
-        this._createArrowsToMatchPoses(renderable, poseArrayMessage, topic, colorStart, colorEnd);
+        this.#createArrowsToMatchPoses(renderable, poseArrayMessage, topic, colorStart, colorEnd);
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.arrows[i]!, poseArrayMessage.poses[i]!);
         }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
@@ -104,11 +104,11 @@ export class Poses extends SceneExtension<PoseRenderable> {
   public constructor(renderer: IRenderer) {
     super("foxglove.Poses", renderer);
 
-    renderer.addSchemaSubscriptions(POSE_STAMPED_DATATYPES, this.handlePoseStamped);
-    renderer.addSchemaSubscriptions(POSE_IN_FRAME_DATATYPES, this.handlePoseInFrame);
+    renderer.addSchemaSubscriptions(POSE_STAMPED_DATATYPES, this.#handlePoseStamped);
+    renderer.addSchemaSubscriptions(POSE_IN_FRAME_DATATYPES, this.#handlePoseInFrame);
     renderer.addSchemaSubscriptions(
       POSE_WITH_COVARIANCE_STAMPED_DATATYPES,
-      this.handlePoseWithCovariance,
+      this.#handlePoseWithCovariance,
     );
   }
 
@@ -204,7 +204,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
       const settings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsPose>
         | undefined;
-      this._updatePoseRenderable(
+      this.#updatePoseRenderable(
         renderable,
         renderable.userData.poseMessage,
         renderable.userData.originalMessage,
@@ -214,27 +214,27 @@ export class Poses extends SceneExtension<PoseRenderable> {
     }
   };
 
-  private handlePoseStamped = (messageEvent: PartialMessageEvent<PoseStamped>): void => {
+  #handlePoseStamped = (messageEvent: PartialMessageEvent<PoseStamped>): void => {
     const poseMessage = normalizePoseStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
+    this.#addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
   };
 
-  private handlePoseInFrame = (messageEvent: PartialMessageEvent<PoseInFrame>): void => {
+  #handlePoseInFrame = (messageEvent: PartialMessageEvent<PoseInFrame>): void => {
     const poseMessage = normalizePoseInFrameToPoseStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
+    this.#addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
   };
 
-  private handlePoseWithCovariance = (
+  #handlePoseWithCovariance = (
     messageEvent: PartialMessageEvent<PoseWithCovarianceStamped>,
   ): void => {
     const poseMessage = normalizePoseWithCovarianceStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
+    this.#addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
   };
 
-  private addPose(
+  #addPose(
     topic: string,
     poseMessage: PoseStamped | PoseWithCovarianceStamped,
     originalMessage: Record<string, RosValue>,
@@ -267,7 +267,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    this._updatePoseRenderable(
+    this.#updatePoseRenderable(
       renderable,
       poseMessage,
       originalMessage,
@@ -276,7 +276,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
     );
   }
 
-  private _updatePoseRenderable(
+  #updatePoseRenderable(
     renderable: PoseRenderable,
     poseMessage: PoseStamped | PoseWithCovarianceStamped,
     originalMessage: Record<string, RosValue>,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishClickTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishClickTool.ts
@@ -66,78 +66,78 @@ export type PublishClickEvent =
   | { type: "foxglove.publish-submit"; publishClickType: "pose" | "pose_estimate"; pose: Pose };
 
 export class PublishClickTool extends SceneExtension<Renderable<BaseUserData>, PublishClickEvent> {
-  private sphere: RenderableSphere;
-  private arrow: RenderableArrow;
+  #sphere: RenderableSphere;
+  #arrow: RenderableArrow;
 
   public publishClickType: PublishClickType = "point";
   public state: PublishClickState = "idle";
 
-  private point1?: THREE.Vector3;
-  private point2?: THREE.Vector3;
+  #point1?: THREE.Vector3;
+  #point2?: THREE.Vector3;
 
   public constructor(renderer: IRenderer) {
     super("foxglove.PublishClickTool", renderer);
 
-    this.sphere = new RenderableSphere("", makeSphereMarker(), undefined, this.renderer);
-    this.arrow = new RenderableArrow(
+    this.#sphere = new RenderableSphere("", makeSphereMarker(), undefined, this.renderer);
+    this.#arrow = new RenderableArrow(
       "",
       makeArrowMarker(this.publishClickType),
       undefined,
       this.renderer,
     );
-    this.sphere.visible = false;
-    this.sphere.mesh.userData.picking = false;
-    this.arrow.visible = false;
-    this.arrow.shaftMesh.userData.picking = false;
-    this.arrow.headMesh.userData.picking = false;
-    this.add(this.sphere);
-    this.add(this.arrow);
-    this._setState("idle");
+    this.#sphere.visible = false;
+    this.#sphere.mesh.userData.picking = false;
+    this.#arrow.visible = false;
+    this.#arrow.shaftMesh.userData.picking = false;
+    this.#arrow.headMesh.userData.picking = false;
+    this.add(this.#sphere);
+    this.add(this.#arrow);
+    this.#setState("idle");
   }
 
   public override dispose(): void {
     super.dispose();
-    this.arrow.dispose();
-    this.sphere.dispose();
-    this.renderer.input.removeListener("click", this._handleClick);
-    this.renderer.input.removeListener("mousemove", this._handleMouseMove);
+    this.#arrow.dispose();
+    this.#sphere.dispose();
+    this.renderer.input.removeListener("click", this.#handleClick);
+    this.renderer.input.removeListener("mousemove", this.#handleMouseMove);
   }
 
   public setPublishClickType(type: PublishClickType): void {
     this.publishClickType = type;
-    this.arrow.update(makeArrowMarker(this.publishClickType), undefined);
+    this.#arrow.update(makeArrowMarker(this.publishClickType), undefined);
     this.dispatchEvent({ type: "foxglove.publish-type-change" });
   }
 
   public start(): void {
-    this._setState("place-first-point");
+    this.#setState("place-first-point");
   }
 
   public stop(): void {
-    this._setState("idle");
+    this.#setState("idle");
   }
 
-  private _setState(state: PublishClickState): void {
+  #setState(state: PublishClickState): void {
     this.state = state;
     switch (state) {
       case "idle":
-        this.point1 = this.point2 = undefined;
-        this.renderer.input.removeListener("click", this._handleClick);
-        this.renderer.input.removeListener("mousemove", this._handleMouseMove);
+        this.#point1 = this.#point2 = undefined;
+        this.renderer.input.removeListener("click", this.#handleClick);
+        this.renderer.input.removeListener("mousemove", this.#handleMouseMove);
         this.dispatchEvent({ type: "foxglove.publish-end" });
         break;
       case "place-first-point":
-        this.renderer.input.addListener("click", this._handleClick);
-        this.renderer.input.addListener("mousemove", this._handleMouseMove);
+        this.renderer.input.addListener("click", this.#handleClick);
+        this.renderer.input.addListener("mousemove", this.#handleMouseMove);
         this.dispatchEvent({ type: "foxglove.publish-start" });
         break;
       case "place-second-point":
         break;
     }
-    this._render();
+    this.#render();
   }
 
-  private _handleMouseMove = (
+  #handleMouseMove = (
     _cursorCoords: THREE.Vector2,
     worldSpaceCursorCoords: THREE.Vector3 | undefined,
     _event: MouseEvent,
@@ -149,16 +149,16 @@ export class PublishClickTool extends SceneExtension<Renderable<BaseUserData>, P
       case "idle":
         break;
       case "place-first-point":
-        (this.point1 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
+        (this.#point1 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
         break;
       case "place-second-point":
-        (this.point2 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
+        (this.#point2 ??= new THREE.Vector3()).copy(worldSpaceCursorCoords);
         break;
     }
-    this._render();
+    this.#render();
   };
 
-  private _handleClick = (
+  #handleClick = (
     _cursorCoords: THREE.Vector2,
     worldSpaceCursorCoords: THREE.Vector3 | undefined,
     _event: MouseEvent,
@@ -171,25 +171,25 @@ export class PublishClickTool extends SceneExtension<Renderable<BaseUserData>, P
       case "idle":
         break;
       case "place-first-point":
-        this.point1 = worldSpaceCursorCoords.clone();
+        this.#point1 = worldSpaceCursorCoords.clone();
         if (this.publishClickType === "point") {
           this.dispatchEvent({
             type: "foxglove.publish-submit",
             publishClickType: this.publishClickType,
-            point: { x: this.point1.x, y: this.point1.y, z: this.point1.z },
+            point: { x: this.#point1.x, y: this.#point1.y, z: this.#point1.z },
           });
-          this._setState("idle");
+          this.#setState("idle");
         } else {
-          this._setState("place-second-point");
+          this.#setState("place-second-point");
         }
         break;
       case "place-second-point":
-        this.point2 = worldSpaceCursorCoords.clone();
-        if (this.point1 && this.publishClickType !== "point") {
-          const p = this.point1.clone();
+        this.#point2 = worldSpaceCursorCoords.clone();
+        if (this.#point1 && this.publishClickType !== "point") {
+          const p = this.#point1.clone();
           const q = new THREE.Quaternion().setFromUnitVectors(
             UNIT_X,
-            tempVec3.subVectors(this.point2, this.point1).normalize(),
+            tempVec3.subVectors(this.#point2, this.#point1).normalize(),
           );
           this.dispatchEvent({
             type: "foxglove.publish-submit",
@@ -200,37 +200,37 @@ export class PublishClickTool extends SceneExtension<Renderable<BaseUserData>, P
             },
           });
         }
-        this._setState("idle");
+        this.#setState("idle");
         break;
     }
-    this._render();
+    this.#render();
   };
 
-  private _render() {
+  #render() {
     if (this.publishClickType === "point") {
-      this.arrow.visible = false;
-      if (this.point1) {
-        this.sphere.visible = true;
-        this.sphere.position.copy(this.point1);
+      this.#arrow.visible = false;
+      if (this.#point1) {
+        this.#sphere.visible = true;
+        this.#sphere.position.copy(this.#point1);
       } else {
-        this.sphere.visible = false;
+        this.#sphere.visible = false;
       }
     } else {
-      this.sphere.visible = false;
-      if (this.point1) {
-        this.arrow.visible = true;
+      this.#sphere.visible = false;
+      if (this.#point1) {
+        this.#arrow.visible = true;
 
-        this.arrow.position.copy(this.point1);
-        if (this.point2) {
-          this.arrow.quaternion.setFromUnitVectors(
+        this.#arrow.position.copy(this.#point1);
+        if (this.#point2) {
+          this.#arrow.quaternion.setFromUnitVectors(
             UNIT_X,
-            tempVec3.subVectors(this.point2, this.point1).normalize(),
+            tempVec3.subVectors(this.#point2, this.#point1).normalize(),
           );
         } else {
-          this.arrow.quaternion.set(0, 0, 0, 1);
+          this.#arrow.quaternion.set(0, 0, 0, 1);
         }
       } else {
-        this.arrow.visible = false;
+        this.#arrow.visible = false;
       }
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishSettings.ts
@@ -27,14 +27,14 @@ export class PublishSettings extends SceneExtension {
 
     renderer.publishClickTool.addEventListener(
       "foxglove.publish-type-change",
-      this.handlePublishToolChange,
+      this.#handlePublishToolChange,
     );
   }
 
   public override dispose(): void {
     this.renderer.publishClickTool.removeEventListener(
       "foxglove.publish-type-change",
-      this.handlePublishToolChange,
+      this.#handlePublishToolChange,
     );
     super.dispose();
   }
@@ -148,7 +148,7 @@ export class PublishSettings extends SceneExtension {
     this.updateSettingsTree();
   };
 
-  private handlePublishToolChange = (): void => {
+  #handlePublishToolChange = (): void => {
     this.renderer.updateConfig((draft) => {
       draft.publish.type = this.renderer.publishClickTool.publishClickType;
       return draft;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
@@ -47,12 +47,12 @@ const SCENE_ENTITIES_DEFAULT_SETTINGS: LayerSettingsEntity = {
 };
 
 export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
-  private primitivePool = new PrimitivePool(this.renderer);
+  #primitivePool = new PrimitivePool(this.renderer);
 
   public constructor(renderer: IRenderer) {
     super("foxglove.SceneEntities", renderer);
 
-    renderer.addSchemaSubscriptions(SCENE_UPDATE_DATATYPES, this.handleSceneUpdate);
+    renderer.addSchemaSubscriptions(SCENE_UPDATE_DATATYPES, this.#handleSceneUpdate);
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -133,21 +133,21 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
     }
   };
 
-  private handleSceneUpdate = (messageEvent: PartialMessageEvent<SceneUpdate>): void => {
+  #handleSceneUpdate = (messageEvent: PartialMessageEvent<SceneUpdate>): void => {
     const topic = messageEvent.topic;
     const sceneUpdates = messageEvent.message;
 
     for (const deletionMsg of sceneUpdates.deletions ?? []) {
       if (deletionMsg) {
         const deletion = normalizeSceneEntityDeletion(deletionMsg);
-        this._getTopicEntities(topic).deleteEntities(deletion);
+        this.#getTopicEntities(topic).deleteEntities(deletion);
       }
     }
 
     for (const entityMsg of sceneUpdates.entities ?? []) {
       if (entityMsg) {
         const entity = normalizeSceneEntity(entityMsg);
-        this._getTopicEntities(topic).addOrUpdateEntity(
+        this.#getTopicEntities(topic).addOrUpdateEntity(
           entity,
           toNanoSec(messageEvent.receiveTime),
         );
@@ -155,14 +155,14 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
     }
   };
 
-  private _getTopicEntities(topic: string): TopicEntities {
+  #getTopicEntities(topic: string): TopicEntities {
     let topicEntities = this.renderables.get(topic);
     if (!topicEntities) {
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsEntity>
         | undefined;
 
-      topicEntities = new TopicEntities(topic, this.primitivePool, this.renderer, {
+      topicEntities = new TopicEntities(topic, this.#primitivePool, this.renderer, {
         receiveTime: -1n,
         messageTime: -1n,
         frameId: "",
@@ -179,7 +179,7 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
 
   public override dispose(): void {
     super.dispose();
-    this.primitivePool.dispose();
+    this.#primitivePool.dispose();
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -52,7 +52,7 @@ const PRIMITIVE_KEYS = {
 
 export class TopicEntities extends Renderable<EntityTopicUserData> {
   public override pickable = false;
-  private renderablesById = new Map<string, EntityRenderables>();
+  #renderablesById = new Map<string, EntityRenderables>();
 
   public constructor(
     name: string,
@@ -65,12 +65,12 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
 
   public override dispose(): void {
     this.children.length = 0;
-    this._deleteAllEntities();
+    this.#deleteAllEntities();
   }
 
   public updateSettings(): void {
     // Updates each individual primitive renderable using the current topic settings
-    for (const renderables of this.renderablesById.values()) {
+    for (const renderables of this.#renderablesById.values()) {
       for (const renderable of Object.values(renderables)) {
         renderable.updateSettings(this.userData.settings);
       }
@@ -78,7 +78,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
   }
 
   public setColorScheme(colorScheme: "dark" | "light"): void {
-    for (const renderables of this.renderablesById.values()) {
+    for (const renderables of this.#renderablesById.values()) {
       for (const renderable of Object.values(renderables)) {
         renderable.setColorScheme(colorScheme);
       }
@@ -92,7 +92,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
       return;
     }
 
-    for (const renderables of this.renderablesById.values()) {
+    for (const renderables of this.#renderablesById.values()) {
       for (const renderable of Object.values(renderables)) {
         const entity = renderable.userData.entity;
         if (!entity) {
@@ -102,7 +102,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
         // Check if this entity has expired
         const expiresAt = renderable.userData.expiresAt;
         if (expiresAt != undefined && currentTime > expiresAt) {
-          this._deleteEntity(entity.id);
+          this.#deleteEntity(entity.id);
           break;
         }
 
@@ -130,10 +130,10 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
   }
 
   public addOrUpdateEntity(entity: SceneEntity, receiveTime: bigint): void {
-    let renderables = this.renderablesById.get(entity.id);
+    let renderables = this.#renderablesById.get(entity.id);
     if (!renderables) {
       renderables = {};
-      this.renderablesById.set(entity.id, renderables);
+      this.#renderablesById.set(entity.id, renderables);
     }
 
     for (const primitiveType of ALL_PRIMITIVE_TYPES) {
@@ -161,10 +161,10 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
   public deleteEntities(deletion: SceneEntityDeletion): void {
     switch (deletion.type) {
       case SceneEntityDeletionType.MATCHING_ID:
-        this._deleteEntity(deletion.id);
+        this.#deleteEntity(deletion.id);
         break;
       case SceneEntityDeletionType.ALL:
-        this._deleteAllEntities();
+        this.#deleteAllEntities();
         break;
       default:
         // Unknown action
@@ -176,7 +176,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
     }
   }
 
-  private _removeRenderables(renderables: EntityRenderables): void {
+  #removeRenderables(renderables: EntityRenderables): void {
     for (const [primitiveType, primitive] of Object.entries(renderables) as [
       PrimitiveType,
       EntityRenderables[PrimitiveType],
@@ -188,18 +188,18 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
     }
   }
 
-  private _deleteEntity(id: string) {
-    const renderables = this.renderablesById.get(id);
+  #deleteEntity(id: string) {
+    const renderables = this.#renderablesById.get(id);
     if (renderables) {
-      this._removeRenderables(renderables);
+      this.#removeRenderables(renderables);
     }
-    this.renderablesById.delete(id);
+    this.#renderablesById.delete(id);
   }
 
-  private _deleteAllEntities() {
-    for (const renderables of this.renderablesById.values()) {
-      this._removeRenderables(renderables);
+  #deleteAllEntities() {
+    for (const renderables of this.#renderablesById.values()) {
+      this.#removeRenderables(renderables);
     }
-    this.renderablesById.clear();
+    this.#renderablesById.clear();
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -214,10 +214,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     }
   }
 
-  #createMarkerRenderable(
-    marker: Marker,
-    receiveTime: bigint,
-  ): RenderableMarker | undefined {
+  #createMarkerRenderable(marker: Marker, receiveTime: bigint): RenderableMarker | undefined {
     const pool = this.renderer.markerPool;
     switch (marker.type) {
       case MarkerType.ARROW:

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -72,13 +72,13 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     switch (marker.action) {
       case MarkerAction.ADD:
       case MarkerAction.MODIFY:
-        this._addOrUpdateMarker(marker, receiveTime);
+        this.#addOrUpdateMarker(marker, receiveTime);
         break;
       case MarkerAction.DELETE:
-        this._deleteMarker(marker.ns, marker.id);
+        this.#deleteMarker(marker.ns, marker.id);
         break;
       case MarkerAction.DELETEALL: {
-        this._deleteAllMarkers(marker.ns);
+        this.#deleteAllMarkers(marker.ns);
         break;
       }
       default:
@@ -122,7 +122,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
         // Check if this marker has expired
         if (expiresIn != undefined) {
           if (currentTime > receiveTime + expiresIn) {
-            this._deleteMarker(ns.namespace, marker.id);
+            this.#deleteMarker(ns.namespace, marker.id);
             continue;
           }
         }
@@ -150,7 +150,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     }
   }
 
-  private _addOrUpdateMarker(marker: Marker, receiveTime: bigint): void {
+  #addOrUpdateMarker(marker: Marker, receiveTime: bigint): void {
     let ns = this.namespaces.get(marker.ns);
     if (!ns) {
       ns = new MarkersNamespace(this.topic, marker.ns, this.renderer);
@@ -161,12 +161,12 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
 
     // Check if the marker with this id changed type
     if (renderable && renderable.userData.marker.type !== marker.type) {
-      this._deleteMarker(marker.ns, marker.id);
+      this.#deleteMarker(marker.ns, marker.id);
       renderable = undefined;
     }
 
     if (!renderable) {
-      renderable = this._createMarkerRenderable(marker, receiveTime);
+      renderable = this.#createMarkerRenderable(marker, receiveTime);
       if (!renderable) {
         return;
       }
@@ -177,7 +177,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     renderable.update(marker, receiveTime);
   }
 
-  private _deleteMarker(ns: string, id: number): boolean {
+  #deleteMarker(ns: string, id: number): boolean {
     const namespace = this.namespaces.get(ns);
     if (namespace) {
       const renderable = namespace.markersById.get(id);
@@ -191,7 +191,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     return false;
   }
 
-  private _deleteAllMarkers(ns: string): void {
+  #deleteAllMarkers(ns: string): void {
     const clearNamespace = (namespace: MarkersNamespace): void => {
       for (const renderable of namespace.markersById.values()) {
         this.remove(renderable);
@@ -214,7 +214,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     }
   }
 
-  private _createMarkerRenderable(
+  #createMarkerRenderable(
     marker: Marker,
     receiveTime: bigint,
   ): RenderableMarker | undefined {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -260,18 +260,18 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
 
   public override removeAllRenderables(): void {
     // Re-add coordinate frames and transforms since the scene has been cleared
-    this._refreshTransforms();
+    this.#refreshTransforms();
   }
 
   /**
    * Re-add coordinate frames and transforms corresponding to existing custom URDFs
    */
-  private _refreshTransforms() {
+  #refreshTransforms() {
     for (const [instanceId, frames] of this.#framesByInstanceId) {
-      this._loadFrames(instanceId, frames);
+      this.#loadFrames(instanceId, frames);
     }
     for (const [instanceId, transforms] of this.#transformsByInstanceId) {
-      this._loadTransforms(instanceId, transforms);
+      this.#loadTransforms(instanceId, transforms);
     }
   }
 
@@ -356,7 +356,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         this.#transformsByInstanceId.delete(instanceId);
 
         // Re-add coordinate frames in case the deleted URDF shared frame names with other URDFs
-        this._refreshTransforms();
+        this.#refreshTransforms();
 
         // Update the settings tree
         this.updateSettingsTree();
@@ -600,8 +600,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const renderer = this.renderer;
     const instanceId = renderable.userData.settings.instanceId;
 
-    this._loadFrames(instanceId, frames);
-    this._loadTransforms(instanceId, transforms);
+    this.#loadFrames(instanceId, frames);
+    this.#loadTransforms(instanceId, transforms);
     this.updateSettingsTree();
 
     // Dispose any existing renderables
@@ -633,7 +633,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
   }
 
-  private _loadFrames(instanceId: string, frames: string[]): void {
+  #loadFrames(instanceId: string, frames: string[]): void {
     this.#framesByInstanceId.set(instanceId, frames);
 
     // Import all coordinate frames from the URDF into the scene
@@ -642,7 +642,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
   }
 
-  private _loadTransforms(instanceId: string, transforms: TransformData[]): void {
+  #loadTransforms(instanceId: string, transforms: TransformData[]): void {
     this.#transformsByInstanceId.set(instanceId, transforms);
 
     // Import all transforms from the URDF into the scene

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -147,30 +147,30 @@ export class UrdfRenderable extends Renderable<UrdfUserData> {
 }
 
 export class Urdfs extends SceneExtension<UrdfRenderable> {
-  private framesByInstanceId = new Map<string, string[]>();
-  private transformsByInstanceId = new Map<string, TransformData[]>();
-  private jointStates = new Map<string, JointPosition>();
+  #framesByInstanceId = new Map<string, string[]>();
+  #transformsByInstanceId = new Map<string, TransformData[]>();
+  #jointStates = new Map<string, JointPosition>();
 
   public constructor(renderer: IRenderer) {
     super("foxglove.Urdfs", renderer);
 
-    renderer.addTopicSubscription(TOPIC_NAME, this.handleRobotDescription);
+    renderer.addTopicSubscription(TOPIC_NAME, this.#handleRobotDescription);
     // Note that this subscription will never happen because it does not appear as a topic in the
     // topic list that can have its visibility toggled on. The ThreeDeeRender subscription logic
     // needs to become more flexible to make this possible
-    renderer.addSchemaSubscriptions(JOINTSTATE_DATATYPES, this.handleJointState);
-    renderer.on("parametersChange", this.handleParametersChange);
+    renderer.addSchemaSubscriptions(JOINTSTATE_DATATYPES, this.#handleJointState);
+    renderer.on("parametersChange", this.#handleParametersChange);
     renderer.addCustomLayerAction({
       layerId: LAYER_ID,
       label: i18next.t("threeDee:addURDF"),
       icon: "PrecisionManufacturing",
-      handler: this.handleAddUrdf,
+      handler: this.#handleAddUrdf,
     });
 
     // Load existing URDF layers from the config
     for (const [instanceId, entry] of Object.entries(renderer.config.layers)) {
       if (entry?.layerId === LAYER_ID) {
-        this._loadUrdf(instanceId, undefined);
+        this.#loadUrdf(instanceId, undefined);
       }
     }
   }
@@ -188,11 +188,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           label: TOPIC_NAME,
           icon: "PrecisionManufacturing",
           visible: config.visible ?? DEFAULT_SETTINGS.visible,
-          handler: this.handleTopicSettingsAction,
+          handler: this.#handleTopicSettingsAction,
           children: urdfChildren(
-            this.transformsByInstanceId.get(TOPIC_NAME),
+            this.#transformsByInstanceId.get(TOPIC_NAME),
             this.renderer.transformTree,
-            this.jointStates,
+            this.#jointStates,
           ),
         },
       });
@@ -212,11 +212,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           icon: "PrecisionManufacturing",
           fields,
           visible: config.visible ?? DEFAULT_SETTINGS.visible,
-          handler: this.handleTopicSettingsAction,
+          handler: this.#handleTopicSettingsAction,
           children: urdfChildren(
-            this.transformsByInstanceId.get(PARAM_KEY),
+            this.#transformsByInstanceId.get(PARAM_KEY),
             this.renderer.transformTree,
-            this.jointStates,
+            this.#jointStates,
           ),
         },
       });
@@ -244,11 +244,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
             visible: config.visible ?? DEFAULT_CUSTOM_SETTINGS.visible,
             actions: [{ type: "action", id: "delete", label: "Delete" }],
             order: layerConfig.order,
-            handler: this.handleLayerSettingsAction,
+            handler: this.#handleLayerSettingsAction,
             children: urdfChildren(
-              this.transformsByInstanceId.get(instanceId),
+              this.#transformsByInstanceId.get(instanceId),
               this.renderer.transformTree,
-              this.jointStates,
+              this.#jointStates,
             ),
           },
         });
@@ -267,10 +267,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
    * Re-add coordinate frames and transforms corresponding to existing custom URDFs
    */
   private _refreshTransforms() {
-    for (const [instanceId, frames] of this.framesByInstanceId) {
+    for (const [instanceId, frames] of this.#framesByInstanceId) {
       this._loadFrames(instanceId, frames);
     }
-    for (const [instanceId, transforms] of this.transformsByInstanceId) {
+    for (const [instanceId, transforms] of this.#transformsByInstanceId) {
       this._loadTransforms(instanceId, transforms);
     }
   }
@@ -317,14 +317,14 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
   }
 
-  private handleTopicSettingsAction = (action: SettingsTreeAction): void => {
+  #handleTopicSettingsAction = (action: SettingsTreeAction): void => {
     if (action.action === "update") {
-      this.handleSettingsUpdate(action);
+      this.#handleSettingsUpdate(action);
       return;
     }
   };
 
-  private handleLayerSettingsAction = (action: SettingsTreeAction): void => {
+  #handleLayerSettingsAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
 
     // Handle menu actions (delete)
@@ -346,14 +346,14 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         }
 
         // Remove transforms from the TF tree
-        const transforms = this.transformsByInstanceId.get(instanceId);
+        const transforms = this.#transformsByInstanceId.get(instanceId);
         if (transforms) {
           for (const { parent, child } of transforms) {
             this.renderer.removeTransform(child, parent, 0n);
           }
         }
-        this.framesByInstanceId.delete(instanceId);
-        this.transformsByInstanceId.delete(instanceId);
+        this.#framesByInstanceId.delete(instanceId);
+        this.#transformsByInstanceId.delete(instanceId);
 
         // Re-add coordinate frames in case the deleted URDF shared frame names with other URDFs
         this._refreshTransforms();
@@ -364,18 +364,18 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       }
       return;
     } /* if (action.action === "update") */ else {
-      this.handleSettingsUpdate(action);
+      this.#handleSettingsUpdate(action);
     }
   };
 
-  private handleSettingsUpdate = (action: { action: "update" } & SettingsTreeAction): void => {
+  #handleSettingsUpdate = (action: { action: "update" } & SettingsTreeAction): void => {
     const path = action.payload.path;
 
     if (path.length === 5 && path[2] === "joints") {
       // ["layers", instanceId, "joints", jointName, "manual"]
       const instanceId = path[1]!;
       const jointName = path[3]!;
-      const transforms = this.transformsByInstanceId.get(instanceId);
+      const transforms = this.#transformsByInstanceId.get(instanceId);
       if (!transforms) {
         return;
       }
@@ -408,22 +408,22 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       this.saveSetting(path, action.payload.value);
       const instanceId = path[1]!;
       if (path[1] === PARAM_KEY) {
-        this._loadUrdf(instanceId, this.renderer.parameters?.get(PARAM_NAME) as string | undefined);
+        this.#loadUrdf(instanceId, this.renderer.parameters?.get(PARAM_NAME) as string | undefined);
       } else {
-        this._loadUrdf(instanceId, undefined);
+        this.#loadUrdf(instanceId, undefined);
       }
     }
   };
 
-  private handleRobotDescription = (messageEvent: PartialMessageEvent<{ data: string }>): void => {
+  #handleRobotDescription = (messageEvent: PartialMessageEvent<{ data: string }>): void => {
     const robotDescription = messageEvent.message.data;
     if (typeof robotDescription !== "string") {
       return;
     }
-    this._loadUrdf(TOPIC_NAME, robotDescription);
+    this.#loadUrdf(TOPIC_NAME, robotDescription);
   };
 
-  private handleJointState = (messageEvent: PartialMessageEvent<JointState>): void => {
+  #handleJointState = (messageEvent: PartialMessageEvent<JointState>): void => {
     const msg = messageEvent.message;
     const names = msg.name ?? [];
     const positions = msg.position ?? [];
@@ -433,22 +433,22 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       const name = names[i]!;
       const position = positions[i] ?? 0;
 
-      const prevTimestamp = this.jointStates.get(name)?.timestamp;
+      const prevTimestamp = this.#jointStates.get(name)?.timestamp;
       if (prevTimestamp == undefined || timestamp >= prevTimestamp) {
-        this.jointStates.set(name, { timestamp, position });
+        this.#jointStates.set(name, { timestamp, position });
       }
     }
   };
 
-  private handleParametersChange = (parameters: ReadonlyMap<string, unknown> | undefined): void => {
+  #handleParametersChange = (parameters: ReadonlyMap<string, unknown> | undefined): void => {
     const robotDescription = parameters?.get(PARAM_NAME);
     if (typeof robotDescription !== "string") {
       return;
     }
-    this._loadUrdf(PARAM_KEY, robotDescription);
+    this.#loadUrdf(PARAM_KEY, robotDescription);
   };
 
-  private handleAddUrdf = (instanceId: string): void => {
+  #handleAddUrdf = (instanceId: string): void => {
     log.info(`Creating ${LAYER_ID} layer ${instanceId}`);
 
     const config: LayerSettingsCustomUrdf = { ...DEFAULT_CUSTOM_SETTINGS, instanceId };
@@ -461,13 +461,13 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     });
 
     // Add the URDF renderable
-    this._loadUrdf(instanceId, undefined);
+    this.#loadUrdf(instanceId, undefined);
 
     // Update the settings tree
     this.updateSettingsTree();
   };
 
-  private _fetchUrdf(instanceId: string, url: string): void {
+  #fetchUrdf(instanceId: string, url: string): void {
     const renderable = this.renderables.get(instanceId);
     if (!renderable) {
       throw new Error(`_fetchUrdf() should only be called for existing renderables`);
@@ -504,7 +504,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       .then((urdf) => {
         log.debug(`Fetched ${urdf.length} byte URDF from ${url}`);
         this.renderer.settings.errors.remove(["layers", instanceId], FETCH_URDF_ERR);
-        this._loadUrdf(instanceId, urdf);
+        this.#loadUrdf(instanceId, urdf);
       })
       .catch((unknown) => {
         const err = unknown as Error;
@@ -514,7 +514,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       });
   }
 
-  private _getCurrentSettings(instanceId: string) {
+  #getCurrentSettings(instanceId: string) {
     const isTopicOrParam = instanceId === TOPIC_NAME || instanceId === PARAM_KEY;
     const baseSettings = isTopicOrParam ? DEFAULT_SETTINGS : DEFAULT_CUSTOM_SETTINGS;
     const userSettings = isTopicOrParam
@@ -524,23 +524,23 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     return settings;
   }
 
-  private _loadUrdf(instanceId: string, urdf: string | undefined): void {
+  #loadUrdf(instanceId: string, urdf: string | undefined): void {
     let renderable = this.renderables.get(instanceId);
     if (renderable && urdf != undefined && renderable.userData.urdf === urdf) {
-      const settings = this._getCurrentSettings(instanceId);
+      const settings = this.#getCurrentSettings(instanceId);
       renderable.userData.settings = settings;
       return;
     }
 
     // Clear any previous parsed data for this instanceId
-    this.transformsByInstanceId.delete(instanceId);
-    this.framesByInstanceId.delete(instanceId);
+    this.#transformsByInstanceId.delete(instanceId);
+    this.#framesByInstanceId.delete(instanceId);
     this.updateSettingsTree();
 
     const isTopicOrParam = instanceId === TOPIC_NAME || instanceId === PARAM_KEY;
     const frameId = this.renderer.fixedFrameId ?? ""; // Unused
     const settingsPath = isTopicOrParam ? ["topics", instanceId] : ["layers", instanceId];
-    const settings = this._getCurrentSettings(instanceId);
+    const settings = this.#getCurrentSettings(instanceId);
     const url = (settings as Partial<LayerSettingsCustomUrdf>).url;
 
     // Create a UrdfRenderable if it does not already exist
@@ -571,7 +571,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
 
       // Fetch the URDF from the URL if we have one
       if (url != undefined) {
-        this._fetchUrdf(instanceId, url);
+        this.#fetchUrdf(instanceId, url);
       }
       return;
     }
@@ -580,7 +580,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const loadedRenderable = renderable;
     parseUrdf(urdf)
       .then((parsed) => {
-        this._loadRobot(loadedRenderable, parsed);
+        this.#loadRobot(loadedRenderable, parsed);
         // the frame from the settings update is called before the robot is loaded
         // need to queue another animation frame after robot has been loaded
         this.renderer.queueAnimationFrame();
@@ -596,7 +596,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       });
   }
 
-  private _loadRobot(renderable: UrdfRenderable, { robot, frames, transforms }: ParsedUrdf): void {
+  #loadRobot(renderable: UrdfRenderable, { robot, frames, transforms }: ParsedUrdf): void {
     const renderer = this.renderer;
     const instanceId = renderable.userData.settings.instanceId;
 
@@ -634,7 +634,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
   }
 
   private _loadFrames(instanceId: string, frames: string[]): void {
-    this.framesByInstanceId.set(instanceId, frames);
+    this.#framesByInstanceId.set(instanceId, frames);
 
     // Import all coordinate frames from the URDF into the scene
     for (const frameId of frames) {
@@ -643,7 +643,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
   }
 
   private _loadTransforms(instanceId: string, transforms: TransformData[]): void {
-    this.transformsByInstanceId.set(instanceId, transforms);
+    this.#transformsByInstanceId.set(instanceId, transforms);
 
     // Import all transforms from the URDF into the scene
     const isTopicOrParam = instanceId === TOPIC_NAME || instanceId === PARAM_KEY;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
@@ -37,7 +37,7 @@ const CONSTRUCTORS = {
  * An object pool for RenderableMarker subclass objects.
  */
 export class MarkerPool {
-  private renderablesByType = new Map<MarkerType, RenderableMarker[]>();
+  #renderablesByType = new Map<MarkerType, RenderableMarker[]>();
 
   public constructor(private renderer: Renderer) {}
 
@@ -47,7 +47,7 @@ export class MarkerPool {
     marker: Marker,
     receiveTime: bigint | undefined,
   ): RenderableMarker {
-    const renderables = this.renderablesByType.get(type);
+    const renderables = this.#renderablesByType.get(type);
     if (renderables) {
       const renderable = renderables.pop();
       if (renderable) {
@@ -65,20 +65,20 @@ export class MarkerPool {
 
   public release(renderable: RenderableMarker): void {
     const type = renderable.userData.marker.type as MarkerType;
-    const renderables = this.renderablesByType.get(type);
+    const renderables = this.#renderablesByType.get(type);
     if (!renderables) {
-      this.renderablesByType.set(type, [renderable]);
+      this.#renderablesByType.set(type, [renderable]);
     } else {
       renderables.push(renderable);
     }
   }
 
   public dispose(): void {
-    for (const renderables of this.renderablesByType.values()) {
+    for (const renderables of this.#renderablesByType.values()) {
       for (const renderable of renderables) {
         renderable.dispose();
       }
     }
-    this.renderablesByType.clear();
+    this.#renderablesByType.clear();
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
@@ -29,8 +29,8 @@ const tempDirection = new THREE.Vector3();
 export class RenderableArrow extends RenderableMarker {
   public shaftMesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
   public headMesh: THREE.Mesh<THREE.ConeGeometry, THREE.MeshStandardMaterial>;
-  private shaftOutline: THREE.LineSegments;
-  private headOutline: THREE.LineSegments;
+  #shaftOutline: THREE.LineSegments;
+  #headOutline: THREE.LineSegments;
 
   public constructor(
     topic: string,
@@ -69,14 +69,14 @@ export class RenderableArrow extends RenderableMarker {
     this.add(this.headMesh);
 
     // Shaft outline
-    this.shaftOutline = new THREE.LineSegments(shaftEdgesGeometry, renderer.outlineMaterial);
-    this.shaftOutline.userData.picking = false;
-    this.shaftMesh.add(this.shaftOutline);
+    this.#shaftOutline = new THREE.LineSegments(shaftEdgesGeometry, renderer.outlineMaterial);
+    this.#shaftOutline.userData.picking = false;
+    this.shaftMesh.add(this.#shaftOutline);
 
     // Head outline
-    this.headOutline = new THREE.LineSegments(headEdgesGeometry, renderer.outlineMaterial);
-    this.headOutline.userData.picking = false;
-    this.headMesh.add(this.headOutline);
+    this.#headOutline = new THREE.LineSegments(headEdgesGeometry, renderer.outlineMaterial);
+    this.#headOutline.userData.picking = false;
+    this.headMesh.add(this.#headOutline);
 
     this.update(marker, receiveTime);
   }
@@ -108,8 +108,8 @@ export class RenderableArrow extends RenderableMarker {
 
     const settings = this.getSettings();
 
-    this.shaftOutline.visible = settings?.showOutlines ?? true;
-    this.headOutline.visible = settings?.showOutlines ?? true;
+    this.#shaftOutline.visible = settings?.showOutlines ?? true;
+    this.#headOutline.visible = settings?.showOutlines ?? true;
 
     // Adapted from <https://github.com/ros-visualization/rviz/blob/noetic-devel/src/rviz/default_plugin/markers/arrow_marker.cpp
     if (marker.points.length === 2) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -11,8 +11,8 @@ import { rgbToThreeColor } from "../../color";
 import { Marker } from "../../ros";
 
 export class RenderableCube extends RenderableMarker {
-  private mesh: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
-  private outline: THREE.LineSegments;
+  #mesh: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
+  #outline: THREE.LineSegments;
 
   public constructor(
     topic: string,
@@ -31,21 +31,21 @@ export class RenderableCube extends RenderableMarker {
       `${this.constructor.name}-cube-edges`,
       () => createEdgesGeometry(cubeGeometry),
     );
-    this.mesh = new THREE.Mesh(cubeGeometry, makeStandardMaterial(marker.color));
-    this.mesh.castShadow = true;
-    this.mesh.receiveShadow = true;
-    this.add(this.mesh);
+    this.#mesh = new THREE.Mesh(cubeGeometry, makeStandardMaterial(marker.color));
+    this.#mesh.castShadow = true;
+    this.#mesh.receiveShadow = true;
+    this.add(this.#mesh);
 
     // Cube outline
-    this.outline = new THREE.LineSegments(cubeEdgesGeometry, renderer.outlineMaterial);
-    this.outline.userData.picking = false;
-    this.mesh.add(this.outline);
+    this.#outline = new THREE.LineSegments(cubeEdgesGeometry, renderer.outlineMaterial);
+    this.#outline.userData.picking = false;
+    this.#mesh.add(this.#outline);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    this.#mesh.material.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -53,16 +53,16 @@ export class RenderableCube extends RenderableMarker {
     const marker = this.userData.marker;
 
     const transparent = marker.color.a < 1;
-    if (transparent !== this.mesh.material.transparent) {
-      this.mesh.material.transparent = transparent;
-      this.mesh.material.depthWrite = !transparent;
-      this.mesh.material.needsUpdate = true;
+    if (transparent !== this.#mesh.material.transparent) {
+      this.#mesh.material.transparent = transparent;
+      this.#mesh.material.depthWrite = !transparent;
+      this.#mesh.material.needsUpdate = true;
     }
 
-    this.outline.visible = this.getSettings()?.showOutlines ?? true;
+    this.#outline.visible = this.getSettings()?.showOutlines ?? true;
 
-    rgbToThreeColor(this.mesh.material.color, marker.color);
-    this.mesh.material.opacity = marker.color.a;
+    rgbToThreeColor(this.#mesh.material.color, marker.color);
+    this.#mesh.material.opacity = marker.color.a;
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
@@ -12,7 +12,7 @@ import type { Renderer } from "../../Renderer";
 import { Marker } from "../../ros";
 
 export class RenderableCubeList extends RenderableMarker {
-  private mesh: DynamicInstancedMesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
+  #mesh: DynamicInstancedMesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
   // outline: THREE.LineSegments | undefined;
 
   public constructor(
@@ -26,16 +26,16 @@ export class RenderableCubeList extends RenderableMarker {
     // Cube instanced mesh
     const material = makeStandardInstancedMaterial(marker);
     const geometry = renderer.sharedGeometry.getGeometry("RenderableCube", createCubeGeometry);
-    this.mesh = new DynamicInstancedMesh(geometry, material, marker.points.length);
-    this.mesh.castShadow = true;
-    this.mesh.receiveShadow = true;
-    this.add(this.mesh);
+    this.#mesh = new DynamicInstancedMesh(geometry, material, marker.points.length);
+    this.#mesh.castShadow = true;
+    this.#mesh.receiveShadow = true;
+    this.add(this.#mesh);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    this.#mesh.material.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -45,11 +45,11 @@ export class RenderableCubeList extends RenderableMarker {
 
     const transparent = markerHasTransparency(marker);
     if (transparent !== markerHasTransparency(prevMarker)) {
-      this.mesh.material.transparent = transparent;
-      this.mesh.material.depthWrite = !transparent;
-      this.mesh.material.needsUpdate = true;
+      this.#mesh.material.transparent = transparent;
+      this.#mesh.material.depthWrite = !transparent;
+      this.#mesh.material.needsUpdate = true;
     }
 
-    this.mesh.set(marker.points, marker.scale, marker.colors, marker.color);
+    this.#mesh.set(marker.points, marker.scale, marker.colors, marker.color);
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -12,8 +12,8 @@ import { cylinderSubdivisions, DetailLevel } from "../../lod";
 import { Marker } from "../../ros";
 
 export class RenderableCylinder extends RenderableMarker {
-  private mesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
-  private outline: THREE.LineSegments;
+  #mesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
+  #outline: THREE.LineSegments;
 
   public constructor(
     topic: string,
@@ -29,25 +29,25 @@ export class RenderableCylinder extends RenderableMarker {
       `${this.constructor.name}-cylinder-${renderer.maxLod}`,
       () => createGeometry(renderer.maxLod),
     );
-    this.mesh = new THREE.Mesh(cylinderGeometry, material);
-    this.mesh.castShadow = true;
-    this.mesh.receiveShadow = true;
-    this.add(this.mesh);
+    this.#mesh = new THREE.Mesh(cylinderGeometry, material);
+    this.#mesh.castShadow = true;
+    this.#mesh.receiveShadow = true;
+    this.add(this.#mesh);
 
     // Cylinder outline
     const edgesGeometry = renderer.sharedGeometry.getGeometry(
       `${this.constructor.name}-edges-${renderer.maxLod}`,
       () => createEdgesGeometry(cylinderGeometry),
     );
-    this.outline = new THREE.LineSegments(edgesGeometry, renderer.outlineMaterial);
-    this.outline.userData.picking = false;
-    this.mesh.add(this.outline);
+    this.#outline = new THREE.LineSegments(edgesGeometry, renderer.outlineMaterial);
+    this.#outline.userData.picking = false;
+    this.#mesh.add(this.#outline);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    this.#mesh.material.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -55,16 +55,16 @@ export class RenderableCylinder extends RenderableMarker {
     const marker = this.userData.marker;
 
     const transparent = marker.color.a < 1;
-    if (transparent !== this.mesh.material.transparent) {
-      this.mesh.material.transparent = transparent;
-      this.mesh.material.depthWrite = !transparent;
-      this.mesh.material.needsUpdate = true;
+    if (transparent !== this.#mesh.material.transparent) {
+      this.#mesh.material.transparent = transparent;
+      this.#mesh.material.depthWrite = !transparent;
+      this.#mesh.material.needsUpdate = true;
     }
 
-    this.outline.visible = this.getSettings()?.showOutlines ?? true;
+    this.#outline.visible = this.getSettings()?.showOutlines ?? true;
 
-    rgbToThreeColor(this.mesh.material.color, marker.color);
-    this.mesh.material.opacity = marker.color.a;
+    rgbToThreeColor(this.#mesh.material.color, marker.color);
+    this.#mesh.material.opacity = marker.color.a;
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
@@ -18,9 +18,9 @@ import { LineMaterial } from "../../LineMaterial";
 import { Marker } from "../../ros";
 
 export class RenderableLineList extends RenderableMarker {
-  private geometry: LineSegmentsGeometry;
-  private linePrepass: LineSegments2;
-  private line: LineSegments2;
+  #geometry: LineSegmentsGeometry;
+  #linePrepass: LineSegments2;
+  #line: LineSegments2;
 
   public constructor(
     topic: string,
@@ -31,7 +31,7 @@ export class RenderableLineList extends RenderableMarker {
   ) {
     super(topic, marker, receiveTime, renderer);
 
-    this.geometry = new LineSegmentsGeometry();
+    this.#geometry = new LineSegmentsGeometry();
 
     const { worldUnits = true } = options;
     const lineOptions = { resolution: this.renderer.input.canvasSize, worldUnits };
@@ -44,30 +44,30 @@ export class RenderableLineList extends RenderableMarker {
 
     // Depth pass 1
     const matLinePrepass = makeLinePrepassMaterial(marker, lineOptions);
-    this.linePrepass = new LineSegments2(this.geometry, matLinePrepass);
-    this.linePrepass.renderOrder = 1;
-    this.linePrepass.userData.picking = false;
-    this.add(this.linePrepass);
+    this.#linePrepass = new LineSegments2(this.#geometry, matLinePrepass);
+    this.#linePrepass.renderOrder = 1;
+    this.#linePrepass.userData.picking = false;
+    this.add(this.#linePrepass);
 
     // Color pass 2
     const matLine = makeLineMaterial(marker, lineOptions);
-    this.line = new LineSegments2(this.geometry, matLine);
-    this.line.renderOrder = 2;
+    this.#line = new LineSegments2(this.#geometry, matLine);
+    this.#line.renderOrder = 2;
     const pickingLineWidth = marker.scale.x * 1.2;
-    this.line.userData.pickingMaterial = makeLinePickingMaterial(pickingLineWidth, lineOptions);
-    this.add(this.line);
+    this.#line.userData.pickingMaterial = makeLinePickingMaterial(pickingLineWidth, lineOptions);
+    this.add(this.#line);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.linePrepass.material.dispose();
-    this.line.material.dispose();
+    this.#linePrepass.material.dispose();
+    this.#line.material.dispose();
 
-    const pickingMaterial = this.line.userData.pickingMaterial as THREE.ShaderMaterial;
+    const pickingMaterial = this.#line.userData.pickingMaterial as THREE.ShaderMaterial;
     pickingMaterial.dispose();
 
-    this.geometry.dispose();
+    this.#geometry.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -84,36 +84,36 @@ export class RenderableLineList extends RenderableMarker {
     const transparent = markerHasTransparency(marker);
 
     if (transparent !== markerHasTransparency(prevMarker)) {
-      this.linePrepass.material.transparent = transparent;
-      this.linePrepass.material.depthWrite = !transparent;
-      this.linePrepass.material.needsUpdate = true;
-      this.line.material.transparent = transparent;
-      this.line.material.depthWrite = !transparent;
-      this.line.material.needsUpdate = true;
+      this.#linePrepass.material.transparent = transparent;
+      this.#linePrepass.material.depthWrite = !transparent;
+      this.#linePrepass.material.needsUpdate = true;
+      this.#line.material.transparent = transparent;
+      this.#line.material.depthWrite = !transparent;
+      this.#line.material.needsUpdate = true;
     }
 
-    const matLinePrepass = this.linePrepass.material as LineMaterial;
+    const matLinePrepass = this.#linePrepass.material as LineMaterial;
     matLinePrepass.lineWidth = lineWidth;
-    const matLine = this.line.material as LineMaterial;
+    const matLine = this.#line.material as LineMaterial;
     matLine.lineWidth = lineWidth;
 
-    const prevPointsLength = (this.geometry.attributes.instanceStart?.count ?? 0) * 2;
+    const prevPointsLength = (this.#geometry.attributes.instanceStart?.count ?? 0) * 2;
     if (pointsLength !== prevPointsLength) {
-      this.geometry.dispose();
-      this.geometry = new LineSegmentsGeometry();
-      this.linePrepass.geometry = this.geometry;
-      this.line.geometry = this.geometry;
+      this.#geometry.dispose();
+      this.#geometry = new LineSegmentsGeometry();
+      this.#linePrepass.#geometry = this.#geometry;
+      this.#line.#geometry = this.#geometry;
     }
 
-    this._setPositions(marker, pointsLength);
-    this._setColors(marker, pointsLength);
+    this.#setPositions(marker, pointsLength);
+    this.#setColors(marker, pointsLength);
 
     // These both update the same `LineSegmentsGeometry` reference, so no need to call both
     // this.linePrepass.computeLineDistances();
-    this.line.computeLineDistances();
+    this.#line.computeLineDistances();
   }
 
-  private _setPositions(marker: Marker, pointsLength: number): void {
+  #setPositions(marker: Marker, pointsLength: number): void {
     const linePositions = new Float32Array(3 * pointsLength);
     for (let i = 0; i < pointsLength; i++) {
       const point = marker.points[i]!;
@@ -123,10 +123,10 @@ export class RenderableLineList extends RenderableMarker {
       linePositions[offset + 2] = point.z;
     }
 
-    this.geometry.setPositions(linePositions);
+    this.#geometry.setPositions(linePositions);
   }
 
-  private _setColors(marker: Marker, pointsLength: number): void {
+  #setColors(marker: Marker, pointsLength: number): void {
     // Converts color-per-point to a flattened typed array
     const rgbaData = new Float32Array(4 * pointsLength);
     this._markerColorsToLinear(marker, pointsLength, (color, i) => {
@@ -139,11 +139,11 @@ export class RenderableLineList extends RenderableMarker {
 
     // [rgba, rgba]
     const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(rgbaData, 8, 1);
-    this.geometry.setAttribute(
+    this.#geometry.setAttribute(
       "instanceColorStart",
       new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0),
     );
-    this.geometry.setAttribute(
+    this.#geometry.setAttribute(
       "instanceColorEnd",
       new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 4),
     );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
@@ -101,8 +101,8 @@ export class RenderableLineList extends RenderableMarker {
     if (pointsLength !== prevPointsLength) {
       this.#geometry.dispose();
       this.#geometry = new LineSegmentsGeometry();
-      this.#linePrepass.#geometry = this.#geometry;
-      this.#line.#geometry = this.#geometry;
+      this.#linePrepass.geometry = this.#geometry;
+      this.#line.geometry = this.#geometry;
     }
 
     this.#setPositions(marker, pointsLength);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -18,9 +18,9 @@ import { LineMaterial } from "../../LineMaterial";
 import { Marker } from "../../ros";
 
 export class RenderableLineStrip extends RenderableMarker {
-  private geometry: LineGeometry;
-  private linePrepass: Line2;
-  private line: Line2;
+  #geometry: LineGeometry;
+  #linePrepass: Line2;
+  #line: Line2;
 
   public constructor(
     topic: string,
@@ -30,7 +30,7 @@ export class RenderableLineStrip extends RenderableMarker {
   ) {
     super(topic, marker, receiveTime, renderer);
 
-    this.geometry = new LineGeometry();
+    this.#geometry = new LineGeometry();
 
     const options = { resolution: renderer.input.canvasSize, worldUnits: true };
 
@@ -42,29 +42,29 @@ export class RenderableLineStrip extends RenderableMarker {
 
     // Depth pass 1
     const matLinePrepass = makeLinePrepassMaterial(marker, options);
-    this.linePrepass = new Line2(this.geometry, matLinePrepass);
-    this.linePrepass.renderOrder = 1;
-    this.linePrepass.userData.picking = false;
-    this.add(this.linePrepass);
+    this.#linePrepass = new Line2(this.#geometry, matLinePrepass);
+    this.#linePrepass.renderOrder = 1;
+    this.#linePrepass.userData.picking = false;
+    this.add(this.#linePrepass);
 
     // Color pass 2
     const matLine = makeLineMaterial(marker, options);
-    this.line = new Line2(this.geometry, matLine);
-    this.line.renderOrder = 2;
+    this.#line = new Line2(this.#geometry, matLine);
+    this.#line.renderOrder = 2;
     const pickingLineWidth = marker.scale.x * 1.2;
-    this.line.userData.pickingMaterial = makeLinePickingMaterial(pickingLineWidth, options);
-    this.add(this.line);
+    this.#line.userData.pickingMaterial = makeLinePickingMaterial(pickingLineWidth, options);
+    this.add(this.#line);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.linePrepass.material.dispose();
-    this.line.material.dispose();
+    this.#linePrepass.material.dispose();
+    this.#line.material.dispose();
 
-    const pickingMaterial = this.line.userData.pickingMaterial as THREE.ShaderMaterial;
+    const pickingMaterial = this.#line.userData.pickingMaterial as THREE.ShaderMaterial;
     pickingMaterial.dispose();
-    this.line.userData.pickingMaterial = undefined;
+    this.#line.userData.pickingMaterial = undefined;
 
     super.dispose();
   }
@@ -81,44 +81,44 @@ export class RenderableLineStrip extends RenderableMarker {
     if (pointsLength === 0) {
       // THREE.LineGeometry.setPositions crashes when given an empty array:
       // https://github.com/foxglove/studio/issues/3954
-      this.linePrepass.visible = false;
-      this.line.visible = false;
+      this.#linePrepass.visible = false;
+      this.#line.visible = false;
       return;
     } else {
-      this.linePrepass.visible = true;
-      this.line.visible = true;
+      this.#linePrepass.visible = true;
+      this.#line.visible = true;
     }
 
     if (transparent !== markerHasTransparency(prevMarker)) {
-      this.linePrepass.material.transparent = transparent;
-      this.linePrepass.material.depthWrite = !transparent;
-      this.linePrepass.material.needsUpdate = true;
-      this.line.material.transparent = transparent;
-      this.line.material.depthWrite = !transparent;
-      this.line.material.needsUpdate = true;
+      this.#linePrepass.material.transparent = transparent;
+      this.#linePrepass.material.depthWrite = !transparent;
+      this.#linePrepass.material.needsUpdate = true;
+      this.#line.material.transparent = transparent;
+      this.#line.material.depthWrite = !transparent;
+      this.#line.material.needsUpdate = true;
     }
 
-    const matLinePrepass = this.linePrepass.material as LineMaterial;
+    const matLinePrepass = this.#linePrepass.material as LineMaterial;
     matLinePrepass.lineWidth = lineWidth;
-    const matLine = this.line.material as LineMaterial;
+    const matLine = this.#line.material as LineMaterial;
     matLine.lineWidth = lineWidth;
 
-    const prevPointsLength = (this.geometry.attributes.instanceStart?.count ?? 0) * 2;
+    const prevPointsLength = (this.#geometry.attributes.instanceStart?.count ?? 0) * 2;
     if (pointsLength !== prevPointsLength) {
-      this.geometry.dispose();
-      this.geometry = new LineGeometry();
-      this.linePrepass.geometry = this.geometry;
-      this.line.geometry = this.geometry;
+      this.#geometry.dispose();
+      this.#geometry = new LineGeometry();
+      this.#linePrepass.#geometry = this.#geometry;
+      this.#line.#geometry = this.#geometry;
     }
 
-    this._setPositions(marker, pointsLength);
-    this._setColors(marker, pointsLength);
+    this.#setPositions(marker, pointsLength);
+    this.#setColors(marker, pointsLength);
 
-    this.linePrepass.computeLineDistances();
-    this.line.computeLineDistances();
+    this.#linePrepass.computeLineDistances();
+    this.#line.computeLineDistances();
   }
 
-  private _setPositions(marker: Marker, pointsLength: number): void {
+  #setPositions(marker: Marker, pointsLength: number): void {
     const linePositions = new Float32Array(3 * pointsLength);
     for (let i = 0; i < pointsLength; i++) {
       const point = marker.points[i]!;
@@ -128,10 +128,10 @@ export class RenderableLineStrip extends RenderableMarker {
       linePositions[offset + 2] = point.z;
     }
 
-    this.geometry.setPositions(linePositions);
+    this.#geometry.setPositions(linePositions);
   }
 
-  private _setColors(marker: Marker, pointsLength: number): void {
+  #setColors(marker: Marker, pointsLength: number): void {
     // Converts color-per-point to pairs format in a flattened typed array
     const rgbaData = new Float32Array(8 * pointsLength);
     const color1: THREE.Vector4Tuple = [0, 0, 0, 0];
@@ -158,11 +158,11 @@ export class RenderableLineStrip extends RenderableMarker {
 
     // [rgba, rgba]
     const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(rgbaData, 8, 1);
-    this.geometry.setAttribute(
+    this.#geometry.setAttribute(
       "instanceColorStart",
       new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0),
     );
-    this.geometry.setAttribute(
+    this.#geometry.setAttribute(
       "instanceColorEnd",
       new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 4),
     );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -107,8 +107,8 @@ export class RenderableLineStrip extends RenderableMarker {
     if (pointsLength !== prevPointsLength) {
       this.#geometry.dispose();
       this.#geometry = new LineGeometry();
-      this.#linePrepass.#geometry = this.#geometry;
-      this.#line.#geometry = this.#geometry;
+      this.#linePrepass.geometry = this.#geometry;
+      this.#line.geometry = this.#geometry;
     }
 
     this.#setPositions(marker, pointsLength);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
@@ -78,7 +78,7 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
     this.userData.messageTime = toNanoSec(marker.header.stamp);
     this.userData.frameId = this.renderer.normalizeFrameId(marker.header.frame_id);
     this.userData.pose = marker.pose;
-    this.userData.marker = this._renderMarker(marker);
+    this.userData.marker = this.#renderMarker(marker);
     this.userData.originalMarker = marker;
     this.userData.expiresIn = hasLifetime ? toNanoSec(marker.lifetime) : undefined;
   }
@@ -112,7 +112,7 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
     }
   }
 
-  private _renderMarker(marker: Marker): Marker {
+  #renderMarker(marker: Marker): Marker {
     const topicName = this.userData.topic;
     const settings = this.renderer.config.topics[topicName] as
       | Partial<LayerSettingsMarker>

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
@@ -11,8 +11,8 @@ import type { IRenderer } from "../../IRenderer";
 import { Marker } from "../../ros";
 
 export class RenderablePoints extends RenderableMarker {
-  private geometry: DynamicBufferGeometry;
-  private points: THREE.Points<DynamicBufferGeometry, THREE.PointsMaterial>;
+  #geometry: DynamicBufferGeometry;
+  #points: THREE.Points<DynamicBufferGeometry, THREE.PointsMaterial>;
 
   public constructor(
     topic: string,
@@ -22,18 +22,18 @@ export class RenderablePoints extends RenderableMarker {
   ) {
     super(topic, marker, receiveTime, renderer);
 
-    this.geometry = new DynamicBufferGeometry();
-    this.geometry.createAttribute("position", Float32Array, 3);
-    this.geometry.createAttribute("color", Uint8Array, 4, true);
+    this.#geometry = new DynamicBufferGeometry();
+    this.#geometry.createAttribute("position", Float32Array, 3);
+    this.#geometry.createAttribute("color", Uint8Array, 4, true);
 
-    this.points = new THREE.Points(this.geometry, makePointsMaterial(marker));
-    this.add(this.points);
+    this.#points = new THREE.Points(this.#geometry, makePointsMaterial(marker));
+    this.add(this.#points);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.points.material.dispose();
+    this.#points.material.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -43,21 +43,21 @@ export class RenderablePoints extends RenderableMarker {
 
     const transparent = markerHasTransparency(marker);
     if (transparent !== markerHasTransparency(prevMarker)) {
-      this.points.material.transparent = transparent;
-      this.points.material.depthWrite = !transparent;
-      this.points.material.needsUpdate = true;
+      this.#points.material.transparent = transparent;
+      this.#points.material.depthWrite = !transparent;
+      this.#points.material.needsUpdate = true;
     }
 
-    this.points.material.size = marker.scale.x;
+    this.#points.material.size = marker.scale.x;
 
     const pointsLength = marker.points.length;
-    this.geometry.resize(pointsLength);
-    this._setPositions(marker, pointsLength);
-    this._setColors(marker, pointsLength);
+    this.#geometry.resize(pointsLength);
+    this.#setPositions(marker, pointsLength);
+    this.#setColors(marker, pointsLength);
   }
 
-  private _setPositions(marker: Marker, pointsLength: number): void {
-    const attribute = this.geometry.getAttribute("position") as THREE.BufferAttribute;
+  #setPositions(marker: Marker, pointsLength: number): void {
+    const attribute = this.#geometry.getAttribute("position") as THREE.BufferAttribute;
     const positions = attribute.array as Float32Array;
     for (let i = 0; i < pointsLength; i++) {
       const point = marker.points[i]!;
@@ -68,9 +68,9 @@ export class RenderablePoints extends RenderableMarker {
     attribute.needsUpdate = true;
   }
 
-  private _setColors(marker: Marker, pointsLength: number): void {
+  #setColors(marker: Marker, pointsLength: number): void {
     // Converts color-per-point to a flattened typed array
-    const attribute = this.geometry.getAttribute("color") as THREE.BufferAttribute;
+    const attribute = this.#geometry.getAttribute("color") as THREE.BufferAttribute;
     const rgbaData = attribute.array as Uint8Array;
     this._markerColorsToLinear(marker, pointsLength, (color, i) => {
       rgbaData[4 * i + 0] = (color[0] * 255) | 0;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
@@ -12,7 +12,7 @@ import type { Renderer } from "../../Renderer";
 import { Marker } from "../../ros";
 
 export class RenderableSphereList extends RenderableMarker {
-  private mesh: DynamicInstancedMesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
+  #mesh: DynamicInstancedMesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
 
   public constructor(
     topic: string,
@@ -28,16 +28,16 @@ export class RenderableSphereList extends RenderableMarker {
       () => createSphereGeometry(renderer.maxLod),
     );
     const material = makeStandardInstancedMaterial(marker);
-    this.mesh = new DynamicInstancedMesh(geometry, material, marker.points.length);
-    this.mesh.castShadow = true;
-    this.mesh.receiveShadow = true;
-    this.add(this.mesh);
+    this.#mesh = new DynamicInstancedMesh(geometry, material, marker.points.length);
+    this.#mesh.castShadow = true;
+    this.#mesh.receiveShadow = true;
+    this.add(this.#mesh);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    this.#mesh.material.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -47,11 +47,11 @@ export class RenderableSphereList extends RenderableMarker {
 
     const transparent = markerHasTransparency(marker);
     if (transparent !== markerHasTransparency(prevMarker)) {
-      this.mesh.material.transparent = transparent;
-      this.mesh.material.depthWrite = !transparent;
-      this.mesh.material.needsUpdate = true;
+      this.#mesh.material.transparent = transparent;
+      this.#mesh.material.depthWrite = !transparent;
+      this.#mesh.material.needsUpdate = true;
     }
 
-    this.mesh.set(marker.points, marker.scale, marker.colors, marker.color);
+    this.#mesh.set(marker.points, marker.scale, marker.colors, marker.color);
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
@@ -10,7 +10,7 @@ import { getLuminance, SRGBToLinear } from "../../color";
 import { Marker } from "../../ros";
 
 export class RenderableTextViewFacing extends RenderableMarker {
-  private label: Label;
+  #label: Label;
 
   public constructor(
     topic: string,
@@ -20,23 +20,23 @@ export class RenderableTextViewFacing extends RenderableMarker {
   ) {
     super(topic, marker, receiveTime, renderer);
 
-    this.label = renderer.labelPool.acquire();
-    this.label.setBillboard(true);
+    this.#label = renderer.labelPool.acquire();
+    this.#label.setBillboard(true);
 
-    this.add(this.label);
+    this.add(this.#label);
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.renderer.labelPool.release(this.label);
+    this.renderer.labelPool.release(this.#label);
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
     super.update(newMarker, receiveTime);
     const marker = this.userData.marker;
 
-    this.label.setText(marker.text);
-    this.label.setColor(
+    this.#label.setText(marker.text);
+    this.#label.setColor(
       SRGBToLinear(marker.color.r),
       SRGBToLinear(marker.color.g),
       SRGBToLinear(marker.color.b),
@@ -44,12 +44,12 @@ export class RenderableTextViewFacing extends RenderableMarker {
 
     const foregroundIsDark = getLuminance(marker.color.r, marker.color.g, marker.color.b) < 0.5;
     if (foregroundIsDark) {
-      this.label.setBackgroundColor(1, 1, 1);
+      this.#label.setBackgroundColor(1, 1, 1);
     } else {
-      this.label.setBackgroundColor(0, 0, 0);
+      this.#label.setBackgroundColor(0, 0, 0);
     }
-    this.label.setOpacity(marker.color.a);
-    this.label.setLineHeight(marker.scale.z);
-    this.label.userData.pose = marker.pose;
+    this.#label.setOpacity(marker.color.a);
+    this.#label.setLineHeight(marker.scale.z);
+    this.#label.userData.pose = marker.pose;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
@@ -34,7 +34,10 @@ export class RenderableTriangleList extends RenderableMarker {
     this.#vertices = new Float32Array(marker.points.length * 3);
     this.#colors = new Float32Array(marker.colors.length * 4);
 
-    this.#mesh = new THREE.Mesh(new THREE.BufferGeometry(), makeStandardVertexColorMaterial(marker));
+    this.#mesh = new THREE.Mesh(
+      new THREE.BufferGeometry(),
+      makeStandardVertexColorMaterial(marker),
+    );
     this.#mesh.castShadow = true;
     this.#mesh.receiveShadow = true;
     this.add(this.#mesh);
@@ -101,7 +104,8 @@ export class RenderableTriangleList extends RenderableMarker {
       this.#colors = new Float32Array(vertexCount * 4);
       dataChanged = true;
     }
-    const { vertices, colors } = this;
+    const vertices = this.#vertices;
+    const colors = this.#colors;
 
     // Update position/color buffers with the new marker data
     for (let i = 0; i < vertexCount; i++) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
@@ -19,9 +19,9 @@ const EMPTY_FLOAT32 = new Float32Array();
 const tempColor = { r: 0, g: 0, b: 0, a: 0 };
 
 export class RenderableTriangleList extends RenderableMarker {
-  private mesh: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
-  private vertices: Float32Array;
-  private colors: Float32Array;
+  #mesh: THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+  #vertices: Float32Array;
+  #colors: Float32Array;
 
   public constructor(
     topic: string,
@@ -31,22 +31,22 @@ export class RenderableTriangleList extends RenderableMarker {
   ) {
     super(topic, marker, receiveTime, renderer);
 
-    this.vertices = new Float32Array(marker.points.length * 3);
-    this.colors = new Float32Array(marker.colors.length * 4);
+    this.#vertices = new Float32Array(marker.points.length * 3);
+    this.#colors = new Float32Array(marker.colors.length * 4);
 
-    this.mesh = new THREE.Mesh(new THREE.BufferGeometry(), makeStandardVertexColorMaterial(marker));
-    this.mesh.castShadow = true;
-    this.mesh.receiveShadow = true;
-    this.add(this.mesh);
+    this.#mesh = new THREE.Mesh(new THREE.BufferGeometry(), makeStandardVertexColorMaterial(marker));
+    this.#mesh.castShadow = true;
+    this.#mesh.receiveShadow = true;
+    this.add(this.#mesh);
 
     this.update(marker, receiveTime);
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
-    this.mesh.geometry.dispose();
-    this.vertices = new Float32Array();
-    this.colors = new Float32Array();
+    this.#mesh.material.dispose();
+    this.#mesh.geometry.dispose();
+    this.#vertices = new Float32Array();
+    this.#colors = new Float32Array();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {
@@ -61,7 +61,7 @@ export class RenderableTriangleList extends RenderableMarker {
         EMPTY_ERR,
         `TRIANGLE_LIST: points is empty`,
       );
-      this.mesh.geometry.setAttribute("position", new THREE.BufferAttribute(EMPTY_FLOAT32, 3));
+      this.#mesh.geometry.setAttribute("position", new THREE.BufferAttribute(EMPTY_FLOAT32, 3));
       return;
     }
     if (vertexCount % 3 !== 0) {
@@ -85,20 +85,20 @@ export class RenderableTriangleList extends RenderableMarker {
 
     const transparent = markerHasTransparency(marker);
     if (transparent !== markerHasTransparency(prevMarker)) {
-      this.mesh.material.transparent = transparent;
-      this.mesh.material.depthWrite = !transparent;
-      this.mesh.material.needsUpdate = true;
+      this.#mesh.material.transparent = transparent;
+      this.#mesh.material.depthWrite = !transparent;
+      this.#mesh.material.needsUpdate = true;
     }
 
     let dataChanged = false;
 
     const count = vertexCount * 3;
-    if (count !== this.vertices.length) {
-      this.vertices = new Float32Array(count);
+    if (count !== this.#vertices.length) {
+      this.#vertices = new Float32Array(count);
       dataChanged = true;
     }
-    if (vertexCount * 4 !== this.colors.length) {
-      this.colors = new Float32Array(vertexCount * 4);
+    if (vertexCount * 4 !== this.#colors.length) {
+      this.#colors = new Float32Array(vertexCount * 4);
       dataChanged = true;
     }
     const { vertices, colors } = this;
@@ -137,7 +137,7 @@ export class RenderableTriangleList extends RenderableMarker {
     }
 
     if (dataChanged) {
-      const geometry = this.mesh.geometry;
+      const geometry = this.#mesh.geometry;
       geometry.setAttribute("position", new THREE.BufferAttribute(vertices, 3));
       geometry.setAttribute("color", new THREE.BufferAttribute(colors, 4));
       // Explicitly tell three.js to send position and color buffers to the GPU

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/PrimitivePool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/PrimitivePool.ts
@@ -29,16 +29,16 @@ const CONSTRUCTORS = {
  * An object pool for RenderablePrimitive subclass objects.
  */
 export class PrimitivePool {
-  private primitivesByType = new Map<PrimitiveType, RenderablePrimitive[]>();
-  private disposed = false;
+  #primitivesByType = new Map<PrimitiveType, RenderablePrimitive[]>();
+  #disposed = false;
 
   public constructor(private renderer: IRenderer) {}
 
   public acquire<T extends PrimitiveType>(type: T): InstanceType<(typeof CONSTRUCTORS)[T]> {
-    if (this.disposed) {
+    if (this.#disposed) {
       throw new Error(`Attempt to acquire PrimitiveType.${type} after PrimitivePool was disposed`);
     }
-    const primitive = this.primitivesByType.get(type)?.pop();
+    const primitive = this.#primitivesByType.get(type)?.pop();
     if (primitive) {
       primitive.prepareForReuse();
       return primitive as InstanceType<(typeof CONSTRUCTORS)[T]>;
@@ -51,30 +51,30 @@ export class PrimitivePool {
     type: T,
     primitive: InstanceType<(typeof CONSTRUCTORS)[T]>,
   ): void {
-    if (this.disposed) {
+    if (this.#disposed) {
       primitive.dispose();
       return;
     }
-    const primitives = this.primitivesByType.get(type);
+    const primitives = this.#primitivesByType.get(type);
     if (!primitives) {
-      this.primitivesByType.set(type, [primitive]);
+      this.#primitivesByType.set(type, [primitive]);
     } else {
       primitives.push(primitive);
     }
   }
 
   public dispose(): void {
-    for (const primitives of this.primitivesByType.values()) {
+    for (const primitives of this.#primitivesByType.values()) {
       for (const primitive of primitives) {
         primitive.dispose();
       }
     }
-    this.primitivesByType.clear();
-    this.disposed = true;
+    this.#primitivesByType.clear();
+    this.#disposed = true;
   }
 
   public setColorScheme(colorScheme: "dark" | "light"): void {
-    for (const primitives of this.primitivesByType.values()) {
+    for (const primitives of this.#primitivesByType.values()) {
       for (const primitive of primitives) {
         primitive.setColorScheme(colorScheme);
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -28,14 +28,8 @@ export class RenderableArrows extends RenderablePrimitive {
   #shaftOutlineGeometry: THREE.InstancedBufferGeometry;
   #headOutlineGeometry: THREE.InstancedBufferGeometry;
 
-  #shaftMesh: THREE.InstancedMesh<
-    THREE.CylinderGeometry,
-    MeshStandardMaterialWithInstanceOpacity
-  >;
-  #headMesh: THREE.InstancedMesh<
-    THREE.ConeGeometry,
-    MeshStandardMaterialWithInstanceOpacity
-  >;
+  #shaftMesh: THREE.InstancedMesh<THREE.CylinderGeometry, MeshStandardMaterialWithInstanceOpacity>;
+  #headMesh: THREE.InstancedMesh<THREE.ConeGeometry, MeshStandardMaterialWithInstanceOpacity>;
   #instanceOpacity: THREE.InstancedBufferAttribute;
   #material = new MeshStandardMaterialWithInstanceOpacity({
     metalness: 0,
@@ -65,7 +59,11 @@ export class RenderableArrows extends RenderablePrimitive {
       .getGeometry(`${this.constructor.name}-shaft`, createShaftGeometry)
       .clone() as THREE.CylinderGeometry;
     this.#shaftGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
-    this.#shaftMesh = new THREE.InstancedMesh(this.#shaftGeometry, this.#material, this.#maxInstances);
+    this.#shaftMesh = new THREE.InstancedMesh(
+      this.#shaftGeometry,
+      this.#material,
+      this.#maxInstances,
+    );
     this.#shaftMesh.count = 0;
     this.add(this.#shaftMesh);
 
@@ -73,7 +71,11 @@ export class RenderableArrows extends RenderablePrimitive {
       .getGeometry(`${this.constructor.name}-head`, createHeadGeometry)
       .clone() as THREE.ConeGeometry;
     this.#headGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
-    this.#headMesh = new THREE.InstancedMesh(this.#headGeometry, this.#material, this.#maxInstances);
+    this.#headMesh = new THREE.InstancedMesh(
+      this.#headGeometry,
+      this.#material,
+      this.#maxInstances,
+    );
     this.#headMesh.count = 0;
     this.add(this.#headMesh);
 
@@ -128,7 +130,11 @@ export class RenderableArrows extends RenderablePrimitive {
 
       this.#headMesh.removeFromParent();
       this.#headMesh.dispose();
-      this.#headMesh = new THREE.InstancedMesh(this.#headGeometry, this.#material, this.#maxInstances);
+      this.#headMesh = new THREE.InstancedMesh(
+        this.#headGeometry,
+        this.#material,
+        this.#maxInstances,
+      );
       this.#headGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
       this.add(this.#headMesh);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -23,21 +23,21 @@ const tempRgba = makeRgba();
 export class RenderableArrows extends RenderablePrimitive {
   // Each needs its own geometries because we attach additional custom attributes to them.
   // so we will need to clone or copy when assigning from shared geometry
-  private shaftGeometry: THREE.CylinderGeometry;
-  private headGeometry: THREE.ConeGeometry;
-  private shaftOutlineGeometry: THREE.InstancedBufferGeometry;
-  private headOutlineGeometry: THREE.InstancedBufferGeometry;
+  #shaftGeometry: THREE.CylinderGeometry;
+  #headGeometry: THREE.ConeGeometry;
+  #shaftOutlineGeometry: THREE.InstancedBufferGeometry;
+  #headOutlineGeometry: THREE.InstancedBufferGeometry;
 
-  private shaftMesh: THREE.InstancedMesh<
+  #shaftMesh: THREE.InstancedMesh<
     THREE.CylinderGeometry,
     MeshStandardMaterialWithInstanceOpacity
   >;
-  private headMesh: THREE.InstancedMesh<
+  #headMesh: THREE.InstancedMesh<
     THREE.ConeGeometry,
     MeshStandardMaterialWithInstanceOpacity
   >;
-  private instanceOpacity: THREE.InstancedBufferAttribute;
-  private material = new MeshStandardMaterialWithInstanceOpacity({
+  #instanceOpacity: THREE.InstancedBufferAttribute;
+  #material = new MeshStandardMaterialWithInstanceOpacity({
     metalness: 0,
     roughness: 1,
     dithering: true,
@@ -47,58 +47,58 @@ export class RenderableArrows extends RenderablePrimitive {
    * The initial count passed to `mesh`'s constructor, i.e. the maximum number of instances it can
    * render before we need to create a new mesh object
    */
-  private maxInstances: number;
+  #maxInstances: number;
 
-  private shaftOutline: THREE.LineSegments;
+  #shaftOutline: THREE.LineSegments;
   private headOutline: THREE.LineSegments;
 
   public constructor(renderer: IRenderer) {
     super("", renderer, undefined);
 
-    this.maxInstances = 16;
-    this.instanceOpacity = new THREE.InstancedBufferAttribute(
-      new Float32Array(this.maxInstances),
+    this.#maxInstances = 16;
+    this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.#maxInstances),
       1,
     );
 
-    this.shaftGeometry = renderer.sharedGeometry
+    this.#shaftGeometry = renderer.sharedGeometry
       .getGeometry(`${this.constructor.name}-shaft`, createShaftGeometry)
       .clone() as THREE.CylinderGeometry;
-    this.shaftGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
-    this.shaftMesh = new THREE.InstancedMesh(this.shaftGeometry, this.material, this.maxInstances);
-    this.shaftMesh.count = 0;
-    this.add(this.shaftMesh);
+    this.#shaftGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+    this.#shaftMesh = new THREE.InstancedMesh(this.#shaftGeometry, this.#material, this.#maxInstances);
+    this.#shaftMesh.count = 0;
+    this.add(this.#shaftMesh);
 
-    this.headGeometry = renderer.sharedGeometry
+    this.#headGeometry = renderer.sharedGeometry
       .getGeometry(`${this.constructor.name}-head`, createHeadGeometry)
       .clone() as THREE.ConeGeometry;
-    this.headGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
-    this.headMesh = new THREE.InstancedMesh(this.headGeometry, this.material, this.maxInstances);
-    this.headMesh.count = 0;
-    this.add(this.headMesh);
+    this.#headGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+    this.#headMesh = new THREE.InstancedMesh(this.#headGeometry, this.#material, this.#maxInstances);
+    this.#headMesh.count = 0;
+    this.add(this.#headMesh);
 
     const shaftEdgesGeometry = renderer.sharedGeometry.getGeometry(
       `${this.constructor.name}-shaftedges`,
-      () => createShaftEdgesGeometry(this.shaftGeometry),
+      () => createShaftEdgesGeometry(this.#shaftGeometry),
     );
-    this.shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(shaftEdgesGeometry);
-    this.shaftOutlineGeometry.setAttribute("instanceMatrix", this.shaftMesh.instanceMatrix);
-    this.shaftOutline = new THREE.LineSegments(
-      this.shaftOutlineGeometry,
+    this.#shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(shaftEdgesGeometry);
+    this.#shaftOutlineGeometry.setAttribute("instanceMatrix", this.#shaftMesh.instanceMatrix);
+    this.#shaftOutline = new THREE.LineSegments(
+      this.#shaftOutlineGeometry,
       renderer.instancedOutlineMaterial,
     );
-    this.shaftOutline.frustumCulled = false;
-    this.shaftOutline.userData.picking = false;
-    this.add(this.shaftOutline);
+    this.#shaftOutline.frustumCulled = false;
+    this.#shaftOutline.userData.picking = false;
+    this.add(this.#shaftOutline);
 
     const headEdgesGeometry = renderer.sharedGeometry.getGeometry(
       `${this.constructor.name}-headedges`,
-      () => createHeadEdgesGeometry(this.headGeometry),
+      () => createHeadEdgesGeometry(this.#headGeometry),
     );
-    this.headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
-    this.headOutlineGeometry.setAttribute("instanceMatrix", this.headMesh.instanceMatrix);
+    this.#headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
+    this.#headOutlineGeometry.setAttribute("instanceMatrix", this.#headMesh.instanceMatrix);
     this.headOutline = new THREE.LineSegments(
-      this.headOutlineGeometry,
+      this.#headOutlineGeometry,
       renderer.instancedOutlineMaterial,
     );
     this.headOutline.frustumCulled = false;
@@ -107,57 +107,57 @@ export class RenderableArrows extends RenderablePrimitive {
   }
 
   private _ensureCapacity(numArrows: number) {
-    if (numArrows > this.maxInstances) {
+    if (numArrows > this.#maxInstances) {
       const newCapacity = Math.ceil(numArrows * 1.5) + 16;
-      this.maxInstances = newCapacity;
+      this.#maxInstances = newCapacity;
 
-      this.instanceOpacity = new THREE.InstancedBufferAttribute(
-        new Float32Array(this.maxInstances),
+      this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.#maxInstances),
         1,
       );
 
-      this.shaftMesh.removeFromParent();
-      this.shaftMesh.dispose();
-      this.shaftMesh = new THREE.InstancedMesh(
-        this.shaftGeometry,
-        this.material,
-        this.maxInstances,
+      this.#shaftMesh.removeFromParent();
+      this.#shaftMesh.dispose();
+      this.#shaftMesh = new THREE.InstancedMesh(
+        this.#shaftGeometry,
+        this.#material,
+        this.#maxInstances,
       );
-      this.shaftGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
-      this.add(this.shaftMesh);
+      this.#shaftGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+      this.add(this.#shaftMesh);
 
-      this.headMesh.removeFromParent();
-      this.headMesh.dispose();
-      this.headMesh = new THREE.InstancedMesh(this.headGeometry, this.material, this.maxInstances);
-      this.headGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
-      this.add(this.headMesh);
+      this.#headMesh.removeFromParent();
+      this.#headMesh.dispose();
+      this.#headMesh = new THREE.InstancedMesh(this.#headGeometry, this.#material, this.#maxInstances);
+      this.#headGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+      this.add(this.#headMesh);
 
       // THREE.js doesn't correctly recompute the new max instance count when dynamically
       // reassigning the attribute of InstancedBufferGeometry, so we just create a new geometry
 
-      this.shaftOutlineGeometry.dispose();
+      this.#shaftOutlineGeometry.dispose();
       const shaftEdgesGeometry = this.renderer.sharedGeometry.getGeometry(
         `${this.constructor.name}-shaftedges`,
-        () => createShaftEdgesGeometry(this.shaftGeometry),
+        () => createShaftEdgesGeometry(this.#shaftGeometry),
       );
-      this.shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(shaftEdgesGeometry);
-      this.shaftOutlineGeometry.instanceCount = newCapacity;
-      this.shaftOutlineGeometry.setAttribute("instanceMatrix", this.shaftMesh.instanceMatrix);
-      this.shaftOutline.geometry = this.shaftOutlineGeometry;
+      this.#shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(shaftEdgesGeometry);
+      this.#shaftOutlineGeometry.instanceCount = newCapacity;
+      this.#shaftOutlineGeometry.setAttribute("instanceMatrix", this.#shaftMesh.instanceMatrix);
+      this.#shaftOutline.geometry = this.#shaftOutlineGeometry;
 
-      this.headOutlineGeometry.dispose();
+      this.#headOutlineGeometry.dispose();
       const headEdgesGeometry = this.renderer.sharedGeometry.getGeometry(
         `${this.constructor.name}-headedges`,
-        () => createHeadEdgesGeometry(this.headGeometry),
+        () => createHeadEdgesGeometry(this.#headGeometry),
       );
-      this.headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
-      this.headOutlineGeometry.instanceCount = newCapacity;
-      this.headOutlineGeometry.setAttribute("instanceMatrix", this.headMesh.instanceMatrix);
-      this.headOutline.geometry = this.headOutlineGeometry;
+      this.#headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
+      this.#headOutlineGeometry.instanceCount = newCapacity;
+      this.#headOutlineGeometry.setAttribute("instanceMatrix", this.#headMesh.instanceMatrix);
+      this.headOutline.geometry = this.#headOutlineGeometry;
     }
   }
 
-  private _updateMesh(arrows: ArrowPrimitive[]) {
+  #updateMesh(arrows: ArrowPrimitive[]) {
     let isTransparent = false;
 
     this._ensureCapacity(arrows.length);
@@ -172,16 +172,16 @@ export class RenderableArrows extends RenderablePrimitive {
       if (color.a < 1) {
         isTransparent = true;
       }
-      this.shaftMesh.setColorAt(i, rgbToThreeColor(tempColor, color));
-      this.headMesh.setColorAt(i, rgbToThreeColor(tempColor, color));
-      this.instanceOpacity.setX(i, color.a);
+      this.#shaftMesh.setColorAt(i, rgbToThreeColor(tempColor, color));
+      this.#headMesh.setColorAt(i, rgbToThreeColor(tempColor, color));
+      this.#instanceOpacity.setX(i, color.a);
       tempQuat.set(
         arrow.pose.orientation.x,
         arrow.pose.orientation.y,
         arrow.pose.orientation.z,
         arrow.pose.orientation.w,
       );
-      this.shaftMesh.setMatrixAt(
+      this.#shaftMesh.setMatrixAt(
         i,
         tempMat4.compose(
           tempVec3.set(arrow.pose.position.x, arrow.pose.position.y, arrow.pose.position.z),
@@ -193,7 +193,7 @@ export class RenderableArrows extends RenderablePrimitive {
       // offset head position by shaft length in direction of arrow pose
       tempVec3.add(tempVec3_2.set(arrow.shaft_length, 0, 0).applyQuaternion(tempQuat));
 
-      this.headMesh.setMatrixAt(
+      this.#headMesh.setMatrixAt(
         i,
         tempMat4.compose(
           tempVec3,
@@ -204,41 +204,41 @@ export class RenderableArrows extends RenderablePrimitive {
       i++;
     }
 
-    if (this.material.transparent !== isTransparent) {
-      this.material.transparent = isTransparent;
-      this.material.depthWrite = !isTransparent;
-      this.material.needsUpdate = true;
+    if (this.#material.transparent !== isTransparent) {
+      this.#material.transparent = isTransparent;
+      this.#material.depthWrite = !isTransparent;
+      this.#material.needsUpdate = true;
     }
 
-    if (this.shaftMesh.count === 0 && arrows.length > 0) {
+    if (this.#shaftMesh.count === 0 && arrows.length > 0) {
       // needed to make colors work: https://discourse.threejs.org/t/instancedmesh-color-doesnt-work-when-initial-count-is-0/41355
-      this.material.needsUpdate = true;
+      this.#material.needsUpdate = true;
     }
-    this.shaftMesh.count = arrows.length;
-    this.headMesh.count = arrows.length;
-    this.shaftOutlineGeometry.instanceCount = arrows.length;
-    this.headOutlineGeometry.instanceCount = arrows.length;
-    this.shaftMesh.instanceMatrix.needsUpdate = true;
-    this.headMesh.instanceMatrix.needsUpdate = true;
-    this.instanceOpacity.needsUpdate = true;
+    this.#shaftMesh.count = arrows.length;
+    this.#headMesh.count = arrows.length;
+    this.#shaftOutlineGeometry.instanceCount = arrows.length;
+    this.#headOutlineGeometry.instanceCount = arrows.length;
+    this.#shaftMesh.instanceMatrix.needsUpdate = true;
+    this.#headMesh.instanceMatrix.needsUpdate = true;
+    this.#instanceOpacity.needsUpdate = true;
 
     // may be null if we were initialized with count 0 and still have 0 primitives
-    if (this.shaftMesh.instanceColor) {
-      this.shaftMesh.instanceColor.needsUpdate = true;
+    if (this.#shaftMesh.instanceColor) {
+      this.#shaftMesh.instanceColor.needsUpdate = true;
     }
-    if (this.headMesh.instanceColor) {
-      this.headMesh.instanceColor.needsUpdate = true;
+    if (this.#headMesh.instanceColor) {
+      this.#headMesh.instanceColor.needsUpdate = true;
     }
   }
 
   public override dispose(): void {
-    this.material.dispose();
-    this.shaftMesh.dispose();
-    this.headMesh.dispose();
-    this.shaftGeometry.dispose();
-    this.headGeometry.dispose();
-    this.shaftOutlineGeometry.dispose();
-    this.headOutlineGeometry.dispose();
+    this.#material.dispose();
+    this.#shaftMesh.dispose();
+    this.#headMesh.dispose();
+    this.#shaftGeometry.dispose();
+    this.#headGeometry.dispose();
+    this.#shaftOutlineGeometry.dispose();
+    this.#headOutlineGeometry.dispose();
   }
 
   public override update(
@@ -251,10 +251,10 @@ export class RenderableArrows extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateMesh(entity.arrows);
+      this.#updateMesh(entity.arrows);
 
       this.headOutline.visible = settings.showOutlines ?? true;
-      this.shaftOutline.visible = settings.showOutlines ?? true;
+      this.#shaftOutline.visible = settings.showOutlines ?? true;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -50,7 +50,7 @@ export class RenderableArrows extends RenderablePrimitive {
   #maxInstances: number;
 
   #shaftOutline: THREE.LineSegments;
-  private headOutline: THREE.LineSegments;
+  #headOutline: THREE.LineSegments;
 
   public constructor(renderer: IRenderer) {
     super("", renderer, undefined);
@@ -97,16 +97,16 @@ export class RenderableArrows extends RenderablePrimitive {
     );
     this.#headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
     this.#headOutlineGeometry.setAttribute("instanceMatrix", this.#headMesh.instanceMatrix);
-    this.headOutline = new THREE.LineSegments(
+    this.#headOutline = new THREE.LineSegments(
       this.#headOutlineGeometry,
       renderer.instancedOutlineMaterial,
     );
-    this.headOutline.frustumCulled = false;
-    this.headOutline.userData.picking = false;
-    this.add(this.headOutline);
+    this.#headOutline.frustumCulled = false;
+    this.#headOutline.userData.picking = false;
+    this.add(this.#headOutline);
   }
 
-  private _ensureCapacity(numArrows: number) {
+  #ensureCapacity(numArrows: number) {
     if (numArrows > this.#maxInstances) {
       const newCapacity = Math.ceil(numArrows * 1.5) + 16;
       this.#maxInstances = newCapacity;
@@ -153,14 +153,14 @@ export class RenderableArrows extends RenderablePrimitive {
       this.#headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
       this.#headOutlineGeometry.instanceCount = newCapacity;
       this.#headOutlineGeometry.setAttribute("instanceMatrix", this.#headMesh.instanceMatrix);
-      this.headOutline.geometry = this.#headOutlineGeometry;
+      this.#headOutline.geometry = this.#headOutlineGeometry;
     }
   }
 
   #updateMesh(arrows: ArrowPrimitive[]) {
     let isTransparent = false;
 
-    this._ensureCapacity(arrows.length);
+    this.#ensureCapacity(arrows.length);
 
     const overrideColor = this.userData.settings.color
       ? stringToRgba(tempRgba, this.userData.settings.color)
@@ -253,7 +253,7 @@ export class RenderableArrows extends RenderablePrimitive {
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
       this.#updateMesh(entity.arrows);
 
-      this.headOutline.visible = settings.showOutlines ?? true;
+      this.#headOutline.visible = settings.showOutlines ?? true;
       this.#shaftOutline.visible = settings.showOutlines ?? true;
     }
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
@@ -68,7 +68,10 @@ export class RenderableCubes extends RenderablePrimitive {
     );
     this.#outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
     this.#outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
-    this.#outline = new THREE.LineSegments(this.#outlineGeometry, renderer.instancedOutlineMaterial);
+    this.#outline = new THREE.LineSegments(
+      this.#outlineGeometry,
+      renderer.instancedOutlineMaterial,
+    );
     this.#outline.frustumCulled = false;
     this.#outline.userData.picking = false;
     this.add(this.#outline);
@@ -95,7 +98,7 @@ export class RenderableCubes extends RenderablePrimitive {
       this.#outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
       this.#outlineGeometry.instanceCount = newCapacity;
       this.#outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
-      this.#outline.#geometry = this.#outlineGeometry;
+      this.#outline.geometry = this.#outlineGeometry;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
@@ -22,9 +22,9 @@ const tempRgba = makeRgba();
 
 export class RenderableCubes extends RenderablePrimitive {
   // Each RenderableCubes needs its own geometry because we attach additional custom attributes to it.
-  private mesh: THREE.InstancedMesh<THREE.BoxGeometry, MeshStandardMaterialWithInstanceOpacity>;
-  private instanceOpacity: THREE.InstancedBufferAttribute;
-  private material = new MeshStandardMaterialWithInstanceOpacity({
+  #mesh: THREE.InstancedMesh<THREE.BoxGeometry, MeshStandardMaterialWithInstanceOpacity>;
+  #instanceOpacity: THREE.InstancedBufferAttribute;
+  #material = new MeshStandardMaterialWithInstanceOpacity({
     metalness: 0,
     roughness: 1,
     dithering: true,
@@ -34,75 +34,75 @@ export class RenderableCubes extends RenderablePrimitive {
    * The initial count passed to `mesh`'s constructor, i.e. the maximum number of instances it can
    * render before we need to create a new mesh object
    */
-  private maxInstances: number;
+  #maxInstances: number;
 
-  private outlineGeometry: THREE.InstancedBufferGeometry;
-  private outline: THREE.LineSegments;
-  private geometry: THREE.BoxGeometry;
+  #outlineGeometry: THREE.InstancedBufferGeometry;
+  #outline: THREE.LineSegments;
+  #geometry: THREE.BoxGeometry;
   // actual shared geometry across instances, only copy -- do not modify
   // stored for ease of use
-  private sharedEdgesGeometry: THREE.EdgesGeometry<THREE.BufferGeometry>;
+  #sharedEdgesGeometry: THREE.EdgesGeometry<THREE.BufferGeometry>;
 
   public constructor(renderer: IRenderer) {
     super("", renderer);
 
     // Cube mesh
-    this.geometry = renderer.sharedGeometry
+    this.#geometry = renderer.sharedGeometry
       .getGeometry(`${this.constructor.name}-cube`, createCubeGeometry)
       .clone() as THREE.BoxGeometry;
 
-    this.maxInstances = 16;
-    this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
-    this.instanceOpacity = new THREE.InstancedBufferAttribute(
-      new Float32Array(this.maxInstances),
+    this.#maxInstances = 16;
+    this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+    this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.#maxInstances),
       1,
     );
-    this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
-    this.mesh.count = 0;
-    this.add(this.mesh);
+    this.#geometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+    this.#mesh.count = 0;
+    this.add(this.#mesh);
 
     // Cube outline
-    this.sharedEdgesGeometry = renderer.sharedGeometry.getGeometry(
+    this.#sharedEdgesGeometry = renderer.sharedGeometry.getGeometry(
       `${this.constructor.name}-edges`,
-      () => createEdgesGeometry(this.geometry),
+      () => createEdgesGeometry(this.#geometry),
     );
-    this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.sharedEdgesGeometry);
-    this.outlineGeometry.setAttribute("instanceMatrix", this.mesh.instanceMatrix);
-    this.outline = new THREE.LineSegments(this.outlineGeometry, renderer.instancedOutlineMaterial);
-    this.outline.frustumCulled = false;
-    this.outline.userData.picking = false;
-    this.add(this.outline);
+    this.#outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
+    this.#outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
+    this.#outline = new THREE.LineSegments(this.#outlineGeometry, renderer.instancedOutlineMaterial);
+    this.#outline.frustumCulled = false;
+    this.#outline.userData.picking = false;
+    this.add(this.#outline);
   }
 
-  private _ensureCapacity(numCubes: number) {
-    if (numCubes > this.maxInstances) {
+  #ensureCapacity(numCubes: number) {
+    if (numCubes > this.#maxInstances) {
       const newCapacity = Math.trunc(numCubes * 1.5) + 16;
-      this.maxInstances = newCapacity;
+      this.#maxInstances = newCapacity;
 
-      this.mesh.removeFromParent();
-      this.mesh.dispose();
-      this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
-      this.instanceOpacity = new THREE.InstancedBufferAttribute(
-        new Float32Array(this.maxInstances),
+      this.#mesh.removeFromParent();
+      this.#mesh.dispose();
+      this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+      this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.#maxInstances),
         1,
       );
-      this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
-      this.add(this.mesh);
+      this.#geometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+      this.add(this.#mesh);
 
       // THREE.js doesn't correctly recompute the new max instance count when dynamically
       // reassigning the attribute of InstancedBufferGeometry, so we just create a new geometry
-      this.outlineGeometry.dispose();
-      this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.sharedEdgesGeometry);
-      this.outlineGeometry.instanceCount = newCapacity;
-      this.outlineGeometry.setAttribute("instanceMatrix", this.mesh.instanceMatrix);
-      this.outline.geometry = this.outlineGeometry;
+      this.#outlineGeometry.dispose();
+      this.#outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
+      this.#outlineGeometry.instanceCount = newCapacity;
+      this.#outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
+      this.#outline.#geometry = this.#outlineGeometry;
     }
   }
 
-  private _updateMesh(cubes: CubePrimitive[]) {
+  #updateMesh(cubes: CubePrimitive[]) {
     let isTransparent = false;
 
-    this._ensureCapacity(cubes.length);
+    this.#ensureCapacity(cubes.length);
 
     const overrideColor = this.userData.settings.color
       ? stringToRgba(tempRgba, this.userData.settings.color)
@@ -114,9 +114,9 @@ export class RenderableCubes extends RenderablePrimitive {
       if (color.a < 1) {
         isTransparent = true;
       }
-      this.mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
-      this.instanceOpacity.setX(i, color.a);
-      this.mesh.setMatrixAt(
+      this.#mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
+      this.#instanceOpacity.setX(i, color.a);
+      this.#mesh.setMatrixAt(
         i,
         tempMat4.compose(
           tempVec3.set(cube.pose.position.x, cube.pose.position.y, cube.pose.position.z),
@@ -132,32 +132,32 @@ export class RenderableCubes extends RenderablePrimitive {
       i++;
     }
 
-    if (this.material.transparent !== isTransparent) {
-      this.material.transparent = isTransparent;
-      this.material.depthWrite = !isTransparent;
-      this.material.needsUpdate = true;
+    if (this.#material.transparent !== isTransparent) {
+      this.#material.transparent = isTransparent;
+      this.#material.depthWrite = !isTransparent;
+      this.#material.needsUpdate = true;
     }
 
-    if (this.mesh.count === 0 && cubes.length > 0) {
+    if (this.#mesh.count === 0 && cubes.length > 0) {
       // needed to make colors work: https://discourse.threejs.org/t/instancedmesh-color-doesnt-work-when-initial-count-is-0/41355
-      this.material.needsUpdate = true;
+      this.#material.needsUpdate = true;
     }
-    this.mesh.count = cubes.length;
-    this.outlineGeometry.instanceCount = cubes.length;
-    this.mesh.instanceMatrix.needsUpdate = true;
-    this.instanceOpacity.needsUpdate = true;
+    this.#mesh.count = cubes.length;
+    this.#outlineGeometry.instanceCount = cubes.length;
+    this.#mesh.instanceMatrix.needsUpdate = true;
+    this.#instanceOpacity.needsUpdate = true;
 
     // may be null if we were initialized with count 0 and still have 0 primitives
-    if (this.mesh.instanceColor) {
-      this.mesh.instanceColor.needsUpdate = true;
+    if (this.#mesh.instanceColor) {
+      this.#mesh.instanceColor.needsUpdate = true;
     }
   }
 
   public override dispose(): void {
-    this.mesh.dispose();
-    this.geometry.dispose();
-    this.material.dispose();
-    this.outlineGeometry.dispose();
+    this.#mesh.dispose();
+    this.#geometry.dispose();
+    this.#material.dispose();
+    this.#outlineGeometry.dispose();
   }
 
   public override update(
@@ -170,8 +170,8 @@ export class RenderableCubes extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateMesh(entity.cubes);
-      this.outline.visible = settings.showOutlines ?? true;
+      this.#updateMesh(entity.cubes);
+      this.#outline.visible = settings.showOutlines ?? true;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -22,10 +22,7 @@ const tempRgba = makeRgba();
 
 export class RenderableCylinders extends RenderablePrimitive {
   // Each RenderableCylinders needs its own geometry because we attach additional custom attributes to it.
-  #mesh: THREE.InstancedMesh<
-    THREE.CylinderGeometry,
-    MeshStandardMaterialWithInstanceOpacity
-  >;
+  #mesh: THREE.InstancedMesh<THREE.CylinderGeometry, MeshStandardMaterialWithInstanceOpacity>;
   #geometry: THREE.CylinderGeometry;
   // actual shared geometry across instances, only copy -- do not modify
   // stored for ease of use
@@ -43,8 +40,8 @@ export class RenderableCylinders extends RenderablePrimitive {
    */
   #maxInstances: number;
 
-  private outlineGeometry: THREE.InstancedBufferGeometry;
-  private outline: THREE.LineSegments;
+  #outlineGeometry: THREE.InstancedBufferGeometry;
+  #outline: THREE.LineSegments;
 
   public constructor(renderer: IRenderer) {
     super("", renderer);
@@ -54,7 +51,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       .clone() as THREE.CylinderGeometry;
     this.#maxInstances = 16;
     this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
-    this.#mesh.userData.#pickingMaterial = this.#pickingMaterial;
+    this.#mesh.userData.pickingMaterial = this.#pickingMaterial;
     this.#instanceOpacity = new THREE.InstancedBufferAttribute(
       new Float32Array(this.#maxInstances),
       1,
@@ -77,14 +74,14 @@ export class RenderableCylinders extends RenderablePrimitive {
       `${this.constructor.name}-edges`,
       () => createEdgesGeometry(this.#geometry),
     );
-    this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
-    this.outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
-    this.outlineGeometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
-    this.outlineGeometry.setAttribute("instanceTopScale", this.#instanceTopScale);
-    this.outline = new THREE.LineSegments(this.outlineGeometry, this.#outlineMaterial);
-    this.outline.frustumCulled = false;
-    this.outline.userData.picking = false;
-    this.add(this.outline);
+    this.#outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
+    this.#outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
+    this.#outlineGeometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
+    this.#outlineGeometry.setAttribute("instanceTopScale", this.#instanceTopScale);
+    this.#outline = new THREE.LineSegments(this.#outlineGeometry, this.#outlineMaterial);
+    this.#outline.frustumCulled = false;
+    this.#outline.userData.picking = false;
+    this.add(this.#outline);
   }
 
   public override setColorScheme(colorScheme: "dark" | "light"): void {
@@ -92,7 +89,7 @@ export class RenderableCylinders extends RenderablePrimitive {
     this.#outlineMaterial.needsUpdate = true;
   }
 
-  private _ensureCapacity(numCubes: number) {
+  #ensureCapacity(numCubes: number) {
     if (numCubes > this.#maxInstances) {
       const newCapacity = Math.trunc(numCubes * 1.5) + 16;
       this.#maxInstances = newCapacity;
@@ -116,25 +113,25 @@ export class RenderableCylinders extends RenderablePrimitive {
       this.#mesh.removeFromParent();
       this.#mesh.dispose();
       this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
-      this.#mesh.userData.#pickingMaterial = this.#pickingMaterial;
+      this.#mesh.userData.pickingMaterial = this.#pickingMaterial;
       this.add(this.#mesh);
 
       // THREE.js doesn't correctly recompute the new max instance count when dynamically
       // reassigning the attribute of InstancedBufferGeometry, so we just create a new geometry
-      this.outlineGeometry.dispose();
-      this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
-      this.outlineGeometry.instanceCount = newCapacity;
-      this.outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
-      this.outlineGeometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
-      this.outlineGeometry.setAttribute("instanceTopScale", this.#instanceTopScale);
-      this.outline.#geometry = this.outlineGeometry;
+      this.#outlineGeometry.dispose();
+      this.#outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
+      this.#outlineGeometry.instanceCount = newCapacity;
+      this.#outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
+      this.#outlineGeometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
+      this.#outlineGeometry.setAttribute("instanceTopScale", this.#instanceTopScale);
+      this.#outline.geometry = this.#outlineGeometry;
     }
   }
 
   #updateMesh(cylinders: CylinderPrimitive[]) {
     let isTransparent = false;
 
-    this._ensureCapacity(cylinders.length);
+    this.#ensureCapacity(cylinders.length);
 
     const overrideColor = this.userData.settings.color
       ? stringToRgba(tempRgba, this.userData.settings.color)
@@ -181,7 +178,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       this.#material.needsUpdate = true;
     }
     this.#mesh.count = cylinders.length;
-    this.outlineGeometry.instanceCount = cylinders.length;
+    this.#outlineGeometry.instanceCount = cylinders.length;
     this.#mesh.instanceMatrix.needsUpdate = true;
     this.#instanceOpacity.needsUpdate = true;
     this.#instanceBottomScale.needsUpdate = true;
@@ -199,7 +196,7 @@ export class RenderableCylinders extends RenderablePrimitive {
     this.#material.dispose();
     this.#pickingMaterial.dispose();
     this.#outlineMaterial.dispose();
-    this.outlineGeometry.dispose();
+    this.#outlineGeometry.dispose();
   }
 
   public override update(
@@ -213,7 +210,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
       this.#updateMesh(entity.cylinders);
-      this.outline.visible = settings.showOutlines ?? true;
+      this.#outline.visible = settings.showOutlines ?? true;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -22,26 +22,26 @@ const tempRgba = makeRgba();
 
 export class RenderableCylinders extends RenderablePrimitive {
   // Each RenderableCylinders needs its own geometry because we attach additional custom attributes to it.
-  private mesh: THREE.InstancedMesh<
+  #mesh: THREE.InstancedMesh<
     THREE.CylinderGeometry,
     MeshStandardMaterialWithInstanceOpacity
   >;
-  private geometry: THREE.CylinderGeometry;
+  #geometry: THREE.CylinderGeometry;
   // actual shared geometry across instances, only copy -- do not modify
   // stored for ease of use
-  private sharedEdgesGeometry: THREE.EdgesGeometry<THREE.BufferGeometry>;
-  private instanceOpacity: THREE.InstancedBufferAttribute;
-  private instanceTopScale: THREE.InstancedBufferAttribute;
-  private instanceBottomScale: THREE.InstancedBufferAttribute;
-  private outlineMaterial = new CylinderOutlineMaterial();
-  private material = new CylinderMaterial();
-  private pickingMaterial = new CylinderPickingMaterial();
+  #sharedEdgesGeometry: THREE.EdgesGeometry<THREE.BufferGeometry>;
+  #instanceOpacity: THREE.InstancedBufferAttribute;
+  #instanceTopScale: THREE.InstancedBufferAttribute;
+  #instanceBottomScale: THREE.InstancedBufferAttribute;
+  #outlineMaterial = new CylinderOutlineMaterial();
+  #material = new CylinderMaterial();
+  #pickingMaterial = new CylinderPickingMaterial();
 
   /**
    * The initial count passed to `mesh`'s constructor, i.e. the maximum number of instances it can
    * render before we need to create a new mesh object
    */
-  private maxInstances: number;
+  #maxInstances: number;
 
   private outlineGeometry: THREE.InstancedBufferGeometry;
   private outline: THREE.LineSegments;
@@ -49,89 +49,89 @@ export class RenderableCylinders extends RenderablePrimitive {
   public constructor(renderer: IRenderer) {
     super("", renderer);
 
-    this.geometry = renderer.sharedGeometry
+    this.#geometry = renderer.sharedGeometry
       .getGeometry(`${this.constructor.name}-cylinder`, createGeometry)
       .clone() as THREE.CylinderGeometry;
-    this.maxInstances = 16;
-    this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
-    this.mesh.userData.pickingMaterial = this.pickingMaterial;
-    this.instanceOpacity = new THREE.InstancedBufferAttribute(
-      new Float32Array(this.maxInstances),
+    this.#maxInstances = 16;
+    this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+    this.#mesh.userData.#pickingMaterial = this.#pickingMaterial;
+    this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.#maxInstances),
       1,
     );
-    this.instanceBottomScale = new THREE.InstancedBufferAttribute(
-      new Float32Array(this.maxInstances),
+    this.#instanceBottomScale = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.#maxInstances),
       1,
     );
-    this.instanceTopScale = new THREE.InstancedBufferAttribute(
-      new Float32Array(this.maxInstances),
+    this.#instanceTopScale = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.#maxInstances),
       1,
     );
-    this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
-    this.geometry.setAttribute("instanceBottomScale", this.instanceBottomScale);
-    this.geometry.setAttribute("instanceTopScale", this.instanceTopScale);
-    this.mesh.count = 0;
-    this.add(this.mesh);
+    this.#geometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+    this.#geometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
+    this.#geometry.setAttribute("instanceTopScale", this.#instanceTopScale);
+    this.#mesh.count = 0;
+    this.add(this.#mesh);
 
-    this.sharedEdgesGeometry = renderer.sharedGeometry.getGeometry(
+    this.#sharedEdgesGeometry = renderer.sharedGeometry.getGeometry(
       `${this.constructor.name}-edges`,
-      () => createEdgesGeometry(this.geometry),
+      () => createEdgesGeometry(this.#geometry),
     );
-    this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.sharedEdgesGeometry);
-    this.outlineGeometry.setAttribute("instanceMatrix", this.mesh.instanceMatrix);
-    this.outlineGeometry.setAttribute("instanceBottomScale", this.instanceBottomScale);
-    this.outlineGeometry.setAttribute("instanceTopScale", this.instanceTopScale);
-    this.outline = new THREE.LineSegments(this.outlineGeometry, this.outlineMaterial);
+    this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
+    this.outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
+    this.outlineGeometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
+    this.outlineGeometry.setAttribute("instanceTopScale", this.#instanceTopScale);
+    this.outline = new THREE.LineSegments(this.outlineGeometry, this.#outlineMaterial);
     this.outline.frustumCulled = false;
     this.outline.userData.picking = false;
     this.add(this.outline);
   }
 
   public override setColorScheme(colorScheme: "dark" | "light"): void {
-    this.outlineMaterial.color.copy(colorScheme === "dark" ? DARK_OUTLINE : LIGHT_OUTLINE);
-    this.outlineMaterial.needsUpdate = true;
+    this.#outlineMaterial.color.copy(colorScheme === "dark" ? DARK_OUTLINE : LIGHT_OUTLINE);
+    this.#outlineMaterial.needsUpdate = true;
   }
 
   private _ensureCapacity(numCubes: number) {
-    if (numCubes > this.maxInstances) {
+    if (numCubes > this.#maxInstances) {
       const newCapacity = Math.trunc(numCubes * 1.5) + 16;
-      this.maxInstances = newCapacity;
+      this.#maxInstances = newCapacity;
 
-      this.instanceOpacity = new THREE.InstancedBufferAttribute(
-        new Float32Array(this.maxInstances),
+      this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.#maxInstances),
         1,
       );
-      this.instanceBottomScale = new THREE.InstancedBufferAttribute(
-        new Float32Array(this.maxInstances),
+      this.#instanceBottomScale = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.#maxInstances),
         1,
       );
-      this.instanceTopScale = new THREE.InstancedBufferAttribute(
-        new Float32Array(this.maxInstances),
+      this.#instanceTopScale = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.#maxInstances),
         1,
       );
-      this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
-      this.geometry.setAttribute("instanceBottomScale", this.instanceBottomScale);
-      this.geometry.setAttribute("instanceTopScale", this.instanceTopScale);
+      this.#geometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+      this.#geometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
+      this.#geometry.setAttribute("instanceTopScale", this.#instanceTopScale);
 
-      this.mesh.removeFromParent();
-      this.mesh.dispose();
-      this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
-      this.mesh.userData.pickingMaterial = this.pickingMaterial;
-      this.add(this.mesh);
+      this.#mesh.removeFromParent();
+      this.#mesh.dispose();
+      this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+      this.#mesh.userData.#pickingMaterial = this.#pickingMaterial;
+      this.add(this.#mesh);
 
       // THREE.js doesn't correctly recompute the new max instance count when dynamically
       // reassigning the attribute of InstancedBufferGeometry, so we just create a new geometry
       this.outlineGeometry.dispose();
-      this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.sharedEdgesGeometry);
+      this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.#sharedEdgesGeometry);
       this.outlineGeometry.instanceCount = newCapacity;
-      this.outlineGeometry.setAttribute("instanceMatrix", this.mesh.instanceMatrix);
-      this.outlineGeometry.setAttribute("instanceBottomScale", this.instanceBottomScale);
-      this.outlineGeometry.setAttribute("instanceTopScale", this.instanceTopScale);
-      this.outline.geometry = this.outlineGeometry;
+      this.outlineGeometry.setAttribute("instanceMatrix", this.#mesh.instanceMatrix);
+      this.outlineGeometry.setAttribute("instanceBottomScale", this.#instanceBottomScale);
+      this.outlineGeometry.setAttribute("instanceTopScale", this.#instanceTopScale);
+      this.outline.#geometry = this.outlineGeometry;
     }
   }
 
-  private _updateMesh(cylinders: CylinderPrimitive[]) {
+  #updateMesh(cylinders: CylinderPrimitive[]) {
     let isTransparent = false;
 
     this._ensureCapacity(cylinders.length);
@@ -146,11 +146,11 @@ export class RenderableCylinders extends RenderablePrimitive {
       if (color.a < 1) {
         isTransparent = true;
       }
-      this.mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
-      this.instanceOpacity.setX(i, color.a);
-      this.instanceBottomScale.setX(i, cylinder.bottom_scale);
-      this.instanceTopScale.setX(i, cylinder.top_scale);
-      this.mesh.setMatrixAt(
+      this.#mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
+      this.#instanceOpacity.setX(i, color.a);
+      this.#instanceBottomScale.setX(i, cylinder.bottom_scale);
+      this.#instanceTopScale.setX(i, cylinder.top_scale);
+      this.#mesh.setMatrixAt(
         i,
         tempMat4.compose(
           tempVec3.set(
@@ -170,35 +170,35 @@ export class RenderableCylinders extends RenderablePrimitive {
       i++;
     }
 
-    if (this.material.transparent !== isTransparent) {
-      this.material.transparent = isTransparent;
-      this.material.depthWrite = !isTransparent;
-      this.material.needsUpdate = true;
+    if (this.#material.transparent !== isTransparent) {
+      this.#material.transparent = isTransparent;
+      this.#material.depthWrite = !isTransparent;
+      this.#material.needsUpdate = true;
     }
 
-    if (this.mesh.count === 0 && cylinders.length > 0) {
+    if (this.#mesh.count === 0 && cylinders.length > 0) {
       // needed to make colors work: https://discourse.threejs.org/t/instancedmesh-color-doesnt-work-when-initial-count-is-0/41355
-      this.material.needsUpdate = true;
+      this.#material.needsUpdate = true;
     }
-    this.mesh.count = cylinders.length;
+    this.#mesh.count = cylinders.length;
     this.outlineGeometry.instanceCount = cylinders.length;
-    this.mesh.instanceMatrix.needsUpdate = true;
-    this.instanceOpacity.needsUpdate = true;
-    this.instanceBottomScale.needsUpdate = true;
-    this.instanceTopScale.needsUpdate = true;
+    this.#mesh.instanceMatrix.needsUpdate = true;
+    this.#instanceOpacity.needsUpdate = true;
+    this.#instanceBottomScale.needsUpdate = true;
+    this.#instanceTopScale.needsUpdate = true;
 
     // may be null if we were initialized with count 0 and still have 0 primitives
-    if (this.mesh.instanceColor) {
-      this.mesh.instanceColor.needsUpdate = true;
+    if (this.#mesh.instanceColor) {
+      this.#mesh.instanceColor.needsUpdate = true;
     }
   }
 
   public override dispose(): void {
-    this.mesh.dispose();
-    this.geometry.dispose();
-    this.material.dispose();
-    this.pickingMaterial.dispose();
-    this.outlineMaterial.dispose();
+    this.#mesh.dispose();
+    this.#geometry.dispose();
+    this.#material.dispose();
+    this.#pickingMaterial.dispose();
+    this.#outlineMaterial.dispose();
     this.outlineGeometry.dispose();
   }
 
@@ -212,7 +212,7 @@ export class RenderableCylinders extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateMesh(entity.cylinders);
+      this.#updateMesh(entity.cylinders);
       this.outline.visible = settings.showOutlines ?? true;
     }
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -20,20 +20,20 @@ import { LayerSettingsEntity } from "../../settings";
 const tempRgba = makeRgba();
 
 export class RenderableLines extends RenderablePrimitive {
-  private _lines: LineSegments2[] = [];
+  #lines: LineSegments2[] = [];
   public constructor(renderer: IRenderer) {
     super("", renderer);
   }
 
-  private _updateLines(lines: LinePrimitive[]) {
+  #updateLines(lines: LinePrimitive[]) {
     this.clear();
-    this._lines.length = 0;
+    this.#lines.length = 0;
 
     for (const primitive of lines) {
       if (primitive.points.length === 0) {
         continue;
       }
-      const line = this._makeLine(primitive);
+      const line = this.#makeLine(primitive);
       const group = new THREE.Group().add(line);
       group.position.set(
         primitive.pose.position.x,
@@ -47,11 +47,11 @@ export class RenderableLines extends RenderablePrimitive {
         primitive.pose.orientation.w,
       );
       this.add(group);
-      this._lines.push(line);
+      this.#lines.push(line);
     }
   }
 
-  private _makeLine(primitive: LinePrimitive) {
+  #makeLine(primitive: LinePrimitive) {
     let geometry: LineSegmentsGeometry;
     const isSegments = primitive.type === LineType.LINE_LIST;
     const isLoop = primitive.type === LineType.LINE_LOOP;
@@ -154,7 +154,7 @@ export class RenderableLines extends RenderablePrimitive {
   }
 
   public override dispose(): void {
-    for (const line of this._lines) {
+    for (const line of this.#lines) {
       line.geometry.dispose();
       line.material.dispose();
       line.userData.pickingMaterial.dispose();
@@ -171,7 +171,7 @@ export class RenderableLines extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateLines(entity.lines);
+      this.#updateLines(entity.lines);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -21,10 +21,10 @@ const tempQuat = new THREE.Quaternion();
 const tempRgba = makeRgba();
 
 export class RenderableSpheres extends RenderablePrimitive {
-  private geometry: THREE.SphereGeometry;
-  private mesh: THREE.InstancedMesh<THREE.SphereGeometry, MeshStandardMaterialWithInstanceOpacity>;
-  private instanceOpacity: THREE.InstancedBufferAttribute;
-  private material = new MeshStandardMaterialWithInstanceOpacity({
+  #geometry: THREE.SphereGeometry;
+  #mesh: THREE.InstancedMesh<THREE.SphereGeometry, MeshStandardMaterialWithInstanceOpacity>;
+  #instanceOpacity: THREE.InstancedBufferAttribute;
+  #material = new MeshStandardMaterialWithInstanceOpacity({
     metalness: 0,
     roughness: 1,
     dithering: true,
@@ -34,47 +34,47 @@ export class RenderableSpheres extends RenderablePrimitive {
    * The initial count passed to `mesh`'s constructor, i.e. the maximum number of instances it can
    * render before we need to create a new mesh object
    */
-  private maxInstances: number;
+  #maxInstances: number;
 
   public constructor(renderer: IRenderer) {
     super("", renderer);
 
     // Sphere mesh
-    this.geometry = renderer.sharedGeometry
+    this.#geometry = renderer.sharedGeometry
       .getGeometry(this.constructor.name, createGeometry)
       .clone() as THREE.SphereGeometry;
-    this.maxInstances = 16;
-    this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
-    this.instanceOpacity = new THREE.InstancedBufferAttribute(
-      new Float32Array(this.maxInstances),
+    this.#maxInstances = 16;
+    this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+    this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.#maxInstances),
       1,
     );
-    this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
-    this.mesh.count = 0;
-    this.add(this.mesh);
+    this.#geometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+    this.#mesh.count = 0;
+    this.add(this.#mesh);
   }
 
-  private _ensureCapacity(numInstances: number) {
-    if (numInstances > this.maxInstances) {
+  #ensureCapacity(numInstances: number) {
+    if (numInstances > this.#maxInstances) {
       const newCapacity = Math.trunc(numInstances * 1.5) + 16;
-      this.maxInstances = newCapacity;
+      this.#maxInstances = newCapacity;
 
-      this.mesh.removeFromParent();
-      this.mesh.dispose();
-      this.mesh = new THREE.InstancedMesh(this.mesh.geometry, this.material, this.maxInstances);
-      this.instanceOpacity = new THREE.InstancedBufferAttribute(
-        new Float32Array(this.maxInstances),
+      this.#mesh.removeFromParent();
+      this.#mesh.dispose();
+      this.#mesh = new THREE.InstancedMesh(this.#mesh.#geometry, this.#material, this.#maxInstances);
+      this.#instanceOpacity = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.#maxInstances),
         1,
       );
-      this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
-      this.add(this.mesh);
+      this.#geometry.setAttribute("instanceOpacity", this.#instanceOpacity);
+      this.add(this.#mesh);
     }
   }
 
-  private _updateMesh(spheres: SpherePrimitive[]) {
+  #updateMesh(spheres: SpherePrimitive[]) {
     let isTransparent = false;
 
-    this._ensureCapacity(spheres.length);
+    this.#ensureCapacity(spheres.length);
 
     const overrideColor = this.userData.settings.color
       ? stringToRgba(tempRgba, this.userData.settings.color)
@@ -86,9 +86,9 @@ export class RenderableSpheres extends RenderablePrimitive {
       if (color.a < 1) {
         isTransparent = true;
       }
-      this.mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
-      this.instanceOpacity.setX(i, color.a);
-      this.mesh.setMatrixAt(
+      this.#mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
+      this.#instanceOpacity.setX(i, color.a);
+      this.#mesh.setMatrixAt(
         i,
         tempMat4.compose(
           tempVec3.set(sphere.pose.position.x, sphere.pose.position.y, sphere.pose.position.z),
@@ -104,30 +104,30 @@ export class RenderableSpheres extends RenderablePrimitive {
       i++;
     }
 
-    if (this.material.transparent !== isTransparent) {
-      this.material.transparent = isTransparent;
-      this.material.depthWrite = !isTransparent;
-      this.material.needsUpdate = true;
+    if (this.#material.transparent !== isTransparent) {
+      this.#material.transparent = isTransparent;
+      this.#material.depthWrite = !isTransparent;
+      this.#material.needsUpdate = true;
     }
 
-    if (this.mesh.count === 0 && spheres.length > 0) {
+    if (this.#mesh.count === 0 && spheres.length > 0) {
       // needed to make colors work: https://discourse.threejs.org/t/instancedmesh-color-doesnt-work-when-initial-count-is-0/41355
-      this.material.needsUpdate = true;
+      this.#material.needsUpdate = true;
     }
-    this.mesh.count = spheres.length;
-    this.mesh.instanceMatrix.needsUpdate = true;
-    this.instanceOpacity.needsUpdate = true;
+    this.#mesh.count = spheres.length;
+    this.#mesh.instanceMatrix.needsUpdate = true;
+    this.#instanceOpacity.needsUpdate = true;
 
     // may be null if we were initialized with count 0 and still have 0 spheres
-    if (this.mesh.instanceColor) {
-      this.mesh.instanceColor.needsUpdate = true;
+    if (this.#mesh.instanceColor) {
+      this.#mesh.instanceColor.needsUpdate = true;
     }
   }
 
   public override dispose(): void {
-    this.mesh.dispose();
-    this.geometry.dispose();
-    this.material.dispose();
+    this.#mesh.dispose();
+    this.#geometry.dispose();
+    this.#material.dispose();
   }
 
   public override update(
@@ -140,7 +140,7 @@ export class RenderableSpheres extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateMesh(entity.spheres);
+      this.#updateMesh(entity.spheres);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -61,7 +61,7 @@ export class RenderableSpheres extends RenderablePrimitive {
 
       this.#mesh.removeFromParent();
       this.#mesh.dispose();
-      this.#mesh = new THREE.InstancedMesh(this.#mesh.#geometry, this.#material, this.#maxInstances);
+      this.#mesh = new THREE.InstancedMesh(this.#mesh.geometry, this.#material, this.#maxInstances);
       this.#instanceOpacity = new THREE.InstancedBufferAttribute(
         new Float32Array(this.#maxInstances),
         1,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
@@ -14,27 +14,27 @@ import { LayerSettingsEntity } from "../../settings";
 const tempRgba = makeRgba();
 
 export class RenderableTexts extends RenderablePrimitive {
-  private labelPool: LabelPool;
-  private labels: Label[] = [];
+  #labelPool: LabelPool;
+  #labels: Label[] = [];
 
   public constructor(renderer: IRenderer) {
     super("", renderer);
 
-    this.labelPool = renderer.labelPool;
+    this.#labelPool = renderer.labelPool;
   }
-  private _ensureCapacity(newLength: number): void {
-    const oldLength = this.labels.length;
+  #ensureCapacity(newLength: number): void {
+    const oldLength = this.#labels.length;
     if (newLength > oldLength) {
       for (let i = oldLength; i < newLength; i++) {
-        const newLabel = this.labelPool.acquire();
-        this.labels.push(newLabel);
+        const newLabel = this.#labelPool.acquire();
+        this.#labels.push(newLabel);
         this.add(newLabel);
       }
     }
   }
 
-  private _updateTexts(texts: TextPrimitive[]) {
-    this._ensureCapacity(texts.length);
+  #updateTexts(texts: TextPrimitive[]) {
+    this.#ensureCapacity(texts.length);
     const overrideColor = this.userData.settings.color
       ? stringToRgba(tempRgba, this.userData.settings.color)
       : undefined;
@@ -42,7 +42,7 @@ export class RenderableTexts extends RenderablePrimitive {
     let i = 0;
     for (const text of texts) {
       const color = overrideColor ?? text.color;
-      const label = this.labels[i];
+      const label = this.#labels[i];
 
       if (!label) {
         throw new Error("invariant: labels array smaller than requested");
@@ -75,17 +75,17 @@ export class RenderableTexts extends RenderablePrimitive {
       i++;
     }
     // need to release the no longer used labels so that they don't linger on the scene
-    if (i < this.labels.length) {
+    if (i < this.#labels.length) {
       // cuts off remaining labels and loops through  them  release to from labelpool
-      for (const label of this.labels.splice(i)) {
-        this.labelPool.release(label);
+      for (const label of this.#labels.splice(i)) {
+        this.#labelPool.release(label);
       }
     }
   }
 
   public override dispose(): void {
-    for (const label of this.labels) {
-      this.labelPool.release(label);
+    for (const label of this.#labels) {
+      this.#labelPool.release(label);
     }
   }
 
@@ -99,7 +99,7 @@ export class RenderableTexts extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateTexts(entity.texts);
+      this.#updateTexts(entity.texts);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -22,25 +22,25 @@ const INVALID_POINT_ERROR_ID = "INVALID_POINT";
 
 type TriangleMesh = THREE.Mesh<DynamicBufferGeometry, THREE.MeshStandardMaterial>;
 export class RenderableTriangles extends RenderablePrimitive {
-  private _triangleMeshes: TriangleMesh[] = [];
+  #triangleMeshes: TriangleMesh[] = [];
   public constructor(renderer: IRenderer) {
     super("", renderer);
   }
 
-  private _ensureCapacity(triCount: number) {
-    while (triCount > this._triangleMeshes.length) {
-      this._triangleMeshes.push(makeTriangleMesh());
+  #ensureCapacity(triCount: number) {
+    while (triCount > this.#triangleMeshes.length) {
+      this.#triangleMeshes.push(makeTriangleMesh());
     }
   }
-  private _updateTriangleMeshes(tris: TriangleListPrimitive[]) {
-    this._ensureCapacity(tris.length);
+  #updateTriangleMeshes(tris: TriangleListPrimitive[]) {
+    this.#ensureCapacity(tris.length);
     // removes all children so that meshes that are still in the _triangleMesh array
     // but don't have a new corresponding primitive  won't be rendered
     this.clear();
 
     let triMeshIdx = 0;
     for (const primitive of tris) {
-      const mesh = this._triangleMeshes[triMeshIdx];
+      const mesh = this.#triangleMeshes[triMeshIdx];
       if (!mesh) {
         continue;
       }
@@ -198,12 +198,12 @@ export class RenderableTriangles extends RenderablePrimitive {
   }
 
   public override dispose(): void {
-    for (const mesh of this._triangleMeshes) {
+    for (const mesh of this.#triangleMeshes) {
       mesh.geometry.dispose();
       mesh.material.dispose();
     }
     this.clear();
-    this._triangleMeshes.length = 0;
+    this.#triangleMeshes.length = 0;
     this.clearErrors();
   }
 
@@ -217,7 +217,7 @@ export class RenderableTriangles extends RenderablePrimitive {
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
-      this._updateTriangleMeshes(entity.triangles);
+      this.#updateTriangleMeshes(entity.triangles);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -53,8 +53,8 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
   public offsetPosition: vec3 | undefined;
   public offsetEulerDegrees: vec3 | undefined;
 
-  private _parent?: CoordinateFrame<UserFrameId>;
-  private _transforms: ArrayMap<Time, Transform>;
+  #parent?: CoordinateFrame<UserFrameId>;
+  #transforms: ArrayMap<Time, Transform>;
 
   public constructor(
     id: ID,
@@ -64,13 +64,13 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
     capacityOverfillPercentage = 0.1,
   ) {
     if (parent) {
-      this._parent = parent;
+      this.#parent = parent;
     }
     this.id = id;
     this.maxStorageTime = maxStorageTime;
     this.maxCapacity = maxCapacity;
     this.capacityOverfillPercentage = capacityOverfillPercentage;
-    this._transforms = new ArrayMap<Time, Transform>();
+    this.#transforms = new ArrayMap<Time, Transform>();
   }
 
   public static assertUserFrame(
@@ -82,7 +82,7 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
   }
 
   public parent(): CoordinateFrame<UserFrameId> | undefined {
-    return this._parent;
+    return this.#parent;
   }
 
   /**
@@ -106,14 +106,14 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
    * Returns true if this frame has no parent frame.
    */
   public isRoot(): boolean {
-    return this._parent == undefined;
+    return this.#parent == undefined;
   }
 
   /**
    * Returns the number of transforms stored in the transform history.
    */
   public transformsSize(): number {
-    return this._transforms.size;
+    return this.#transforms.size;
   }
 
   /**
@@ -121,10 +121,10 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
    * a different frame, the transform history is cleared.
    */
   public setParent(parent: CoordinateFrame<UserFrameId>): void {
-    if (this._parent && this._parent !== parent) {
-      this._transforms.clear();
+    if (this.#parent && this.#parent !== parent) {
+      this.#transforms.clear();
     }
-    this._parent = parent;
+    this.#parent = parent;
   }
 
   /**
@@ -134,7 +134,7 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
    * @returns The ancestor frame, or undefined if not found
    */
   public findAncestor(id: string): CoordinateFrame<UserFrameId> | undefined {
-    let ancestor = this._parent;
+    let ancestor = this.#parent;
     while (ancestor) {
       if (ancestor.id === id) {
         return ancestor;
@@ -153,37 +153,37 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
    * If a transform with an identical timestamp already exists, it is replaced.
    */
   public addTransform(time: Time, transform: Transform): void {
-    this._transforms.set(time, transform);
+    this.#transforms.set(time, transform);
 
     // Remove transforms that are too old
     // percent over the maxCapacity
     const overfillPercent =
-      Math.max(0, this._transforms.size - this.maxCapacity) / this.maxCapacity;
+      Math.max(0, this.#transforms.size - this.maxCapacity) / this.maxCapacity;
 
     // Trim down to the maximum history size if we've exceeded the overfill
     if (overfillPercent > this.capacityOverfillPercentage) {
-      const overfillIndex = this._transforms.size - this.maxCapacity;
+      const overfillIndex = this.#transforms.size - this.maxCapacity;
       // guaranteed to be more than minKey
-      let removeBeforeTime = this._transforms.at(overfillIndex)![0];
-      const endTime = this._transforms.maxKey()!;
+      let removeBeforeTime = this.#transforms.at(overfillIndex)![0];
+      const endTime = this.#transforms.maxKey()!;
       // not guaranteed to be more than minKey
       const startTime = endTime - this.maxStorageTime;
       // at the very least we remove the overfill, but if the maxStorageTime enforces a  larger trim we take that
       // we can't afford to check maxStorageTime every time we add a transform, so we only check it when overfill is full
       removeBeforeTime = startTime > removeBeforeTime ? startTime : removeBeforeTime;
 
-      this._transforms.removeBefore(removeBeforeTime);
+      this.#transforms.removeBefore(removeBeforeTime);
     }
   }
 
   /** Remove all transforms with timestamps greater than the given timestamp. */
   public removeTransformsAfter(time: Time): void {
-    this._transforms.removeAfter(time);
+    this.#transforms.removeAfter(time);
   }
 
   /** Removes a transform with a specific timestamp */
   public removeTransformAt(time: Time): void {
-    this._transforms.remove(time);
+    this.#transforms.remove(time);
   }
 
   /**
@@ -207,13 +207,13 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
     maxDelta: Duration,
   ): boolean {
     // perf-sensitive: function params instead of options object to avoid allocations
-    const transformCount = this._transforms.size;
+    const transformCount = this.#transforms.size;
     if (transformCount === 0) {
       return false;
     } else if (transformCount === 1) {
       // If only a single transform exists, check if `time` is before or equal to
       // `latestTime + maxDelta`
-      const [latestTime, latestTf] = this._transforms.maxEntry()!;
+      const [latestTime, latestTf] = this.#transforms.maxEntry()!;
       if (time <= latestTime + maxDelta) {
         outLower[0] = outUpper[0] = latestTime;
         outLower[1] = outUpper[1] = latestTf;
@@ -222,20 +222,20 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
       return false;
     }
 
-    const index = this._transforms.binarySearch(time);
+    const index = this.#transforms.binarySearch(time);
     if (index >= 0) {
       // If the time is exactly on an existing transform, return it
-      const [_, tf] = this._transforms.at(index)!;
+      const [_, tf] = this.#transforms.at(index)!;
       outLower[0] = outUpper[0] = time;
       outLower[1] = outUpper[1] = tf;
       return true;
     }
 
     const greaterThanIndex = ~index;
-    if (greaterThanIndex >= this._transforms.size) {
+    if (greaterThanIndex >= this.#transforms.size) {
       // If the time is greater than all existing transforms, return the last
       // transform
-      const [latestTime, latestTf] = this._transforms.maxEntry()!;
+      const [latestTime, latestTf] = this.#transforms.maxEntry()!;
       if (time <= latestTime + maxDelta) {
         outLower[0] = outUpper[0] = latestTime;
         outLower[1] = outUpper[1] = latestTf;
@@ -248,7 +248,7 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
     if (lessThanIndex < 0) {
       // If the time is less than all existing transforms, return the first
       // transform
-      const [earliestTime, earliestTf] = this._transforms.minEntry()!;
+      const [earliestTime, earliestTf] = this.#transforms.minEntry()!;
       if (earliestTime + maxDelta >= time) {
         outLower[0] = outUpper[0] = earliestTime;
         outLower[1] = outUpper[1] = earliestTf;
@@ -257,8 +257,8 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
       return false;
     }
 
-    const [lteTime, lteTf] = this._transforms.at(lessThanIndex)!;
-    const [gtTime, gtTf] = this._transforms.at(greaterThanIndex)!;
+    const [lteTime, lteTf] = this.#transforms.at(lessThanIndex)!;
+    const [gtTime, gtTf] = this.#transforms.at(greaterThanIndex)!;
     outLower[0] = lteTime;
     outLower[1] = lteTf;
     outUpper[0] = gtTime;

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/* eslint-disable no-underscore-dangle */
 /* eslint-disable @foxglove/no-boolean-parameters */
 
 import { mat4, quat, vec3, vec4 } from "gl-matrix";
@@ -96,8 +95,8 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
     CoordinateFrame.assertUserFrame(this);
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let root: CoordinateFrame<UserFrameId> = this;
-    while (root._parent) {
-      root = root._parent;
+    while (root.#parent) {
+      root = root.#parent;
     }
     return root as CoordinateFrame<ID>;
   }
@@ -139,7 +138,7 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
       if (ancestor.id === id) {
         return ancestor;
       }
-      ancestor = ancestor._parent;
+      ancestor = ancestor.#parent;
     }
     return undefined;
   }
@@ -330,7 +329,7 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
           ? out
           : undefined;
       }
-      curSrcFrame = curSrcFrame._parent;
+      curSrcFrame = curSrcFrame.#parent;
     }
 
     return undefined;
@@ -483,12 +482,12 @@ export class CoordinateFrame<ID extends AnyFrameId = UserFrameId> {
 
       mat4.multiply(out, tempTransform.matrix(), out);
 
-      if (curFrame._parent == undefined) {
+      if (curFrame.#parent == undefined) {
         throw new Error(
           `Frame "${parentFrame.displayName()}" is not a parent of "${childFrame.displayName()}"`,
         );
       }
-      curFrame = curFrame._parent;
+      curFrame = curFrame.#parent;
     }
 
     return true;

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/Transform.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/Transform.ts
@@ -12,48 +12,48 @@ import { Pose, getRotationNoScaling, mat4Identity, quatIdentity, vec3Identity } 
  * are automatically kept in sync.
  */
 export class Transform {
-  private _position: vec3;
-  private _rotation: quat;
-  private _matrix: mat4;
+  #position: vec3;
+  #rotation: quat;
+  #matrix: mat4;
 
   public constructor(matrixOrPosition: mat4 | vec3, rotation?: quat) {
     if (matrixOrPosition.length === 16) {
-      this._matrix = matrixOrPosition;
-      this._position = [0, 0, 0];
-      this._rotation = [0, 0, 0, 1];
-      mat4.getTranslation(this._position, this._matrix);
-      getRotationNoScaling(this._rotation, this._matrix);
+      this.#matrix = matrixOrPosition;
+      this.#position = [0, 0, 0];
+      this.#rotation = [0, 0, 0, 1];
+      mat4.getTranslation(this.#position, this.#matrix);
+      getRotationNoScaling(this.#rotation, this.#matrix);
     } else if (matrixOrPosition.length === 3 && rotation != undefined) {
-      this._position = matrixOrPosition;
-      this._rotation = rotation;
-      quat.normalize(this._rotation, this._rotation);
-      this._matrix = mat4.fromRotationTranslation(mat4Identity(), this._rotation, this._position);
+      this.#position = matrixOrPosition;
+      this.#rotation = rotation;
+      quat.normalize(this.#rotation, this.#rotation);
+      this.#matrix = mat4.fromRotationTranslation(mat4Identity(), this.#rotation, this.#position);
     } else {
       throw new Error(`new Transform() expected either mat4 or vec3 + quat`);
     }
   }
 
   public position(): ReadonlyVec3 {
-    return this._position;
+    return this.#position;
   }
 
   public rotation(): ReadonlyQuat {
-    return this._rotation;
+    return this.#rotation;
   }
 
   public matrix(): ReadonlyMat4 {
-    return this._matrix;
+    return this.#matrix;
   }
 
   public setPosition(position: ReadonlyVec3): this {
-    vec3.copy(this._position, position);
-    mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
+    vec3.copy(this.#position, position);
+    mat4.fromRotationTranslation(this.#matrix, this.#rotation, this.#position);
     return this;
   }
 
   public setRotation(rotation: ReadonlyQuat): this {
-    quat.normalize(this._rotation, rotation);
-    mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
+    quat.normalize(this.#rotation, rotation);
+    mat4.fromRotationTranslation(this.#matrix, this.#rotation, this.#position);
     return this;
   }
 
@@ -63,9 +63,9 @@ export class Transform {
    * update the matrix once
    */
   public setPositionRotation(position: ReadonlyVec3, rotation: ReadonlyQuat): this {
-    vec3.copy(this._position, position);
-    quat.normalize(this._rotation, rotation);
-    mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
+    vec3.copy(this.#position, position);
+    quat.normalize(this.#rotation, rotation);
+    mat4.fromRotationTranslation(this.#matrix, this.#rotation, this.#position);
     return this;
   }
 
@@ -73,16 +73,16 @@ export class Transform {
    * Update position and rotation from a Pose object
    */
   public setPose(pose: Readonly<Pose>): this {
-    vec3.set(this._position, pose.position.x, pose.position.y, pose.position.z);
+    vec3.set(this.#position, pose.position.x, pose.position.y, pose.position.z);
     quat.set(
-      this._rotation,
+      this.#rotation,
       pose.orientation.x,
       pose.orientation.y,
       pose.orientation.z,
       pose.orientation.w,
     );
-    quat.normalize(this._rotation, this._rotation);
-    mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
+    quat.normalize(this.#rotation, this.#rotation);
+    mat4.fromRotationTranslation(this.#matrix, this.#rotation, this.#position);
     return this;
   }
 
@@ -90,9 +90,9 @@ export class Transform {
    * Update position and rotation from a matrix with unit scale
    */
   public setMatrixUnscaled(matrix: ReadonlyMat4): this {
-    mat4.copy(this._matrix, matrix);
-    mat4.getTranslation(this._position, matrix);
-    getRotationNoScaling(this._rotation, matrix); // A faster mat4.getRotation when there is no scaling
+    mat4.copy(this.#matrix, matrix);
+    mat4.getTranslation(this.#position, matrix);
+    getRotationNoScaling(this.#rotation, matrix); // A faster mat4.getRotation when there is no scaling
     return this;
   }
 
@@ -101,22 +101,22 @@ export class Transform {
    */
   public copy(other: Transform): this {
     // eslint-disable-next-line no-underscore-dangle
-    vec3.copy(this._position, other._position);
+    vec3.copy(this.#position, other._position);
     // eslint-disable-next-line no-underscore-dangle
-    quat.copy(this._rotation, other._rotation);
+    quat.copy(this.#rotation, other._rotation);
     // eslint-disable-next-line no-underscore-dangle
-    mat4.copy(this._matrix, other._matrix);
+    mat4.copy(this.#matrix, other._matrix);
     return this;
   }
 
   public toPose(out: Pose): void {
-    out.position.x = this._position[0];
-    out.position.y = this._position[1];
-    out.position.z = this._position[2];
-    out.orientation.x = this._rotation[0];
-    out.orientation.y = this._rotation[1];
-    out.orientation.z = this._rotation[2];
-    out.orientation.w = this._rotation[3];
+    out.position.x = this.#position[0];
+    out.position.y = this.#position[1];
+    out.position.z = this.#position[2];
+    out.orientation.x = this.#rotation[0];
+    out.orientation.y = this.#rotation[1];
+    out.orientation.z = this.#rotation[2];
+    out.orientation.w = this.#rotation[3];
   }
 
   public static Identity(): Transform {

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/Transform.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/Transform.ts
@@ -100,12 +100,9 @@ export class Transform {
    * Copy the values in another transform into this one
    */
   public copy(other: Transform): this {
-    // eslint-disable-next-line no-underscore-dangle
-    vec3.copy(this.#position, other._position);
-    // eslint-disable-next-line no-underscore-dangle
-    quat.copy(this.#rotation, other._rotation);
-    // eslint-disable-next-line no-underscore-dangle
-    mat4.copy(this.#matrix, other._matrix);
+    vec3.copy(this.#position, other.#position);
+    quat.copy(this.#rotation, other.#rotation);
+    mat4.copy(this.#matrix, other.#matrix);
     return this;
   }
 
@@ -135,12 +132,9 @@ export class Transform {
    * @returns A reference to `out`
    */
   public static Interpolate(out: Transform, a: Transform, b: Transform, t: number): Transform {
-    // eslint-disable-next-line no-underscore-dangle
-    vec3.lerp(out._position, a.position(), b.position(), t);
-    // eslint-disable-next-line no-underscore-dangle
-    quat.slerp(out._rotation, a.rotation(), b.rotation(), t);
-    // eslint-disable-next-line no-underscore-dangle
-    out.setPositionRotation(out._position, out._rotation);
+    vec3.lerp(out.#position, a.position(), b.position(), t);
+    quat.slerp(out.#rotation, a.rotation(), b.rotation(), t);
+    out.setPositionRotation(out.#position, out.#rotation);
     return out;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -20,22 +20,22 @@ export enum AddTransformResult {
  * for getting and creating frames and adding transforms between frames.
  */
 export class TransformTree {
-  private _frames = new Map<string, CoordinateFrame>();
-  private _maxStorageTime: Duration;
-  private _maxCapacityPerFrame: number;
+  #frames = new Map<string, CoordinateFrame>();
+  #maxStorageTime: Duration;
+  #maxCapacityPerFrame: number;
   public defaultRootFrame: CoordinateFrame<FallbackFrameId>;
 
   public constructor(
     maxStorageTime = MAX_DURATION,
     maxCapacityPerFrame = DEFAULT_MAX_CAPACITY_PER_FRAME,
   ) {
-    this._maxStorageTime = maxStorageTime;
-    this._maxCapacityPerFrame = maxCapacityPerFrame;
+    this.#maxStorageTime = maxStorageTime;
+    this.#maxCapacityPerFrame = maxCapacityPerFrame;
     this.defaultRootFrame = new CoordinateFrame(
       CoordinateFrame.FALLBACK_FRAME_ID,
       undefined,
-      this._maxStorageTime,
-      this._maxCapacityPerFrame,
+      this.#maxStorageTime,
+      this.#maxCapacityPerFrame,
     );
     this.defaultRootFrame.addTransform(0n, Transform.Identity());
   }
@@ -51,7 +51,7 @@ export class TransformTree {
     const frame = this.getOrCreateFrame(frameId);
     const curParentFrame = frame.parent();
     if (curParentFrame == undefined || curParentFrame.id !== parentFrameId) {
-      cycleDetected = this._checkParentForCycle(frameId, parentFrameId);
+      cycleDetected = this.#checkParentForCycle(frameId, parentFrameId);
       // This frame was previously unparented but now we know its parent, or we
       // are reparenting this frame
       if (!cycleDetected) {
@@ -83,14 +83,14 @@ export class TransformTree {
       return;
     }
     child.removeTransformAt(stamp);
-    this._removeEmptyAncestors(child);
+    this.#removeEmptyAncestors(child);
   }
 
   /**
    * Walk up the tree starting from `candidate` and prune frames with no history entries and no
    * children.
    */
-  private _removeEmptyAncestors(candidate: CoordinateFrame): void {
+  #removeEmptyAncestors(candidate: CoordinateFrame): void {
     if (candidate.transformsSize() > 0) {
       // don't want to delete this frame, it is not empty
       return;
@@ -99,10 +99,10 @@ export class TransformTree {
     // Build a list of children for each frame in the tree, used to check whether nodes are leaf
     // nodes
     const childrenByParentId = new Map<string, Set<string>>();
-    for (const frame of this._frames.values()) {
+    for (const frame of this.#frames.values()) {
       childrenByParentId.set(frame.id, new Set());
     }
-    for (const frame of this._frames.values()) {
+    for (const frame of this.#frames.values()) {
       const parent = frame.parent();
       if (parent === candidate) {
         // can't delete this frame or its ancestors, it still has children
@@ -133,7 +133,7 @@ export class TransformTree {
         // can't delete this frame or its ancestors, it still has children
         return;
       }
-      this._frames.delete(current.id);
+      this.#frames.delete(current.id);
       childrenByParentId.delete(current.id);
       const parentId = current.parent()?.id;
       if (parentId) {
@@ -143,11 +143,11 @@ export class TransformTree {
   }
 
   public clear(): void {
-    this._frames.clear();
+    this.#frames.clear();
   }
 
   public clearAfter(time: Time): void {
-    for (const frame of this._frames.values()) {
+    for (const frame of this.#frames.values()) {
       frame.removeTransformsAfter(time);
     }
   }
@@ -156,27 +156,27 @@ export class TransformTree {
     if (id === CoordinateFrame.FALLBACK_FRAME_ID) {
       return true;
     }
-    return this._frames.has(id);
+    return this.#frames.has(id);
   }
 
   public frame<ID extends AnyFrameId>(id: ID): CoordinateFrame<ID> | undefined {
     if (id === CoordinateFrame.FALLBACK_FRAME_ID) {
       return this.defaultRootFrame as CoordinateFrame<ID>;
     }
-    return this._frames.get(id) as CoordinateFrame<ID>;
+    return this.#frames.get(id) as CoordinateFrame<ID>;
   }
 
   public getOrCreateFrame(id: string): CoordinateFrame {
-    let frame = this._frames.get(id);
+    let frame = this.#frames.get(id);
     if (!frame) {
-      frame = new CoordinateFrame(id, undefined, this._maxStorageTime, this._maxCapacityPerFrame);
-      this._frames.set(id, frame);
+      frame = new CoordinateFrame(id, undefined, this.#maxStorageTime, this.#maxCapacityPerFrame);
+      this.#frames.set(id, frame);
     }
     return frame;
   }
 
   public frames(): ReadonlyMap<string, CoordinateFrame> {
-    return this._frames;
+    return this.#frames;
   }
 
   public apply(
@@ -202,7 +202,7 @@ export class TransformTree {
   public frameList(): { label: string; value: string }[] {
     type FrameEntry = { id: string; children: FrameEntry[] };
 
-    const frames = Array.from(this._frames.values());
+    const frames = Array.from(this.#frames.values());
     const frameMap = new Map<string, FrameEntry>(
       frames.map((frame) => [frame.id, { id: frame.id, children: [] }]),
     );
@@ -245,7 +245,7 @@ export class TransformTree {
 
     return output;
   }
-  private _checkParentForCycle(frameId: string, parentFrameId: string): boolean {
+  #checkParentForCycle(frameId: string, parentFrameId: string): boolean {
     if (frameId === parentFrameId) {
       return true;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -261,10 +261,8 @@ export class TransformTree {
   }
 
   public static Clone(tree: TransformTree): TransformTree {
-    // eslint-disable-next-line no-underscore-dangle
-    const newTree = new TransformTree(tree._maxStorageTime, tree._maxCapacityPerFrame);
-    // eslint-disable-next-line no-underscore-dangle
-    newTree._frames = tree._frames;
+    const newTree = new TransformTree(tree.#maxStorageTime, tree.#maxCapacityPerFrame);
+    newTree.#frames = tree.#frames;
     return newTree;
   }
 }

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -15,20 +15,20 @@ const log = Log.getLogger(__filename);
 type EventData = { [key: string]: string | number | boolean };
 
 export default class AnalyticsMetricsCollector implements PlayerMetricsCollectorInterface {
-  private metadata: EventData = {};
-  private _analytics: IAnalytics;
+  #metadata: EventData = {};
+  #analytics: IAnalytics;
 
   public constructor(analytics: IAnalytics) {
     log.debug("New AnalyticsMetricsCollector");
-    this._analytics = analytics;
+    this.#analytics = analytics;
   }
 
   public setProperty(key: string, value: string | number | boolean): void {
-    this.metadata[key] = value;
+    this.#metadata[key] = value;
   }
 
   public logEvent(event: AppEvent, data?: EventData): void {
-    void this._analytics.logEvent(event, { ...this.metadata, ...data });
+    void this.#analytics.logEvent(event, { ...this.#metadata, ...data });
   }
 
   public playerConstructed(): void {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -214,7 +214,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#problems.addProblem("ws:connection-failed", {
           severity: "error",
           message: "Insecure WebSocket connection",
-          tip: `Check that the WebSocket server at ${this.#url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+          tip: `Check that the WebSocket server at ${
+            this.#url
+          } is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
         });
         this.#emitState();
       }
@@ -244,7 +246,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#problems.addProblem("ws:connection-failed", {
         severity: "error",
         message: "Connection failed",
-        tip: `Check that the WebSocket server at ${this.#url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+        tip: `Check that the WebSocket server at ${
+          this.#url
+        } is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
       });
 
       this.#emitState();

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -74,17 +74,17 @@ type ResolvedService = {
 };
 
 export default class FoxgloveWebSocketPlayer implements Player {
-  private readonly _sourceId: string;
+  readonly #sourceId: string;
 
-  private _url: string; // WebSocket URL.
-  private _name: string;
-  private _client?: FoxgloveClient; // The client when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player session.
-  private _serverCapabilities: string[] = [];
-  private _playerCapabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
-  private _supportedEncodings?: string[];
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed: boolean = false; // Whether the player has been completely closed using close().
+  #url: string; // WebSocket URL.
+  #name: string;
+  #client?: FoxgloveClient; // The client when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player session.
+  #serverCapabilities: string[] = [];
+  #playerCapabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
+  #supportedEncodings?: string[];
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed: boolean = false; // Whether the player has been completely closed using close().
   private _topics?: Topic[]; // Topics as published by the WebSocket.
   private _topicsStats = new Map<string, TopicStats>(); // Topic names to topic statistics.
   private _datatypes: RosDatatypes = new Map(); // Datatypes as published by the WebSocket.
@@ -141,42 +141,42 @@ export default class FoxgloveWebSocketPlayer implements Player {
     sourceId: string;
   }) {
     this._metricsCollector = metricsCollector;
-    this._url = url;
-    this._name = url;
+    this.#url = url;
+    this.#name = url;
     this._metricsCollector.playerConstructed();
-    this._sourceId = sourceId;
+    this.#sourceId = sourceId;
     this._urlState = {
-      sourceId: this._sourceId,
-      parameters: { url: this._url },
+      sourceId: this.#sourceId,
+      parameters: { url: this.#url },
     };
-    this._open();
+    this.#open();
   }
 
-  private _open = (): void => {
-    if (this._closed) {
+  #open = (): void => {
+    if (this.#closed) {
       return;
     }
-    if (this._client != undefined) {
+    if (this.#client != undefined) {
       throw new Error(`Attempted to open a second Foxglove WebSocket connection`);
     }
-    log.info(`Opening connection to ${this._url}`);
+    log.info(`Opening connection to ${this.#url}`);
 
     // Set a timeout to abort the connection if we are still not connected by then.
     // This will abort hanging connection attempts that can for whatever reason not
     // establish a connection with the server.
     this._connectionAttemptTimeout = setTimeout(() => {
-      this._client?.close();
+      this.#client?.close();
     }, 10000);
 
-    this._client = new FoxgloveClient({
+    this.#client = new FoxgloveClient({
       ws:
         typeof Worker !== "undefined"
-          ? new WorkerSocketAdapter(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
-          : new WebSocket(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
+          ? new WorkerSocketAdapter(this.#url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
+          : new WebSocket(this.#url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
     });
 
-    this._client.on("open", () => {
-      if (this._closed) {
+    this.#client.on("open", () => {
+      if (this.#closed) {
         return;
       }
       if (this._connectionAttemptTimeout != undefined) {
@@ -204,7 +204,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._resolvedSubscriptionsByTopic.clear();
     });
 
-    this._client.on("error", (err) => {
+    this.#client.on("error", (err) => {
       log.error(err);
 
       if (
@@ -214,7 +214,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this._problems.addProblem("ws:connection-failed", {
           severity: "error",
           message: "Insecure WebSocket connection",
-          tip: `Check that the WebSocket server at ${this._url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+          tip: `Check that the WebSocket server at ${this.#url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
         });
         this._emitState();
       }
@@ -226,7 +226,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     // Note: We explicitly avoid clearing state like start/end times, datatypes, etc to preserve
     // this during a disconnect event. Any necessary state clearing is handled once a new connection
     // is established
-    this._client.on("close", (event) => {
+    this.#client.on("close", (event) => {
       log.info("Connection closed:", event);
       this._presence = PlayerPresence.RECONNECTING;
 
@@ -238,20 +238,20 @@ export default class FoxgloveWebSocketPlayer implements Player {
         clearTimeout(this._connectionAttemptTimeout);
       }
 
-      this._client?.close();
-      this._client = undefined;
+      this.#client?.close();
+      this.#client = undefined;
 
       this._problems.addProblem("ws:connection-failed", {
         severity: "error",
         message: "Connection failed",
-        tip: `Check that the WebSocket server at ${this._url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+        tip: `Check that the WebSocket server at ${this.#url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
       });
 
       this._emitState();
-      this._openTimeout = setTimeout(this._open, 3000);
+      this._openTimeout = setTimeout(this.#open, 3000);
     });
 
-    this._client.on("serverInfo", (event) => {
+    this.#client.on("serverInfo", (event) => {
       if (!Array.isArray(event.capabilities)) {
         this._problems.addProblem("ws:invalid-capabilities", {
           severity: "warn",
@@ -260,15 +260,15 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       const newSessionId = event.sessionId ?? uuidv4();
-      if (this._id !== newSessionId) {
+      if (this.#id !== newSessionId) {
         this._resetSessionState();
       }
 
-      this._id = newSessionId;
-      this._name = `${this._url}\n${event.name}`;
-      this._serverCapabilities = Array.isArray(event.capabilities) ? event.capabilities : [];
-      this._serverPublishesTime = this._serverCapabilities.includes(ServerCapability.time);
-      this._supportedEncodings = event.supportedEncodings;
+      this.#id = newSessionId;
+      this.#name = `${this.#url}\n${event.name}`;
+      this.#serverCapabilities = Array.isArray(event.capabilities) ? event.capabilities : [];
+      this._serverPublishesTime = this.#serverCapabilities.includes(ServerCapability.time);
+      this.#supportedEncodings = event.supportedEncodings;
       this._datatypes = new Map();
 
       // If the server publishes the time we clear any existing clockTime we might have and let the
@@ -299,8 +299,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       if (event.capabilities.includes(ServerCapability.clientPublish)) {
-        this._playerCapabilities = this._playerCapabilities.concat(PlayerCapabilities.advertise);
-        this._setupPublishers();
+        this.#playerCapabilities = this.#playerCapabilities.concat(PlayerCapabilities.advertise);
+        this.#setupPublishers();
       }
       if (event.capabilities.includes(ServerCapability.services)) {
         this._serviceCallEncoding = event.supportedEncodings?.find((e) =>
@@ -309,7 +309,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
         const problemId = "callService:unsupportedEncoding";
         if (this._serviceCallEncoding) {
-          this._playerCapabilities = this._playerCapabilities.concat(
+          this.#playerCapabilities = this.#playerCapabilities.concat(
             PlayerCapabilities.callServices,
           );
           this._problems.removeProblem(problemId);
@@ -324,27 +324,27 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       if (event.capabilities.includes(ServerCapability.parameters)) {
-        this._playerCapabilities = this._playerCapabilities.concat(
+        this.#playerCapabilities = this.#playerCapabilities.concat(
           PlayerCapabilities.getParameters,
           PlayerCapabilities.setParameters,
         );
 
         // Periodically request all available parameters.
         this._getParameterInterval = setInterval(() => {
-          this._client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
+          this.#client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
         }, GET_ALL_PARAMS_PERIOD_MS);
 
-        this._client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
+        this.#client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
       }
 
       if (event.capabilities.includes(ServerCapability.connectionGraph)) {
-        this._client?.subscribeConnectionGraph();
+        this.#client?.subscribeConnectionGraph();
       }
 
       this._emitState();
     });
 
-    this._client.on("status", (event) => {
+    this.#client.on("status", (event) => {
       const msg = `FoxgloveWebSocket: ${event.message}`;
       if (event.level === StatusLevel.INFO) {
         log.info(msg);
@@ -368,7 +368,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    this._client.on("advertise", (newChannels) => {
+    this.#client.on("advertise", (newChannels) => {
       for (const channel of newChannels) {
         let parsedChannel;
         try {
@@ -444,12 +444,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this._channelsById.set(channel.id, resolvedChannel);
         this._channelsByTopic.set(channel.topic, resolvedChannel);
       }
-      this._updateTopicsAndDatatypes();
+      this.#updateTopicsAndDatatypes();
       this._emitState();
       this._processUnresolvedSubscriptions();
     });
 
-    this._client.on("unadvertise", (removedChannels) => {
+    this.#client.on("unadvertise", (removedChannels) => {
       for (const id of removedChannels) {
         const chanInfo = this._channelsById.get(id);
         if (!chanInfo) {
@@ -466,18 +466,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
           if (channel.id === id) {
             this._resolvedSubscriptionsById.delete(subId);
             this._resolvedSubscriptionsByTopic.delete(channel.topic);
-            this._client?.unsubscribe(subId);
+            this.#client?.unsubscribe(subId);
             this._unresolvedSubscriptions.add(channel.topic);
           }
         }
         this._channelsById.delete(id);
         this._channelsByTopic.delete(chanInfo.channel.topic);
       }
-      this._updateTopicsAndDatatypes();
+      this.#updateTopicsAndDatatypes();
       this._emitState();
     });
 
-    this._client.on("message", ({ subscriptionId, data }) => {
+    this.#client.on("message", ({ subscriptionId, data }) => {
       if (!this._hasReceivedMessage) {
         this._hasReceivedMessage = true;
         this._metricsCollector.recordTimeToFirstMsgs();
@@ -524,7 +524,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    this._client.on("time", ({ timestamp }) => {
+    this.#client.on("time", ({ timestamp }) => {
       if (!this._serverPublishesTime) {
         return;
       }
@@ -539,7 +539,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    this._client.on("parameterValues", ({ parameters, id }) => {
+    this.#client.on("parameterValues", ({ parameters, id }) => {
       const newParameters = parameters.filter((param) => !this._parameters.has(param.name));
 
       if (id === GET_ALL_PARAMS_REQUEST_ID) {
@@ -554,14 +554,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
       if (
         newParameters.length > 0 &&
-        this._serverCapabilities.includes(ServerCapability.parametersSubscribe)
+        this.#serverCapabilities.includes(ServerCapability.parametersSubscribe)
       ) {
         // Subscribe to value updates of new parameters
-        this._client?.subscribeParameterUpdates(newParameters.map((p) => p.name));
+        this.#client?.subscribeParameterUpdates(newParameters.map((p) => p.name));
       }
     });
 
-    this._client.on("advertiseServices", (services) => {
+    this.#client.on("advertiseServices", (services) => {
       if (!this._serviceCallEncoding) {
         return;
       }
@@ -619,7 +619,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    this._client.on("unadvertiseServices", (serviceIds) => {
+    this.#client.on("unadvertiseServices", (serviceIds) => {
       for (const serviceId of serviceIds) {
         const service: ResolvedService | undefined = Object.values(this._servicesByName).find(
           (srv) => srv.service.id === serviceId,
@@ -630,7 +630,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
     });
 
-    this._client.on("serviceCallResponse", (response) => {
+    this.#client.on("serviceCallResponse", (response) => {
       const responseCallback = this._serviceResponseCbs.get(response.callId);
       if (!responseCallback) {
         this._problems.addProblem(`callService:${response.callId}`, {
@@ -643,7 +643,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._serviceResponseCbs.delete(response.callId);
     });
 
-    this._client.on("connectionGraphUpdate", (event) => {
+    this.#client.on("connectionGraphUpdate", (event) => {
       if (event.publishedTopics.length > 0 || event.removedTopics.length > 0) {
         const newMap: Map<string, Set<string>> = new Map(this._publishedTopics ?? new Map());
         for (const { name, publisherIds } of event.publishedTopics) {
@@ -673,7 +673,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     });
   };
 
-  private _updateTopicsAndDatatypes() {
+  #updateTopicsAndDatatypes() {
     // Build a new topics array from this._channelsById
     const topics: Topic[] = Array.from(this._channelsById.values(), (chanInfo) => ({
       name: chanInfo.channel.topic,
@@ -703,18 +703,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
     if (!this._topics) {
-      return this._listener({
-        name: this._name,
+      return this.#listener({
+        name: this.#name,
         presence: this._presence,
         progress: {},
-        capabilities: this._playerCapabilities,
+        capabilities: this.#playerCapabilities,
         profile: undefined,
-        playerId: this._id,
+        playerId: this.#id,
         activeData: undefined,
         problems: this._problems.problems(),
         urlState: this._urlState,
@@ -731,13 +731,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     const messages = this._parsedMessages;
     this._parsedMessages = [];
-    return this._listener({
-      name: this._name,
+    return this.#listener({
+      name: this.#name,
       presence: this._presence,
       progress: {},
-      capabilities: this._playerCapabilities,
+      capabilities: this.#playerCapabilities,
       profile: this._profile,
-      playerId: this._id,
+      playerId: this.#id,
       problems: this._problems.problems(),
       urlState: this._urlState,
 
@@ -763,13 +763,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
+    this.#listener = listener;
     this._emitState();
   }
 
   public close(): void {
-    this._closed = true;
-    this._client?.close();
+    this.#closed = true;
+    this.#client?.close();
     this._metricsCollector.close();
     this._hasReceivedMessage = false;
     if (this._openTimeout != undefined) {
@@ -785,7 +785,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
     const newTopics = new Set(subscriptions.map(({ topic }) => topic));
 
-    if (!this._client || this._closed) {
+    if (!this.#client || this.#closed) {
       // Remember requested subscriptions so we can retry subscribing when
       // the client is available.
       this._unresolvedSubscriptions = newTopics;
@@ -800,7 +800,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     for (const [topic, subId] of this._resolvedSubscriptionsByTopic) {
       if (!newTopics.has(topic)) {
-        this._client.unsubscribe(subId);
+        this.#client.unsubscribe(subId);
         this._resolvedSubscriptionsByTopic.delete(topic);
         this._resolvedSubscriptionsById.delete(subId);
         this._recentlyCanceledSubscriptions.add(subId);
@@ -824,14 +824,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   private _processUnresolvedSubscriptions() {
-    if (!this._client) {
+    if (!this.#client) {
       return;
     }
 
     for (const topic of this._unresolvedSubscriptions) {
       const chanInfo = this._channelsByTopic.get(topic);
       if (chanInfo) {
-        const subId = this._client.subscribe(chanInfo.channel.id);
+        const subId = this.#client.subscribe(chanInfo.channel.id);
         this._unresolvedSubscriptions.delete(topic);
         this._resolvedSubscriptionsByTopic.set(topic, subId);
         this._resolvedSubscriptionsById.set(subId, chanInfo);
@@ -843,20 +843,20 @@ export default class FoxgloveWebSocketPlayer implements Player {
     // Since `setPublishers` is rarely called, we can get away with just unadvertising existing
     // channels und re-advertising them again
     for (const channel of this._publicationsByTopic.values()) {
-      this._client?.unadvertise(channel.id);
+      this.#client?.unadvertise(channel.id);
     }
     this._publicationsByTopic.clear();
     this._unresolvedPublications = publishers;
-    this._setupPublishers();
+    this.#setupPublishers();
   }
 
   public setParameter(key: string, value: ParameterValue): void {
-    if (!this._client) {
+    if (!this.#client) {
       throw new Error(`Attempted to set parameters without a valid Foxglove WebSocket connection`);
     }
 
     log.debug(`FoxgloveWebSocketPlayer.setParameter(key=${key}, value=${value})`);
-    this._client.setParameters([{ name: key, value: value as Parameter["value"] }], uuidv4());
+    this.#client.setParameters([{ name: key, value: value as Parameter["value"] }], uuidv4());
 
     // Pre-actively update our parameter map, such that a change is detected if our update failed
     this._parameters.set(key, value);
@@ -864,7 +864,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   public publish({ topic, msg }: PublishPayload): void {
-    if (!this._client) {
+    if (!this.#client) {
       throw new Error(`Attempted to publish without a valid Foxglove WebSocket connection`);
     }
 
@@ -881,18 +881,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
           : value;
       };
       const message = Buffer.from(JSON.stringify(msg, replacer) ?? "");
-      this._client.sendMessage(clientChannel.id, message);
+      this.#client.sendMessage(clientChannel.id, message);
     } else if (
       ROS_ENCODINGS.includes(clientChannel.encoding) &&
       clientChannel.messageWriter != undefined
     ) {
       const message = clientChannel.messageWriter.writeMessage(msg);
-      this._client.sendMessage(clientChannel.id, message);
+      this.#client.sendMessage(clientChannel.id, message);
     }
   }
 
   public async callService(serviceName: string, request: unknown): Promise<unknown> {
-    if (!this._client) {
+    if (!this.#client) {
       throw new Error(
         `Attempted to call service ${serviceName} without a valid Foxglove WebSocket connection.`,
       );
@@ -920,7 +920,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     const message = requestMessageWriter.writeMessage(request);
     serviceCallRequest.data = new DataView(message.buffer);
-    this._client.sendServiceCallRequest(serviceCallRequest);
+    this.#client.sendServiceCallRequest(serviceCallRequest);
 
     return await new Promise<Record<string, unknown>>((resolve, reject) => {
       this._serviceResponseCbs.set(serviceCallRequest.callId, (response: ServiceCallResponse) => {
@@ -951,9 +951,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
     return this._clockTime ?? ZERO_TIME;
   }
 
-  private _setupPublishers(): void {
+  #setupPublishers(): void {
     // This function will be called again once a connection is established
-    if (!this._client || this._closed) {
+    if (!this.#client || this.#closed) {
       return;
     }
 
@@ -963,8 +963,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     this._problems.removeProblems((id) => id.startsWith("pub:"));
 
-    const encoding = this._supportedEncodings
-      ? this._supportedEncodings.find((e) => SUPPORTED_PUBLICATION_ENCODINGS.includes(e))
+    const encoding = this.#supportedEncodings
+      ? this.#supportedEncodings.find((e) => SUPPORTED_PUBLICATION_ENCODINGS.includes(e))
       : FALLBACK_PUBLICATION_ENCODING;
 
     for (const { topic, schemaName, options } of this._unresolvedPublications) {
@@ -1003,7 +1003,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           encoding === "ros1" ? new Ros1MessageWriter(msgdef) : new Ros2MessageWriter(msgdef);
       }
 
-      const channelId = this._client.advertise(topic, encoding, schemaName);
+      const channelId = this.#client.advertise(topic, encoding, schemaName);
       this._publicationsByTopic.set(topic, {
         id: channelId,
         topic,

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -85,51 +85,51 @@ export default class FoxgloveWebSocketPlayer implements Player {
   #supportedEncodings?: string[];
   #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
   #closed: boolean = false; // Whether the player has been completely closed using close().
-  private _topics?: Topic[]; // Topics as published by the WebSocket.
-  private _topicsStats = new Map<string, TopicStats>(); // Topic names to topic statistics.
-  private _datatypes: RosDatatypes = new Map(); // Datatypes as published by the WebSocket.
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _receivedBytes: number = 0;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _hasReceivedMessage = false;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _problems = new PlayerProblemManager();
-  private _numTimeSeeks = 0;
-  private _profile?: string;
-  private _urlState: PlayerState["urlState"];
+  #topics?: Topic[]; // Topics as published by the WebSocket.
+  #topicsStats = new Map<string, TopicStats>(); // Topic names to topic statistics.
+  #datatypes: RosDatatypes = new Map(); // Datatypes as published by the WebSocket.
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #receivedBytes: number = 0;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #hasReceivedMessage = false;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #problems = new PlayerProblemManager();
+  #numTimeSeeks = 0;
+  #profile?: string;
+  #urlState: PlayerState["urlState"];
 
   /** Earliest time seen */
-  private _startTime?: Time;
+  #startTime?: Time;
   /** Latest time seen */
-  private _endTime?: Time;
+  #endTime?: Time;
   /* The most recent published time, if available */
-  private _clockTime?: Time;
+  #clockTime?: Time;
   /* Flag indicating if the server publishes time messages */
-  private _serverPublishesTime = false;
+  #serverPublishesTime = false;
 
-  private _unresolvedSubscriptions = new Set<string>();
-  private _resolvedSubscriptionsByTopic = new Map<string, SubscriptionId>();
-  private _resolvedSubscriptionsById = new Map<SubscriptionId, ResolvedChannel>();
-  private _channelsByTopic = new Map<string, ResolvedChannel>();
-  private _channelsById = new Map<ChannelId, ResolvedChannel>();
-  private _unsupportedChannelIds = new Set<ChannelId>();
-  private _recentlyCanceledSubscriptions = new Set<SubscriptionId>();
-  private _parameters = new Map<string, ParameterValue>();
-  private _getParameterInterval?: ReturnType<typeof setInterval>;
-  private _openTimeout?: ReturnType<typeof setInterval>;
-  private _connectionAttemptTimeout?: ReturnType<typeof setInterval>;
-  private _unresolvedPublications: AdvertiseOptions[] = [];
-  private _publicationsByTopic = new Map<string, Publication>();
-  private _serviceCallEncoding?: string;
-  private _servicesByName = new Map<string, ResolvedService>();
-  private _serviceResponseCbs = new Map<
+  #unresolvedSubscriptions = new Set<string>();
+  #resolvedSubscriptionsByTopic = new Map<string, SubscriptionId>();
+  #resolvedSubscriptionsById = new Map<SubscriptionId, ResolvedChannel>();
+  #channelsByTopic = new Map<string, ResolvedChannel>();
+  #channelsById = new Map<ChannelId, ResolvedChannel>();
+  #unsupportedChannelIds = new Set<ChannelId>();
+  #recentlyCanceledSubscriptions = new Set<SubscriptionId>();
+  #parameters = new Map<string, ParameterValue>();
+  #getParameterInterval?: ReturnType<typeof setInterval>;
+  #openTimeout?: ReturnType<typeof setInterval>;
+  #connectionAttemptTimeout?: ReturnType<typeof setInterval>;
+  #unresolvedPublications: AdvertiseOptions[] = [];
+  #publicationsByTopic = new Map<string, Publication>();
+  #serviceCallEncoding?: string;
+  #servicesByName = new Map<string, ResolvedService>();
+  #serviceResponseCbs = new Map<
     ServiceCallRequest["callId"],
     (response: ServiceCallResponse) => void
   >();
-  private _publishedTopics?: Map<string, Set<string>>;
-  private _subscribedTopics?: Map<string, Set<string>>;
-  private _advertisedServices?: Map<string, Set<string>>;
-  private _nextServiceCallId = 0;
+  #publishedTopics?: Map<string, Set<string>>;
+  #subscribedTopics?: Map<string, Set<string>>;
+  #advertisedServices?: Map<string, Set<string>>;
+  #nextServiceCallId = 0;
 
   public constructor({
     url,
@@ -140,12 +140,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
     metricsCollector: PlayerMetricsCollectorInterface;
     sourceId: string;
   }) {
-    this._metricsCollector = metricsCollector;
+    this.#metricsCollector = metricsCollector;
     this.#url = url;
     this.#name = url;
-    this._metricsCollector.playerConstructed();
+    this.#metricsCollector.playerConstructed();
     this.#sourceId = sourceId;
-    this._urlState = {
+    this.#urlState = {
       sourceId: this.#sourceId,
       parameters: { url: this.#url },
     };
@@ -164,7 +164,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     // Set a timeout to abort the connection if we are still not connected by then.
     // This will abort hanging connection attempts that can for whatever reason not
     // establish a connection with the server.
-    this._connectionAttemptTimeout = setTimeout(() => {
+    this.#connectionAttemptTimeout = setTimeout(() => {
       this.#client?.close();
     }, 10000);
 
@@ -179,29 +179,29 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (this.#closed) {
         return;
       }
-      if (this._connectionAttemptTimeout != undefined) {
-        clearTimeout(this._connectionAttemptTimeout);
+      if (this.#connectionAttemptTimeout != undefined) {
+        clearTimeout(this.#connectionAttemptTimeout);
       }
-      this._presence = PlayerPresence.PRESENT;
-      this._resetSessionState();
-      this._problems.clear();
-      this._channelsById.clear();
-      this._channelsByTopic.clear();
-      this._servicesByName.clear();
-      this._serviceResponseCbs.clear();
-      this._parameters.clear();
-      this._profile = undefined;
-      this._publishedTopics = undefined;
-      this._subscribedTopics = undefined;
-      this._advertisedServices = undefined;
-      this._publicationsByTopic.clear();
-      this._datatypes = new Map();
+      this.#presence = PlayerPresence.PRESENT;
+      this.#resetSessionState();
+      this.#problems.clear();
+      this.#channelsById.clear();
+      this.#channelsByTopic.clear();
+      this.#servicesByName.clear();
+      this.#serviceResponseCbs.clear();
+      this.#parameters.clear();
+      this.#profile = undefined;
+      this.#publishedTopics = undefined;
+      this.#subscribedTopics = undefined;
+      this.#advertisedServices = undefined;
+      this.#publicationsByTopic.clear();
+      this.#datatypes = new Map();
 
-      for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
-        this._unresolvedSubscriptions.add(topic);
+      for (const topic of this.#resolvedSubscriptionsByTopic.keys()) {
+        this.#unresolvedSubscriptions.add(topic);
       }
-      this._resolvedSubscriptionsById.clear();
-      this._resolvedSubscriptionsByTopic.clear();
+      this.#resolvedSubscriptionsById.clear();
+      this.#resolvedSubscriptionsByTopic.clear();
     });
 
     this.#client.on("error", (err) => {
@@ -211,12 +211,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
         (err as unknown as undefined | { message?: string })?.message != undefined &&
         err.message.includes("insecure WebSocket connection")
       ) {
-        this._problems.addProblem("ws:connection-failed", {
+        this.#problems.addProblem("ws:connection-failed", {
           severity: "error",
           message: "Insecure WebSocket connection",
           tip: `Check that the WebSocket server at ${this.#url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
         });
-        this._emitState();
+        this.#emitState();
       }
     });
 
@@ -228,32 +228,32 @@ export default class FoxgloveWebSocketPlayer implements Player {
     // is established
     this.#client.on("close", (event) => {
       log.info("Connection closed:", event);
-      this._presence = PlayerPresence.RECONNECTING;
+      this.#presence = PlayerPresence.RECONNECTING;
 
-      if (this._getParameterInterval != undefined) {
-        clearInterval(this._getParameterInterval);
-        this._getParameterInterval = undefined;
+      if (this.#getParameterInterval != undefined) {
+        clearInterval(this.#getParameterInterval);
+        this.#getParameterInterval = undefined;
       }
-      if (this._connectionAttemptTimeout != undefined) {
-        clearTimeout(this._connectionAttemptTimeout);
+      if (this.#connectionAttemptTimeout != undefined) {
+        clearTimeout(this.#connectionAttemptTimeout);
       }
 
       this.#client?.close();
       this.#client = undefined;
 
-      this._problems.addProblem("ws:connection-failed", {
+      this.#problems.addProblem("ws:connection-failed", {
         severity: "error",
         message: "Connection failed",
         tip: `Check that the WebSocket server at ${this.#url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
       });
 
-      this._emitState();
-      this._openTimeout = setTimeout(this.#open, 3000);
+      this.#emitState();
+      this.#openTimeout = setTimeout(this.#open, 3000);
     });
 
     this.#client.on("serverInfo", (event) => {
       if (!Array.isArray(event.capabilities)) {
-        this._problems.addProblem("ws:invalid-capabilities", {
+        this.#problems.addProblem("ws:invalid-capabilities", {
           severity: "warn",
           message: `Server sent an invalid or missing capabilities field: '${event.capabilities}'`,
         });
@@ -261,27 +261,27 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
       const newSessionId = event.sessionId ?? uuidv4();
       if (this.#id !== newSessionId) {
-        this._resetSessionState();
+        this.#resetSessionState();
       }
 
       this.#id = newSessionId;
       this.#name = `${this.#url}\n${event.name}`;
       this.#serverCapabilities = Array.isArray(event.capabilities) ? event.capabilities : [];
-      this._serverPublishesTime = this.#serverCapabilities.includes(ServerCapability.time);
+      this.#serverPublishesTime = this.#serverCapabilities.includes(ServerCapability.time);
       this.#supportedEncodings = event.supportedEncodings;
-      this._datatypes = new Map();
+      this.#datatypes = new Map();
 
       // If the server publishes the time we clear any existing clockTime we might have and let the
       // server override
-      if (this._serverPublishesTime) {
-        this._clockTime = undefined;
+      if (this.#serverPublishesTime) {
+        this.#clockTime = undefined;
       }
 
       const maybeRosDistro = event.metadata?.["ROS_DISTRO"];
       if (maybeRosDistro) {
         const rosDistro = maybeRosDistro;
         const isRos1 = ["melodic", "noetic"].includes(rosDistro);
-        this._profile = isRos1 ? "ros1" : "ros2";
+        this.#profile = isRos1 ? "ros1" : "ros2";
 
         // Add common ROS message definitions
         const rosDataTypes = isRos1
@@ -292,10 +292,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
         for (const dataType in rosDataTypes) {
           const msgDef = (rosDataTypes as Record<string, MessageDefinition>)[dataType]!;
-          this._datatypes.set(dataType, msgDef);
-          this._datatypes.set(dataTypeToFullName(dataType), msgDef);
+          this.#datatypes.set(dataType, msgDef);
+          this.#datatypes.set(dataTypeToFullName(dataType), msgDef);
         }
-        this._datatypes = new Map(this._datatypes); // Signal that datatypes changed.
+        this.#datatypes = new Map(this.#datatypes); // Signal that datatypes changed.
       }
 
       if (event.capabilities.includes(ServerCapability.clientPublish)) {
@@ -303,18 +303,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#setupPublishers();
       }
       if (event.capabilities.includes(ServerCapability.services)) {
-        this._serviceCallEncoding = event.supportedEncodings?.find((e) =>
+        this.#serviceCallEncoding = event.supportedEncodings?.find((e) =>
           SUPPORTED_SERVICE_ENCODINGS.includes(e),
         );
 
         const problemId = "callService:unsupportedEncoding";
-        if (this._serviceCallEncoding) {
+        if (this.#serviceCallEncoding) {
           this.#playerCapabilities = this.#playerCapabilities.concat(
             PlayerCapabilities.callServices,
           );
-          this._problems.removeProblem(problemId);
+          this.#problems.removeProblem(problemId);
         } else {
-          this._problems.addProblem(problemId, {
+          this.#problems.addProblem(problemId, {
             severity: "warn",
             message: `Calling services is disabled as no compatible encoding could be found. \
             The server supports [${event.supportedEncodings?.join(", ")}], \
@@ -330,7 +330,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         );
 
         // Periodically request all available parameters.
-        this._getParameterInterval = setInterval(() => {
+        this.#getParameterInterval = setInterval(() => {
           this.#client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
         }, GET_ALL_PARAMS_PERIOD_MS);
 
@@ -341,7 +341,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#client?.subscribeConnectionGraph();
       }
 
-      this._emitState();
+      this.#emitState();
     });
 
     this.#client.on("status", (event) => {
@@ -364,8 +364,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
           "Server is dropping messages to the client. Check if you are subscribing to large or frequent topics or adjust your server send buffer limit.";
       }
 
-      this._problems.addProblem(event.message, problem);
-      this._emitState();
+      this.#problems.addProblem(event.message, problem);
+      this.#emitState();
     });
 
     this.#client.on("advertise", (newChannels) => {
@@ -422,84 +422,84 @@ export default class FoxgloveWebSocketPlayer implements Player {
             schema: { name: channel.schemaName, encoding: schemaEncoding, data: schemaData },
           });
         } catch (error) {
-          this._unsupportedChannelIds.add(channel.id);
-          this._problems.addProblem(`schema:${channel.topic}`, {
+          this.#unsupportedChannelIds.add(channel.id);
+          this.#problems.addProblem(`schema:${channel.topic}`, {
             severity: "error",
             message: `Failed to parse channel schema on ${channel.topic}`,
             error,
           });
-          this._emitState();
+          this.#emitState();
           continue;
         }
-        const existingChannel = this._channelsByTopic.get(channel.topic);
+        const existingChannel = this.#channelsByTopic.get(channel.topic);
         if (existingChannel && !isEqual(channel, existingChannel.channel)) {
-          this._problems.addProblem(`duplicate-topic:${channel.topic}`, {
+          this.#problems.addProblem(`duplicate-topic:${channel.topic}`, {
             severity: "error",
             message: `Multiple channels advertise the same topic: ${channel.topic} (${existingChannel.channel.id} and ${channel.id})`,
           });
-          this._emitState();
+          this.#emitState();
           continue;
         }
         const resolvedChannel = { channel, parsedChannel };
-        this._channelsById.set(channel.id, resolvedChannel);
-        this._channelsByTopic.set(channel.topic, resolvedChannel);
+        this.#channelsById.set(channel.id, resolvedChannel);
+        this.#channelsByTopic.set(channel.topic, resolvedChannel);
       }
       this.#updateTopicsAndDatatypes();
-      this._emitState();
-      this._processUnresolvedSubscriptions();
+      this.#emitState();
+      this.#processUnresolvedSubscriptions();
     });
 
     this.#client.on("unadvertise", (removedChannels) => {
       for (const id of removedChannels) {
-        const chanInfo = this._channelsById.get(id);
+        const chanInfo = this.#channelsById.get(id);
         if (!chanInfo) {
-          if (!this._unsupportedChannelIds.delete(id)) {
-            this._problems.addProblem(`unadvertise:${id}`, {
+          if (!this.#unsupportedChannelIds.delete(id)) {
+            this.#problems.addProblem(`unadvertise:${id}`, {
               severity: "error",
               message: `Server unadvertised channel ${id} that was not advertised`,
             });
-            this._emitState();
+            this.#emitState();
           }
           continue;
         }
-        for (const [subId, { channel }] of this._resolvedSubscriptionsById) {
+        for (const [subId, { channel }] of this.#resolvedSubscriptionsById) {
           if (channel.id === id) {
-            this._resolvedSubscriptionsById.delete(subId);
-            this._resolvedSubscriptionsByTopic.delete(channel.topic);
+            this.#resolvedSubscriptionsById.delete(subId);
+            this.#resolvedSubscriptionsByTopic.delete(channel.topic);
             this.#client?.unsubscribe(subId);
-            this._unresolvedSubscriptions.add(channel.topic);
+            this.#unresolvedSubscriptions.add(channel.topic);
           }
         }
-        this._channelsById.delete(id);
-        this._channelsByTopic.delete(chanInfo.channel.topic);
+        this.#channelsById.delete(id);
+        this.#channelsByTopic.delete(chanInfo.channel.topic);
       }
       this.#updateTopicsAndDatatypes();
-      this._emitState();
+      this.#emitState();
     });
 
     this.#client.on("message", ({ subscriptionId, data }) => {
-      if (!this._hasReceivedMessage) {
-        this._hasReceivedMessage = true;
-        this._metricsCollector.recordTimeToFirstMsgs();
+      if (!this.#hasReceivedMessage) {
+        this.#hasReceivedMessage = true;
+        this.#metricsCollector.recordTimeToFirstMsgs();
       }
-      const chanInfo = this._resolvedSubscriptionsById.get(subscriptionId);
+      const chanInfo = this.#resolvedSubscriptionsById.get(subscriptionId);
       if (!chanInfo) {
-        const wasRecentlyCanceled = this._recentlyCanceledSubscriptions.has(subscriptionId);
+        const wasRecentlyCanceled = this.#recentlyCanceledSubscriptions.has(subscriptionId);
         if (!wasRecentlyCanceled) {
-          this._problems.addProblem(`message-missing-subscription:${subscriptionId}`, {
+          this.#problems.addProblem(`message-missing-subscription:${subscriptionId}`, {
             severity: "warn",
             message: `Received message on unknown subscription id: ${subscriptionId}. This might be a WebSocket server bug.`,
           });
-          this._emitState();
+          this.#emitState();
         }
         return;
       }
 
       try {
-        this._receivedBytes += data.byteLength;
-        const receiveTime = this._getCurrentTime();
+        this.#receivedBytes += data.byteLength;
+        const receiveTime = this.#getCurrentTime();
         const topic = chanInfo.channel.topic;
-        this._parsedMessages.push({
+        this.#parsedMessages.push({
           topic,
           receiveTime,
           message: chanInfo.parsedChannel.deserialize(data),
@@ -508,49 +508,49 @@ export default class FoxgloveWebSocketPlayer implements Player {
         });
 
         // Update the message count for this topic
-        let stats = this._topicsStats.get(topic);
+        let stats = this.#topicsStats.get(topic);
         if (!stats) {
           stats = { numMessages: 0 };
-          this._topicsStats.set(topic, stats);
+          this.#topicsStats.set(topic, stats);
         }
         stats.numMessages++;
       } catch (error) {
-        this._problems.addProblem(`message:${chanInfo.channel.topic}`, {
+        this.#problems.addProblem(`message:${chanInfo.channel.topic}`, {
           severity: "error",
           message: `Failed to parse message on ${chanInfo.channel.topic}`,
           error,
         });
       }
-      this._emitState();
+      this.#emitState();
     });
 
     this.#client.on("time", ({ timestamp }) => {
-      if (!this._serverPublishesTime) {
+      if (!this.#serverPublishesTime) {
         return;
       }
 
       const time = fromNanoSec(timestamp);
-      if (this._clockTime != undefined && isLessThan(time, this._clockTime)) {
-        this._numTimeSeeks++;
-        this._parsedMessages = [];
+      if (this.#clockTime != undefined && isLessThan(time, this.#clockTime)) {
+        this.#numTimeSeeks++;
+        this.#parsedMessages = [];
       }
 
-      this._clockTime = time;
-      this._emitState();
+      this.#clockTime = time;
+      this.#emitState();
     });
 
     this.#client.on("parameterValues", ({ parameters, id }) => {
-      const newParameters = parameters.filter((param) => !this._parameters.has(param.name));
+      const newParameters = parameters.filter((param) => !this.#parameters.has(param.name));
 
       if (id === GET_ALL_PARAMS_REQUEST_ID) {
         // Reset params
-        this._parameters = new Map(parameters.map((param) => [param.name, param.value]));
+        this.#parameters = new Map(parameters.map((param) => [param.name, param.value]));
       } else {
         // Update params
-        parameters.forEach((param) => this._parameters.set(param.name, param.value));
+        parameters.forEach((param) => this.#parameters.set(param.name, param.value));
       }
 
-      this._emitState();
+      this.#emitState();
 
       if (
         newParameters.length > 0 &&
@@ -562,26 +562,26 @@ export default class FoxgloveWebSocketPlayer implements Player {
     });
 
     this.#client.on("advertiseServices", (services) => {
-      if (!this._serviceCallEncoding) {
+      if (!this.#serviceCallEncoding) {
         return;
       }
 
       let schemaEncoding: string;
-      if (this._serviceCallEncoding === "json") {
+      if (this.#serviceCallEncoding === "json") {
         schemaEncoding = "jsonschema";
-      } else if (this._serviceCallEncoding === "ros1") {
+      } else if (this.#serviceCallEncoding === "ros1") {
         schemaEncoding = "ros1msg";
-      } else if (this._serviceCallEncoding === "cdr") {
+      } else if (this.#serviceCallEncoding === "cdr") {
         schemaEncoding = "ros2msg";
       } else {
-        throw new Error(`Unsupported encoding "${this._serviceCallEncoding}"`);
+        throw new Error(`Unsupported encoding "${this.#serviceCallEncoding}"`);
       }
 
       for (const service of services) {
         const requestType = `${service.type}_Request`;
         const responseType = `${service.type}_Response`;
         const parsedRequest = parseChannel({
-          messageEncoding: this._serviceCallEncoding,
+          messageEncoding: this.#serviceCallEncoding,
           schema: {
             name: requestType,
             encoding: schemaEncoding,
@@ -589,7 +589,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           },
         });
         const parsedResponse = parseChannel({
-          messageEncoding: this._serviceCallEncoding,
+          messageEncoding: this.#serviceCallEncoding,
           schema: {
             name: responseType,
             encoding: schemaEncoding,
@@ -597,188 +597,188 @@ export default class FoxgloveWebSocketPlayer implements Player {
           },
         });
         const requestMsgDef = rosDatatypesToMessageDefinition(parsedRequest.datatypes, requestType);
-        const requestMessageWriter = ROS_ENCODINGS.includes(this._serviceCallEncoding)
-          ? this._serviceCallEncoding === "ros1"
+        const requestMessageWriter = ROS_ENCODINGS.includes(this.#serviceCallEncoding)
+          ? this.#serviceCallEncoding === "ros1"
             ? new Ros1MessageWriter(requestMsgDef)
             : new Ros2MessageWriter(requestMsgDef)
           : new JsonMessageWriter();
 
         // Add type definitions for service response and request
         for (const [name, types] of [...parsedRequest.datatypes, ...parsedResponse.datatypes]) {
-          this._datatypes.set(name, types);
+          this.#datatypes.set(name, types);
         }
-        this._datatypes = new Map(this._datatypes); // Signal that datatypes changed.
+        this.#datatypes = new Map(this.#datatypes); // Signal that datatypes changed.
 
         const resolvedService: ResolvedService = {
           service,
           parsedResponse,
           requestMessageWriter,
         };
-        this._servicesByName.set(service.name, resolvedService);
+        this.#servicesByName.set(service.name, resolvedService);
       }
-      this._emitState();
+      this.#emitState();
     });
 
     this.#client.on("unadvertiseServices", (serviceIds) => {
       for (const serviceId of serviceIds) {
-        const service: ResolvedService | undefined = Object.values(this._servicesByName).find(
+        const service: ResolvedService | undefined = Object.values(this.#servicesByName).find(
           (srv) => srv.service.id === serviceId,
         );
         if (service) {
-          this._servicesByName.delete(service.service.name);
+          this.#servicesByName.delete(service.service.name);
         }
       }
     });
 
     this.#client.on("serviceCallResponse", (response) => {
-      const responseCallback = this._serviceResponseCbs.get(response.callId);
+      const responseCallback = this.#serviceResponseCbs.get(response.callId);
       if (!responseCallback) {
-        this._problems.addProblem(`callService:${response.callId}`, {
+        this.#problems.addProblem(`callService:${response.callId}`, {
           severity: "error",
           message: `Received a response for a service for which no callback was registered`,
         });
         return;
       }
       responseCallback(response);
-      this._serviceResponseCbs.delete(response.callId);
+      this.#serviceResponseCbs.delete(response.callId);
     });
 
     this.#client.on("connectionGraphUpdate", (event) => {
       if (event.publishedTopics.length > 0 || event.removedTopics.length > 0) {
-        const newMap: Map<string, Set<string>> = new Map(this._publishedTopics ?? new Map());
+        const newMap: Map<string, Set<string>> = new Map(this.#publishedTopics ?? new Map());
         for (const { name, publisherIds } of event.publishedTopics) {
           newMap.set(name, new Set(publisherIds));
         }
         event.removedTopics.forEach((topic) => newMap.delete(topic));
-        this._publishedTopics = newMap;
+        this.#publishedTopics = newMap;
       }
       if (event.subscribedTopics.length > 0 || event.removedTopics.length > 0) {
-        const newMap: Map<string, Set<string>> = new Map(this._subscribedTopics ?? new Map());
+        const newMap: Map<string, Set<string>> = new Map(this.#subscribedTopics ?? new Map());
         for (const { name, subscriberIds } of event.subscribedTopics) {
           newMap.set(name, new Set(subscriberIds));
         }
         event.removedTopics.forEach((topic) => newMap.delete(topic));
-        this._subscribedTopics = newMap;
+        this.#subscribedTopics = newMap;
       }
       if (event.advertisedServices.length > 0 || event.removedServices.length > 0) {
-        const newMap: Map<string, Set<string>> = new Map(this._advertisedServices ?? new Map());
+        const newMap: Map<string, Set<string>> = new Map(this.#advertisedServices ?? new Map());
         for (const { name, providerIds } of event.advertisedServices) {
           newMap.set(name, new Set(providerIds));
         }
         event.removedServices.forEach((service) => newMap.delete(service));
-        this._advertisedServices = newMap;
+        this.#advertisedServices = newMap;
       }
 
-      this._emitState();
+      this.#emitState();
     });
   };
 
   #updateTopicsAndDatatypes() {
     // Build a new topics array from this._channelsById
-    const topics: Topic[] = Array.from(this._channelsById.values(), (chanInfo) => ({
+    const topics: Topic[] = Array.from(this.#channelsById.values(), (chanInfo) => ({
       name: chanInfo.channel.topic,
       schemaName: chanInfo.channel.schemaName,
     }));
 
     // Remove stats entries for removed topics
     const topicsSet = new Set<string>(topics.map((topic) => topic.name));
-    for (const topic of this._topicsStats.keys()) {
+    for (const topic of this.#topicsStats.keys()) {
       if (!topicsSet.has(topic)) {
-        this._topicsStats.delete(topic);
+        this.#topicsStats.delete(topic);
       }
     }
 
-    this._topics = topics;
+    this.#topics = topics;
 
     // Update the _datatypes map;
-    for (const { parsedChannel } of this._channelsById.values()) {
+    for (const { parsedChannel } of this.#channelsById.values()) {
       for (const [name, types] of parsedChannel.datatypes) {
-        this._datatypes.set(name, types);
+        this.#datatypes.set(name, types);
       }
     }
-    this._datatypes = new Map(this._datatypes); // Signal that datatypes changed.
-    this._emitState();
+    this.#datatypes = new Map(this.#datatypes); // Signal that datatypes changed.
+    this.#emitState();
   }
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
+  #emitState = debouncePromise(() => {
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    if (!this._topics) {
+    if (!this.#topics) {
       return this.#listener({
         name: this.#name,
-        presence: this._presence,
+        presence: this.#presence,
         progress: {},
         capabilities: this.#playerCapabilities,
         profile: undefined,
         playerId: this.#id,
         activeData: undefined,
-        problems: this._problems.problems(),
-        urlState: this._urlState,
+        problems: this.#problems.problems(),
+        urlState: this.#urlState,
       });
     }
 
-    const currentTime = this._getCurrentTime();
-    if (!this._startTime || isLessThan(currentTime, this._startTime)) {
-      this._startTime = currentTime;
+    const currentTime = this.#getCurrentTime();
+    if (!this.#startTime || isLessThan(currentTime, this.#startTime)) {
+      this.#startTime = currentTime;
     }
-    if (!this._endTime || isGreaterThan(currentTime, this._endTime)) {
-      this._endTime = currentTime;
+    if (!this.#endTime || isGreaterThan(currentTime, this.#endTime)) {
+      this.#endTime = currentTime;
     }
 
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
     return this.#listener({
       name: this.#name,
-      presence: this._presence,
+      presence: this.#presence,
       progress: {},
       capabilities: this.#playerCapabilities,
-      profile: this._profile,
+      profile: this.#profile,
       playerId: this.#id,
-      problems: this._problems.problems(),
-      urlState: this._urlState,
+      problems: this.#problems.problems(),
+      urlState: this.#urlState,
 
       activeData: {
         messages,
-        totalBytesReceived: this._receivedBytes,
-        startTime: this._startTime,
-        endTime: this._endTime,
+        totalBytesReceived: this.#receivedBytes,
+        startTime: this.#startTime,
+        endTime: this.#endTime,
         currentTime,
         isPlaying: true,
         speed: 1,
-        lastSeekTime: this._numTimeSeeks,
-        topics: this._topics,
+        lastSeekTime: this.#numTimeSeeks,
+        topics: this.#topics,
         // Always copy topic stats since message counts and timestamps are being updated
-        topicStats: new Map(this._topicsStats),
-        datatypes: this._datatypes,
-        parameters: new Map(this._parameters),
-        publishedTopics: this._publishedTopics,
-        subscribedTopics: this._subscribedTopics,
-        services: this._advertisedServices,
+        topicStats: new Map(this.#topicsStats),
+        datatypes: this.#datatypes,
+        parameters: new Map(this.#parameters),
+        publishedTopics: this.#publishedTopics,
+        subscribedTopics: this.#subscribedTopics,
+        services: this.#advertisedServices,
       },
     });
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.#listener = listener;
-    this._emitState();
+    this.#emitState();
   }
 
   public close(): void {
     this.#closed = true;
     this.#client?.close();
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
-    if (this._openTimeout != undefined) {
-      clearTimeout(this._openTimeout);
-      this._openTimeout = undefined;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
+    if (this.#openTimeout != undefined) {
+      clearTimeout(this.#openTimeout);
+      this.#openTimeout = undefined;
     }
-    if (this._getParameterInterval != undefined) {
-      clearInterval(this._getParameterInterval);
-      this._getParameterInterval = undefined;
+    if (this.#getParameterInterval != undefined) {
+      clearInterval(this.#getParameterInterval);
+      this.#getParameterInterval = undefined;
     }
   }
 
@@ -788,53 +788,53 @@ export default class FoxgloveWebSocketPlayer implements Player {
     if (!this.#client || this.#closed) {
       // Remember requested subscriptions so we can retry subscribing when
       // the client is available.
-      this._unresolvedSubscriptions = newTopics;
+      this.#unresolvedSubscriptions = newTopics;
       return;
     }
 
     for (const topic of newTopics) {
-      if (!this._resolvedSubscriptionsByTopic.has(topic)) {
-        this._unresolvedSubscriptions.add(topic);
+      if (!this.#resolvedSubscriptionsByTopic.has(topic)) {
+        this.#unresolvedSubscriptions.add(topic);
       }
     }
 
-    for (const [topic, subId] of this._resolvedSubscriptionsByTopic) {
+    for (const [topic, subId] of this.#resolvedSubscriptionsByTopic) {
       if (!newTopics.has(topic)) {
         this.#client.unsubscribe(subId);
-        this._resolvedSubscriptionsByTopic.delete(topic);
-        this._resolvedSubscriptionsById.delete(subId);
-        this._recentlyCanceledSubscriptions.add(subId);
+        this.#resolvedSubscriptionsByTopic.delete(topic);
+        this.#resolvedSubscriptionsById.delete(subId);
+        this.#recentlyCanceledSubscriptions.add(subId);
 
         // Reset the message count for this topic
-        this._topicsStats.delete(topic);
+        this.#topicsStats.delete(topic);
 
         setTimeout(
-          () => this._recentlyCanceledSubscriptions.delete(subId),
+          () => this.#recentlyCanceledSubscriptions.delete(subId),
           SUBSCRIPTION_WARNING_SUPPRESSION_MS,
         );
       }
     }
-    for (const topic of this._unresolvedSubscriptions) {
+    for (const topic of this.#unresolvedSubscriptions) {
       if (!newTopics.has(topic)) {
-        this._unresolvedSubscriptions.delete(topic);
+        this.#unresolvedSubscriptions.delete(topic);
       }
     }
 
-    this._processUnresolvedSubscriptions();
+    this.#processUnresolvedSubscriptions();
   }
 
-  private _processUnresolvedSubscriptions() {
+  #processUnresolvedSubscriptions() {
     if (!this.#client) {
       return;
     }
 
-    for (const topic of this._unresolvedSubscriptions) {
-      const chanInfo = this._channelsByTopic.get(topic);
+    for (const topic of this.#unresolvedSubscriptions) {
+      const chanInfo = this.#channelsByTopic.get(topic);
       if (chanInfo) {
         const subId = this.#client.subscribe(chanInfo.channel.id);
-        this._unresolvedSubscriptions.delete(topic);
-        this._resolvedSubscriptionsByTopic.set(topic, subId);
-        this._resolvedSubscriptionsById.set(subId, chanInfo);
+        this.#unresolvedSubscriptions.delete(topic);
+        this.#resolvedSubscriptionsByTopic.set(topic, subId);
+        this.#resolvedSubscriptionsById.set(subId, chanInfo);
       }
     }
   }
@@ -842,11 +842,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
   public setPublishers(publishers: AdvertiseOptions[]): void {
     // Since `setPublishers` is rarely called, we can get away with just unadvertising existing
     // channels und re-advertising them again
-    for (const channel of this._publicationsByTopic.values()) {
+    for (const channel of this.#publicationsByTopic.values()) {
       this.#client?.unadvertise(channel.id);
     }
-    this._publicationsByTopic.clear();
-    this._unresolvedPublications = publishers;
+    this.#publicationsByTopic.clear();
+    this.#unresolvedPublications = publishers;
     this.#setupPublishers();
   }
 
@@ -859,8 +859,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this.#client.setParameters([{ name: key, value: value as Parameter["value"] }], uuidv4());
 
     // Pre-actively update our parameter map, such that a change is detected if our update failed
-    this._parameters.set(key, value);
-    this._emitState();
+    this.#parameters.set(key, value);
+    this.#emitState();
   }
 
   public publish({ topic, msg }: PublishPayload): void {
@@ -868,7 +868,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       throw new Error(`Attempted to publish without a valid Foxglove WebSocket connection`);
     }
 
-    const clientChannel = this._publicationsByTopic.get(topic);
+    const clientChannel = this.#publicationsByTopic.get(topic);
     if (!clientChannel) {
       throw new Error(`Tried to publish on topic '${topic}' that has not been advertised before.`);
     }
@@ -902,7 +902,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       throw new Error("FoxgloveWebSocketPlayer#callService request must be an object.");
     }
 
-    const resolvedService = this._servicesByName.get(serviceName);
+    const resolvedService = this.#servicesByName.get(serviceName);
     if (!resolvedService) {
       throw new Error(
         `Tried to call service '${serviceName}' that has not been advertised before.`,
@@ -913,8 +913,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     const serviceCallRequest: ServiceCallPayload = {
       serviceId: service.id,
-      callId: ++this._nextServiceCallId,
-      encoding: this._serviceCallEncoding!,
+      callId: ++this.#nextServiceCallId,
+      encoding: this.#serviceCallEncoding!,
       data: new DataView(new Uint8Array().buffer),
     };
 
@@ -923,7 +923,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this.#client.sendServiceCallRequest(serviceCallRequest);
 
     return await new Promise<Record<string, unknown>>((resolve, reject) => {
-      this._serviceResponseCbs.set(serviceCallRequest.callId, (response: ServiceCallResponse) => {
+      this.#serviceResponseCbs.set(serviceCallRequest.callId, (response: ServiceCallResponse) => {
         try {
           const data = parsedResponse.deserialize(response.data);
           resolve(data as Record<string, unknown>);
@@ -940,15 +940,15 @@ export default class FoxgloveWebSocketPlayer implements Player {
   //
   // For servers which publish a clock, we return that time. If the server disconnects we continue
   // to return the last known time. For servers which do not publish a clock, we use wall time.
-  private _getCurrentTime(): Time {
+  #getCurrentTime(): Time {
     // If the server does not publish the time, then we set the clock time to realtime as long as
     // the server is connected. When the server is not connected, time stops.
-    if (!this._serverPublishesTime) {
-      this._clockTime =
-        this._presence === PlayerPresence.PRESENT ? fromMillis(Date.now()) : this._clockTime;
+    if (!this.#serverPublishesTime) {
+      this.#clockTime =
+        this.#presence === PlayerPresence.PRESENT ? fromMillis(Date.now()) : this.#clockTime;
     }
 
-    return this._clockTime ?? ZERO_TIME;
+    return this.#clockTime ?? ZERO_TIME;
   }
 
   #setupPublishers(): void {
@@ -957,22 +957,22 @@ export default class FoxgloveWebSocketPlayer implements Player {
       return;
     }
 
-    if (this._unresolvedPublications.length === 0) {
+    if (this.#unresolvedPublications.length === 0) {
       return;
     }
 
-    this._problems.removeProblems((id) => id.startsWith("pub:"));
+    this.#problems.removeProblems((id) => id.startsWith("pub:"));
 
     const encoding = this.#supportedEncodings
       ? this.#supportedEncodings.find((e) => SUPPORTED_PUBLICATION_ENCODINGS.includes(e))
       : FALLBACK_PUBLICATION_ENCODING;
 
-    for (const { topic, schemaName, options } of this._unresolvedPublications) {
+    for (const { topic, schemaName, options } of this.#unresolvedPublications) {
       const encodingProblemId = `pub:encoding:${topic}`;
       const msgdefProblemId = `pub:msgdef:${topic}`;
 
       if (!encoding) {
-        this._problems.addProblem(encodingProblemId, {
+        this.#problems.addProblem(encodingProblemId, {
           severity: "warn",
           message: `Cannot advertise topic '${topic}': Server does not support one of the following encodings for client-side publishing: ${SUPPORTED_PUBLICATION_ENCODINGS}`,
         });
@@ -991,7 +991,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           msgdef = rosDatatypesToMessageDefinition(datatypes, schemaName);
         } catch (error) {
           log.debug(error);
-          this._problems.addProblem(msgdefProblemId, {
+          this.#problems.addProblem(msgdefProblemId, {
             severity: "warn",
             message: `Unknown message definition for "${topic}"`,
             tip: `Try subscribing to the topic "${topic}" before publishing to it`,
@@ -1004,7 +1004,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       const channelId = this.#client.advertise(topic, encoding, schemaName);
-      this._publicationsByTopic.set(topic, {
+      this.#publicationsByTopic.set(topic, {
         id: channelId,
         topic,
         encoding,
@@ -1013,20 +1013,20 @@ export default class FoxgloveWebSocketPlayer implements Player {
       });
     }
 
-    this._unresolvedPublications = [];
-    this._emitState();
+    this.#unresolvedPublications = [];
+    this.#emitState();
   }
 
-  private _resetSessionState(): void {
-    this._startTime = undefined;
-    this._endTime = undefined;
-    this._clockTime = undefined;
-    this._topicsStats = new Map();
-    this._parsedMessages = [];
-    this._receivedBytes = 0;
-    this._hasReceivedMessage = false;
-    this._problems.clear();
-    this._parameters.clear();
+  #resetSessionState(): void {
+    this.#startTime = undefined;
+    this.#endTime = undefined;
+    this.#clockTime = undefined;
+    this.#topicsStats = new Map();
+    this.#parsedMessages = [];
+    this.#receivedBytes = 0;
+    this.#hasReceivedMessage = false;
+    this.#problems.clear();
+    this.#parameters.clear();
   }
 }
 

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -31,14 +31,14 @@ import {
 type BagSource = { type: "file"; file: File } | { type: "remote"; url: string };
 
 export class BagIterableSource implements IIterableSource {
-  private readonly _source: BagSource;
+  readonly #source: BagSource;
 
-  private _bag: Bag | undefined;
-  private _readersByConnectionId = new Map<number, MessageReader>();
-  private _datatypesByConnectionId = new Map<number, string>();
+  #bag: Bag | undefined;
+  #readersByConnectionId = new Map<number, MessageReader>();
+  #datatypesByConnectionId = new Map<number, string>();
 
   public constructor(source: BagSource) {
-    this._source = source;
+    this.#source = source;
   }
 
   public async initialize(): Promise<Initalization> {
@@ -46,8 +46,8 @@ export class BagIterableSource implements IIterableSource {
     const bzip2 = await Bzip2.init();
 
     let fileLike: Filelike | undefined;
-    if (this._source.type === "remote") {
-      const bagUrl = this._source.url;
+    if (this.#source.type === "remote") {
+      const bagUrl = this.#source.url;
       const fileReader = new BrowserHttpReader(bagUrl);
       const remoteReader = new CachedFilelike({
         fileReader,
@@ -62,10 +62,10 @@ export class BagIterableSource implements IIterableSource {
 
       fileLike = remoteReader;
     } else {
-      fileLike = new BlobReader(this._source.file);
+      fileLike = new BlobReader(this.#source.file);
     }
 
-    this._bag = new Bag(fileLike, {
+    this.#bag = new Bag(fileLike, {
       parse: false,
       decompress: {
         bz2: (buffer: Uint8Array, size: number) => {
@@ -77,15 +77,15 @@ export class BagIterableSource implements IIterableSource {
       },
     });
 
-    await this._bag.open();
+    await this.#bag.open();
 
     const problems: PlayerProblem[] = [];
-    const chunksOverlapCount = getBagChunksOverlapCount(this._bag.chunkInfos);
+    const chunksOverlapCount = getBagChunksOverlapCount(this.#bag.chunkInfos);
     // If >25% of the chunks overlap, show a warning. It's common for a small number of chunks to overlap
     // since it looks like `rosbag record` has a bit of a race condition, and that's not too terrible, so
     // only warn when there's a more serious slowdown.
-    if (chunksOverlapCount > this._bag.chunkInfos.length * 0.25) {
-      const message = `This bag has many overlapping chunks (${chunksOverlapCount} out of ${this._bag.chunkInfos.length}). This results in more memory use during playback.`;
+    if (chunksOverlapCount > this.#bag.chunkInfos.length * 0.25) {
+      const message = `This bag has many overlapping chunks (${chunksOverlapCount} out of ${this.#bag.chunkInfos.length}). This results in more memory use during playback.`;
       const tip = "Re-sort the messages in your bag by receive time.";
       problems.push({
         severity: "warn",
@@ -94,8 +94,8 @@ export class BagIterableSource implements IIterableSource {
       });
     }
 
-    const numMessagesByConnectionIndex: number[] = new Array(this._bag.connections.size).fill(0);
-    this._bag.chunkInfos.forEach((info) => {
+    const numMessagesByConnectionIndex: number[] = new Array(this.#bag.connections.size).fill(0);
+    this.#bag.chunkInfos.forEach((info) => {
       info.connections.forEach(({ conn, count }) => {
         numMessagesByConnectionIndex[conn] += count;
       });
@@ -105,7 +105,7 @@ export class BagIterableSource implements IIterableSource {
     const topics = new Map<string, Topic>();
     const topicStats = new Map<string, TopicStats>();
     const publishersByTopic: Initalization["publishersByTopic"] = new Map();
-    for (const [id, connection] of this._bag.connections) {
+    for (const [id, connection] of this.#bag.connections) {
       const schemaName = connection.type;
       if (!schemaName) {
         continue;
@@ -139,8 +139,8 @@ export class BagIterableSource implements IIterableSource {
 
       const parsedDefinition = parseMessageDefinition(connection.messageDefinition);
       const reader = new MessageReader(parsedDefinition);
-      this._readersByConnectionId.set(id, reader);
-      this._datatypesByConnectionId.set(id, schemaName);
+      this.#readersByConnectionId.set(id, reader);
+      this.#datatypesByConnectionId.set(id, schemaName);
 
       for (const definition of parsedDefinition) {
         // In parsed definitions, the first definition (root) does not have a name as is meant to
@@ -156,8 +156,8 @@ export class BagIterableSource implements IIterableSource {
     return {
       topics: Array.from(topics.values()),
       topicStats,
-      start: this._bag.startTime ?? { sec: 0, nsec: 0 },
-      end: this._bag.endTime ?? { sec: 0, nsec: 0 },
+      start: this.#bag.startTime ?? { sec: 0, nsec: 0 },
+      end: this.#bag.endTime ?? { sec: 0, nsec: 0 },
       problems,
       profile: "ros1",
       datatypes,
@@ -168,25 +168,25 @@ export class BagIterableSource implements IIterableSource {
   public async *messageIterator(
     opt: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
-    yield* this._messageIterator({ ...opt, reverse: false });
+    yield* this.#messageIterator({ ...opt, reverse: false });
   }
 
-  private async *_messageIterator(
+  async *#messageIterator(
     opt: MessageIteratorArgs & { reverse: boolean },
   ): AsyncGenerator<Readonly<IteratorResult>> {
-    if (!this._bag) {
+    if (!this.#bag) {
       throw new Error("Invariant: uninitialized");
     }
 
     const end = opt.end;
 
-    const iterator = this._bag.messageIterator({
+    const iterator = this.#bag.messageIterator({
       topics: opt.topics,
       reverse: opt.reverse,
       start: opt.start,
     });
 
-    const readersByConnectionId = this._readersByConnectionId;
+    const readersByConnectionId = this.#readersByConnectionId;
     for await (const bagMsgEvent of iterator) {
       const connectionId = bagMsgEvent.connectionId;
       const reader = readersByConnectionId.get(connectionId);
@@ -195,7 +195,7 @@ export class BagIterableSource implements IIterableSource {
         return;
       }
 
-      const schemaName = this._datatypesByConnectionId.get(connectionId);
+      const schemaName = this.#datatypesByConnectionId.get(connectionId);
       if (!schemaName) {
         yield {
           type: "problem",
@@ -250,7 +250,7 @@ export class BagIterableSource implements IIterableSource {
       // NOTE: An iterator is made for each topic to get the latest message on that topic.
       // An single iterator for all the topics could result in iterating through many
       // irrelevant messages to get to an older message on a topic.
-      for await (const result of this._messageIterator({
+      for await (const result of this.#messageIterator({
         topics: [topic],
         start: time,
         reverse: true,

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -85,7 +85,9 @@ export class BagIterableSource implements IIterableSource {
     // since it looks like `rosbag record` has a bit of a race condition, and that's not too terrible, so
     // only warn when there's a more serious slowdown.
     if (chunksOverlapCount > this.#bag.chunkInfos.length * 0.25) {
-      const message = `This bag has many overlapping chunks (${chunksOverlapCount} out of ${this.#bag.chunkInfos.length}). This results in more memory use during playback.`;
+      const message = `This bag has many overlapping chunks (${chunksOverlapCount} out of ${
+        this.#bag.chunkInfos.length
+      }). This results in more memory use during playback.`;
       const tip = "Re-sort the messages in your bag by receive time.";
       problems.push({
         severity: "warn",

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -49,53 +49,53 @@ type LoadArgs = {
  * BlockLoader manages loading blocks from a source. Blocks are fixed time span containers for messages.
  */
 export class BlockLoader {
-  private source: IIterableSource;
-  private blocks: Blocks = [];
-  private start: Time;
-  private end: Time;
-  private blockDurationNanos: number;
-  private topics: Set<string> = new Set();
-  private maxCacheSize: number = 0;
-  private problemManager: PlayerProblemManager;
-  private stopped: boolean = false;
-  private activeChangeCondvar: Condvar = new Condvar();
+  #source: IIterableSource;
+  #blocks: Blocks = [];
+  #start: Time;
+  #end: Time;
+  #blockDurationNanos: number;
+  #topics: Set<string> = new Set();
+  #maxCacheSize: number = 0;
+  #problemManager: PlayerProblemManager;
+  #stopped: boolean = false;
+  #activeChangeCondvar: Condvar = new Condvar();
   private abortController: AbortController;
 
   public constructor(args: BlockLoaderArgs) {
-    this.source = args.source;
-    this.start = args.start;
-    this.end = args.end;
-    this.maxCacheSize = args.cacheSizeBytes;
-    this.problemManager = args.problemManager;
+    this.#source = args.source;
+    this.#start = args.start;
+    this.#end = args.end;
+    this.#maxCacheSize = args.cacheSizeBytes;
+    this.#problemManager = args.problemManager;
     this.abortController = new AbortController();
 
-    const totalNs = Number(toNanoSec(subtractTimes(this.end, this.start))) + 1; // +1 since times are inclusive.
+    const totalNs = Number(toNanoSec(subtractTimes(this.#end, this.#start))) + 1; // +1 since times are inclusive.
     if (totalNs > Number.MAX_SAFE_INTEGER * 0.9) {
       throw new Error("Time range is too long to be supported");
     }
 
-    this.blockDurationNanos = Math.ceil(
+    this.#blockDurationNanos = Math.ceil(
       Math.max(args.minBlockDurationNs, totalNs / args.maxBlocks),
     );
 
-    const blockCount = Math.ceil(totalNs / this.blockDurationNanos);
+    const blockCount = Math.ceil(totalNs / this.#blockDurationNanos);
 
     log.debug(`Block count: ${blockCount}`);
-    this.blocks = Array.from({ length: blockCount });
+    this.#blocks = Array.from({ length: blockCount });
   }
 
   public setTopics(topics: Set<string>): void {
-    if (isEqual(topics, this.topics)) {
+    if (isEqual(topics, this.#topics)) {
       return;
     }
 
     this.abortController.abort();
-    this.topics = topics;
-    this.activeChangeCondvar.notifyAll();
+    this.#topics = topics;
+    this.#activeChangeCondvar.notifyAll();
     log.debug(`Preloaded topics: ${[...topics].join(", ")}`);
 
     // Update all the blocks with any missing topics
-    for (const block of this.blocks) {
+    for (const block of this.#blocks) {
       if (block) {
         const blockTopics = Object.keys(block.messagesByTopic);
         const needTopics = new Set(topics);
@@ -111,10 +111,10 @@ export class BlockLoader {
    * Remove topics that are no longer requested to be preloaded from blocks to free up space
    */
   private _removeUnusedBlockTopics(): number {
-    const topics = this.topics;
+    const topics = this.#topics;
     let totalBytesRemoved = 0;
-    for (let i = 0; i < this.blocks.length; i++) {
-      const block = this.blocks[i];
+    for (let i = 0; i < this.#blocks.length; i++) {
+      const block = this.#blocks[i];
       if (block) {
         let blockBytesRemoved = 0;
         const newMessagesByTopic: Record<string, MessageEvent<unknown>[]> = {
@@ -131,7 +131,7 @@ export class BlockLoader {
           }
         }
         if (blockBytesRemoved > 0) {
-          this.blocks[i] = {
+          this.#blocks[i] = {
             ...block,
             messagesByTopic: newMessagesByTopic,
             sizeInBytes: block.sizeInBytes - blockBytesRemoved,
@@ -145,53 +145,53 @@ export class BlockLoader {
 
   public async stopLoading(): Promise<void> {
     log.debug("Stop loading blocks");
-    this.stopped = true;
-    this.activeChangeCondvar.notifyAll();
+    this.#stopped = true;
+    this.#activeChangeCondvar.notifyAll();
   }
 
   public async startLoading(args: LoadArgs): Promise<void> {
     log.debug("Start loading process");
-    this.stopped = false;
+    this.#stopped = false;
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    while (!this.stopped) {
+    while (!this.#stopped) {
       this.abortController = new AbortController();
 
-      const topics = this.topics;
+      const topics = this.#topics;
 
       await this.load({ progress: args.progress });
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (this.stopped) {
+      if (this.#stopped) {
         break;
       }
 
       // Wait for topics to possibly change.
-      if (this.topics === topics) {
-        await this.activeChangeCondvar.wait();
+      if (this.#topics === topics) {
+        await this.#activeChangeCondvar.wait();
       }
     }
   }
 
   private async load(args: { progress: LoadArgs["progress"] }): Promise<void> {
-    const topics = this.topics;
+    const topics = this.#topics;
 
     // Ignore changing the blocks if the topic list is empty
     if (topics.size === 0) {
-      args.progress(this.calculateProgress(topics));
+      args.progress(this.#calculateProgress(topics));
       return;
     }
 
-    if (this.blocks.length === 0) {
+    if (this.#blocks.length === 0) {
       return;
     }
 
     log.debug("loading blocks", { topics });
     const beginBlockId = 0;
-    const lastBlockId = this.blocks.length;
+    const lastBlockId = this.#blocks.length;
 
     const { progress } = args;
-    let totalBlockSizeBytes = this.cacheSize();
+    let totalBlockSizeBytes = this.#cacheSize();
 
     for (let blockId = beginBlockId; blockId < lastBlockId; ++blockId) {
       // Topics we will fetch for this range
@@ -199,7 +199,7 @@ export class BlockLoader {
 
       // Keep looking for a block that needs loading
       {
-        const existingBlock = this.blocks[blockId];
+        const existingBlock = this.#blocks[blockId];
 
         // The current block has everything, so we can move to the next block
         if (existingBlock?.needTopics.size === 0) {
@@ -214,8 +214,8 @@ export class BlockLoader {
       // Now we look for the last block. We do this by finding blocks that need the same topics to fetch.
       // This creates a continuous span of the same topics to fetch
       let endBlockId = blockId;
-      for (let endIdx = blockId + 1; endIdx < this.blocks.length; ++endIdx) {
-        const nextBlock = this.blocks[endIdx];
+      for (let endIdx = blockId + 1; endIdx < this.#blocks.length; ++endIdx) {
+        const nextBlock = this.#blocks[endIdx];
 
         const needTopics = nextBlock?.needTopics ?? topics;
 
@@ -229,8 +229,8 @@ export class BlockLoader {
         endBlockId = endIdx;
       }
 
-      const cursorStartTime = this.blockIdToStartTime(blockId);
-      const cursorEndTime = clampTime(this.blockIdToEndTime(endBlockId), this.start, this.end);
+      const cursorStartTime = this.#blockIdToStartTime(blockId);
+      const cursorEndTime = clampTime(this.blockIdToEndTime(endBlockId), this.#start, this.#end);
 
       const iteratorArgs: MessageIteratorArgs = {
         topics: Array.from(topicsToFetch),
@@ -242,11 +242,11 @@ export class BlockLoader {
       // If the source provides a message cursor we use its message cursor, otherwise we make one
       // using the source's message iterator.
       const cursor =
-        this.source.getMessageCursor?.({ ...iteratorArgs, abort: this.abortController.signal }) ??
-        new IteratorCursor(this.source.messageIterator(iteratorArgs), this.abortController.signal);
+        this.#source.getMessageCursor?.({ ...iteratorArgs, abort: this.abortController.signal }) ??
+        new IteratorCursor(this.#source.messageIterator(iteratorArgs), this.abortController.signal);
 
       for (let currentBlockId = blockId; currentBlockId <= endBlockId; ++currentBlockId) {
-        const untilTime = clampTime(this.blockIdToEndTime(currentBlockId), this.start, this.end);
+        const untilTime = clampTime(this.blockIdToEndTime(currentBlockId), this.#start, this.#end);
 
         const results = await cursor.readUntil(untilTime);
         // No results means cursor aborted or eof
@@ -265,8 +265,8 @@ export class BlockLoader {
 
         // Empty result set does not require further processing and does not change the size
         if (results.length === 0) {
-          const existingBlock = this.blocks[currentBlockId];
-          this.blocks[currentBlockId] = {
+          const existingBlock = this.#blocks[currentBlockId];
+          this.#blocks[currentBlockId] = {
             needTopics: new Set(),
             messagesByTopic: {
               ...existingBlock?.messagesByTopic,
@@ -281,7 +281,7 @@ export class BlockLoader {
         let sizeInBytes = 0;
         for (const iterResult of results) {
           if (iterResult.type === "problem") {
-            this.problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+            this.#problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
             continue;
           }
 
@@ -296,14 +296,14 @@ export class BlockLoader {
           // topic in our results. If we don't, thats a problem.
           const problemKey = `unexpected-topic-${msgTopic}`;
           if (!arr) {
-            this.problemManager.addProblem(problemKey, {
+            this.#problemManager.addProblem(problemKey, {
               severity: "error",
               message: `Received a message on an unexpected topic: ${msgTopic}.`,
             });
 
             continue;
           }
-          this.problemManager.removeProblem(problemKey);
+          this.#problemManager.removeProblem(problemKey);
 
           const messageSizeInBytes = iterResult.msgEvent.sizeInBytes;
           totalBlockSizeBytes += messageSizeInBytes;
@@ -311,27 +311,27 @@ export class BlockLoader {
 
           sizeInBytes += messageSizeInBytes;
 
-          if (totalBlockSizeBytes < this.maxCacheSize) {
-            this.problemManager.removeProblem("cache-full");
+          if (totalBlockSizeBytes < this.#maxCacheSize) {
+            this.#problemManager.removeProblem("cache-full");
             continue;
           }
           // cache over capacity, try removing unused topics
           const removedSize = this._removeUnusedBlockTopics();
           totalBlockSizeBytes -= removedSize;
-          if (totalBlockSizeBytes > this.maxCacheSize) {
-            this.problemManager.addProblem("cache-full", {
+          if (totalBlockSizeBytes > this.#maxCacheSize) {
+            this.#problemManager.addProblem("cache-full", {
               severity: "error",
               message: `Cache is full. Preloading for topics [${Array.from(topicsToFetch).join(
                 ", ",
-              )}] has stopped on block ${currentBlockId + 1}/${this.blocks.length}.`,
+              )}] has stopped on block ${currentBlockId + 1}/${this.#blocks.length}.`,
               tip: "Try reducing the number of topics that require preloading at a given time (e.g. in plots), or try to reduce the time range of the file.",
             });
             return;
           }
         }
 
-        const existingBlock = this.blocks[currentBlockId];
-        this.blocks[currentBlockId] = {
+        const existingBlock = this.#blocks[currentBlockId];
+        this.#blocks[currentBlockId] = {
           needTopics: new Set(),
           messagesByTopic: {
             ...existingBlock?.messagesByTopic,
@@ -341,7 +341,7 @@ export class BlockLoader {
           sizeInBytes: (existingBlock?.sizeInBytes ?? 0) + sizeInBytes,
         };
 
-        progress(this.calculateProgress(topics));
+        progress(this.#calculateProgress(topics));
       }
 
       await cursor.end();
@@ -349,9 +349,9 @@ export class BlockLoader {
     }
   }
 
-  private calculateProgress(topics: Set<string>): Progress {
+  #calculateProgress(topics: Set<string>): Progress {
     const fullyLoadedFractionRanges = simplify(
-      filterMap(this.blocks, (thisBlock, blockIndex) => {
+      filterMap(this.#blocks, (thisBlock, blockIndex) => {
         if (!thisBlock) {
           return;
         }
@@ -372,18 +372,18 @@ export class BlockLoader {
     return {
       fullyLoadedFractionRanges: fullyLoadedFractionRanges.map((range) => ({
         // Convert block ranges into fractions.
-        start: range.start / this.blocks.length,
-        end: range.end / this.blocks.length,
+        start: range.start / this.#blocks.length,
+        end: range.end / this.#blocks.length,
       })),
       messageCache: {
-        blocks: this.blocks.slice(),
-        startTime: this.start,
+        blocks: this.#blocks.slice(),
+        startTime: this.#start,
       },
     };
   }
 
-  private cacheSize(): number {
-    return this.blocks.reduce((prev, block) => {
+  #cacheSize(): number {
+    return this.#blocks.reduce((prev, block) => {
       if (!block) {
         return prev;
       }
@@ -392,12 +392,12 @@ export class BlockLoader {
     }, 0);
   }
 
-  private blockIdToStartTime(id: number): Time {
-    return add(this.start, fromNanoSec(BigInt(id) * BigInt(this.blockDurationNanos)));
+  #blockIdToStartTime(id: number): Time {
+    return add(this.#start, fromNanoSec(BigInt(id) * BigInt(this.#blockDurationNanos)));
   }
 
   // The end time of a block is the start time of the next block minus 1 nanosecond
   private blockIdToEndTime(id: number): Time {
-    return add(this.start, fromNanoSec(BigInt(id + 1) * BigInt(this.blockDurationNanos) - 1n));
+    return add(this.#start, fromNanoSec(BigInt(id + 1) * BigInt(this.#blockDurationNanos) - 1n));
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -59,7 +59,7 @@ export class BlockLoader {
   #problemManager: PlayerProblemManager;
   #stopped: boolean = false;
   #activeChangeCondvar: Condvar = new Condvar();
-  private abortController: AbortController;
+  #abortController: AbortController;
 
   public constructor(args: BlockLoaderArgs) {
     this.#source = args.source;
@@ -67,7 +67,7 @@ export class BlockLoader {
     this.#end = args.end;
     this.#maxCacheSize = args.cacheSizeBytes;
     this.#problemManager = args.problemManager;
-    this.abortController = new AbortController();
+    this.#abortController = new AbortController();
 
     const totalNs = Number(toNanoSec(subtractTimes(this.#end, this.#start))) + 1; // +1 since times are inclusive.
     if (totalNs > Number.MAX_SAFE_INTEGER * 0.9) {
@@ -89,7 +89,7 @@ export class BlockLoader {
       return;
     }
 
-    this.abortController.abort();
+    this.#abortController.abort();
     this.#topics = topics;
     this.#activeChangeCondvar.notifyAll();
     log.debug(`Preloaded topics: ${[...topics].join(", ")}`);
@@ -110,7 +110,7 @@ export class BlockLoader {
   /**
    * Remove topics that are no longer requested to be preloaded from blocks to free up space
    */
-  private _removeUnusedBlockTopics(): number {
+  #removeUnusedBlockTopics(): number {
     const topics = this.#topics;
     let totalBytesRemoved = 0;
     for (let i = 0; i < this.#blocks.length; i++) {
@@ -155,11 +155,11 @@ export class BlockLoader {
 
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     while (!this.#stopped) {
-      this.abortController = new AbortController();
+      this.#abortController = new AbortController();
 
       const topics = this.#topics;
 
-      await this.load({ progress: args.progress });
+      await this.#load({ progress: args.progress });
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (this.#stopped) {
@@ -173,7 +173,7 @@ export class BlockLoader {
     }
   }
 
-  private async load(args: { progress: LoadArgs["progress"] }): Promise<void> {
+  async #load(args: { progress: LoadArgs["progress"] }): Promise<void> {
     const topics = this.#topics;
 
     // Ignore changing the blocks if the topic list is empty
@@ -230,7 +230,7 @@ export class BlockLoader {
       }
 
       const cursorStartTime = this.#blockIdToStartTime(blockId);
-      const cursorEndTime = clampTime(this.blockIdToEndTime(endBlockId), this.#start, this.#end);
+      const cursorEndTime = clampTime(this.#blockIdToEndTime(endBlockId), this.#start, this.#end);
 
       const iteratorArgs: MessageIteratorArgs = {
         topics: Array.from(topicsToFetch),
@@ -242,11 +242,11 @@ export class BlockLoader {
       // If the source provides a message cursor we use its message cursor, otherwise we make one
       // using the source's message iterator.
       const cursor =
-        this.#source.getMessageCursor?.({ ...iteratorArgs, abort: this.abortController.signal }) ??
-        new IteratorCursor(this.#source.messageIterator(iteratorArgs), this.abortController.signal);
+        this.#source.getMessageCursor?.({ ...iteratorArgs, abort: this.#abortController.signal }) ??
+        new IteratorCursor(this.#source.messageIterator(iteratorArgs), this.#abortController.signal);
 
       for (let currentBlockId = blockId; currentBlockId <= endBlockId; ++currentBlockId) {
-        const untilTime = clampTime(this.blockIdToEndTime(currentBlockId), this.#start, this.#end);
+        const untilTime = clampTime(this.#blockIdToEndTime(currentBlockId), this.#start, this.#end);
 
         const results = await cursor.readUntil(untilTime);
         // No results means cursor aborted or eof
@@ -316,7 +316,7 @@ export class BlockLoader {
             continue;
           }
           // cache over capacity, try removing unused topics
-          const removedSize = this._removeUnusedBlockTopics();
+          const removedSize = this.#removeUnusedBlockTopics();
           totalBlockSizeBytes -= removedSize;
           if (totalBlockSizeBytes > this.#maxCacheSize) {
             this.#problemManager.addProblem("cache-full", {
@@ -397,7 +397,7 @@ export class BlockLoader {
   }
 
   // The end time of a block is the start time of the next block minus 1 nanosecond
-  private blockIdToEndTime(id: number): Time {
+  #blockIdToEndTime(id: number): Time {
     return add(this.#start, fromNanoSec(BigInt(id + 1) * BigInt(this.#blockDurationNanos) - 1n));
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -243,7 +243,10 @@ export class BlockLoader {
       // using the source's message iterator.
       const cursor =
         this.#source.getMessageCursor?.({ ...iteratorArgs, abort: this.#abortController.signal }) ??
-        new IteratorCursor(this.#source.messageIterator(iteratorArgs), this.#abortController.signal);
+        new IteratorCursor(
+          this.#source.messageIterator(iteratorArgs),
+          this.#abortController.signal,
+        );
 
       for (let currentBlockId = blockId; currentBlockId <= endBlockId; ++currentBlockId) {
         const untilTime = clampTime(this.#blockIdToEndTime(currentBlockId), this.#start, this.#end);
@@ -281,7 +284,10 @@ export class BlockLoader {
         let sizeInBytes = 0;
         for (const iterResult of results) {
           if (iterResult.type === "problem") {
-            this.#problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+            this.#problemManager.addProblem(
+              `connid-${iterResult.connectionId}`,
+              iterResult.problem,
+            );
             continue;
           }
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -72,7 +72,7 @@ class BufferedIterableSource implements IIterableSource {
     return this.#initResult;
   }
 
-  private async startProducer(args: MessageIteratorArgs): Promise<void> {
+  async #startProducer(args: MessageIteratorArgs): Promise<void> {
     if (!this.#initResult) {
       throw new Error("Invariant: uninitialized");
     }
@@ -203,7 +203,7 @@ class BufferedIterableSource implements IIterableSource {
     this.#readDone = false;
 
     // Create and start the producer when the messageIterator function is called.
-    this.#producer = this.startProducer(args);
+    this.#producer = this.#startProducer(args);
 
     // Rather than messageIterator itself being a generator, we return a generator function. This is
     // so the setup code above will run when the messageIterator is called rather than when .next()
@@ -221,30 +221,30 @@ class BufferedIterableSource implements IIterableSource {
         }
 
         for (;;) {
-          const item = self.cache.dequeue();
+          const item = self.#cache.dequeue();
           if (!item) {
-            if (self.readDone) {
+            if (self.#readDone) {
               break;
             }
 
             // Wait for more stuff to load
-            await self.readSignal.wait();
+            await self.#readSignal.wait();
             continue;
           }
 
           if (item.type === "stamp") {
-            self.readHead = item.stamp;
+            self.#readHead = item.stamp;
           }
 
           // When there is a new message update the readHead for the producer to know where we are
           // currently reading
           if (item.type === "message-event") {
-            self.readHead = item.msgEvent.receiveTime;
+            self.#readHead = item.msgEvent.receiveTime;
           }
 
           // Notify the producer thread that it can load more data. Since our producer and consumer are on the same _thread_
           // this notification is picked up on the next tick.
-          self.writeSignal.notifyAll();
+          self.#writeSignal.notifyAll();
 
           yield item;
         }

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -36,49 +36,49 @@ type Options = {
  * reading from the underlying source and populating the cache.
  */
 class BufferedIterableSource implements IIterableSource {
-  private source: CachingIterableSource;
+  #source: CachingIterableSource;
 
-  private readDone = false;
-  private aborted = false;
+  #readDone = false;
+  #aborted = false;
 
   // The producer uses this signal to notify a waiting consumer there is data to consume.
-  private readSignal = new Condvar();
+  #readSignal = new Condvar();
 
   // The consumer uses this signal to notify a waiting producer that something has been consumed.
-  private writeSignal = new Condvar();
+  #writeSignal = new Condvar();
 
   // The producer loads results into the cache and the consumer reads from the cache.
-  private cache = new VecQueue<IteratorResult>();
+  #cache = new VecQueue<IteratorResult>();
 
   // The location of the consumer read head
-  private readHead: Time = { sec: 0, nsec: 0 };
+  #readHead: Time = { sec: 0, nsec: 0 };
 
   // The promise for the current producer. The message generator starts a producer and awaits the
   // producer before exiting.
-  private producer?: Promise<void>;
+  #producer?: Promise<void>;
 
-  private initResult?: Initalization;
+  #initResult?: Initalization;
 
   // How far ahead of the read head we should try to keep buffering
-  private readAheadDuration: Time;
+  #readAheadDuration: Time;
 
   public constructor(source: IIterableSource, opt?: Options) {
-    this.readAheadDuration = opt?.readAheadDuration ?? DEFAULT_READ_AHEAD_DURATION;
-    this.source = new CachingIterableSource(source);
+    this.#readAheadDuration = opt?.readAheadDuration ?? DEFAULT_READ_AHEAD_DURATION;
+    this.#source = new CachingIterableSource(source);
   }
 
   public async initialize(): Promise<Initalization> {
-    this.initResult = await this.source.initialize();
-    return this.initResult;
+    this.#initResult = await this.#source.initialize();
+    return this.#initResult;
   }
 
   private async startProducer(args: MessageIteratorArgs): Promise<void> {
-    if (!this.initResult) {
+    if (!this.#initResult) {
       throw new Error("Invariant: uninitialized");
     }
 
     if (args.topics.length === 0) {
-      this.readDone = true;
+      this.#readDone = true;
       return;
     }
 
@@ -86,25 +86,25 @@ class BufferedIterableSource implements IIterableSource {
 
     // Clear the cache and start producing into an empty array, the consumer removes elements from
     // the start of the array.
-    this.cache.clear();
+    this.#cache.clear();
 
     try {
-      const sourceIterator = this.source.messageIterator({
+      const sourceIterator = this.#source.messageIterator({
         topics: args.topics,
-        start: this.readHead,
+        start: this.#readHead,
         consumptionType: "partial",
       });
 
       // Messages are read from the source until reaching the readUntil time. Then we wait for the read head
       // to move forward and adjust readUntil
       let readUntil = clampTime(
-        addTime(this.readHead, this.readAheadDuration),
-        this.initResult.start,
-        this.initResult.end,
+        addTime(this.#readHead, this.#readAheadDuration),
+        this.#initResult.start,
+        this.#initResult.end,
       );
 
       for await (const result of sourceIterator) {
-        if (this.aborted) {
+        if (this.#aborted) {
           return;
         }
 
@@ -112,7 +112,7 @@ class BufferedIterableSource implements IIterableSource {
         //
         // Since reading a result from the iterator is async, we update the readUntil after we have
         // the result so we can have the latest readHead
-        readUntil = addTime(this.readHead, this.readAheadDuration);
+        readUntil = addTime(this.#readHead, this.#readAheadDuration);
 
         // When receiving a stamp result we enqueue the result into the cache and notify a reader.
         if (result.type === "stamp" && compare(result.stamp, readUntil) >= 0) {
@@ -121,25 +121,25 @@ class BufferedIterableSource implements IIterableSource {
           while (compare(result.stamp, readUntil) >= 0) {
             // The producer may have aborted while we are waiting for the read head to progress
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            if (this.aborted) {
+            if (this.#aborted) {
               return;
             }
 
             // enqueue the stamp and wakeup the reader
             // but the reader might not be reading - cause it is not being read from
-            this.cache.enqueue(result);
-            this.readSignal.notifyAll();
+            this.#cache.enqueue(result);
+            this.#readSignal.notifyAll();
 
-            await this.writeSignal.wait();
-            readUntil = addTime(this.readHead, this.readAheadDuration);
+            await this.#writeSignal.wait();
+            readUntil = addTime(this.#readHead, this.#readAheadDuration);
           }
           continue;
         }
 
-        this.cache.enqueue(result);
+        this.#cache.enqueue(result);
 
         // Indicate to the consumer that it can try reading again
-        this.readSignal.notifyAll();
+        this.#readSignal.notifyAll();
 
         // Keep reading while the messages we receive are <= the readUntil time.
         if (
@@ -150,60 +150,60 @@ class BufferedIterableSource implements IIterableSource {
         }
 
         // If we didn't load anything into the cache keep reading
-        if (this.cache.size() === 0) {
+        if (this.#cache.size() === 0) {
           continue;
         }
 
         // Wait for consumer thread to read something before trying to load more data
-        await this.writeSignal.wait();
+        await this.#writeSignal.wait();
       }
     } finally {
       // Indicate to the consumer that it can try reading again
-      this.readSignal.notifyAll();
-      this.readDone = true;
+      this.#readSignal.notifyAll();
+      this.#readDone = true;
     }
 
     log.debug("producer done");
   }
 
   public async terminate(): Promise<void> {
-    this.cache.clear();
-    await this.source.terminate();
+    this.#cache.clear();
+    await this.#source.terminate();
   }
 
   public async stopProducer(): Promise<void> {
     log.debug("Stopping producer");
-    this.aborted = true;
-    this.writeSignal.notifyAll();
-    await this.producer;
-    this.producer = undefined;
+    this.#aborted = true;
+    this.#writeSignal.notifyAll();
+    await this.#producer;
+    this.#producer = undefined;
   }
 
   public loadedRanges(): Range[] {
-    return this.source.loadedRanges();
+    return this.#source.loadedRanges();
   }
 
   public messageIterator(
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
-    if (!this.initResult) {
+    if (!this.#initResult) {
       throw new Error("Invariant: uninitialized");
     }
 
-    if (this.producer) {
+    if (this.#producer) {
       throw new Error("Invariant: BufferedIterableSource allows only one messageIterator");
     }
 
-    const start = args.start ?? this.initResult.start;
+    const start = args.start ?? this.#initResult.start;
 
     // Setup the initial cacheUntilTime to start buffing data
-    this.readHead = start;
+    this.#readHead = start;
 
-    this.aborted = false;
-    this.readDone = false;
+    this.#aborted = false;
+    this.#readDone = false;
 
     // Create and start the producer when the messageIterator function is called.
-    this.producer = this.startProducer(args);
+    this.#producer = this.startProducer(args);
 
     // Rather than messageIterator itself being a generator, we return a generator function. This is
     // so the setup code above will run when the messageIterator is called rather than when .next()
@@ -258,7 +258,7 @@ class BufferedIterableSource implements IIterableSource {
   public async getBackfillMessages(
     args: GetBackfillMessagesArgs,
   ): Promise<MessageEvent<unknown>[]> {
-    return await this.source.getBackfillMessages(args);
+    return await this.#source.getBackfillMessages(args);
   }
 }
 

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -53,9 +53,9 @@ type PlayerStateWithoutPlayerId = Omit<PlayerState, "playerId">;
 class PlayerStateStore {
   public done: Promise<PlayerStateWithoutPlayerId[]>;
 
-  private playerStates: PlayerStateWithoutPlayerId[] = [];
-  private expected: number;
-  private resolve: (arg0: PlayerStateWithoutPlayerId[]) => void = () => {
+  #playerStates: PlayerStateWithoutPlayerId[] = [];
+  #expected: number;
+  #resolve: (arg0: PlayerStateWithoutPlayerId[]) => void = () => {
     // no-op
   };
 
@@ -63,9 +63,9 @@ class PlayerStateStore {
    * @param expected - number of state transitions to be listened to before done is resolved
    */
   public constructor(expected: number) {
-    this.expected = expected;
+    this.#expected = expected;
     this.done = new Promise((resolve) => {
-      this.resolve = resolve;
+      this.#resolve = resolve;
     });
   }
 
@@ -74,13 +74,13 @@ class PlayerStateStore {
   // if it exceeds it will throw an error and break the test
   public async add(state: PlayerState): Promise<void> {
     const { playerId: _playerId, ...rest } = state;
-    this.playerStates.push(rest);
-    if (this.playerStates.length === this.expected) {
-      this.resolve(this.playerStates);
+    this.#playerStates.push(rest);
+    if (this.#playerStates.length === this.#expected) {
+      this.#resolve(this.#playerStates);
     }
-    if (this.playerStates.length > this.expected) {
+    if (this.#playerStates.length > this.#expected) {
       const error = new Error(
-        `Expected: ${this.expected} messages, received: ${this.playerStates.length}`,
+        `Expected: ${this.#expected} messages, received: ${this.#playerStates.length}`,
       );
       this.done = Promise.reject(error);
       throw error;
@@ -92,10 +92,10 @@ class PlayerStateStore {
    * @param expected - number of state transitions to be listened to before done is resolved
    */
   public reset(expected: number): void {
-    this.expected = expected;
-    this.playerStates = [];
+    this.#expected = expected;
+    this.#playerStates = [];
     this.done = new Promise((resolve) => {
-      this.resolve = resolve;
+      this.#resolve = resolve;
     });
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -104,17 +104,17 @@ type IterablePlayerState =
  * detecting that there is another state waiting and cooperatively ending itself.
  */
 export class IterablePlayer implements Player {
-  private _urlParams?: Record<string, string>;
-  private _name?: string;
-  private _nextState?: IterablePlayerState;
-  private _state: IterablePlayerState = "preinit";
-  private _runningState: boolean = false;
+  #urlParams?: Record<string, string>;
+  #name?: string;
+  #nextState?: IterablePlayerState;
+  #state: IterablePlayerState = "preinit";
+  #runningState: boolean = false;
 
-  private _isPlaying: boolean = false;
-  private _listener?: (playerState: PlayerState) => Promise<void>;
-  private _speed: number = 1.0;
-  private _start?: Time;
-  private _end?: Time;
+  #isPlaying: boolean = false;
+  #listener?: (playerState: PlayerState) => Promise<void>;
+  #speed: number = 1.0;
+  #start?: Time;
+  #end?: Time;
   private _enablePreload = true;
 
   // next read start time indicates where to start reading for the next tick
@@ -178,8 +178,8 @@ export class IterablePlayer implements Player {
 
     this._iterableSource = source;
     this._bufferedSource = new BufferedIterableSource(source);
-    this._name = name;
-    this._urlParams = urlParams;
+    this.#name = name;
+    this.#urlParams = urlParams;
     this._metricsCollector = metricsCollector ?? new NoopMetricsCollector();
     this._metricsCollector.playerConstructed();
     this._enablePreload = enablePreload ?? true;
@@ -191,10 +191,10 @@ export class IterablePlayer implements Player {
   }
 
   public setListener(listener: (playerState: PlayerState) => Promise<void>): void {
-    if (this._listener) {
+    if (this.#listener) {
       throw new Error("Cannot setListener again");
     }
-    this._listener = listener;
+    this.#listener = listener;
     this._setState("initialize");
   }
 
@@ -207,7 +207,7 @@ export class IterablePlayer implements Player {
   }
 
   private startPlayImpl(opt?: { untilTime: Time }): void {
-    if (this._isPlaying || this._untilTime || !this._start || !this._end) {
+    if (this.#isPlaying || this._untilTime || !this.#start || !this.#end) {
       return;
     }
 
@@ -215,35 +215,35 @@ export class IterablePlayer implements Player {
       if (this._currentTime && compare(opt.untilTime, this._currentTime) <= 0) {
         throw new Error("Invariant: playUntil time must be after the current time");
       }
-      this._untilTime = clampTime(opt.untilTime, this._start, this._end);
+      this._untilTime = clampTime(opt.untilTime, this.#start, this.#end);
     }
-    this._metricsCollector.play(this._speed);
-    this._isPlaying = true;
+    this._metricsCollector.play(this.#speed);
+    this.#isPlaying = true;
 
     // If we are idling we can start playing, if we have a next state queued we let that state
     // finish and it will see that we should be playing
-    if (this._state === "idle" && (!this._nextState || this._nextState === "idle")) {
+    if (this.#state === "idle" && (!this.#nextState || this.#nextState === "idle")) {
       this._setState("play");
     }
   }
 
   public pausePlayback(): void {
-    if (!this._isPlaying) {
+    if (!this.#isPlaying) {
       return;
     }
     this._metricsCollector.pause();
     // clear out last tick millis so we don't read a huge chunk when we unpause
     this._lastTickMillis = undefined;
-    this._isPlaying = false;
+    this.#isPlaying = false;
     this._untilTime = undefined;
-    if (this._state === "play") {
+    if (this.#state === "play") {
       this._setState("idle");
     }
   }
 
   public setPlaybackSpeed(speed: number): void {
     delete this._lastRangeMillis;
-    this._speed = speed;
+    this.#speed = speed;
     this._metricsCollector.setSpeed(speed);
 
     // Queue event state update to update speed in player state to UI
@@ -252,18 +252,18 @@ export class IterablePlayer implements Player {
 
   public seekPlayback(time: Time): void {
     // Wait to perform seek until initialization is complete
-    if (this._state === "preinit" || this._state === "initialize") {
-      log.debug(`Ignoring seek, state=${this._state}`);
+    if (this.#state === "preinit" || this.#state === "initialize") {
+      log.debug(`Ignoring seek, state=${this.#state}`);
       this._seekTarget = time;
       return;
     }
 
-    if (!this._start || !this._end) {
+    if (!this.#start || !this.#end) {
       throw new Error("invariant: initialized but no start/end set");
     }
 
     // Limit seek to within the valid range
-    const targetTime = clampTime(time, this._start, this._end);
+    const targetTime = clampTime(time, this.#start, this.#end);
 
     // We are already seeking to this time, no need to reset seeking
     if (this._seekTarget && compare(this._seekTarget, targetTime) === 0) {
@@ -308,8 +308,8 @@ export class IterablePlayer implements Player {
     // If the player is playing, the playing state will detect any subscription changes and adjust
     // iterators accordignly. However if we are idle or already seeking then we need to manually
     // trigger the backfill.
-    if (this._state === "idle" || this._state === "seek-backfill" || this._state === "play") {
-      if (!this._isPlaying && this._currentTime) {
+    if (this.#state === "idle" || this.#state === "seek-backfill" || this.#state === "play") {
+      if (!this.#isPlaying && this._currentTime) {
         this._seekTarget ??= this._currentTime;
         this._untilTime = undefined;
 
@@ -346,7 +346,7 @@ export class IterablePlayer implements Player {
   /** Request the state to switch to newState */
   private _setState(newState: IterablePlayerState) {
     log.debug(`Set next state: ${newState}`);
-    this._nextState = newState;
+    this.#nextState = newState;
     this._abort?.abort();
     this._abort = undefined;
     void this._runState();
@@ -358,15 +358,15 @@ export class IterablePlayer implements Player {
    * Ensures that only one state is running at a time.
    * */
   private async _runState() {
-    if (this._runningState) {
+    if (this.#runningState) {
       return;
     }
 
-    this._runningState = true;
+    this.#runningState = true;
     try {
-      while (this._nextState) {
-        const state = (this._state = this._nextState);
-        this._nextState = undefined;
+      while (this.#nextState) {
+        const state = (this.#state = this.#nextState);
+        this.#nextState = undefined;
 
         log.debug(`Start state: ${state}`);
 
@@ -383,7 +383,7 @@ export class IterablePlayer implements Player {
             this._queueEmitState();
             break;
           case "initialize":
-            await this._stateInitialize();
+            await this.#stateInitialize();
             break;
           case "start-play":
             await this._stateStartPlay();
@@ -412,7 +412,7 @@ export class IterablePlayer implements Player {
       this._setError((err as Error).message, err);
       this._queueEmitState();
     } finally {
-      this._runningState = false;
+      this.#runningState = false;
     }
   }
 
@@ -423,11 +423,11 @@ export class IterablePlayer implements Player {
       message,
       error,
     });
-    this._isPlaying = false;
+    this.#isPlaying = false;
   }
 
   // Initialize the source and player members
-  private async _stateInitialize(): Promise<void> {
+  async #stateInitialize(): Promise<void> {
     // emit state indicating start of initialization
     this._queueEmitState();
 
@@ -451,12 +451,12 @@ export class IterablePlayer implements Player {
       }
 
       this._profile = profile;
-      this._start = start;
+      this.#start = start;
       this._currentTime = this._seekTarget ?? start;
-      this._end = end;
+      this.#end = end;
       this._publishedTopics = publishersByTopic;
       this._providerDatatypes = datatypes;
-      this._name = name ?? this._name;
+      this.#name = name ?? this.#name;
 
       // Studio does not like duplicate topics or topics with different datatypes
       // Check for duplicates or for mismatched datatypes
@@ -490,8 +490,8 @@ export class IterablePlayer implements Player {
           this._blockLoader = new BlockLoader({
             cacheSizeBytes: DEFAULT_CACHE_SIZE_BYTES,
             source: this._iterableSource,
-            start: this._start,
-            end: this._end,
+            start: this.#start,
+            end: this.#end,
             maxBlocks: MAX_BLOCKS,
             minBlockDurationNs: MIN_MEM_CACHE_BLOCK_SIZE_NS,
             problemManager: this._problemManager,
@@ -499,8 +499,8 @@ export class IterablePlayer implements Player {
         } catch (err) {
           log.error(err);
 
-          const startStr = toRFC3339String(this._start);
-          const endStr = toRFC3339String(this._end);
+          const startStr = toRFC3339String(this.#start);
+          const endStr = toRFC3339String(this.#end);
 
           this._problemManager.addProblem("block-loader", {
             severity: "warn",
@@ -517,7 +517,7 @@ export class IterablePlayer implements Player {
     }
     this._queueEmitState();
 
-    if (!this._hasError && this._start) {
+    if (!this._hasError && this.#start) {
       // Wait a bit until panels have had the chance to subscribe to topics before we start
       // playback.
       await delay(START_DELAY_MS);
@@ -525,13 +525,13 @@ export class IterablePlayer implements Player {
       this._blockLoader?.setTopics(this._preloadTopics);
 
       // Block loadings is constantly running and tries to keep the preloaded messages in memory
-      this._blockLoadingProcess = this.startBlockLoading();
+      this._blockLoadingProcess = this.#startBlockLoading();
 
       this._setState("start-play");
     }
   }
 
-  private async resetPlaybackIterator() {
+  async #resetPlaybackIterator() {
     if (!this._currentTime) {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
@@ -557,15 +557,15 @@ export class IterablePlayer implements Player {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
 
-    await this.resetPlaybackIterator();
-    this._setState(this._isPlaying ? "play" : "idle");
+    await this.#resetPlaybackIterator();
+    this._setState(this.#isPlaying ? "play" : "idle");
   }
 
   // Read a small amount of data from the datasource with the hope of producing a message or two.
   // Without an initial read, the user would be looking at a blank layout since no messages have yet
   // been delivered.
   private async _stateStartPlay() {
-    if (!this._start || !this._end) {
+    if (!this.#start || !this.#end) {
       throw new Error("Invariant: start and end must be set");
     }
 
@@ -576,21 +576,21 @@ export class IterablePlayer implements Player {
     }
 
     const stopTime = clampTime(
-      add(this._start, fromNanoSec(SEEK_ON_START_NS)),
-      this._start,
-      this._end,
+      add(this.#start, fromNanoSec(SEEK_ON_START_NS)),
+      this.#start,
+      this.#end,
     );
 
-    log.debug(`Playing from ${toString(this._start)} to ${toString(stopTime)}`);
+    log.debug(`Playing from ${toString(this.#start)} to ${toString(stopTime)}`);
 
     if (this._playbackIterator) {
       throw new Error("Invariant. playbackIterator was already set");
     }
 
-    log.debug("Initializing forward iterator from", this._start);
+    log.debug("Initializing forward iterator from", this.#start);
     this._playbackIterator = this._bufferedSource.messageIterator({
       topics: Array.from(this._allTopics),
-      start: this._start,
+      start: this.#start,
       consumptionType: "partial",
     });
 
@@ -615,7 +615,7 @@ export class IterablePlayer implements Player {
         const iterResult = result.value;
         // Bail if a new state is requested while we are loading messages
         // This usually happens when seeking before the initial load is complete
-        if (this._nextState) {
+        if (this.#nextState) {
           return;
         }
 
@@ -653,7 +653,7 @@ export class IterablePlayer implements Player {
   // Process a seek request. The seek is performed by requesting a getBackfillMessages from the source.
   // This provides the last message on all subscribed topics.
   private async _stateSeekBackfill() {
-    if (!this._start || !this._end) {
+    if (!this.#start || !this.#end) {
       throw new Error("invariant: stateSeekBackfill prior to initialization");
     }
 
@@ -662,7 +662,7 @@ export class IterablePlayer implements Player {
     }
 
     // Ensure the seek time is always within the data source bounds
-    const targetTime = clampTime(this._seekTarget, this._start, this._end);
+    const targetTime = clampTime(this._seekTarget, this.#start, this.#end);
 
     this._lastMessageEvent = undefined;
 
@@ -691,7 +691,7 @@ export class IterablePlayer implements Player {
       // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
       clearTimeout(seekAckTimeout);
 
-      if (this._nextState) {
+      if (this.#nextState) {
         return;
       }
 
@@ -700,17 +700,17 @@ export class IterablePlayer implements Player {
       this._lastSeekEmitTime = Date.now();
       this._presence = PlayerPresence.PRESENT;
       this._queueEmitState();
-      await this.resetPlaybackIterator();
-      this._setState(this._isPlaying ? "play" : "idle");
+      await this.#resetPlaybackIterator();
+      this._setState(this.#isPlaying ? "play" : "idle");
     } catch (err) {
-      if (this._nextState && err instanceof DOMException && err.name === "AbortError") {
+      if (this.#nextState && err instanceof DOMException && err.name === "AbortError") {
         log.debug("Aborted backfill");
       } else {
         throw err;
       }
     } finally {
       // Unless the next state is a seek backfill, we clear the seek target since we have finished seeking
-      if (this._nextState !== "seek-backfill") {
+      if (this.#nextState !== "seek-backfill") {
         this._seekTarget = undefined;
       }
       clearTimeout(seekAckTimeout);
@@ -720,13 +720,13 @@ export class IterablePlayer implements Player {
 
   /** Emit the player state to the registered listener */
   private async _emitStateImpl() {
-    if (!this._listener) {
+    if (!this.#listener) {
       return;
     }
 
     if (this._hasError) {
-      return await this._listener({
-        name: this._name,
+      return await this.#listener({
+        name: this.#name,
         presence: PlayerPresence.ERROR,
         progress: {},
         capabilities: this._capabilities,
@@ -736,7 +736,7 @@ export class IterablePlayer implements Player {
         problems: this._problemManager.problems(),
         urlState: {
           sourceId: this._sourceId,
-          parameters: this._urlParams,
+          parameters: this.#urlParams,
         },
       });
     }
@@ -745,15 +745,15 @@ export class IterablePlayer implements Player {
     this._messages = [];
 
     let activeData: PlayerStateActiveData | undefined;
-    if (this._start && this._end && this._currentTime) {
+    if (this.#start && this.#end && this._currentTime) {
       activeData = {
         messages,
         totalBytesReceived: this._receivedBytes,
         currentTime: this._currentTime,
-        startTime: this._start,
-        endTime: this._end,
-        isPlaying: this._isPlaying,
-        speed: this._speed,
+        startTime: this.#start,
+        endTime: this.#end,
+        isPlaying: this.#isPlaying,
+        speed: this.#speed,
         lastSeekTime: this._lastSeekEmitTime,
         topics: this._providerTopics,
         topicStats: this._providerTopicStats,
@@ -763,7 +763,7 @@ export class IterablePlayer implements Player {
     }
 
     const data: PlayerState = {
-      name: this._name,
+      name: this.#name,
       presence: this._presence,
       progress: this._progress,
       capabilities: this._capabilities,
@@ -773,21 +773,21 @@ export class IterablePlayer implements Player {
       activeData,
       urlState: {
         sourceId: this._sourceId,
-        parameters: this._urlParams,
+        parameters: this.#urlParams,
       },
     };
 
-    return await this._listener(data);
+    return await this.#listener(data);
   }
 
   /**
    * Run one tick loop by reading from the message iterator a "tick" worth of messages.
    * */
-  private async _tick(): Promise<void> {
-    if (!this._isPlaying) {
+  async #tick(): Promise<void> {
+    if (!this.#isPlaying) {
       return;
     }
-    if (!this._start || !this._end) {
+    if (!this.#start || !this.#end) {
       throw new Error("Invariant: start & end should be set before tick()");
     }
 
@@ -803,7 +803,7 @@ export class IterablePlayer implements Player {
     // Read at most 300ms worth of messages, otherwise things can get out of control if rendering
     // is very slow. Also, smooth over the range that we request, so that a single slow frame won't
     // cause the next frame to also be unnecessarily slow by increasing the frame size.
-    let rangeMillis = Math.min(durationMillis * this._speed, 300);
+    let rangeMillis = Math.min(durationMillis * this.#speed, 300);
     if (this._lastRangeMillis != undefined) {
       rangeMillis = this._lastRangeMillis * 0.9 + rangeMillis * 0.1;
     }
@@ -816,7 +816,7 @@ export class IterablePlayer implements Player {
     // The end time when we want to stop reading messages and emit state for the tick
     // The end time is inclusive.
     const targetTime = add(this._currentTime, fromMillis(rangeMillis));
-    const end: Time = clampTime(targetTime, this._start, this._untilTime ?? this._end);
+    const end: Time = clampTime(targetTime, this.#start, this._untilTime ?? this.#end);
 
     // If a lastStamp is available from the previous tick we check the stamp against our current
     // tick's end time. If this stamp is after our current tick's end time then we don't need to
@@ -883,7 +883,7 @@ export class IterablePlayer implements Player {
         }
 
         const result = await this._playbackIterator.next();
-        if (result.done === true || this._nextState) {
+        if (result.done === true || this.#nextState) {
           break;
         }
         const iterResult = result.value;
@@ -915,7 +915,7 @@ export class IterablePlayer implements Player {
     // Set the presence back to PRESENT since we are no longer buffering
     this._presence = PlayerPresence.PRESENT;
 
-    if (this._nextState) {
+    if (this.#nextState) {
       return;
     }
 
@@ -935,7 +935,7 @@ export class IterablePlayer implements Player {
   }
 
   private async _stateIdle() {
-    this._isPlaying = false;
+    this.#isPlaying = false;
     this._presence = PlayerPresence.PRESENT;
     this._queueEmitState();
 
@@ -961,7 +961,7 @@ export class IterablePlayer implements Player {
       // buffering behind the scenes. Every second we emit state with an update to show that
       // buffering is happening.
       await Promise.race([delay(1000), aborted]);
-      if (this._nextState) {
+      if (this.#nextState) {
         break;
       }
     }
@@ -973,7 +973,7 @@ export class IterablePlayer implements Player {
     if (!this._currentTime) {
       throw new Error("Invariant: currentTime not set before statePlay");
     }
-    if (!this._start || !this._end) {
+    if (!this.#start || !this.#end) {
       throw new Error("Invariant: start & end should be set before statePlay");
     }
 
@@ -982,8 +982,8 @@ export class IterablePlayer implements Player {
     const allTopics = this._allTopics;
 
     try {
-      while (this._isPlaying && !this._hasError && !this._nextState) {
-        if (compare(this._currentTime, this._end) >= 0) {
+      while (this.#isPlaying && !this._hasError && !this.#nextState) {
+        if (compare(this._currentTime, this.#end) >= 0) {
           // Playback has ended. Reset internal trackers for maintaining the playback speed.
           this._lastTickMillis = undefined;
           this._lastRangeMillis = undefined;
@@ -994,9 +994,9 @@ export class IterablePlayer implements Player {
 
         const start = Date.now();
 
-        await this._tick();
+        await this.#tick();
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
-        if (this._nextState) {
+        if (this.#nextState) {
           return;
         }
 
@@ -1030,7 +1030,7 @@ export class IterablePlayer implements Player {
   }
 
   private async _stateClose() {
-    this._isPlaying = false;
+    this.#isPlaying = false;
     this._metricsCollector.close();
     await this._blockLoader?.stopLoading();
     await this._blockLoadingProcess;
@@ -1041,7 +1041,7 @@ export class IterablePlayer implements Player {
     await this._iterableSource.terminate?.();
   }
 
-  private async startBlockLoading() {
+  async #startBlockLoading() {
     await this._blockLoader?.startLoading({
       progress: async (progress) => {
         this._progress = {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -239,7 +239,7 @@ export class IterablePlayer implements Player {
   }
 
   public setPlaybackSpeed(speed: number): void {
-    delete this.#lastRangeMillis;
+    this.#lastRangeMillis = undefined;
     this.#speed = speed;
     this.#metricsCollector.setSpeed(speed);
 

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -115,79 +115,79 @@ export class IterablePlayer implements Player {
   #speed: number = 1.0;
   #start?: Time;
   #end?: Time;
-  private _enablePreload = true;
+  #enablePreload = true;
 
   // next read start time indicates where to start reading for the next tick
   // after a tick read, it is set to 1nsec past the end of the read operation (preparing for the next tick)
-  private _lastTickMillis?: number;
+  #lastTickMillis?: number;
   // This is the "lastSeekTime" emitted in the playerState. This indicates the emit is due to a seek.
-  private _lastSeekEmitTime: number = Date.now();
+  #lastSeekEmitTime: number = Date.now();
 
-  private _providerTopics: Topic[] = [];
-  private _providerTopicStats = new Map<string, TopicStats>();
-  private _providerDatatypes: RosDatatypes = new Map();
+  #providerTopics: Topic[] = [];
+  #providerTopicStats = new Map<string, TopicStats>();
+  #providerDatatypes: RosDatatypes = new Map();
 
-  private _capabilities: string[] = [
+  #capabilities: string[] = [
     PlayerCapabilities.setSpeed,
     PlayerCapabilities.playbackControl,
   ];
-  private _profile: string | undefined;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _subscriptions: SubscribePayload[] = [];
-  private _allTopics: Set<string> = new Set();
-  private _preloadTopics: Set<string> = new Set();
+  #profile: string | undefined;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #subscriptions: SubscribePayload[] = [];
+  #allTopics: Set<string> = new Set();
+  #preloadTopics: Set<string> = new Set();
 
-  private _progress: Progress = {};
-  private _id: string = uuidv4();
-  private _messages: MessageEvent<unknown>[] = [];
-  private _receivedBytes: number = 0;
-  private _hasError = false;
-  private _lastRangeMillis?: number;
-  private _lastMessageEvent?: MessageEvent<unknown>;
-  private _lastStamp?: Time;
-  private _publishedTopics = new Map<string, Set<string>>();
-  private _seekTarget?: Time;
-  private _presence = PlayerPresence.INITIALIZING;
+  #progress: Progress = {};
+  #id: string = uuidv4();
+  #messages: MessageEvent<unknown>[] = [];
+  #receivedBytes: number = 0;
+  #hasError = false;
+  #lastRangeMillis?: number;
+  #lastMessageEvent?: MessageEvent<unknown>;
+  #lastStamp?: Time;
+  #publishedTopics = new Map<string, Set<string>>();
+  #seekTarget?: Time;
+  #presence = PlayerPresence.INITIALIZING;
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
-  private _currentTime?: Time;
+  #currentTime?: Time;
 
-  private _problemManager = new PlayerProblemManager();
+  #problemManager = new PlayerProblemManager();
 
-  private _iterableSource: IIterableSource;
-  private _bufferedSource: BufferedIterableSource;
+  #iterableSource: IIterableSource;
+  #bufferedSource: BufferedIterableSource;
 
   // Some states register an abort controller to signal they should abort
-  private _abort?: AbortController;
+  #abort?: AbortController;
 
   // The iterator for reading messages during playback
-  private _playbackIterator?: AsyncIterator<Readonly<IteratorResult>>;
+  #playbackIterator?: AsyncIterator<Readonly<IteratorResult>>;
 
-  private _blockLoader?: BlockLoader;
-  private _blockLoadingProcess?: Promise<void>;
+  #blockLoader?: BlockLoader;
+  #blockLoadingProcess?: Promise<void>;
 
-  private _queueEmitState: ReturnType<typeof debouncePromise>;
+  #queueEmitState: ReturnType<typeof debouncePromise>;
 
-  private readonly _sourceId: string;
+  readonly #sourceId: string;
 
-  private _untilTime?: Time;
+  #untilTime?: Time;
 
   public constructor(options: IterablePlayerOptions) {
     const { metricsCollector, urlParams, source, name, enablePreload, sourceId } = options;
 
-    this._iterableSource = source;
-    this._bufferedSource = new BufferedIterableSource(source);
+    this.#iterableSource = source;
+    this.#bufferedSource = new BufferedIterableSource(source);
     this.#name = name;
     this.#urlParams = urlParams;
-    this._metricsCollector = metricsCollector ?? new NoopMetricsCollector();
-    this._metricsCollector.playerConstructed();
-    this._enablePreload = enablePreload ?? true;
-    this._sourceId = sourceId;
+    this.#metricsCollector = metricsCollector ?? new NoopMetricsCollector();
+    this.#metricsCollector.playerConstructed();
+    this.#enablePreload = enablePreload ?? true;
+    this.#sourceId = sourceId;
 
     // Wrap emitStateImpl in a debouncePromise for our states to call. Since we can emit from states
     // or from block loading updates we use debouncePromise to guard against concurrent emits.
-    this._queueEmitState = debouncePromise(this._emitStateImpl.bind(this));
+    this.#queueEmitState = debouncePromise(this.#emitStateImpl.bind(this));
   }
 
   public setListener(listener: (playerState: PlayerState) => Promise<void>): void {
@@ -195,35 +195,35 @@ export class IterablePlayer implements Player {
       throw new Error("Cannot setListener again");
     }
     this.#listener = listener;
-    this._setState("initialize");
+    this.#setState("initialize");
   }
 
   public startPlayback(): void {
-    this.startPlayImpl();
+    this.#startPlayImpl();
   }
 
   public playUntil(time: Time): void {
-    this.startPlayImpl({ untilTime: time });
+    this.#startPlayImpl({ untilTime: time });
   }
 
-  private startPlayImpl(opt?: { untilTime: Time }): void {
-    if (this.#isPlaying || this._untilTime || !this.#start || !this.#end) {
+  #startPlayImpl(opt?: { untilTime: Time }): void {
+    if (this.#isPlaying || this.#untilTime || !this.#start || !this.#end) {
       return;
     }
 
     if (opt?.untilTime) {
-      if (this._currentTime && compare(opt.untilTime, this._currentTime) <= 0) {
+      if (this.#currentTime && compare(opt.untilTime, this.#currentTime) <= 0) {
         throw new Error("Invariant: playUntil time must be after the current time");
       }
-      this._untilTime = clampTime(opt.untilTime, this.#start, this.#end);
+      this.#untilTime = clampTime(opt.untilTime, this.#start, this.#end);
     }
-    this._metricsCollector.play(this.#speed);
+    this.#metricsCollector.play(this.#speed);
     this.#isPlaying = true;
 
     // If we are idling we can start playing, if we have a next state queued we let that state
     // finish and it will see that we should be playing
     if (this.#state === "idle" && (!this.#nextState || this.#nextState === "idle")) {
-      this._setState("play");
+      this.#setState("play");
     }
   }
 
@@ -231,30 +231,30 @@ export class IterablePlayer implements Player {
     if (!this.#isPlaying) {
       return;
     }
-    this._metricsCollector.pause();
+    this.#metricsCollector.pause();
     // clear out last tick millis so we don't read a huge chunk when we unpause
-    this._lastTickMillis = undefined;
+    this.#lastTickMillis = undefined;
     this.#isPlaying = false;
-    this._untilTime = undefined;
+    this.#untilTime = undefined;
     if (this.#state === "play") {
-      this._setState("idle");
+      this.#setState("idle");
     }
   }
 
   public setPlaybackSpeed(speed: number): void {
-    delete this._lastRangeMillis;
+    delete this.#lastRangeMillis;
     this.#speed = speed;
-    this._metricsCollector.setSpeed(speed);
+    this.#metricsCollector.setSpeed(speed);
 
     // Queue event state update to update speed in player state to UI
-    this._queueEmitState();
+    this.#queueEmitState();
   }
 
   public seekPlayback(time: Time): void {
     // Wait to perform seek until initialization is complete
     if (this.#state === "preinit" || this.#state === "initialize") {
       log.debug(`Ignoring seek, state=${this.#state}`);
-      this._seekTarget = time;
+      this.#seekTarget = time;
       return;
     }
 
@@ -266,55 +266,55 @@ export class IterablePlayer implements Player {
     const targetTime = clampTime(time, this.#start, this.#end);
 
     // We are already seeking to this time, no need to reset seeking
-    if (this._seekTarget && compare(this._seekTarget, targetTime) === 0) {
+    if (this.#seekTarget && compare(this.#seekTarget, targetTime) === 0) {
       log.debug(`Ignoring seek, already seeking to this time`);
       return;
     }
 
     // We are already at this time, no need to reset seeking
-    if (this._currentTime && compare(this._currentTime, targetTime) === 0) {
+    if (this.#currentTime && compare(this.#currentTime, targetTime) === 0) {
       log.debug(`Ignoring seek, already at this time`);
       return;
     }
 
-    this._metricsCollector.seek(targetTime);
-    this._seekTarget = targetTime;
-    this._untilTime = undefined;
+    this.#metricsCollector.seek(targetTime);
+    this.#seekTarget = targetTime;
+    this.#untilTime = undefined;
 
-    this._setState("seek-backfill");
+    this.#setState("seek-backfill");
   }
 
   public setSubscriptions(newSubscriptions: SubscribePayload[]): void {
     log.debug("set subscriptions", newSubscriptions);
-    this._subscriptions = newSubscriptions;
-    this._metricsCollector.setSubscriptions(newSubscriptions);
+    this.#subscriptions = newSubscriptions;
+    this.#metricsCollector.setSubscriptions(newSubscriptions);
 
-    const allTopics = new Set(this._subscriptions.map((subscription) => subscription.topic));
+    const allTopics = new Set(this.#subscriptions.map((subscription) => subscription.topic));
     const preloadTopics = new Set(
-      filterMap(this._subscriptions, (sub) =>
+      filterMap(this.#subscriptions, (sub) =>
         sub.preloadType !== "partial" ? sub.topic : undefined,
       ),
     );
 
     // If there are no changes to topics there's no reason to perform a "seek" to trigger loading
-    if (isEqual(allTopics, this._allTopics) && isEqual(preloadTopics, this._preloadTopics)) {
+    if (isEqual(allTopics, this.#allTopics) && isEqual(preloadTopics, this.#preloadTopics)) {
       return;
     }
 
-    this._allTopics = allTopics;
-    this._preloadTopics = preloadTopics;
-    this._blockLoader?.setTopics(this._preloadTopics);
+    this.#allTopics = allTopics;
+    this.#preloadTopics = preloadTopics;
+    this.#blockLoader?.setTopics(this.#preloadTopics);
 
     // If the player is playing, the playing state will detect any subscription changes and adjust
     // iterators accordignly. However if we are idle or already seeking then we need to manually
     // trigger the backfill.
     if (this.#state === "idle" || this.#state === "seek-backfill" || this.#state === "play") {
-      if (!this.#isPlaying && this._currentTime) {
-        this._seekTarget ??= this._currentTime;
-        this._untilTime = undefined;
+      if (!this.#isPlaying && this.#currentTime) {
+        this.#seekTarget ??= this.#currentTime;
+        this.#untilTime = undefined;
 
         // Trigger a seek backfill to load any missing messages and reset the forward iterator
-        this._setState("seek-backfill");
+        this.#setState("seek-backfill");
       }
     }
   }
@@ -336,7 +336,7 @@ export class IterablePlayer implements Player {
   }
 
   public close(): void {
-    this._setState("close");
+    this.#setState("close");
   }
 
   public setGlobalVariables(): void {
@@ -344,12 +344,12 @@ export class IterablePlayer implements Player {
   }
 
   /** Request the state to switch to newState */
-  private _setState(newState: IterablePlayerState) {
+  #setState(newState: IterablePlayerState) {
     log.debug(`Set next state: ${newState}`);
     this.#nextState = newState;
-    this._abort?.abort();
-    this._abort = undefined;
-    void this._runState();
+    this.#abort?.abort();
+    this.#abort = undefined;
+    void this.#runState();
   }
 
   /**
@@ -357,7 +357,7 @@ export class IterablePlayer implements Player {
    *
    * Ensures that only one state is running at a time.
    * */
-  private async _runState() {
+  async #runState() {
     if (this.#runningState) {
       return;
     }
@@ -372,53 +372,53 @@ export class IterablePlayer implements Player {
 
         // If we are going into a state other than play or idle we throw away the playback iterator since
         // we will need to make a new one.
-        if (state !== "idle" && state !== "play" && this._playbackIterator) {
+        if (state !== "idle" && state !== "play" && this.#playbackIterator) {
           log.debug("Ending playback iterator because next state is not IDLE or PLAY");
-          await this._playbackIterator.return?.();
-          this._playbackIterator = undefined;
+          await this.#playbackIterator.return?.();
+          this.#playbackIterator = undefined;
         }
 
         switch (state) {
           case "preinit":
-            this._queueEmitState();
+            this.#queueEmitState();
             break;
           case "initialize":
             await this.#stateInitialize();
             break;
           case "start-play":
-            await this._stateStartPlay();
+            await this.#stateStartPlay();
             break;
           case "idle":
-            await this._stateIdle();
+            await this.#stateIdle();
             break;
           case "seek-backfill":
             // We allow aborting requests when moving on to the next state
-            await this._stateSeekBackfill();
+            await this.#stateSeekBackfill();
             break;
           case "play":
-            await this._statePlay();
+            await this.#statePlay();
             break;
           case "close":
-            await this._stateClose();
+            await this.#stateClose();
             break;
           case "reset-playback-iterator":
-            await this._stateResetPlaybackIterator();
+            await this.#stateResetPlaybackIterator();
         }
 
         log.debug(`Done state ${state}`);
       }
     } catch (err) {
       log.error(err);
-      this._setError((err as Error).message, err);
-      this._queueEmitState();
+      this.#setError((err as Error).message, err);
+      this.#queueEmitState();
     } finally {
       this.#runningState = false;
     }
   }
 
-  private _setError(message: string, error?: Error): void {
-    this._hasError = true;
-    this._problemManager.addProblem("global-error", {
+  #setError(message: string, error?: Error): void {
+    this.#hasError = true;
+    this.#problemManager.addProblem("global-error", {
       severity: "error",
       message,
       error,
@@ -429,7 +429,7 @@ export class IterablePlayer implements Player {
   // Initialize the source and player members
   async #stateInitialize(): Promise<void> {
     // emit state indicating start of initialization
-    this._queueEmitState();
+    this.#queueEmitState();
 
     try {
       const {
@@ -442,20 +442,20 @@ export class IterablePlayer implements Player {
         publishersByTopic,
         datatypes,
         name,
-      } = await this._bufferedSource.initialize();
+      } = await this.#bufferedSource.initialize();
 
       // Prior to initialization, the seekTarget may have been set to an out-of-bounds value
       // This brings the value in bounds
-      if (this._seekTarget) {
-        this._seekTarget = clampTime(this._seekTarget, start, end);
+      if (this.#seekTarget) {
+        this.#seekTarget = clampTime(this.#seekTarget, start, end);
       }
 
-      this._profile = profile;
+      this.#profile = profile;
       this.#start = start;
-      this._currentTime = this._seekTarget ?? start;
+      this.#currentTime = this.#seekTarget ?? start;
       this.#end = end;
-      this._publishedTopics = publishersByTopic;
-      this._providerDatatypes = datatypes;
+      this.#publishedTopics = publishersByTopic;
+      this.#providerDatatypes = datatypes;
       this.#name = name ?? this.#name;
 
       // Studio does not like duplicate topics or topics with different datatypes
@@ -475,26 +475,26 @@ export class IterablePlayer implements Player {
         uniqueTopics.set(topic.name, topic);
       }
 
-      this._providerTopics = Array.from(uniqueTopics.values());
-      this._providerTopicStats = topicStats;
+      this.#providerTopics = Array.from(uniqueTopics.values());
+      this.#providerTopicStats = topicStats;
 
       let idx = 0;
       for (const problem of problems) {
-        this._problemManager.addProblem(`init-problem-${idx}`, problem);
+        this.#problemManager.addProblem(`init-problem-${idx}`, problem);
         idx += 1;
       }
 
-      if (this._enablePreload) {
+      if (this.#enablePreload) {
         // --- setup block loader which loads messages for _full_ subscriptions in the "background"
         try {
-          this._blockLoader = new BlockLoader({
+          this.#blockLoader = new BlockLoader({
             cacheSizeBytes: DEFAULT_CACHE_SIZE_BYTES,
-            source: this._iterableSource,
+            source: this.#iterableSource,
             start: this.#start,
             end: this.#end,
             maxBlocks: MAX_BLOCKS,
             minBlockDurationNs: MIN_MEM_CACHE_BLOCK_SIZE_NS,
-            problemManager: this._problemManager,
+            problemManager: this.#problemManager,
           });
         } catch (err) {
           log.error(err);
@@ -502,7 +502,7 @@ export class IterablePlayer implements Player {
           const startStr = toRFC3339String(this.#start);
           const endStr = toRFC3339String(this.#end);
 
-          this._problemManager.addProblem("block-loader", {
+          this.#problemManager.addProblem("block-loader", {
             severity: "warn",
             message: "Failed to initialize message preloading",
             tip: `The start (${startStr}) and end (${endStr}) of your data is too far apart.`,
@@ -511,67 +511,67 @@ export class IterablePlayer implements Player {
         }
       }
 
-      this._presence = PlayerPresence.PRESENT;
+      this.#presence = PlayerPresence.PRESENT;
     } catch (error) {
-      this._setError(`Error initializing: ${error.message}`, error);
+      this.#setError(`Error initializing: ${error.message}`, error);
     }
-    this._queueEmitState();
+    this.#queueEmitState();
 
-    if (!this._hasError && this.#start) {
+    if (!this.#hasError && this.#start) {
       // Wait a bit until panels have had the chance to subscribe to topics before we start
       // playback.
       await delay(START_DELAY_MS);
 
-      this._blockLoader?.setTopics(this._preloadTopics);
+      this.#blockLoader?.setTopics(this.#preloadTopics);
 
       // Block loadings is constantly running and tries to keep the preloaded messages in memory
-      this._blockLoadingProcess = this.#startBlockLoading();
+      this.#blockLoadingProcess = this.#startBlockLoading();
 
-      this._setState("start-play");
+      this.#setState("start-play");
     }
   }
 
   async #resetPlaybackIterator() {
-    if (!this._currentTime) {
+    if (!this.#currentTime) {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
 
-    const next = add(this._currentTime, { sec: 0, nsec: 1 });
+    const next = add(this.#currentTime, { sec: 0, nsec: 1 });
 
     log.debug("Ending previous iterator");
-    await this._playbackIterator?.return?.();
+    await this.#playbackIterator?.return?.();
 
     // set the playIterator to the seek time
-    await this._bufferedSource.stopProducer();
+    await this.#bufferedSource.stopProducer();
 
     log.debug("Initializing forward iterator from", next);
-    this._playbackIterator = this._bufferedSource.messageIterator({
-      topics: Array.from(this._allTopics),
+    this.#playbackIterator = this.#bufferedSource.messageIterator({
+      topics: Array.from(this.#allTopics),
       start: next,
       consumptionType: "partial",
     });
   }
 
-  private async _stateResetPlaybackIterator() {
-    if (!this._currentTime) {
+  async #stateResetPlaybackIterator() {
+    if (!this.#currentTime) {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
 
     await this.#resetPlaybackIterator();
-    this._setState(this.#isPlaying ? "play" : "idle");
+    this.#setState(this.#isPlaying ? "play" : "idle");
   }
 
   // Read a small amount of data from the datasource with the hope of producing a message or two.
   // Without an initial read, the user would be looking at a blank layout since no messages have yet
   // been delivered.
-  private async _stateStartPlay() {
+  async #stateStartPlay() {
     if (!this.#start || !this.#end) {
       throw new Error("Invariant: start and end must be set");
     }
 
     // If we have a target seek time, the seekPlayback function will take care of backfilling messages.
-    if (this._seekTarget) {
-      this._setState("seek-backfill");
+    if (this.#seekTarget) {
+      this.#setState("seek-backfill");
       return;
     }
 
@@ -583,32 +583,32 @@ export class IterablePlayer implements Player {
 
     log.debug(`Playing from ${toString(this.#start)} to ${toString(stopTime)}`);
 
-    if (this._playbackIterator) {
+    if (this.#playbackIterator) {
       throw new Error("Invariant. playbackIterator was already set");
     }
 
     log.debug("Initializing forward iterator from", this.#start);
-    this._playbackIterator = this._bufferedSource.messageIterator({
-      topics: Array.from(this._allTopics),
+    this.#playbackIterator = this.#bufferedSource.messageIterator({
+      topics: Array.from(this.#allTopics),
       start: this.#start,
       consumptionType: "partial",
     });
 
-    this._lastMessageEvent = undefined;
-    this._messages = [];
+    this.#lastMessageEvent = undefined;
+    this.#messages = [];
 
     const messageEvents: MessageEvent<unknown>[] = [];
 
     // If we take too long to read the data, we set the player into a BUFFERING presence. This
     // indicates that the player is waiting to load more data.
     const tickTimeout = setTimeout(() => {
-      this._presence = PlayerPresence.BUFFERING;
-      this._queueEmitState();
+      this.#presence = PlayerPresence.BUFFERING;
+      this.#queueEmitState();
     }, 100);
 
     try {
       for (;;) {
-        const result = await this._playbackIterator.next();
+        const result = await this.#playbackIterator.next();
         if (result.done === true) {
           break;
         }
@@ -620,19 +620,19 @@ export class IterablePlayer implements Player {
         }
 
         if (iterResult.type === "problem") {
-          this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+          this.#problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
           continue;
         }
 
         if (iterResult.type === "stamp" && compare(iterResult.stamp, stopTime) >= 0) {
-          this._lastStamp = iterResult.stamp;
+          this.#lastStamp = iterResult.stamp;
           break;
         }
 
         if (iterResult.type === "message-event") {
           // The message is past the tick end time, we need to save it for next tick
           if (compare(iterResult.msgEvent.receiveTime, stopTime) > 0) {
-            this._lastMessageEvent = iterResult.msgEvent;
+            this.#lastMessageEvent = iterResult.msgEvent;
             break;
           }
 
@@ -643,28 +643,28 @@ export class IterablePlayer implements Player {
       clearTimeout(tickTimeout);
     }
 
-    this._currentTime = stopTime;
-    this._messages = messageEvents;
-    this._presence = PlayerPresence.PRESENT;
-    this._queueEmitState();
-    this._setState("idle");
+    this.#currentTime = stopTime;
+    this.#messages = messageEvents;
+    this.#presence = PlayerPresence.PRESENT;
+    this.#queueEmitState();
+    this.#setState("idle");
   }
 
   // Process a seek request. The seek is performed by requesting a getBackfillMessages from the source.
   // This provides the last message on all subscribed topics.
-  private async _stateSeekBackfill() {
+  async #stateSeekBackfill() {
     if (!this.#start || !this.#end) {
       throw new Error("invariant: stateSeekBackfill prior to initialization");
     }
 
-    if (!this._seekTarget) {
+    if (!this.#seekTarget) {
       return;
     }
 
     // Ensure the seek time is always within the data source bounds
-    const targetTime = clampTime(this._seekTarget, this.#start, this.#end);
+    const targetTime = clampTime(this.#seekTarget, this.#start, this.#end);
 
-    this._lastMessageEvent = undefined;
+    this.#lastMessageEvent = undefined;
 
     // If the backfill does not complete within 100 milliseconds, we emit with no messages to
     // indicate buffering. This provides feedback to the user that we've acknowledged their seek
@@ -672,20 +672,20 @@ export class IterablePlayer implements Player {
     //
     // Note: we explicitly avoid setting _lastSeekEmitTime so panels do not reset visualizations
     const seekAckTimeout = setTimeout(() => {
-      this._presence = PlayerPresence.BUFFERING;
-      this._messages = [];
-      this._currentTime = targetTime;
-      this._queueEmitState();
+      this.#presence = PlayerPresence.BUFFERING;
+      this.#messages = [];
+      this.#currentTime = targetTime;
+      this.#queueEmitState();
     }, 100);
 
-    const topics = Array.from(this._allTopics);
+    const topics = Array.from(this.#allTopics);
 
     try {
-      this._abort = new AbortController();
-      const messages = await this._bufferedSource.getBackfillMessages({
+      this.#abort = new AbortController();
+      const messages = await this.#bufferedSource.getBackfillMessages({
         topics,
         time: targetTime,
-        abortSignal: this._abort.signal,
+        abortSignal: this.#abort.signal,
       });
 
       // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
@@ -695,13 +695,13 @@ export class IterablePlayer implements Player {
         return;
       }
 
-      this._messages = messages;
-      this._currentTime = targetTime;
-      this._lastSeekEmitTime = Date.now();
-      this._presence = PlayerPresence.PRESENT;
-      this._queueEmitState();
+      this.#messages = messages;
+      this.#currentTime = targetTime;
+      this.#lastSeekEmitTime = Date.now();
+      this.#presence = PlayerPresence.PRESENT;
+      this.#queueEmitState();
       await this.#resetPlaybackIterator();
-      this._setState(this.#isPlaying ? "play" : "idle");
+      this.#setState(this.#isPlaying ? "play" : "idle");
     } catch (err) {
       if (this.#nextState && err instanceof DOMException && err.name === "AbortError") {
         log.debug("Aborted backfill");
@@ -711,68 +711,68 @@ export class IterablePlayer implements Player {
     } finally {
       // Unless the next state is a seek backfill, we clear the seek target since we have finished seeking
       if (this.#nextState !== "seek-backfill") {
-        this._seekTarget = undefined;
+        this.#seekTarget = undefined;
       }
       clearTimeout(seekAckTimeout);
-      this._abort = undefined;
+      this.#abort = undefined;
     }
   }
 
   /** Emit the player state to the registered listener */
-  private async _emitStateImpl() {
+  async #emitStateImpl() {
     if (!this.#listener) {
       return;
     }
 
-    if (this._hasError) {
+    if (this.#hasError) {
       return await this.#listener({
         name: this.#name,
         presence: PlayerPresence.ERROR,
         progress: {},
-        capabilities: this._capabilities,
-        profile: this._profile,
-        playerId: this._id,
+        capabilities: this.#capabilities,
+        profile: this.#profile,
+        playerId: this.#id,
         activeData: undefined,
-        problems: this._problemManager.problems(),
+        problems: this.#problemManager.problems(),
         urlState: {
-          sourceId: this._sourceId,
+          sourceId: this.#sourceId,
           parameters: this.#urlParams,
         },
       });
     }
 
-    const messages = this._messages;
-    this._messages = [];
+    const messages = this.#messages;
+    this.#messages = [];
 
     let activeData: PlayerStateActiveData | undefined;
-    if (this.#start && this.#end && this._currentTime) {
+    if (this.#start && this.#end && this.#currentTime) {
       activeData = {
         messages,
-        totalBytesReceived: this._receivedBytes,
-        currentTime: this._currentTime,
+        totalBytesReceived: this.#receivedBytes,
+        currentTime: this.#currentTime,
         startTime: this.#start,
         endTime: this.#end,
         isPlaying: this.#isPlaying,
         speed: this.#speed,
-        lastSeekTime: this._lastSeekEmitTime,
-        topics: this._providerTopics,
-        topicStats: this._providerTopicStats,
-        datatypes: this._providerDatatypes,
-        publishedTopics: this._publishedTopics,
+        lastSeekTime: this.#lastSeekEmitTime,
+        topics: this.#providerTopics,
+        topicStats: this.#providerTopicStats,
+        datatypes: this.#providerDatatypes,
+        publishedTopics: this.#publishedTopics,
       };
     }
 
     const data: PlayerState = {
       name: this.#name,
-      presence: this._presence,
-      progress: this._progress,
-      capabilities: this._capabilities,
-      profile: this._profile,
-      playerId: this._id,
-      problems: this._problemManager.problems(),
+      presence: this.#presence,
+      progress: this.#progress,
+      capabilities: this.#capabilities,
+      profile: this.#profile,
+      playerId: this.#id,
+      problems: this.#problemManager.problems(),
       activeData,
       urlState: {
-        sourceId: this._sourceId,
+        sourceId: this.#sourceId,
         parameters: this.#urlParams,
       },
     };
@@ -795,28 +795,28 @@ export class IterablePlayer implements Player {
     // the time since our last read and how fast we're currently playing back
     const tickTime = performance.now();
     const durationMillis =
-      this._lastTickMillis != undefined && this._lastTickMillis !== 0
-        ? tickTime - this._lastTickMillis
+      this.#lastTickMillis != undefined && this.#lastTickMillis !== 0
+        ? tickTime - this.#lastTickMillis
         : 20;
-    this._lastTickMillis = tickTime;
+    this.#lastTickMillis = tickTime;
 
     // Read at most 300ms worth of messages, otherwise things can get out of control if rendering
     // is very slow. Also, smooth over the range that we request, so that a single slow frame won't
     // cause the next frame to also be unnecessarily slow by increasing the frame size.
     let rangeMillis = Math.min(durationMillis * this.#speed, 300);
-    if (this._lastRangeMillis != undefined) {
-      rangeMillis = this._lastRangeMillis * 0.9 + rangeMillis * 0.1;
+    if (this.#lastRangeMillis != undefined) {
+      rangeMillis = this.#lastRangeMillis * 0.9 + rangeMillis * 0.1;
     }
-    this._lastRangeMillis = rangeMillis;
+    this.#lastRangeMillis = rangeMillis;
 
-    if (!this._currentTime) {
+    if (!this.#currentTime) {
       throw new Error("Invariant: Tried to play with no current time.");
     }
 
     // The end time when we want to stop reading messages and emit state for the tick
     // The end time is inclusive.
-    const targetTime = add(this._currentTime, fromMillis(rangeMillis));
-    const end: Time = clampTime(targetTime, this.#start, this._untilTime ?? this.#end);
+    const targetTime = add(this.#currentTime, fromMillis(rangeMillis));
+    const end: Time = clampTime(targetTime, this.#start, this.#untilTime ?? this.#end);
 
     // If a lastStamp is available from the previous tick we check the stamp against our current
     // tick's end time. If this stamp is after our current tick's end time then we don't need to
@@ -825,83 +825,83 @@ export class IterablePlayer implements Player {
     //
     // If we have a lastStamp but it isn't after the tick end, then we clear it and proceed with the
     // tick logic.
-    if (this._lastStamp) {
-      if (compare(this._lastStamp, end) >= 0) {
+    if (this.#lastStamp) {
+      if (compare(this.#lastStamp, end) >= 0) {
         // Wait for the previous render frame to finish
-        await this._queueEmitState.currentPromise;
+        await this.#queueEmitState.currentPromise;
 
-        this._currentTime = end;
-        this._messages = [];
-        this._queueEmitState();
+        this.#currentTime = end;
+        this.#messages = [];
+        this.#queueEmitState();
 
-        if (this._untilTime && compare(this._currentTime, this._untilTime) >= 0) {
+        if (this.#untilTime && compare(this.#currentTime, this.#untilTime) >= 0) {
           this.pausePlayback();
         }
         return;
       }
 
-      this._lastStamp = undefined;
+      this.#lastStamp = undefined;
     }
 
     const msgEvents: MessageEvent<unknown>[] = [];
 
     // When ending the previous tick, we might have already read a message from the iterator which
     // belongs to our tick. This logic brings that message into our current batch of message events.
-    if (this._lastMessageEvent) {
+    if (this.#lastMessageEvent) {
       // If the last message we saw is still ahead of the tick end time, we don't emit anything
-      if (compare(this._lastMessageEvent.receiveTime, end) > 0) {
+      if (compare(this.#lastMessageEvent.receiveTime, end) > 0) {
         // Wait for the previous render frame to finish
-        await this._queueEmitState.currentPromise;
+        await this.#queueEmitState.currentPromise;
 
-        this._currentTime = end;
-        this._messages = msgEvents;
-        this._queueEmitState();
+        this.#currentTime = end;
+        this.#messages = msgEvents;
+        this.#queueEmitState();
 
-        if (this._untilTime && compare(this._currentTime, this._untilTime) >= 0) {
+        if (this.#untilTime && compare(this.#currentTime, this.#untilTime) >= 0) {
           this.pausePlayback();
         }
         return;
       }
 
-      msgEvents.push(this._lastMessageEvent);
-      this._lastMessageEvent = undefined;
+      msgEvents.push(this.#lastMessageEvent);
+      this.#lastMessageEvent = undefined;
     }
 
     // If we take too long to read the tick data, we set the player into a BUFFERING presence. This
     // indicates that the player is waiting to load more data. When the tick finally finishes, we
     // clear this timeout.
     const tickTimeout = setTimeout(() => {
-      this._presence = PlayerPresence.BUFFERING;
-      this._queueEmitState();
+      this.#presence = PlayerPresence.BUFFERING;
+      this.#queueEmitState();
     }, 500);
 
     try {
       // Read from the iterator through the end of the tick time
       for (;;) {
-        if (!this._playbackIterator) {
+        if (!this.#playbackIterator) {
           throw new Error("Invariant. this._playbackIterator is undefined.");
         }
 
-        const result = await this._playbackIterator.next();
+        const result = await this.#playbackIterator.next();
         if (result.done === true || this.#nextState) {
           break;
         }
         const iterResult = result.value;
 
         if (iterResult.type === "problem") {
-          this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+          this.#problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
           continue;
         }
 
         if (iterResult.type === "stamp" && compare(iterResult.stamp, end) >= 0) {
-          this._lastStamp = iterResult.stamp;
+          this.#lastStamp = iterResult.stamp;
           break;
         }
 
         if (iterResult.type === "message-event") {
           // The message is past the tick end time, we need to save it for next tick
           if (compare(iterResult.msgEvent.receiveTime, end) > 0) {
-            this._lastMessageEvent = iterResult.msgEvent;
+            this.#lastMessageEvent = iterResult.msgEvent;
             break;
           }
 
@@ -913,7 +913,7 @@ export class IterablePlayer implements Player {
     }
 
     // Set the presence back to PRESENT since we are no longer buffering
-    this._presence = PlayerPresence.PRESENT;
+    this.#presence = PlayerPresence.PRESENT;
 
     if (this.#nextState) {
       return;
@@ -922,27 +922,27 @@ export class IterablePlayer implements Player {
     // Wait on any active emit state to finish as part of this tick
     // Without waiting on the emit state to finish we might drop messages since our emitState
     // might get debounced
-    await this._queueEmitState.currentPromise;
+    await this.#queueEmitState.currentPromise;
 
-    this._currentTime = end;
-    this._messages = msgEvents;
-    this._queueEmitState();
+    this.#currentTime = end;
+    this.#messages = msgEvents;
+    this.#queueEmitState();
 
     // This tick has reached the end of the untilTime so we go back to pause
-    if (this._untilTime && compare(this._currentTime, this._untilTime) >= 0) {
+    if (this.#untilTime && compare(this.#currentTime, this.#untilTime) >= 0) {
       this.pausePlayback();
     }
   }
 
-  private async _stateIdle() {
+  async #stateIdle() {
     this.#isPlaying = false;
-    this._presence = PlayerPresence.PRESENT;
-    this._queueEmitState();
+    this.#presence = PlayerPresence.PRESENT;
+    this.#queueEmitState();
 
-    if (this._abort) {
+    if (this.#abort) {
       throw new Error("Invariant: some other abort controller exists");
     }
-    const abort = (this._abort = new AbortController());
+    const abort = (this.#abort = new AbortController());
 
     const aborted = new Promise<void>((resolve) => {
       abort.signal.addEventListener("abort", () => {
@@ -951,11 +951,11 @@ export class IterablePlayer implements Player {
     });
 
     for (;;) {
-      this._progress = {
-        fullyLoadedFractionRanges: this._bufferedSource.loadedRanges(),
-        messageCache: this._progress.messageCache,
+      this.#progress = {
+        fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+        messageCache: this.#progress.messageCache,
       };
-      this._queueEmitState();
+      this.#queueEmitState();
 
       // When idling nothing is querying the source, but our buffered source might be
       // buffering behind the scenes. Every second we emit state with an update to show that
@@ -967,10 +967,10 @@ export class IterablePlayer implements Player {
     }
   }
 
-  private async _statePlay() {
-    this._presence = PlayerPresence.PRESENT;
+  async #statePlay() {
+    this.#presence = PlayerPresence.PRESENT;
 
-    if (!this._currentTime) {
+    if (!this.#currentTime) {
       throw new Error("Invariant: currentTime not set before statePlay");
     }
     if (!this.#start || !this.#end) {
@@ -979,16 +979,16 @@ export class IterablePlayer implements Player {
 
     // Track the identity of allTopics, if this changes we need to reset our iterator to
     // get new messages for new topics
-    const allTopics = this._allTopics;
+    const allTopics = this.#allTopics;
 
     try {
-      while (this.#isPlaying && !this._hasError && !this.#nextState) {
-        if (compare(this._currentTime, this.#end) >= 0) {
+      while (this.#isPlaying && !this.#hasError && !this.#nextState) {
+        if (compare(this.#currentTime, this.#end) >= 0) {
           // Playback has ended. Reset internal trackers for maintaining the playback speed.
-          this._lastTickMillis = undefined;
-          this._lastRangeMillis = undefined;
-          this._lastStamp = undefined;
-          this._setState("idle");
+          this.#lastTickMillis = undefined;
+          this.#lastRangeMillis = undefined;
+          this.#lastStamp = undefined;
+          this.#setState("idle");
           return;
         }
 
@@ -1001,19 +1001,19 @@ export class IterablePlayer implements Player {
         }
 
         // If subscriptions changed, update to the new subscriptions
-        if (this._allTopics !== allTopics) {
+        if (this.#allTopics !== allTopics) {
           // Discard any last message event since the new iterator will repeat it
-          this._lastMessageEvent = undefined;
+          this.#lastMessageEvent = undefined;
 
           // Bail playback and reset the playback iterator when topics have changed so we can load
           // the new topics
-          this._setState("reset-playback-iterator");
+          this.#setState("reset-playback-iterator");
           return;
         }
 
-        this._progress = {
-          fullyLoadedFractionRanges: this._bufferedSource.loadedRanges(),
-          messageCache: this._progress.messageCache,
+        this.#progress = {
+          fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+          messageCache: this.#progress.messageCache,
         };
 
         const time = Date.now() - start;
@@ -1024,32 +1024,32 @@ export class IterablePlayer implements Player {
         }
       }
     } catch (err) {
-      this._setError((err as Error).message, err);
-      this._queueEmitState();
+      this.#setError((err as Error).message, err);
+      this.#queueEmitState();
     }
   }
 
-  private async _stateClose() {
+  async #stateClose() {
     this.#isPlaying = false;
-    this._metricsCollector.close();
-    await this._blockLoader?.stopLoading();
-    await this._blockLoadingProcess;
-    await this._bufferedSource.stopProducer();
-    await this._bufferedSource.terminate();
-    await this._playbackIterator?.return?.();
-    this._playbackIterator = undefined;
-    await this._iterableSource.terminate?.();
+    this.#metricsCollector.close();
+    await this.#blockLoader?.stopLoading();
+    await this.#blockLoadingProcess;
+    await this.#bufferedSource.stopProducer();
+    await this.#bufferedSource.terminate();
+    await this.#playbackIterator?.return?.();
+    this.#playbackIterator = undefined;
+    await this.#iterableSource.terminate?.();
   }
 
   async #startBlockLoading() {
-    await this._blockLoader?.startLoading({
+    await this.#blockLoader?.startLoading({
       progress: async (progress) => {
-        this._progress = {
-          fullyLoadedFractionRanges: this._progress.fullyLoadedFractionRanges,
+        this.#progress = {
+          fullyLoadedFractionRanges: this.#progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache,
         };
 
-        this._queueEmitState();
+        this.#queueEmitState();
       },
     });
   }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -127,10 +127,7 @@ export class IterablePlayer implements Player {
   #providerTopicStats = new Map<string, TopicStats>();
   #providerDatatypes: RosDatatypes = new Map();
 
-  #capabilities: string[] = [
-    PlayerCapabilities.setSpeed,
-    PlayerCapabilities.playbackControl,
-  ];
+  #capabilities: string[] = [PlayerCapabilities.setSpeed, PlayerCapabilities.playbackControl];
   #profile: string | undefined;
   #metricsCollector: PlayerMetricsCollectorInterface;
   #subscriptions: SubscribePayload[] = [];

--- a/packages/studio-base/src/players/IterablePlayer/IteratorCursor.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IteratorCursor.ts
@@ -11,28 +11,28 @@ const TIME_ZERO = Object.freeze({ sec: 0, nsec: 0 });
 
 /// IteratorCursor implements a IMessageCursor interface on top of an AsyncIterable
 class IteratorCursor implements IMessageCursor {
-  private _iter: AsyncIterableIterator<Readonly<IteratorResult>>;
+  #iter: AsyncIterableIterator<Readonly<IteratorResult>>;
   // readUntil reads from the iterator inclusive of end time. To do this, it reads from the iterator
   // until it receives a receiveTime after end time to signal it has received all the messages
   // inclusive of end time. Since iterators are read once, this last result must be stored for the
   // next readUntil call otherwise it would be lost.
-  private _lastIteratorResult?: IteratorResult;
-  private _abort?: AbortSignal;
+  #lastIteratorResult?: IteratorResult;
+  #abort?: AbortSignal;
 
   public constructor(
     iterator: AsyncIterableIterator<Readonly<IteratorResult>>,
     abort?: AbortSignal,
   ) {
-    this._iter = iterator;
-    this._abort = abort;
+    this.#iter = iterator;
+    this.#abort = abort;
   }
 
   public async next(): ReturnType<IMessageCursor["next"]> {
-    if (this._abort?.aborted === true) {
+    if (this.#abort?.aborted === true) {
       return undefined;
     }
 
-    const result = await this._iter.next();
+    const result = await this.#iter.next();
     return result.value;
   }
 
@@ -82,7 +82,7 @@ class IteratorCursor implements IMessageCursor {
   public async readUntil(end: Time): ReturnType<IMessageCursor["readUntil"]> {
     // Assign to a variable to fool typescript control flow analysis which does not understand
     // that this value could change after the _await_
-    const isAborted = this._abort?.aborted;
+    const isAborted = this.#abort?.aborted;
     if (isAborted === true) {
       return undefined;
     }
@@ -91,27 +91,27 @@ class IteratorCursor implements IMessageCursor {
 
     // if the last result is still past end time, return empty results
     if (
-      this._lastIteratorResult?.type === "stamp" &&
-      compare(this._lastIteratorResult.stamp, end) >= 0
+      this.#lastIteratorResult?.type === "stamp" &&
+      compare(this.#lastIteratorResult.stamp, end) >= 0
     ) {
       return results;
     }
 
     if (
-      this._lastIteratorResult?.type === "message-event" &&
-      compare(this._lastIteratorResult.msgEvent.receiveTime, end) > 0
+      this.#lastIteratorResult?.type === "message-event" &&
+      compare(this.#lastIteratorResult.msgEvent.receiveTime, end) > 0
     ) {
       return results;
     }
 
-    if (this._lastIteratorResult) {
-      results.push(this._lastIteratorResult);
-      this._lastIteratorResult = undefined;
+    if (this.#lastIteratorResult) {
+      results.push(this.#lastIteratorResult);
+      this.#lastIteratorResult = undefined;
     }
 
     for (;;) {
-      const result = await this._iter.next();
-      if (this._abort?.aborted === true) {
+      const result = await this.#iter.next();
+      if (this.#abort?.aborted === true) {
         return undefined;
       }
 
@@ -121,11 +121,11 @@ class IteratorCursor implements IMessageCursor {
 
       const value = result.value;
       if (value.type === "stamp" && compare(value.stamp, end) >= 0) {
-        this._lastIteratorResult = value;
+        this.#lastIteratorResult = value;
         break;
       }
       if (value.type === "message-event" && compare(value.msgEvent.receiveTime, end) > 0) {
-        this._lastIteratorResult = value;
+        this.#lastIteratorResult = value;
         break;
       }
       results.push(value);
@@ -135,7 +135,7 @@ class IteratorCursor implements IMessageCursor {
   }
 
   public async end(): ReturnType<IMessageCursor["end"]> {
-    await this._iter.return?.();
+    await this.#iter.return?.();
   }
 }
 

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -21,22 +21,22 @@ import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 const log = Logger.getLogger(__filename);
 
 export class McapIndexedIterableSource implements IIterableSource {
-  private reader: McapIndexedReader;
-  private channelInfoById = new Map<
+  #reader: McapIndexedReader;
+  #channelInfoById = new Map<
     number,
     { channel: McapTypes.Channel; parsedChannel: ParsedChannel; schemaName: string | undefined }
   >();
-  private start?: Time;
-  private end?: Time;
+  #start?: Time;
+  #end?: Time;
 
   public constructor(reader: McapIndexedReader) {
-    this.reader = reader;
+    this.#reader = reader;
   }
 
   public async initialize(): Promise<Initalization> {
     let startTime: bigint | undefined;
     let endTime: bigint | undefined;
-    for (const chunk of this.reader.chunkIndexes) {
+    for (const chunk of this.#reader.chunkIndexes) {
       if (startTime == undefined || chunk.messageStartTime < startTime) {
         startTime = chunk.messageStartTime;
       }
@@ -51,8 +51,8 @@ export class McapIndexedIterableSource implements IIterableSource {
     const problems: PlayerProblem[] = [];
     const publishersByTopic = new Map<string, Set<string>>();
 
-    for (const channel of this.reader.channelsById.values()) {
-      const schema = this.reader.schemasById.get(channel.schemaId);
+    for (const channel of this.#reader.channelsById.values()) {
+      const schema = this.#reader.schemasById.get(channel.schemaId);
       if (channel.schemaId !== 0 && schema == undefined) {
         problems.push({
           severity: "error",
@@ -72,14 +72,14 @@ export class McapIndexedIterableSource implements IIterableSource {
         });
         continue;
       }
-      this.channelInfoById.set(channel.id, { channel, parsedChannel, schemaName: schema?.name });
+      this.#channelInfoById.set(channel.id, { channel, parsedChannel, schemaName: schema?.name });
 
       let topic = topicsByName.get(channel.topic);
       if (!topic) {
         topic = { name: channel.topic, schemaName: schema?.name };
         topicsByName.set(channel.topic, topic);
 
-        const numMessages = this.reader.statistics?.channelMessageCounts.get(channel.id);
+        const numMessages = this.#reader.statistics?.channelMessageCounts.get(channel.id);
         if (numMessages != undefined) {
           topicStats.set(channel.topic, { numMessages: Number(numMessages) });
         }
@@ -102,15 +102,15 @@ export class McapIndexedIterableSource implements IIterableSource {
       }
     }
 
-    this.start = fromNanoSec(startTime ?? 0n);
-    this.end = fromNanoSec(endTime ?? startTime ?? 0n);
+    this.#start = fromNanoSec(startTime ?? 0n);
+    this.#end = fromNanoSec(endTime ?? startTime ?? 0n);
 
     return {
-      start: this.start,
-      end: this.end,
+      start: this.#start,
+      end: this.#end,
       topics: [...topicsByName.values()],
       datatypes,
-      profile: this.reader.header.profile,
+      profile: this.#reader.header.profile,
       problems,
       publishersByTopic,
       topicStats,
@@ -121,19 +121,19 @@ export class McapIndexedIterableSource implements IIterableSource {
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
     const topics = args.topics;
-    const start = args.start ?? this.start;
-    const end = args.end ?? this.end;
+    const start = args.start ?? this.#start;
+    const end = args.end ?? this.#end;
 
     if (topics.length === 0 || !start || !end) {
       return;
     }
 
-    for await (const message of this.reader.readMessages({
+    for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
       endTime: toNanoSec(end),
       topics,
     })) {
-      const channelInfo = this.channelInfoById.get(message.channelId);
+      const channelInfo = this.#channelInfoById.get(message.channelId);
       if (!channelInfo) {
         yield {
           type: "problem",
@@ -179,12 +179,12 @@ export class McapIndexedIterableSource implements IIterableSource {
       // NOTE: An iterator is made for each topic to get the latest message on that topic.
       // An single iterator for all the topics could result in iterating through many
       // irrelevant messages to get to an older message on a topic.
-      for await (const message of this.reader.readMessages({
+      for await (const message of this.#reader.readMessages({
         endTime: toNanoSec(time),
         topics: [topic],
         reverse: true,
       })) {
-        const channelInfo = this.channelInfoById.get(message.channelId);
+        const channelInfo = this.#channelInfoById.get(message.channelId);
         if (!channelInfo) {
           log.error(`Missing channel info for channel: ${message.channelId} on topic: ${topic}`);
           continue;

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -40,15 +40,15 @@ async function tryCreateIndexedReader(readable: McapTypes.IReadable) {
 }
 
 export class McapIterableSource implements IIterableSource {
-  private _source: McapSource;
-  private _sourceImpl: IIterableSource | undefined;
+  #source: McapSource;
+  #sourceImpl: IIterableSource | undefined;
 
   public constructor(source: McapSource) {
-    this._source = source;
+    this.#source = source;
   }
 
   public async initialize(): Promise<Initalization> {
-    const source = this._source;
+    const source = this.#source;
 
     switch (source.type) {
       case "file": {
@@ -60,9 +60,9 @@ export class McapIterableSource implements IIterableSource {
         const readable = new FileReadable(source.file);
         const reader = await tryCreateIndexedReader(readable);
         if (reader) {
-          this._sourceImpl = new McapIndexedIterableSource(reader);
+          this.#sourceImpl = new McapIndexedIterableSource(reader);
         } else {
-          this._sourceImpl = new McapUnindexedIterableSource({
+          this.#sourceImpl = new McapUnindexedIterableSource({
             size: source.file.size,
             stream: source.file.stream(),
           });
@@ -74,7 +74,7 @@ export class McapIterableSource implements IIterableSource {
         await readable.open();
         const reader = await tryCreateIndexedReader(readable);
         if (reader) {
-          this._sourceImpl = new McapIndexedIterableSource(reader);
+          this.#sourceImpl = new McapIndexedIterableSource(reader);
         } else {
           const response = await fetch(source.url);
           if (!response.body) {
@@ -85,7 +85,7 @@ export class McapIterableSource implements IIterableSource {
             throw new Error(`Remote file is missing Content-Length header. <${source.url}>`);
           }
 
-          this._sourceImpl = new McapUnindexedIterableSource({
+          this.#sourceImpl = new McapUnindexedIterableSource({
             size: parseInt(size),
             stream: response.body,
           });
@@ -94,26 +94,26 @@ export class McapIterableSource implements IIterableSource {
       }
     }
 
-    return await this._sourceImpl.initialize();
+    return await this.#sourceImpl.initialize();
   }
 
   public messageIterator(
     opt: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
-    if (!this._sourceImpl) {
+    if (!this.#sourceImpl) {
       throw new Error("Invariant: uninitialized");
     }
 
-    return this._sourceImpl.messageIterator(opt);
+    return this.#sourceImpl.messageIterator(opt);
   }
 
   public async getBackfillMessages(
     args: GetBackfillMessagesArgs,
   ): Promise<MessageEvent<unknown>[]> {
-    if (!this._sourceImpl) {
+    if (!this.#sourceImpl) {
       throw new Error("Invariant: uninitialized");
     }
 
-    return await this._sourceImpl.getBackfillMessages(args);
+    return await this.#sourceImpl.getBackfillMessages(args);
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -6,27 +6,27 @@ import BrowserHttpReader from "@foxglove/studio-base/util/BrowserHttpReader";
 import CachedFilelike from "@foxglove/studio-base/util/CachedFilelike";
 
 export class RemoteFileReadable {
-  private remoteReader: CachedFilelike;
+  #remoteReader: CachedFilelike;
 
   public constructor(url: string) {
     const fileReader = new BrowserHttpReader(url);
-    this.remoteReader = new CachedFilelike({
+    this.#remoteReader = new CachedFilelike({
       fileReader,
       cacheSizeInBytes: 1024 * 1024 * 200, // 200MiB
     });
   }
 
   public async open(): Promise<void> {
-    await this.remoteReader.open(); // Important that we call this first, because it might throw an error if the file can't be read.
+    await this.#remoteReader.open(); // Important that we call this first, because it might throw an error if the file can't be read.
   }
 
   public async size(): Promise<bigint> {
-    return BigInt(this.remoteReader.size());
+    return BigInt(this.#remoteReader.size());
   }
   public async read(offset: bigint, size: bigint): Promise<Uint8Array> {
     if (offset + size > Number.MAX_SAFE_INTEGER) {
       throw new Error(`Read too large: offset ${offset}, size ${size}`);
     }
-    return await this.remoteReader.read(Number(offset), Number(size));
+    return await this.#remoteReader.read(Number(offset), Number(size));
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSource.ts
@@ -34,28 +34,28 @@ const LOG_TOPIC = "Log";
 const log = Logger.getLogger(__filename);
 
 export class UlogIterableSource implements IIterableSource {
-  private options: UlogOptions;
-  private ulog?: ULog;
-  private start?: Time;
-  private end?: Time;
+  #options: UlogOptions;
+  #ulog?: ULog;
+  #start?: Time;
+  #end?: Time;
 
   public constructor(options: UlogOptions) {
-    this.options = options;
+    this.#options = options;
   }
 
   public async initialize(): Promise<Initalization> {
-    const file = this.options.file;
-    const bytes = this.options.file.size;
+    const file = this.#options.file;
+    const bytes = this.#options.file.size;
     log.debug(`initialize(${bytes} bytes)`);
 
     const startTime = performance.now();
-    this.ulog = new ULog(new BlobReader(file), { chunkSize: CHUNK_SIZE });
-    await this.ulog.open();
+    this.#ulog = new ULog(new BlobReader(file), { chunkSize: CHUNK_SIZE });
+    await this.#ulog.open();
     const durationMs = performance.now() - startTime;
     log.debug(`opened in ${durationMs.toFixed(2)}ms`);
 
-    const counts = this.ulog.dataMessageCounts()!;
-    const timeRange = this.ulog.timeRange() ?? [0n, 0n];
+    const counts = this.#ulog.dataMessageCounts()!;
+    const timeRange = this.#ulog.timeRange() ?? [0n, 0n];
     const start = fromMicros(Number(timeRange[0]));
     const end = fromMicros(Number(timeRange[1]));
 
@@ -65,10 +65,10 @@ export class UlogIterableSource implements IIterableSource {
     const datatypes: RosDatatypes = new Map();
     const messageDefinitionsByTopic: MessageDefinitionsByTopic = {};
     const parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
-    const header = this.ulog.header!;
+    const header = this.#ulog.header!;
 
     topics.push({ name: LOG_TOPIC, schemaName: "rosgraph_msgs/Log" });
-    topicStats.set(LOG_TOPIC, { numMessages: this.ulog.logCount() ?? 0 });
+    topicStats.set(LOG_TOPIC, { numMessages: this.#ulog.logCount() ?? 0 });
     datatypes.set("rosgraph_msgs/Log", ros1["rosgraph_msgs/Log"]);
 
     for (const msgDef of header.definitions.values()) {
@@ -76,13 +76,13 @@ export class UlogIterableSource implements IIterableSource {
     }
 
     const topicNames = new Set<string>();
-    for (const [msgId, msgDef] of this.ulog.subscriptions.entries()) {
+    for (const [msgId, msgDef] of this.#ulog.subscriptions.entries()) {
       const count = counts.get(msgId);
       if (count == undefined || count === 0) {
         continue;
       }
 
-      const name = messageIdToTopic(msgId, this.ulog);
+      const name = messageIdToTopic(msgId, this.#ulog);
       if (name && !topicNames.has(name)) {
         topicNames.add(name);
         topics.push({ name, schemaName: msgDef.name });
@@ -102,8 +102,8 @@ export class UlogIterableSource implements IIterableSource {
 
     log.debug(`message definitions parsed`);
 
-    this.start = start;
-    this.end = end;
+    this.#start = start;
+    this.#end = end;
 
     return {
       start,
@@ -120,13 +120,13 @@ export class UlogIterableSource implements IIterableSource {
   public async *messageIterator(
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
-    if (this.ulog == undefined) {
+    if (this.#ulog == undefined) {
       throw new Error(`UlogDataProvider is not initialized`);
     }
 
     const topics = args.topics;
-    const start = args.start ?? this.start;
-    const end = args.end ?? this.end;
+    const start = args.start ?? this.#start;
+    const end = args.end ?? this.#end;
 
     if (!start || !end) {
       throw new Error(`UlogDataProvider is not initialized`);
@@ -139,11 +139,11 @@ export class UlogIterableSource implements IIterableSource {
     const startTime = BigInt(Math.floor(toMicroSec(start)));
     const endTime = BigInt(Math.floor(toMicroSec(end)));
 
-    for await (const msg of this.ulog.readMessages({ startTime, endTime })) {
+    for await (const msg of this.#ulog.readMessages({ startTime, endTime })) {
       if (msg.type === MessageType.Data) {
         const timestamp = (msg.value as { timestamp: bigint }).timestamp;
         const receiveTime = fromMicros(Number(timestamp));
-        const sub = this.ulog.subscriptions.get(msg.msgId);
+        const sub = this.#ulog.subscriptions.get(msg.msgId);
         const topic = sub?.name;
         if (topic && topics.includes(topic) && isTimeInRangeInclusive(receiveTime, start, end)) {
           yield {

--- a/packages/studio-base/src/players/PlayerProblemManager.ts
+++ b/packages/studio-base/src/players/PlayerProblemManager.ts
@@ -10,52 +10,52 @@ import { PlayerProblem } from "@foxglove/studio-base/players/types";
  * needs to re-process player problems.
  */
 export default class PlayerProblemManager {
-  private _problemsById = new Map<string, PlayerProblem>();
-  private _problems?: PlayerProblem[];
+  #problemsById = new Map<string, PlayerProblem>();
+  #problems?: PlayerProblem[];
 
   /**
    * Returns the current set of problems. Subsequent calls will return the same object as long as
    * problems have not been added/removed.
    */
   public problems(): PlayerProblem[] {
-    return (this._problems ??= Array.from(this._problemsById.values()));
+    return (this.#problems ??= Array.from(this.#problemsById.values()));
   }
 
   public addProblem(id: string, problem: PlayerProblem): void {
     console[problem.severity].call(console, "Player problem", id, problem);
-    this._problemsById.set(id, problem);
-    this._problems = undefined;
+    this.#problemsById.set(id, problem);
+    this.#problems = undefined;
   }
 
   public hasProblem(id: string): boolean {
-    return this._problemsById.has(id);
+    return this.#problemsById.has(id);
   }
 
   public removeProblem(id: string): boolean {
-    const changed = this._problemsById.delete(id);
+    const changed = this.#problemsById.delete(id);
     if (changed) {
-      this._problems = undefined;
+      this.#problems = undefined;
     }
     return changed;
   }
 
   public removeProblems(predicate: (id: string, problem: PlayerProblem) => boolean): boolean {
     let changed = false;
-    for (const [id, problem] of this._problemsById) {
+    for (const [id, problem] of this.#problemsById) {
       if (predicate(id, problem)) {
-        if (this._problemsById.delete(id)) {
+        if (this.#problemsById.delete(id)) {
           changed = true;
         }
       }
     }
     if (changed) {
-      this._problems = undefined;
+      this.#problems = undefined;
     }
     return changed;
   }
 
   public clear(): void {
-    this._problemsById.clear();
-    this._problems = undefined;
+    this.#problemsById.clear();
+    this.#problems = undefined;
   }
 }

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -584,10 +584,7 @@ export default class Ros1Player implements Player {
     // no-op
   }
 
-  #getRosDatatypes = (
-    datatype: string,
-    messageDefinition: MessageDefinition[],
-  ): RosDatatypes => {
+  #getRosDatatypes = (datatype: string, messageDefinition: MessageDefinition[]): RosDatatypes => {
     const typesByName: RosDatatypes = new Map();
     for (const def of messageDefinition) {
       // The first definition usually doesn't have an explicit name so we use the datatype
@@ -647,7 +644,9 @@ export default class Ros1Player implements Player {
           severity: "warn",
           message: "Unable to update connection graph",
           tip: `The connection graph contains information about publishers and subscribers. A
-stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${this.#url}.`,
+stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${
+            this.#url
+          }.`,
           error,
         },
         { skipEmit: true },

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -59,16 +59,16 @@ type Ros1PlayerOpts = {
 
 // Connects to `rosmaster` instance using `@foxglove/ros1`
 export default class Ros1Player implements Player {
-  private _url: string; // rosmaster URL.
-  private _hostname?: string; // ROS_HOSTNAME
-  private _rosNode?: RosNode; // Our ROS node when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed: boolean = false; // Whether the player has been completely closed using close().
-  private _providerTopics?: TopicWithSchemaName[]; // Topics as advertised by rosmaster.
-  private _providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
-  private _providerDatatypes: RosDatatypes = new Map(); // All ROS message definitions received from subscriptions and set by publishers.
-  private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
+  #url: string; // rosmaster URL.
+  #hostname?: string; // ROS_HOSTNAME
+  #rosNode?: RosNode; // Our ROS node when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player.
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed: boolean = false; // Whether the player has been completely closed using close().
+  #providerTopics?: TopicWithSchemaName[]; // Topics as advertised by rosmaster.
+  #providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
+  #providerDatatypes: RosDatatypes = new Map(); // All ROS message definitions received from subscriptions and set by publishers.
+  #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
   private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
   private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
   private _parameters = new Map<string, ParameterValue>(); // rosparams
@@ -88,8 +88,8 @@ export default class Ros1Player implements Player {
   public constructor({ url, hostname, metricsCollector, sourceId }: Ros1PlayerOpts) {
     log.info(`initializing Ros1Player (url=${url}, hostname=${hostname})`);
     this._metricsCollector = metricsCollector;
-    this._url = url;
-    this._hostname = hostname;
+    this.#url = url;
+    this.#hostname = hostname;
     this._start = this._getCurrentTime();
     this._metricsCollector.playerConstructed();
     this._sourceId = sourceId;
@@ -98,13 +98,13 @@ export default class Ros1Player implements Player {
 
   private _open = async (): Promise<void> => {
     const os = OsContextSingleton;
-    if (this._closed || os == undefined) {
+    if (this.#closed || os == undefined) {
       return;
     }
     this._presence = PlayerPresence.INITIALIZING;
 
     const hostname =
-      this._hostname ??
+      this.#hostname ??
       RosNode.GetRosHostname(os.getEnvVar, os.getHostname, os.getNetworkInterfaces);
 
     const net = await Sockets.Create();
@@ -124,25 +124,25 @@ export default class Ros1Player implements Player {
     }
     await tcpServer.listen(undefined, listenHostname, 10);
 
-    if (this._rosNode == undefined) {
+    if (this.#rosNode == undefined) {
       const rosNode = new RosNode({
         name: `/foxglovestudio_${os.pid}`,
         hostname,
         pid: os.pid,
-        rosMasterUri: this._url,
+        rosMasterUri: this.#url,
         httpServer: httpServer as unknown as HttpServer,
         tcpSocketCreate,
         tcpServer,
         log: rosLog,
       });
-      this._rosNode = rosNode;
+      this.#rosNode = rosNode;
 
       rosNode.on("paramUpdate", ({ key, value, prevValue, callerId }) => {
         log.debug("paramUpdate", key, value, prevValue, callerId);
         this._parameters = new Map(rosNode.parameters);
       });
       rosNode.on("error", (error) => {
-        this._addProblem(Problem.Node, {
+        this.#addProblem(Problem.Node, {
           severity: "warn",
           message: "ROS node error",
           tip: `Connectivity will be automatically re-established`,
@@ -151,7 +151,7 @@ export default class Ros1Player implements Player {
       });
     }
 
-    await this._rosNode.start();
+    await this.#rosNode.start();
 
     // Process any advertise requests made before our node was ready.
     this.setPublishers(this._requestedPublishers);
@@ -163,7 +163,7 @@ export default class Ros1Player implements Player {
     this._presence = PlayerPresence.PRESENT;
   };
 
-  private _addProblem(
+  #addProblem(
     id: string,
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
@@ -196,18 +196,18 @@ export default class Ros1Player implements Player {
   }
 
   private _topicsChanged = (newTopics: Topic[]): boolean => {
-    if (!this._providerTopics || newTopics.length !== this._providerTopics.length) {
+    if (!this.#providerTopics || newTopics.length !== this.#providerTopics.length) {
       return true;
     }
-    return !isEqual(this._providerTopics, newTopics);
+    return !isEqual(this.#providerTopics, newTopics);
   };
 
   private _requestTopics = async (): Promise<void> => {
     if (this._requestTopicsTimeout) {
       clearTimeout(this._requestTopicsTimeout);
     }
-    const rosNode = this._rosNode;
-    if (!rosNode || this._closed) {
+    const rosNode = this.#rosNode;
+    if (!rosNode || this.#closed) {
       return;
     }
 
@@ -223,13 +223,13 @@ export default class Ros1Player implements Player {
       if (this._topicsChanged(sortedTopics)) {
         // Remove stats entries for removed topics
         const topicsSet = new Set<string>(topics.map((topic) => topic.name));
-        for (const topic of this._providerTopicsStats.keys()) {
+        for (const topic of this.#providerTopicsStats.keys()) {
           if (!topicsSet.has(topic)) {
-            this._providerTopicsStats.delete(topic);
+            this.#providerTopicsStats.delete(topic);
           }
         }
 
-        this._providerTopics = sortedTopics;
+        this.#providerTopics = sortedTopics;
       }
 
       // Try subscribing again, since we might now be able to subscribe to some new topics.
@@ -244,12 +244,12 @@ export default class Ros1Player implements Player {
         }
         this._clearProblem(Problem.Parameters, { skipEmit: true });
       } catch (error) {
-        this._addProblem(
+        this.#addProblem(
           Problem.Parameters,
           {
             severity: "warn",
             message: "ROS parameter fetch failed",
-            tip: `Ensure that roscore is running and accessible at: ${this._url}`,
+            tip: `Ensure that roscore is running and accessible at: ${this.#url}`,
             error,
           },
           { skipEmit: true },
@@ -264,12 +264,12 @@ export default class Ros1Player implements Player {
       this._emitState();
     } catch (error) {
       this._presence = PlayerPresence.INITIALIZING;
-      this._addProblem(
+      this.#addProblem(
         Problem.Connection,
         {
           severity: "error",
           message: "ROS connection failed",
-          tip: `Ensure that roscore is running and accessible at: ${this._url}`,
+          tip: `Ensure that roscore is running and accessible at: ${this.#url}`,
           error,
         },
         { skipEmit: false },
@@ -283,20 +283,20 @@ export default class Ros1Player implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const providerTopics = this._providerTopics;
+    const providerTopics = this.#providerTopics;
     const start = this._start;
     if (!providerTopics || !start) {
-      return this._listener({
-        name: this._url,
+      return this.#listener({
+        name: this.#url,
         presence: this._presence,
         progress: {},
         capabilities: CAPABILITIES,
         profile: "ros1",
-        playerId: this._id,
+        playerId: this.#id,
         problems: this._problems.problems(),
         activeData: undefined,
       });
@@ -314,22 +314,22 @@ export default class Ros1Player implements Player {
     const currentTime = this._getCurrentTime();
     const messages = this._parsedMessages;
     this._parsedMessages = [];
-    return this._listener({
-      name: this._url,
+    return this.#listener({
+      name: this.#url,
       presence: this._presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: "ros1",
-      playerId: this._id,
+      playerId: this.#id,
       problems: this._problems.problems(),
       urlState: {
         sourceId: this._sourceId,
-        parameters: { url: this._url },
+        parameters: { url: this.#url },
       },
 
       activeData: {
         messages,
-        totalBytesReceived: this._rosNode?.receivedBytes() ?? 0,
+        totalBytesReceived: this.#rosNode?.receivedBytes() ?? 0,
         startTime: start,
         endTime: currentTime,
         currentTime,
@@ -340,9 +340,9 @@ export default class Ros1Player implements Player {
         lastSeekTime: 1,
         topics: providerTopics,
         // Always copy topic stats since message counts and timestamps are being updated
-        topicStats: new Map(this._providerTopicsStats),
-        datatypes: this._providerDatatypes,
-        publishedTopics: this._publishedTopics,
+        topicStats: new Map(this.#providerTopicsStats),
+        datatypes: this.#providerDatatypes,
+        publishedTopics: this.#publishedTopics,
         subscribedTopics: this._subscribedTopics,
         services: this._services,
         parameters: this._parameters,
@@ -351,14 +351,14 @@ export default class Ros1Player implements Player {
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
+    this.#listener = listener;
     this._emitState();
   }
 
   public close(): void {
-    this._closed = true;
-    if (this._rosNode) {
-      this._rosNode.shutdown();
+    this.#closed = true;
+    if (this.#rosNode) {
+      this.#rosNode.shutdown();
     }
     if (this._emitTimer != undefined) {
       clearTimeout(this._emitTimer);
@@ -371,15 +371,15 @@ export default class Ros1Player implements Player {
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
     this._requestedSubscriptions = subscriptions;
 
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
     // Subscribe to additional topics used by Ros1Player itself
-    this._addInternalSubscriptions(subscriptions);
+    this.#addInternalSubscriptions(subscriptions);
 
     // See what topics we actually can subscribe to.
-    const availableTopicsByTopicName = keyBy(this._providerTopics ?? [], ({ name }) => name);
+    const availableTopicsByTopicName = keyBy(this.#providerTopics ?? [], ({ name }) => name);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
@@ -387,26 +387,26 @@ export default class Ros1Player implements Player {
     // Subscribe to all topics that we aren't subscribed to yet.
     for (const topicName of topicNames) {
       const availTopic = availableTopicsByTopicName[topicName];
-      if (!availTopic || this._rosNode.subscriptions.has(topicName)) {
+      if (!availTopic || this.#rosNode.subscriptions.has(topicName)) {
         continue;
       }
 
       const { schemaName } = availTopic;
-      const subscription = this._rosNode.subscribe({ topic: topicName, dataType: schemaName });
+      const subscription = this.#rosNode.subscribe({ topic: topicName, dataType: schemaName });
 
       subscription.on("header", (_header, msgdef, _reader) => {
         // We have to create a new object instead of just updating _providerDatatypes to support
         // shallow memo downstream.
-        const newDatatypes = this._getRosDatatypes(schemaName, msgdef);
-        this._providerDatatypes = new Map([...this._providerDatatypes, ...newDatatypes]);
+        const newDatatypes = this.#getRosDatatypes(schemaName, msgdef);
+        this.#providerDatatypes = new Map([...this.#providerDatatypes, ...newDatatypes]);
       });
       subscription.on("message", (message, data, _pub) => {
-        this._handleMessage(topicName, message, data.byteLength, schemaName, true);
+        this.#handleMessage(topicName, message, data.byteLength, schemaName, true);
         // Clear any existing subscription problems for this topic if we're receiving messages again.
         this._clearProblem(`subscribe:${topicName}`, { skipEmit: true });
       });
       subscription.on("error", (error) => {
-        this._addProblem(`subscribe:${topicName}`, {
+        this.#addProblem(`subscribe:${topicName}`, {
           severity: "warn",
           message: `Topic subscription error for "${topicName}"`,
           tip: `The subscription to "${topicName}" will be automatically re-established`,
@@ -416,17 +416,17 @@ export default class Ros1Player implements Player {
     }
 
     // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const topicName of this._rosNode.subscriptions.keys()) {
+    for (const topicName of this.#rosNode.subscriptions.keys()) {
       if (!topicNames.includes(topicName)) {
-        this._rosNode.unsubscribe(topicName);
+        this.#rosNode.unsubscribe(topicName);
 
         // Reset the message count for this topic
-        this._providerTopicsStats.delete(topicName);
+        this.#providerTopicsStats.delete(topicName);
       }
     }
   }
 
-  private _handleMessage = (
+  #handleMessage = (
     topic: string,
     message: unknown,
     sizeInBytes: number,
@@ -435,7 +435,7 @@ export default class Ros1Player implements Player {
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     external: boolean,
   ): void => {
-    if (this._providerTopics == undefined) {
+    if (this.#providerTopics == undefined) {
       return;
     }
 
@@ -454,14 +454,14 @@ export default class Ros1Player implements Player {
       schemaName,
     };
     this._parsedMessages.push(msg);
-    this._handleInternalMessage(msg);
+    this.#handleInternalMessage(msg);
 
     // Update the message count for this topic
-    let stats = this._providerTopicsStats.get(topic);
-    if (this._rosNode?.subscriptions.has(topic) === true) {
+    let stats = this.#providerTopicsStats.get(topic);
+    if (this.#rosNode?.subscriptions.has(topic) === true) {
       if (!stats) {
         stats = { numMessages: 0 };
-        this._providerTopicsStats.set(topic, stats);
+        this.#providerTopicsStats.set(topic, stats);
       }
       stats.numMessages++;
       stats.firstMessageTime ??= receiveTime;
@@ -478,7 +478,7 @@ export default class Ros1Player implements Player {
   public setPublishers(publishers: AdvertiseOptions[]): void {
     this._requestedPublishers = publishers;
 
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
@@ -489,17 +489,17 @@ export default class Ros1Player implements Player {
     this._clearPublishProblems({ skipEmit: true });
 
     // Unadvertise any topics that were previously published and no longer appear in the list
-    for (const topic of this._rosNode.publications.keys()) {
+    for (const topic of this.#rosNode.publications.keys()) {
       if (!topics.has(topic)) {
-        this._rosNode.unadvertise(topic);
+        this.#rosNode.unadvertise(topic);
       }
     }
 
     // Unadvertise any topics where the dataType changed
     for (const { topic, schemaName: datatype } of validPublishers) {
-      const existingPub = this._rosNode.publications.get(topic);
+      const existingPub = this.#rosNode.publications.get(topic);
       if (existingPub != undefined && existingPub.dataType !== datatype) {
-        this._rosNode.unadvertise(topic);
+        this.#rosNode.unadvertise(topic);
       }
     }
 
@@ -507,7 +507,7 @@ export default class Ros1Player implements Player {
     for (const advertiseOptions of validPublishers) {
       const { topic, schemaName: dataType, options } = advertiseOptions;
 
-      if (this._rosNode.publications.has(topic)) {
+      if (this.#rosNode.publications.has(topic)) {
         continue;
       }
 
@@ -524,7 +524,7 @@ export default class Ros1Player implements Player {
         msgdef = rosDatatypesToMessageDefinition(datatypes, dataType);
       } catch (error) {
         log.debug(error);
-        this._addProblem(msgdefProblemId, {
+        this.#addProblem(msgdefProblemId, {
           severity: "warn",
           message: `Unknown message definition for "${topic}"`,
           tip: `Try subscribing to the topic "${topic}" before publishing to it`,
@@ -533,8 +533,8 @@ export default class Ros1Player implements Player {
       }
 
       // Advertise this topic to ROS as being published by us
-      this._rosNode.advertise({ topic, dataType, messageDefinition: msgdef }).catch((error) =>
-        this._addProblem(advertiseProblemId, {
+      this.#rosNode.advertise({ topic, dataType, messageDefinition: msgdef }).catch((error) =>
+        this.#addProblem(advertiseProblemId, {
           severity: "error",
           message: `Failed to advertise "${topic}"`,
           error,
@@ -547,26 +547,26 @@ export default class Ros1Player implements Player {
 
   public setParameter(key: string, value: ParameterValue): void {
     log.debug(`Ros1Player.setParameter(key=${key}, value=${value})`);
-    void this._rosNode?.setParameter(key, value);
+    void this.#rosNode?.setParameter(key, value);
   }
 
   public publish({ topic, msg }: PublishPayload): void {
     const problemId = `publish:${topic}`;
 
-    if (this._rosNode != undefined) {
-      if (this._rosNode.isAdvertising(topic)) {
-        this._rosNode
+    if (this.#rosNode != undefined) {
+      if (this.#rosNode.isAdvertising(topic)) {
+        this.#rosNode
           .publish(topic, msg)
           .then(() => this._clearProblem(problemId))
           .catch((error) =>
-            this._addProblem(problemId, {
+            this.#addProblem(problemId, {
               severity: "error",
               message: `Publishing to ${topic} failed`,
               error,
             }),
           );
       } else {
-        this._addProblem(problemId, {
+        this.#addProblem(problemId, {
           severity: "warn",
           message: `Unable to publish to "${topic}"`,
           tip: `ROS1 may be disconnected. Please try again in a moment`,
@@ -584,7 +584,7 @@ export default class Ros1Player implements Player {
     // no-op
   }
 
-  private _getRosDatatypes = (
+  #getRosDatatypes = (
     datatype: string,
     messageDefinition: MessageDefinition[],
   ): RosDatatypes => {
@@ -600,7 +600,7 @@ export default class Ros1Player implements Player {
     return typesByName;
   };
 
-  private _addInternalSubscriptions(subscriptions: SubscribePayload[]): void {
+  #addInternalSubscriptions(subscriptions: SubscribePayload[]): void {
     // Always subscribe to /clock if available
     if (subscriptions.find((sub) => sub.topic === "/clock") == undefined) {
       subscriptions.unshift({
@@ -609,7 +609,7 @@ export default class Ros1Player implements Player {
     }
   }
 
-  private _handleInternalMessage(msg: MessageEvent<unknown>): void {
+  #handleInternalMessage(msg: MessageEvent<unknown>): void {
     const maybeClockMsg = msg.message as { clock?: Time };
     if (msg.topic === "/clock" && maybeClockMsg.clock && !isNaN(maybeClockMsg.clock.sec)) {
       const time = maybeClockMsg.clock;
@@ -631,28 +631,28 @@ export default class Ros1Player implements Player {
     try {
       const graph = await rosNode.getSystemState();
       if (
-        !isEqual(this._publishedTopics, graph.publishers) ||
+        !isEqual(this.#publishedTopics, graph.publishers) ||
         !isEqual(this._subscribedTopics, graph.subscribers) ||
         !isEqual(this._services, graph.services)
       ) {
-        this._publishedTopics = graph.publishers;
+        this.#publishedTopics = graph.publishers;
         this._subscribedTopics = graph.subscribers;
         this._services = graph.services;
       }
       this._clearProblem(Problem.Graph, { skipEmit: true });
     } catch (error) {
-      this._addProblem(
+      this.#addProblem(
         Problem.Graph,
         {
           severity: "warn",
           message: "Unable to update connection graph",
           tip: `The connection graph contains information about publishers and subscribers. A
-stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${this._url}.`,
+stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${this.#url}.`,
           error,
         },
         { skipEmit: true },
       );
-      this._publishedTopics = new Map();
+      this.#publishedTopics = new Map();
       this._subscribedTopics = new Map();
       this._services = new Map();
     }

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -69,39 +69,39 @@ export default class Ros1Player implements Player {
   #providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
   #providerDatatypes: RosDatatypes = new Map(); // All ROS message definitions received from subscriptions and set by publishers.
   #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
-  private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
-  private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
-  private _parameters = new Map<string, ParameterValue>(); // rosparams
-  private _start?: Time; // The time at which we started playing.
-  private _clockTime?: Time; // The most recent published `/clock` time, if available
-  private _requestedPublishers: AdvertiseOptions[] = []; // Requested publishers by setPublishers()
-  private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
-  private _hasReceivedMessage = false;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _problems = new PlayerProblemManager();
-  private _emitTimer?: ReturnType<typeof setTimeout>;
-  private readonly _sourceId: string;
+  #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
+  #services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
+  #parameters = new Map<string, ParameterValue>(); // rosparams
+  #start?: Time; // The time at which we started playing.
+  #clockTime?: Time; // The most recent published `/clock` time, if available
+  #requestedPublishers: AdvertiseOptions[] = []; // Requested publishers by setPublishers()
+  #requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
+  #hasReceivedMessage = false;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #problems = new PlayerProblemManager();
+  #emitTimer?: ReturnType<typeof setTimeout>;
+  readonly #sourceId: string;
 
   public constructor({ url, hostname, metricsCollector, sourceId }: Ros1PlayerOpts) {
     log.info(`initializing Ros1Player (url=${url}, hostname=${hostname})`);
-    this._metricsCollector = metricsCollector;
+    this.#metricsCollector = metricsCollector;
     this.#url = url;
     this.#hostname = hostname;
-    this._start = this._getCurrentTime();
-    this._metricsCollector.playerConstructed();
-    this._sourceId = sourceId;
-    void this._open();
+    this.#start = this.#getCurrentTime();
+    this.#metricsCollector.playerConstructed();
+    this.#sourceId = sourceId;
+    void this.#open();
   }
 
-  private _open = async (): Promise<void> => {
+  #open = async (): Promise<void> => {
     const os = OsContextSingleton;
     if (this.#closed || os == undefined) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
+    this.#presence = PlayerPresence.INITIALIZING;
 
     const hostname =
       this.#hostname ??
@@ -139,7 +139,7 @@ export default class Ros1Player implements Player {
 
       rosNode.on("paramUpdate", ({ key, value, prevValue, callerId }) => {
         log.debug("paramUpdate", key, value, prevValue, callerId);
-        this._parameters = new Map(rosNode.parameters);
+        this.#parameters = new Map(rosNode.parameters);
       });
       rosNode.on("error", (error) => {
         this.#addProblem(Problem.Node, {
@@ -154,13 +154,13 @@ export default class Ros1Player implements Player {
     await this.#rosNode.start();
 
     // Process any advertise requests made before our node was ready.
-    this.setPublishers(this._requestedPublishers);
+    this.setPublishers(this.#requestedPublishers);
 
     // Request topics *after* setting publishers in case we want to subscribe
     // to topics we are publishing.
-    await this._requestTopics();
+    await this.#requestTopics();
 
-    this._presence = PlayerPresence.PRESENT;
+    this.#presence = PlayerPresence.PRESENT;
   };
 
   #addProblem(
@@ -168,43 +168,43 @@ export default class Ros1Player implements Player {
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
   ): void {
-    this._problems.addProblem(id, problem);
+    this.#problems.addProblem(id, problem);
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
-  private _clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
-    if (this._problems.removeProblem(id)) {
+  #clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
+    if (this.#problems.removeProblem(id)) {
       if (!skipEmit) {
-        this._emitState();
+        this.#emitState();
       }
     }
   }
 
-  private _clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
+  #clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
     if (
-      this._problems.removeProblems(
+      this.#problems.removeProblems(
         (id) =>
           id.startsWith("msgdef:") || id.startsWith("advertise:") || id.startsWith("publish:"),
       )
     ) {
       if (!skipEmit) {
-        this._emitState();
+        this.#emitState();
       }
     }
   }
 
-  private _topicsChanged = (newTopics: Topic[]): boolean => {
+  #topicsChanged = (newTopics: Topic[]): boolean => {
     if (!this.#providerTopics || newTopics.length !== this.#providerTopics.length) {
       return true;
     }
     return !isEqual(this.#providerTopics, newTopics);
   };
 
-  private _requestTopics = async (): Promise<void> => {
-    if (this._requestTopicsTimeout) {
-      clearTimeout(this._requestTopicsTimeout);
+  #requestTopics = async (): Promise<void> => {
+    if (this.#requestTopicsTimeout) {
+      clearTimeout(this.#requestTopicsTimeout);
     }
     const rosNode = this.#rosNode;
     if (!rosNode || this.#closed) {
@@ -220,7 +220,7 @@ export default class Ros1Player implements Player {
       // Sort them for easy comparison
       const sortedTopics = sortBy(topics, "name");
 
-      if (this._topicsChanged(sortedTopics)) {
+      if (this.#topicsChanged(sortedTopics)) {
         // Remove stats entries for removed topics
         const topicsSet = new Set<string>(topics.map((topic) => topic.name));
         for (const topic of this.#providerTopicsStats.keys()) {
@@ -233,16 +233,16 @@ export default class Ros1Player implements Player {
       }
 
       // Try subscribing again, since we might now be able to subscribe to some new topics.
-      this.setSubscriptions(this._requestedSubscriptions);
+      this.setSubscriptions(this.#requestedSubscriptions);
 
       // Subscribe to all parameters
       try {
         const params = await rosNode.subscribeAllParams();
-        if (!isEqual(params, this._parameters)) {
-          this._parameters = new Map();
-          params.forEach((value, key) => this._parameters.set(key, value));
+        if (!isEqual(params, this.#parameters)) {
+          this.#parameters = new Map();
+          params.forEach((value, key) => this.#parameters.set(key, value));
         }
-        this._clearProblem(Problem.Parameters, { skipEmit: true });
+        this.#clearProblem(Problem.Parameters, { skipEmit: true });
       } catch (error) {
         this.#addProblem(
           Problem.Parameters,
@@ -257,13 +257,13 @@ export default class Ros1Player implements Player {
       }
 
       // Fetch the full graph topology
-      await this._updateConnectionGraph(rosNode);
+      await this.#updateConnectionGraph(rosNode);
 
-      this._clearProblem(Problem.Connection, { skipEmit: true });
-      this._presence = PlayerPresence.PRESENT;
-      this._emitState();
+      this.#clearProblem(Problem.Connection, { skipEmit: true });
+      this.#presence = PlayerPresence.PRESENT;
+      this.#emitState();
     } catch (error) {
-      this._presence = PlayerPresence.INITIALIZING;
+      this.#presence = PlayerPresence.INITIALIZING;
       this.#addProblem(
         Problem.Connection,
         {
@@ -276,54 +276,54 @@ export default class Ros1Player implements Player {
       );
     } finally {
       // Regardless of what happens, request topics again in a little bit.
-      this._requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
+      this.#requestTopicsTimeout = setTimeout(this.#requestTopics, 3000);
     }
   };
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
+  #emitState = debouncePromise(() => {
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
     const providerTopics = this.#providerTopics;
-    const start = this._start;
+    const start = this.#start;
     if (!providerTopics || !start) {
       return this.#listener({
         name: this.#url,
-        presence: this._presence,
+        presence: this.#presence,
         progress: {},
         capabilities: CAPABILITIES,
         profile: "ros1",
         playerId: this.#id,
-        problems: this._problems.problems(),
+        problems: this.#problems.problems(),
         activeData: undefined,
       });
     }
 
     // Time is always moving forward even if we don't get messages from the server.
     // If we are not connected, don't emit updates since we are not longer getting new data
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
-    const currentTime = this._getCurrentTime();
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
+    const currentTime = this.#getCurrentTime();
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
     return this.#listener({
       name: this.#url,
-      presence: this._presence,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: "ros1",
       playerId: this.#id,
-      problems: this._problems.problems(),
+      problems: this.#problems.problems(),
       urlState: {
-        sourceId: this._sourceId,
+        sourceId: this.#sourceId,
         parameters: { url: this.#url },
       },
 
@@ -343,16 +343,16 @@ export default class Ros1Player implements Player {
         topicStats: new Map(this.#providerTopicsStats),
         datatypes: this.#providerDatatypes,
         publishedTopics: this.#publishedTopics,
-        subscribedTopics: this._subscribedTopics,
-        services: this._services,
-        parameters: this._parameters,
+        subscribedTopics: this.#subscribedTopics,
+        services: this.#services,
+        parameters: this.#parameters,
       },
     });
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.#listener = listener;
-    this._emitState();
+    this.#emitState();
   }
 
   public close(): void {
@@ -360,16 +360,16 @@ export default class Ros1Player implements Player {
     if (this.#rosNode) {
       this.#rosNode.shutdown();
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
   }
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._requestedSubscriptions = subscriptions;
+    this.#requestedSubscriptions = subscriptions;
 
     if (!this.#rosNode || this.#closed) {
       return;
@@ -403,7 +403,7 @@ export default class Ros1Player implements Player {
       subscription.on("message", (message, data, _pub) => {
         this.#handleMessage(topicName, message, data.byteLength, schemaName, true);
         // Clear any existing subscription problems for this topic if we're receiving messages again.
-        this._clearProblem(`subscribe:${topicName}`, { skipEmit: true });
+        this.#clearProblem(`subscribe:${topicName}`, { skipEmit: true });
       });
       subscription.on("error", (error) => {
         this.#addProblem(`subscribe:${topicName}`, {
@@ -439,11 +439,11 @@ export default class Ros1Player implements Player {
       return;
     }
 
-    const receiveTime = this._getCurrentTime();
+    const receiveTime = this.#getCurrentTime();
 
-    if (external && !this._hasReceivedMessage) {
-      this._hasReceivedMessage = true;
-      this._metricsCollector.recordTimeToFirstMsgs();
+    if (external && !this.#hasReceivedMessage) {
+      this.#hasReceivedMessage = true;
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
 
     const msg: MessageEvent<unknown> = {
@@ -453,7 +453,7 @@ export default class Ros1Player implements Player {
       sizeInBytes,
       schemaName,
     };
-    this._parsedMessages.push(msg);
+    this.#parsedMessages.push(msg);
     this.#handleInternalMessage(msg);
 
     // Update the message count for this topic
@@ -472,11 +472,11 @@ export default class Ros1Player implements Player {
       }
     }
 
-    this._emitState();
+    this.#emitState();
   };
 
   public setPublishers(publishers: AdvertiseOptions[]): void {
-    this._requestedPublishers = publishers;
+    this.#requestedPublishers = publishers;
 
     if (!this.#rosNode || this.#closed) {
       return;
@@ -486,7 +486,7 @@ export default class Ros1Player implements Player {
     const topics = new Set<string>(validPublishers.map(({ topic }) => topic));
 
     // Clear all problems related to publishing
-    this._clearPublishProblems({ skipEmit: true });
+    this.#clearPublishProblems({ skipEmit: true });
 
     // Unadvertise any topics that were previously published and no longer appear in the list
     for (const topic of this.#rosNode.publications.keys()) {
@@ -542,7 +542,7 @@ export default class Ros1Player implements Player {
       );
     }
 
-    this._emitState();
+    this.#emitState();
   }
 
   public setParameter(key: string, value: ParameterValue): void {
@@ -557,7 +557,7 @@ export default class Ros1Player implements Player {
       if (this.#rosNode.isAdvertising(topic)) {
         this.#rosNode
           .publish(topic, msg)
-          .then(() => this._clearProblem(problemId))
+          .then(() => this.#clearProblem(problemId))
           .catch((error) =>
             this.#addProblem(problemId, {
               severity: "error",
@@ -618,28 +618,28 @@ export default class Ros1Player implements Player {
         return;
       }
 
-      if (this._clockTime == undefined) {
-        this._start = time;
+      if (this.#clockTime == undefined) {
+        this.#start = time;
       }
 
-      this._clockTime = time;
-      (msg as { receiveTime: Time }).receiveTime = this._getCurrentTime();
+      this.#clockTime = time;
+      (msg as { receiveTime: Time }).receiveTime = this.#getCurrentTime();
     }
   }
 
-  private async _updateConnectionGraph(rosNode: RosNode): Promise<void> {
+  async #updateConnectionGraph(rosNode: RosNode): Promise<void> {
     try {
       const graph = await rosNode.getSystemState();
       if (
         !isEqual(this.#publishedTopics, graph.publishers) ||
-        !isEqual(this._subscribedTopics, graph.subscribers) ||
-        !isEqual(this._services, graph.services)
+        !isEqual(this.#subscribedTopics, graph.subscribers) ||
+        !isEqual(this.#services, graph.services)
       ) {
         this.#publishedTopics = graph.publishers;
-        this._subscribedTopics = graph.subscribers;
-        this._services = graph.services;
+        this.#subscribedTopics = graph.subscribers;
+        this.#services = graph.services;
       }
-      this._clearProblem(Problem.Graph, { skipEmit: true });
+      this.#clearProblem(Problem.Graph, { skipEmit: true });
     } catch (error) {
       this.#addProblem(
         Problem.Graph,
@@ -653,12 +653,12 @@ stale graph may result in missing topics you expect. Ensure that roscore is reac
         { skipEmit: true },
       );
       this.#publishedTopics = new Map();
-      this._subscribedTopics = new Map();
-      this._services = new Map();
+      this.#subscribedTopics = new Map();
+      this.#services = new Map();
     }
   }
 
-  private _getCurrentTime(): Time {
-    return this._clockTime ?? fromMillis(Date.now());
+  #getCurrentTime(): Time {
+    return this.#clockTime ?? fromMillis(Date.now());
   }
 }

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -65,32 +65,32 @@ export default class Ros2Player implements Player {
   #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
   // private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
   // private _parameters = new Map<string, ParameterValue>(); // rosparams
-  private _start?: Time; // The time at which we started playing.
-  private _clockTime?: Time; // The most recent published `/clock` time, if available
-  private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _updateTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _updateTopics().
-  private _hasReceivedMessage = false;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _problems = new PlayerProblemManager();
-  private _emitTimer?: ReturnType<typeof setTimeout>;
-  private readonly _sourceId: string;
+  #start?: Time; // The time at which we started playing.
+  #clockTime?: Time; // The most recent published `/clock` time, if available
+  #requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #updateTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _updateTopics().
+  #hasReceivedMessage = false;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #problems = new PlayerProblemManager();
+  #emitTimer?: ReturnType<typeof setTimeout>;
+  readonly #sourceId: string;
 
   public constructor({ domainId, metricsCollector, sourceId }: Ros2PlayerOpts) {
     log.info(`initializing Ros2Player (domainId=${domainId})`);
     this.#domainId = domainId;
-    this._metricsCollector = metricsCollector;
-    this._start = this._getCurrentTime();
-    this._metricsCollector.playerConstructed();
-    this._sourceId = sourceId;
+    this.#metricsCollector = metricsCollector;
+    this.#start = this.#getCurrentTime();
+    this.#metricsCollector.playerConstructed();
+    this.#sourceId = sourceId;
 
-    this._importRos2MsgDefs();
+    this.#importRos2MsgDefs();
 
-    void this._open();
+    void this.#open();
   }
 
-  private _importRos2MsgDefs(): void {
+  #importRos2MsgDefs(): void {
     // Add common message definitions from ROS2 (rcl_interfaces, common_interfaces, etc)
     for (const dataType in ros2galactic) {
       const msgDef = (ros2galactic as Record<string, MessageDefinition>)[dataType]!;
@@ -122,11 +122,11 @@ export default class Ros2Player implements Player {
     });
   }
 
-  private _open = async (): Promise<void> => {
+  #open = async (): Promise<void> => {
     if (this.#closed || OsContextSingleton == undefined) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
+    this.#presence = PlayerPresence.INITIALIZING;
 
     const net = await Sockets.Create();
     // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -143,7 +143,7 @@ export default class Ros2Player implements Player {
       this.#rosNode = rosNode;
 
       // When new publications are discovered, immediately call _updateTopics()
-      rosNode.on("discoveredPublication", (_pub) => debounce(() => this._updateTopics(), 500));
+      rosNode.on("discoveredPublication", (_pub) => debounce(() => this.#updateTopics(), 500));
 
       // rosNode.on("paramUpdate", ({ key, value, prevValue, callerId }) => {
       //   log.debug("paramUpdate", key, value, prevValue, callerId);
@@ -153,38 +153,38 @@ export default class Ros2Player implements Player {
 
     await this.#rosNode.start();
 
-    this._updateTopics();
-    this._presence = PlayerPresence.PRESENT;
+    this.#updateTopics();
+    this.#presence = PlayerPresence.PRESENT;
   };
 
-  private _addProblemAndEmit(id: string, problem: PlayerProblem): void {
-    this._problems.addProblem(id, problem);
-    this._emitState();
+  #addProblemAndEmit(id: string, problem: PlayerProblem): void {
+    this.#problems.addProblem(id, problem);
+    this.#emitState();
   }
 
-  private _clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
+  #clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
     if (
-      this._problems.removeProblems(
+      this.#problems.removeProblems(
         (id) =>
           id.startsWith("msgdef:") || id.startsWith("advertise:") || id.startsWith("publish:"),
       )
     ) {
       if (!skipEmit) {
-        this._emitState();
+        this.#emitState();
       }
     }
   }
 
-  private _topicsChanged = (newTopics: Topic[]): boolean => {
+  #topicsChanged = (newTopics: Topic[]): boolean => {
     if (!this.#providerTopics || newTopics.length !== this.#providerTopics.length) {
       return true;
     }
     return !isEqual(this.#providerTopics, newTopics);
   };
 
-  private _updateTopics = (): void => {
-    if (this._updateTopicsTimeout) {
-      clearTimeout(this._updateTopicsTimeout);
+  #updateTopics = (): void => {
+    if (this.#updateTopicsTimeout) {
+      clearTimeout(this.#updateTopicsTimeout);
     }
     const rosNode = this.#rosNode;
     if (!rosNode || this.#closed) {
@@ -201,9 +201,9 @@ export default class Ros2Player implements Player {
         }
         const dataType = dataTypes.values().next().value as string;
         const problemId = `subscription:${topic}`;
-        if (dataTypes.size > 1 && !this._problems.hasProblem(problemId)) {
+        if (dataTypes.size > 1 && !this.#problems.hasProblem(problemId)) {
           const message = `Multiple data types for "${topic}": ${Array.from(dataTypes).join(", ")}`;
-          this._problems.addProblem(problemId, {
+          this.#problems.addProblem(problemId, {
             severity: "warn",
             message,
             tip: `Only data type "${dataType}" will be used`,
@@ -216,7 +216,7 @@ export default class Ros2Player implements Player {
       // Sort them for easy comparison
       const sortedTopics: TopicWithSchemaName[] = sortBy(topics, "name");
 
-      if (this._topicsChanged(sortedTopics)) {
+      if (this.#topicsChanged(sortedTopics)) {
         // Remove stats entries for removed topics
         const topicsSet = new Set<string>(topics.map((topic) => topic.name));
         for (const topic of this.#providerTopicsStats.keys()) {
@@ -228,7 +228,7 @@ export default class Ros2Player implements Player {
         this.#providerTopics = sortedTopics;
 
         // Try subscribing again, since we might be able to subscribe to additional topics
-        this.setSubscriptions(this._requestedSubscriptions);
+        this.setSubscriptions(this.#requestedSubscriptions);
       }
 
       // Subscribe to all parameters
@@ -253,13 +253,13 @@ export default class Ros2Player implements Player {
       // }
 
       // Fetch the full graph topology
-      this._updateConnectionGraph(rosNode);
+      this.#updateConnectionGraph(rosNode);
 
-      this._presence = PlayerPresence.PRESENT;
-      this._emitState();
+      this.#presence = PlayerPresence.PRESENT;
+      this.#emitState();
     } catch (error) {
-      this._presence = PlayerPresence.INITIALIZING;
-      this._addProblemAndEmit(Problem.Connection, {
+      this.#presence = PlayerPresence.INITIALIZING;
+      this.#addProblemAndEmit(Problem.Connection, {
         severity: "error",
         message: "ROS connection failed",
         tip: `Ensure a ROS 2 DDS system is running on the local network and UDP multicast is supported`,
@@ -267,53 +267,53 @@ export default class Ros2Player implements Player {
       });
     } finally {
       // Regardless of what happens, update topics again in a little bit
-      this._updateTopicsTimeout = setTimeout(this._updateTopics, 3000);
+      this.#updateTopicsTimeout = setTimeout(this.#updateTopics, 3000);
     }
   };
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
+  #emitState = debouncePromise(() => {
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
     const providerTopics = this.#providerTopics;
-    const start = this._start;
+    const start = this.#start;
     if (!providerTopics || !start) {
       return this.#listener({
-        presence: this._presence,
+        presence: this.#presence,
         progress: {},
         capabilities: CAPABILITIES,
         profile: "ros2",
         playerId: this.#id,
-        problems: this._problems.problems(),
+        problems: this.#problems.problems(),
         activeData: undefined,
       });
     }
 
     // Time is always moving forward even if we don't get messages from the server.
     // If we are not connected, don't emit updates since we are not longer getting new data
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
-    const currentTime = this._getCurrentTime();
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
+    const currentTime = this.#getCurrentTime();
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
     return this.#listener({
-      presence: this._presence,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: "ros2",
       name: "ROS2",
       playerId: this.#id,
-      problems: this._problems.problems(),
+      problems: this.#problems.problems(),
       urlState: {
-        sourceId: this._sourceId,
+        sourceId: this.#sourceId,
         parameters: { url: String(this.#domainId) },
       },
 
@@ -342,7 +342,7 @@ export default class Ros2Player implements Player {
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.#listener = listener;
-    this._emitState();
+    this.#emitState();
   }
 
   public close(): void {
@@ -350,16 +350,16 @@ export default class Ros2Player implements Player {
     if (this.#rosNode) {
       void this.#rosNode.shutdown();
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
   }
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._requestedSubscriptions = subscriptions;
+    this.#requestedSubscriptions = subscriptions;
 
     if (!this.#rosNode || this.#closed) {
       return;
@@ -387,23 +387,23 @@ export default class Ros2Player implements Player {
       // Find the first publisher for this topic to mimic its QoS history settings
       const rosEndpoint = publishedTopics.get(topicName)?.[0];
       if (!rosEndpoint) {
-        this._problems.addProblem(`subscription:${topicName}`, {
+        this.#problems.addProblem(`subscription:${topicName}`, {
           severity: "warn",
           message: `No publisher for "${topicName}" ("${schemaName}")`,
           tip: `Publish "${topicName}"`,
         });
         continue;
       } else {
-        this._problems.removeProblem(`subscription:${topicName}`);
+        this.#problems.removeProblem(`subscription:${topicName}`);
       }
 
       // Try to retrieve the ROS message definition for this topic
       let msgDefinition: MessageDefinition[] | undefined;
       try {
         msgDefinition = rosDatatypesToMessageDefinition(this.#providerDatatypes, schemaName);
-        this._problems.removeProblem(`msgdef:${topicName}`);
+        this.#problems.removeProblem(`msgdef:${topicName}`);
       } catch (error) {
-        this._problems.addProblem(`msgdef:${topicName}`, {
+        this.#problems.addProblem(`msgdef:${topicName}`, {
           severity: "warn",
           message: `Unknown message definition for "${topicName}" ("${schemaName}")`,
           tip: `Only core ROS 2 data types are currently supported`,
@@ -440,11 +440,11 @@ export default class Ros2Player implements Player {
       subscription.on("message", (timestamp, message, data, _pub) => {
         this.#handleMessage(topicName, timestamp, message, schemaName, data.byteLength, true);
         // Clear any existing subscription problems for this topic if we're receiving messages again.
-        this._problems.removeProblem(`subscription:${topicName}`);
+        this.#problems.removeProblem(`subscription:${topicName}`);
       });
       subscription.on("error", (err) => {
         log.error(`Subscription error for ${topicName}: ${err}`);
-        this._problems.addProblem(`subscription:${topicName}`, {
+        this.#problems.addProblem(`subscription:${topicName}`, {
           severity: "error",
           message: `Error receiving messages on "${topicName}"`,
           tip: `Report this error if you continue experiencing issues`,
@@ -478,12 +478,12 @@ export default class Ros2Player implements Player {
       return;
     }
 
-    const receiveTime = this._getCurrentTime();
+    const receiveTime = this.#getCurrentTime();
     const publishTime = timestamp;
 
-    if (external && !this._hasReceivedMessage) {
-      this._hasReceivedMessage = true;
-      this._metricsCollector.recordTimeToFirstMsgs();
+    if (external && !this.#hasReceivedMessage) {
+      this.#hasReceivedMessage = true;
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
 
     if (message != undefined) {
@@ -495,7 +495,7 @@ export default class Ros2Player implements Player {
         sizeInBytes,
         schemaName,
       };
-      this._parsedMessages.push(msg);
+      this.#parsedMessages.push(msg);
       this.#handleInternalMessage(msg);
     }
 
@@ -515,7 +515,7 @@ export default class Ros2Player implements Player {
       }
     }
 
-    this._emitState();
+    this.#emitState();
   };
 
   public setPublishers(_publishers: AdvertiseOptions[]): void {
@@ -524,8 +524,8 @@ export default class Ros2Player implements Player {
     }
 
     // Clear all problems related to publishing
-    this._clearPublishProblems({ skipEmit: false });
-    this._emitState();
+    this.#clearPublishProblems({ skipEmit: false });
+    this.#emitState();
   }
 
   public setParameter(_key: string, _value: ParameterValue): void {
@@ -563,16 +563,16 @@ export default class Ros2Player implements Player {
         return;
       }
 
-      if (this._clockTime == undefined) {
-        this._start = time;
+      if (this.#clockTime == undefined) {
+        this.#start = time;
       }
 
-      this._clockTime = time;
-      (msg as { receiveTime: Time }).receiveTime = this._getCurrentTime();
+      this.#clockTime = time;
+      (msg as { receiveTime: Time }).receiveTime = this.#getCurrentTime();
     }
   }
 
-  private _updateConnectionGraph(_rosNode: RosNode): void {
+  #updateConnectionGraph(_rosNode: RosNode): void {
     //     try {
     //       const graph = await rosNode.getSystemState();
     //       if (
@@ -603,8 +603,8 @@ export default class Ros2Player implements Player {
     //     }
   }
 
-  private _getCurrentTime(): Time {
-    return this._clockTime ?? fromMillis(Date.now());
+  #getCurrentTime(): Time {
+    return this.#clockTime ?? fromMillis(Date.now());
   }
 }
 

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -53,16 +53,16 @@ type Ros2PlayerOpts = {
 
 // Connects to a ROS 2 network using RTPS over UDP, discovering peers via UDP multicast.
 export default class Ros2Player implements Player {
-  private _domainId: number; // ROS 2 DDS (RTPS) domain
-  private _rosNode?: RosNode; // Our ROS node when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed = false; // Whether the player has been completely closed using close().
-  private _providerTopics?: TopicWithSchemaName[]; // Topics as advertised by peers
-  private _providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
-  private _providerDatatypes = new Map<string, MessageDefinition>(); // All known ROS 2 message definitions.
-  private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
-  private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
+  #domainId: number; // ROS 2 DDS (RTPS) domain
+  #rosNode?: RosNode; // Our ROS node when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player.
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed = false; // Whether the player has been completely closed using close().
+  #providerTopics?: TopicWithSchemaName[]; // Topics as advertised by peers
+  #providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
+  #providerDatatypes = new Map<string, MessageDefinition>(); // All known ROS 2 message definitions.
+  #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
+  #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
   // private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
   // private _parameters = new Map<string, ParameterValue>(); // rosparams
   private _start?: Time; // The time at which we started playing.
@@ -79,7 +79,7 @@ export default class Ros2Player implements Player {
 
   public constructor({ domainId, metricsCollector, sourceId }: Ros2PlayerOpts) {
     log.info(`initializing Ros2Player (domainId=${domainId})`);
-    this._domainId = domainId;
+    this.#domainId = domainId;
     this._metricsCollector = metricsCollector;
     this._start = this._getCurrentTime();
     this._metricsCollector.playerConstructed();
@@ -94,8 +94,8 @@ export default class Ros2Player implements Player {
     // Add common message definitions from ROS2 (rcl_interfaces, common_interfaces, etc)
     for (const dataType in ros2galactic) {
       const msgDef = (ros2galactic as Record<string, MessageDefinition>)[dataType]!;
-      this._providerDatatypes.set(dataType, msgDef);
-      this._providerDatatypes.set(dataTypeToFullName(dataType), msgDef);
+      this.#providerDatatypes.set(dataType, msgDef);
+      this.#providerDatatypes.set(dataTypeToFullName(dataType), msgDef);
     }
 
     // Add message definitions from foxglove schemas
@@ -105,17 +105,17 @@ export default class Ros2Player implements Player {
         { rosVersion: 2 },
       );
       const msgDef: MessageDefinition = { name: rosMsgInterfaceName, definitions: fields };
-      this._providerDatatypes.set(rosMsgInterfaceName, msgDef);
-      this._providerDatatypes.set(rosFullInterfaceName, msgDef);
+      this.#providerDatatypes.set(rosMsgInterfaceName, msgDef);
+      this.#providerDatatypes.set(rosFullInterfaceName, msgDef);
     }
 
     // Add the legacy foxglove_msgs/ImageMarkerArray message definition
-    this._providerDatatypes.set("foxglove_msgs/ImageMarkerArray", {
+    this.#providerDatatypes.set("foxglove_msgs/ImageMarkerArray", {
       definitions: [
         { name: "markers", type: "visualization_msgs/ImageMarker", isComplex: true, isArray: true },
       ],
     });
-    this._providerDatatypes.set("foxglove_msgs/msg/ImageMarkerArray", {
+    this.#providerDatatypes.set("foxglove_msgs/msg/ImageMarkerArray", {
       definitions: [
         { name: "markers", type: "visualization_msgs/ImageMarker", isComplex: true, isArray: true },
       ],
@@ -123,7 +123,7 @@ export default class Ros2Player implements Player {
   }
 
   private _open = async (): Promise<void> => {
-    if (this._closed || OsContextSingleton == undefined) {
+    if (this.#closed || OsContextSingleton == undefined) {
       return;
     }
     this._presence = PlayerPresence.INITIALIZING;
@@ -132,15 +132,15 @@ export default class Ros2Player implements Player {
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     const udpSocketCreate = () => net.createUdpSocket();
 
-    if (this._rosNode == undefined) {
+    if (this.#rosNode == undefined) {
       const rosNode = new RosNode({
         name: `/foxglovestudio_${OsContextSingleton.pid}`,
-        domainId: this._domainId,
+        domainId: this.#domainId,
         udpSocketCreate,
         getNetworkInterfaces: OsContextSingleton.getNetworkInterfaces,
         log: rosLog,
       });
-      this._rosNode = rosNode;
+      this.#rosNode = rosNode;
 
       // When new publications are discovered, immediately call _updateTopics()
       rosNode.on("discoveredPublication", (_pub) => debounce(() => this._updateTopics(), 500));
@@ -151,7 +151,7 @@ export default class Ros2Player implements Player {
       // });
     }
 
-    await this._rosNode.start();
+    await this.#rosNode.start();
 
     this._updateTopics();
     this._presence = PlayerPresence.PRESENT;
@@ -176,18 +176,18 @@ export default class Ros2Player implements Player {
   }
 
   private _topicsChanged = (newTopics: Topic[]): boolean => {
-    if (!this._providerTopics || newTopics.length !== this._providerTopics.length) {
+    if (!this.#providerTopics || newTopics.length !== this.#providerTopics.length) {
       return true;
     }
-    return !isEqual(this._providerTopics, newTopics);
+    return !isEqual(this.#providerTopics, newTopics);
   };
 
   private _updateTopics = (): void => {
     if (this._updateTopicsTimeout) {
       clearTimeout(this._updateTopicsTimeout);
     }
-    const rosNode = this._rosNode;
-    if (!rosNode || this._closed) {
+    const rosNode = this.#rosNode;
+    if (!rosNode || this.#closed) {
       return;
     }
 
@@ -219,13 +219,13 @@ export default class Ros2Player implements Player {
       if (this._topicsChanged(sortedTopics)) {
         // Remove stats entries for removed topics
         const topicsSet = new Set<string>(topics.map((topic) => topic.name));
-        for (const topic of this._providerTopicsStats.keys()) {
+        for (const topic of this.#providerTopicsStats.keys()) {
           if (!topicsSet.has(topic)) {
-            this._providerTopicsStats.delete(topic);
+            this.#providerTopicsStats.delete(topic);
           }
         }
 
-        this._providerTopics = sortedTopics;
+        this.#providerTopics = sortedTopics;
 
         // Try subscribing again, since we might be able to subscribe to additional topics
         this.setSubscriptions(this._requestedSubscriptions);
@@ -274,19 +274,19 @@ export default class Ros2Player implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const providerTopics = this._providerTopics;
+    const providerTopics = this.#providerTopics;
     const start = this._start;
     if (!providerTopics || !start) {
-      return this._listener({
+      return this.#listener({
         presence: this._presence,
         progress: {},
         capabilities: CAPABILITIES,
         profile: "ros2",
-        playerId: this._id,
+        playerId: this.#id,
         problems: this._problems.problems(),
         activeData: undefined,
       });
@@ -304,22 +304,22 @@ export default class Ros2Player implements Player {
     const currentTime = this._getCurrentTime();
     const messages = this._parsedMessages;
     this._parsedMessages = [];
-    return this._listener({
+    return this.#listener({
       presence: this._presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: "ros2",
       name: "ROS2",
-      playerId: this._id,
+      playerId: this.#id,
       problems: this._problems.problems(),
       urlState: {
         sourceId: this._sourceId,
-        parameters: { url: String(this._domainId) },
+        parameters: { url: String(this.#domainId) },
       },
 
       activeData: {
         messages,
-        totalBytesReceived: this._rosNode?.receivedBytes() ?? 0,
+        totalBytesReceived: this.#rosNode?.receivedBytes() ?? 0,
         startTime: start,
         endTime: currentTime,
         currentTime,
@@ -330,10 +330,10 @@ export default class Ros2Player implements Player {
         lastSeekTime: 1,
         topics: providerTopics,
         // Always copy topic stats since message counts and timestamps are being updated
-        topicStats: new Map(this._providerTopicsStats),
-        datatypes: this._providerDatatypes,
-        publishedTopics: this._publishedTopics,
-        subscribedTopics: this._subscribedTopics,
+        topicStats: new Map(this.#providerTopicsStats),
+        datatypes: this.#providerDatatypes,
+        publishedTopics: this.#publishedTopics,
+        subscribedTopics: this.#subscribedTopics,
         // services: this._services,
         // parameters: this._parameters,
       },
@@ -341,14 +341,14 @@ export default class Ros2Player implements Player {
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
+    this.#listener = listener;
     this._emitState();
   }
 
   public close(): void {
-    this._closed = true;
-    if (this._rosNode) {
-      void this._rosNode.shutdown();
+    this.#closed = true;
+    if (this.#rosNode) {
+      void this.#rosNode.shutdown();
     }
     if (this._emitTimer != undefined) {
       clearTimeout(this._emitTimer);
@@ -361,25 +361,25 @@ export default class Ros2Player implements Player {
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
     this._requestedSubscriptions = subscriptions;
 
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
     // Subscribe to additional topics used by Ros2Player itself
-    this._addInternalSubscriptions(subscriptions);
+    this.#addInternalSubscriptions(subscriptions);
 
     // Filter down to topics we can actually subscribe to
-    const availableTopicsByTopicName = keyBy(this._providerTopics ?? [], ({ name }) => name);
+    const availableTopicsByTopicName = keyBy(this.#providerTopics ?? [], ({ name }) => name);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
 
-    const publishedTopics = this._rosNode.getPublishedTopics();
+    const publishedTopics = this.#rosNode.getPublishedTopics();
 
     // Subscribe to all topics that we aren't subscribed to yet
     for (const topicName of topicNames) {
       const availableTopic = availableTopicsByTopicName[topicName];
-      if (!availableTopic || this._rosNode.subscriptions.has(topicName)) {
+      if (!availableTopic || this.#rosNode.subscriptions.has(topicName)) {
         continue;
       }
       const schemaName = availableTopic.schemaName;
@@ -400,7 +400,7 @@ export default class Ros2Player implements Player {
       // Try to retrieve the ROS message definition for this topic
       let msgDefinition: MessageDefinition[] | undefined;
       try {
-        msgDefinition = rosDatatypesToMessageDefinition(this._providerDatatypes, schemaName);
+        msgDefinition = rosDatatypesToMessageDefinition(this.#providerDatatypes, schemaName);
         this._problems.removeProblem(`msgdef:${topicName}`);
       } catch (error) {
         this._problems.addProblem(`msgdef:${topicName}`, {
@@ -428,7 +428,7 @@ export default class Ros2Player implements Player {
         maxBlockingTime: rosEndpoint.reliability.maxBlockingTime,
       };
 
-      const subscription = this._rosNode.subscribe({
+      const subscription = this.#rosNode.subscribe({
         topic: topicName,
         dataType: schemaName,
         durability,
@@ -438,7 +438,7 @@ export default class Ros2Player implements Player {
       });
 
       subscription.on("message", (timestamp, message, data, _pub) => {
-        this._handleMessage(topicName, timestamp, message, schemaName, data.byteLength, true);
+        this.#handleMessage(topicName, timestamp, message, schemaName, data.byteLength, true);
         // Clear any existing subscription problems for this topic if we're receiving messages again.
         this._problems.removeProblem(`subscription:${topicName}`);
       });
@@ -454,17 +454,17 @@ export default class Ros2Player implements Player {
     }
 
     // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const topicName of this._rosNode.subscriptions.keys()) {
+    for (const topicName of this.#rosNode.subscriptions.keys()) {
       if (!topicNames.includes(topicName)) {
-        this._rosNode.unsubscribe(topicName);
+        this.#rosNode.unsubscribe(topicName);
 
         // Reset the message count for this topic
-        this._providerTopicsStats.delete(topicName);
+        this.#providerTopicsStats.delete(topicName);
       }
     }
   }
 
-  private _handleMessage = (
+  #handleMessage = (
     topic: string,
     timestamp: Time,
     message: unknown,
@@ -474,7 +474,7 @@ export default class Ros2Player implements Player {
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     external: boolean,
   ): void => {
-    if (this._providerTopics == undefined) {
+    if (this.#providerTopics == undefined) {
       return;
     }
 
@@ -496,15 +496,15 @@ export default class Ros2Player implements Player {
         schemaName,
       };
       this._parsedMessages.push(msg);
-      this._handleInternalMessage(msg);
+      this.#handleInternalMessage(msg);
     }
 
     // Update the message count for this topic
-    let stats = this._providerTopicsStats.get(topic);
-    if (this._rosNode?.subscriptions.has(topic) === true) {
+    let stats = this.#providerTopicsStats.get(topic);
+    if (this.#rosNode?.subscriptions.has(topic) === true) {
       if (!stats) {
         stats = { numMessages: 0 };
-        this._providerTopicsStats.set(topic, stats);
+        this.#providerTopicsStats.set(topic, stats);
       }
       stats.numMessages++;
       stats.firstMessageTime ??= receiveTime;
@@ -519,7 +519,7 @@ export default class Ros2Player implements Player {
   };
 
   public setPublishers(_publishers: AdvertiseOptions[]): void {
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
@@ -545,7 +545,7 @@ export default class Ros2Player implements Player {
     // no-op
   }
 
-  private _addInternalSubscriptions(subscriptions: SubscribePayload[]): void {
+  #addInternalSubscriptions(subscriptions: SubscribePayload[]): void {
     // Always subscribe to /clock if available
     if (subscriptions.find((sub) => sub.topic === "/clock") == undefined) {
       subscriptions.unshift({
@@ -554,7 +554,7 @@ export default class Ros2Player implements Player {
     }
   }
 
-  private _handleInternalMessage(msg: MessageEvent<unknown>): void {
+  #handleInternalMessage(msg: MessageEvent<unknown>): void {
     const maybeClockMsg = msg.message as { clock?: Time };
     if (msg.topic === "/clock" && maybeClockMsg.clock && !isNaN(maybeClockMsg.clock.sec)) {
       const time = maybeClockMsg.clock;

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -48,11 +48,11 @@ class MockRosClient {
     workerInstance = this;
   }
 
-  private _topics: string[] = [];
-  private _types: string[] = [];
-  private _typedefs_full_text: string[] = [];
-  private _connectCallback?: () => void;
-  private _messages: any[] = [];
+  #topics: string[] = [];
+  #types: string[] = [];
+  #typedefs_full_text: string[] = [];
+  #connectCallback?: () => void;
+  #messages: any[] = [];
 
   public setup({
     topics = [],
@@ -65,17 +65,17 @@ class MockRosClient {
     typedefs?: string[];
     messages?: any[];
   }) {
-    this._topics = topics;
-    this._types = types;
-    this._typedefs_full_text = typedefs;
-    this._messages = messages;
+    this.#topics = topics;
+    this.#types = types;
+    this.#typedefs_full_text = typedefs;
+    this.#messages = messages;
 
-    this._connectCallback?.();
+    this.#connectCallback?.();
   }
 
   public on(op: string, callback: () => void) {
     if (op === "connection") {
-      this._connectCallback = callback;
+      this.#connectCallback = callback;
     }
   }
 
@@ -85,14 +85,14 @@ class MockRosClient {
 
   public getTopicsAndRawTypes(callback: (...args: unknown[]) => void) {
     callback({
-      topics: this._topics,
-      types: this._types,
-      typedefs_full_text: this._typedefs_full_text,
+      topics: this.#topics,
+      types: this.#types,
+      typedefs_full_text: this.#typedefs_full_text,
     });
   }
 
   public getMessagesByTopicName(topicName: string): { message: unknown }[] {
-    return this._messages.filter(({ topic }) => topic === topicName);
+    return this.#messages.filter(({ topic }) => topic === topicName);
   }
 
   public getNodes(callback: (nodes: string[]) => void, _errCb: (error: Error) => void) {
@@ -109,14 +109,14 @@ class MockRosClient {
 }
 
 class MockRosTopic {
-  private _name: string = "";
+  #name: string = "";
 
   public constructor({ name }: { name: string }) {
-    this._name = name;
+    this.#name = name;
   }
 
   public subscribe(callback: (arg: unknown) => void) {
-    workerInstance.getMessagesByTopicName(this._name).forEach(({ message }) => callback(message));
+    workerInstance.getMessagesByTopicName(this.#name).forEach(({ message }) => callback(message));
   }
 }
 

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -93,32 +93,32 @@ export default class RosbridgePlayer implements Player {
   #providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
   #providerDatatypes?: RosDatatypes; // Datatypes as published by the WebSocket.
   #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
-  private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
-  private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
-  private _messageReadersByDatatype: {
+  #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
+  #services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
+  #messageReadersByDatatype: {
     [datatype: string]: LazyMessageReader | ROS2MessageReader;
   } = {};
-  private _start?: Time; // The time at which we started playing.
-  private _clockTime?: Time; // The most recent published `/clock` time, if available
+  #start?: Time; // The time at which we started playing.
+  #clockTime?: Time; // The most recent published `/clock` time, if available
   // active subscriptions
-  private _topicSubscriptions = new Map<string, roslib.Topic>();
-  private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
+  #topicSubscriptions = new Map<string, roslib.Topic>();
+  #requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
   // active publishers for the current connection
-  private _topicPublishers = new Map<string, roslib.Topic>();
+  #topicPublishers = new Map<string, roslib.Topic>();
   // which topics we want to advertise to other nodes
-  private _advertisements: AdvertiseOptions[] = [];
-  private _parsedTopics: Set<string> = new Set();
-  private _receivedBytes: number = 0;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _hasReceivedMessage = false;
-  private _presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
-  private _problems = new PlayerProblemManager();
-  private _emitTimer?: ReturnType<typeof setTimeout>;
-  private _serviceTypeCache = new Map<string, Promise<string>>();
-  private readonly _sourceId: string;
-  private _rosVersion: 1 | 2 | undefined;
+  #advertisements: AdvertiseOptions[] = [];
+  #parsedTopics: Set<string> = new Set();
+  #receivedBytes: number = 0;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #hasReceivedMessage = false;
+  #presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
+  #problems = new PlayerProblemManager();
+  #emitTimer?: ReturnType<typeof setTimeout>;
+  #serviceTypeCache = new Map<string, Promise<string>>();
+  readonly #sourceId: string;
+  #rosVersion: 1 | 2 | undefined;
 
   public constructor({
     url,
@@ -129,23 +129,23 @@ export default class RosbridgePlayer implements Player {
     metricsCollector: PlayerMetricsCollectorInterface;
     sourceId: string;
   }) {
-    this._presence = PlayerPresence.INITIALIZING;
-    this._metricsCollector = metricsCollector;
+    this.#presence = PlayerPresence.INITIALIZING;
+    this.#metricsCollector = metricsCollector;
     this.#url = url;
-    this._start = fromMillis(Date.now());
-    this._metricsCollector.playerConstructed();
-    this._sourceId = sourceId;
-    this._open();
+    this.#start = fromMillis(Date.now());
+    this.#metricsCollector.playerConstructed();
+    this.#sourceId = sourceId;
+    this.#open();
   }
 
-  private _open = (): void => {
+  #open = (): void => {
     if (this.#closed) {
       return;
     }
     if (this.#rosClient != undefined) {
       throw new Error(`Attempted to open a second Rosbridge connection`);
     }
-    this._problems.removeProblem("rosbridge:connection-failed");
+    this.#problems.removeProblem("rosbridge:connection-failed");
     log.info(`Opening connection to ${this.#url}`);
 
     // `workersocket` will open the actual WebSocket connection in a WebWorker.
@@ -156,65 +156,65 @@ export default class RosbridgePlayer implements Player {
       if (this.#closed) {
         return;
       }
-      this._presence = PlayerPresence.PRESENT;
-      this._problems.removeProblem("rosbridge:connection-failed");
+      this.#presence = PlayerPresence.PRESENT;
+      this.#problems.removeProblem("rosbridge:connection-failed");
       this.#rosClient = rosClient;
 
-      this._setupPublishers();
-      void this._requestTopics({ forceUpdate: true });
+      this.#setupPublishers();
+      void this.#requestTopics({ forceUpdate: true });
     });
 
     rosClient.on("error", (err) => {
       if (err) {
-        this._problems.addProblem("rosbridge:error", {
+        this.#problems.addProblem("rosbridge:error", {
           severity: "warn",
           message: "Rosbridge error",
           error: err,
         });
-        this._emitState();
+        this.#emitState();
       }
     });
 
     rosClient.on("close", () => {
-      this._presence = PlayerPresence.RECONNECTING;
+      this.#presence = PlayerPresence.RECONNECTING;
 
-      if (this._requestTopicsTimeout) {
-        clearTimeout(this._requestTopicsTimeout);
+      if (this.#requestTopicsTimeout) {
+        clearTimeout(this.#requestTopicsTimeout);
       }
-      for (const [topicName, topic] of this._topicSubscriptions) {
+      for (const [topicName, topic] of this.#topicSubscriptions) {
         topic.unsubscribe();
-        this._topicSubscriptions.delete(topicName);
+        this.#topicSubscriptions.delete(topicName);
       }
       rosClient.close(); // ensure the underlying worker is cleaned up
-      delete this.#rosClient;
+      this.#rosClient = undefined;
 
-      this._problems.addProblem("rosbridge:connection-failed", {
+      this.#problems.addProblem("rosbridge:connection-failed", {
         severity: "error",
         message: "Connection failed",
         tip: `Check that the rosbridge WebSocket server at ${this.#url} is reachable.`,
       });
 
-      this._emitState();
+      this.#emitState();
 
       // Try connecting again.
-      setTimeout(this._open, 3000);
+      setTimeout(this.#open, 3000);
     });
   };
 
-  private _topicsChanged = (newTopics: Topic[]): boolean => {
+  #topicsChanged = (newTopics: Topic[]): boolean => {
     if (!this.#providerTopics || newTopics.length !== this.#providerTopics.length) {
       return true;
     }
     return !isEqual(this.#providerTopics, newTopics);
   };
 
-  private async _requestTopics(opt?: { forceUpdate: boolean }): Promise<void> {
+  async #requestTopics(opt?: { forceUpdate: boolean }): Promise<void> {
     const { forceUpdate = false } = opt ?? {};
     // clear problems before each topics request so we don't have stale problems from previous failed requests
-    this._problems.removeProblems((id) => id.startsWith("requestTopics:"));
+    this.#problems.removeProblems((id) => id.startsWith("requestTopics:"));
 
-    if (this._requestTopicsTimeout) {
-      clearTimeout(this._requestTopicsTimeout);
+    if (this.#requestTopicsTimeout) {
+      clearTimeout(this.#requestTopicsTimeout);
     }
     const rosClient = this.#rosClient;
     if (!rosClient || this.#closed) {
@@ -225,12 +225,12 @@ export default class RosbridgePlayer implements Player {
     // that the connection is doing anything and studio shows no errors and no data.
     // This logic adds a warning after 5 seconds (picked arbitrarily) to display a notice to the user.
     const topicsStallWarningTimeout = setTimeout(() => {
-      this._problems.addProblem("topicsAndRawTypesTimeout", {
+      this.#problems.addProblem("topicsAndRawTypesTimeout", {
         severity: "warn",
         message: "Taking too long to get topics and raw types.",
       });
 
-      this._emitState();
+      this.#emitState();
     }, 5000);
 
     try {
@@ -241,7 +241,7 @@ export default class RosbridgePlayer implements Player {
       }>((resolve, reject) => rosClient.getTopicsAndRawTypes(resolve, reject));
 
       clearTimeout(topicsStallWarningTimeout);
-      this._problems.removeProblem("topicsAndRawTypesTimeout");
+      this.#problems.removeProblem("topicsAndRawTypesTimeout");
 
       const topicsMissingDatatypes: string[] = [];
       const topics: TopicWithSchemaName[] = [];
@@ -251,14 +251,14 @@ export default class RosbridgePlayer implements Player {
       // Automatically detect the ROS version based on the datatypes.
       // The rosbridge server itself publishes /rosout so the topic should be reliably present.
       if (result.types.includes("rcl_interfaces/msg/Log")) {
-        this._rosVersion = 2;
-        this._problems.removeProblem("unknownRosVersion");
+        this.#rosVersion = 2;
+        this.#problems.removeProblem("unknownRosVersion");
       } else if (result.types.includes("rosgraph_msgs/Log")) {
-        this._rosVersion = 1;
-        this._problems.removeProblem("unknownRosVersion");
+        this.#rosVersion = 1;
+        this.#problems.removeProblem("unknownRosVersion");
       } else {
-        this._rosVersion = 1;
-        this._problems.addProblem("unknownRosVersion", {
+        this.#rosVersion = 1;
+        this.#problems.addProblem("unknownRosVersion", {
           severity: "warn",
           message: "Unable to detect ROS version, assuming ROS 1",
         });
@@ -276,12 +276,12 @@ export default class RosbridgePlayer implements Player {
         topics.push({ name: topicName, schemaName: type });
         datatypeDescriptions.push({ type, messageDefinition });
         const parsedDefinition = parseMessageDefinition(messageDefinition, {
-          ros2: this._rosVersion === 2,
+          ros2: this.#rosVersion === 2,
         });
         // https://github.com/typescript-eslint/typescript-eslint/issues/6632
         if (!messageReaders[type]) {
           messageReaders[type] =
-            this._rosVersion !== 2
+            this.#rosVersion !== 2
               ? new LazyMessageReader(parsedDefinition)
               : new ROS2MessageReader(parsedDefinition);
         }
@@ -291,12 +291,12 @@ export default class RosbridgePlayer implements Player {
       // we want to bail and avoid updating readers, subscribers, etc.
       // However, during a re-connect, we _do_ want to refresh this list and re-subscribe
       const sortedTopics = sortBy(topics, "name");
-      if (!forceUpdate && !this._topicsChanged(sortedTopics)) {
+      if (!forceUpdate && !this.#topicsChanged(sortedTopics)) {
         return;
       }
 
       if (topicsMissingDatatypes.length > 0) {
-        this._problems.addProblem("requestTopics:missing-types", {
+        this.#problems.addProblem("requestTopics:missing-types", {
           severity: "warn",
           message: "Could not resolve all message types",
           tip: `Message types could not be found for these topics: ${topicsMissingDatatypes.join(
@@ -316,53 +316,55 @@ export default class RosbridgePlayer implements Player {
       this.#providerTopics = sortedTopics;
 
       this.#providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
-        ros2: this._rosVersion === 2,
+        ros2: this.#rosVersion === 2,
       });
-      this._messageReadersByDatatype = messageReaders;
+      this.#messageReadersByDatatype = messageReaders;
 
       // Try subscribing again, since we might now be able to subscribe to some new topics.
-      this.setSubscriptions(this._requestedSubscriptions);
+      this.setSubscriptions(this.#requestedSubscriptions);
 
       // Refresh the full graph topology
       this.#refreshSystemState().catch((error) => log.error(error));
     } catch (error) {
       log.error(error);
       clearTimeout(topicsStallWarningTimeout);
-      this._problems.removeProblem("topicsAndRawTypesTimeout");
+      this.#problems.removeProblem("topicsAndRawTypesTimeout");
 
-      this._problems.addProblem("requestTopics:error", {
+      this.#problems.addProblem("requestTopics:error", {
         severity: "error",
         message: "Failed to fetch topics from rosbridge",
         error,
       });
     } finally {
-      this._emitState();
+      this.#emitState();
 
       // Regardless of what happens, request topics again in a little bit.
-      this._requestTopicsTimeout = setTimeout(() => void this._requestTopics(), 3000);
+      this.#requestTopicsTimeout = setTimeout(() => void this.#requestTopics(), 3000);
     }
   }
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
+  #emitState = debouncePromise(() => {
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const { _providerTopics, _providerDatatypes, _start } = this;
-    if (!_providerTopics || !_providerDatatypes || !_start) {
+    const providerTopics = this.#providerTopics;
+    const providerDatatypes = this.#providerDatatypes;
+    const start = this.#start;
+    if (!providerTopics || !providerDatatypes || !start) {
       return this.#listener({
         name: this.#url,
-        presence: this._presence,
+        presence: this.#presence,
         progress: {},
         capabilities: CAPABILITIES,
         profile: undefined,
         playerId: this.#id,
         activeData: undefined,
-        problems: this._problems.problems(),
+        problems: this.#problems.problems(),
         urlState: {
-          sourceId: this._sourceId,
+          sourceId: this.#sourceId,
           parameters: { url: this.#url },
         },
       });
@@ -370,33 +372,33 @@ export default class RosbridgePlayer implements Player {
 
     // When connected
     // Time is always moving forward even if we don't get messages from the server.
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
-    const currentTime = this._getCurrentTime();
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
+    const currentTime = this.#getCurrentTime();
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
     return this.#listener({
       name: this.#url,
-      presence: this._presence,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
-      profile: this._rosVersion === 2 ? "ros2" : "ros1",
+      profile: this.#rosVersion === 2 ? "ros2" : "ros1",
       playerId: this.#id,
-      problems: this._problems.problems(),
+      problems: this.#problems.problems(),
       urlState: {
-        sourceId: this._sourceId,
+        sourceId: this.#sourceId,
         parameters: { url: this.#url },
       },
 
       activeData: {
         messages,
-        totalBytesReceived: this._receivedBytes,
-        startTime: _start,
+        totalBytesReceived: this.#receivedBytes,
+        startTime: start,
         endTime: currentTime,
         currentTime,
         isPlaying: true,
@@ -404,20 +406,20 @@ export default class RosbridgePlayer implements Player {
         // We don't support seeking, so we need to set this to any fixed value. Just avoid 0 so
         // that we don't accidentally hit falsy checks.
         lastSeekTime: 1,
-        topics: _providerTopics,
+        topics: providerTopics,
         // Always copy topic stats since message counts and timestamps are being updated
         topicStats: new Map(this.#providerTopicsStats),
-        datatypes: _providerDatatypes,
+        datatypes: providerDatatypes,
         publishedTopics: this.#publishedTopics,
-        subscribedTopics: this._subscribedTopics,
-        services: this._services,
+        subscribedTopics: this.#subscribedTopics,
+        services: this.#services,
       },
     });
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.#listener = listener;
-    this._emitState();
+    this.#emitState();
   }
 
   public close(): void {
@@ -425,16 +427,16 @@ export default class RosbridgePlayer implements Player {
     if (this.#rosClient) {
       this.#rosClient.close();
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
   }
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._requestedSubscriptions = subscriptions;
+    this.#requestedSubscriptions = subscriptions;
 
     if (!this.#rosClient || this.#closed) {
       return;
@@ -443,7 +445,7 @@ export default class RosbridgePlayer implements Player {
     // Subscribe to additional topics used by RosbridgePlayer itself
     this.#addInternalSubscriptions(subscriptions);
 
-    this._parsedTopics = new Set(subscriptions.map(({ topic }) => topic));
+    this.#parsedTopics = new Set(subscriptions.map(({ topic }) => topic));
 
     // See what topics we actually can subscribe to.
     const availableTopicsByTopicName = keyBy(this.#providerTopics ?? [], ({ name }) => name);
@@ -453,7 +455,7 @@ export default class RosbridgePlayer implements Player {
 
     // Subscribe to all topics that we aren't subscribed to yet.
     for (const topicName of topicNames) {
-      if (this._topicSubscriptions.has(topicName)) {
+      if (this.#topicSubscriptions.has(topicName)) {
         continue;
       }
       const topic = new roslib.Topic({
@@ -467,7 +469,7 @@ export default class RosbridgePlayer implements Player {
       }
 
       const { schemaName } = availTopic;
-      const messageReader = this._messageReadersByDatatype[schemaName];
+      const messageReader = this.#messageReadersByDatatype[schemaName];
       if (!messageReader) {
         continue;
       }
@@ -485,14 +487,14 @@ export default class RosbridgePlayer implements Player {
           if (messageReader instanceof LazyMessageReader) {
             const msgSize = messageReader.size(bytes);
             if (msgSize > bytes.byteLength) {
-              this._problems.addProblem(problemId, {
+              this.#problems.addProblem(problemId, {
                 severity: "error",
                 message: `Message buffer not large enough on ${topicName}`,
                 error: new Error(
                   `Cannot read ${msgSize} byte message from ${bytes.byteLength} byte buffer`,
                 ),
               });
-              this._emitState();
+              this.#emitState();
               return;
             }
           }
@@ -504,21 +506,21 @@ export default class RosbridgePlayer implements Player {
             const time = innerMessage.clock;
             const seconds = toSec(innerMessage.clock);
             if (!isNaN(seconds)) {
-              if (this._clockTime == undefined) {
-                this._start = time;
+              if (this.#clockTime == undefined) {
+                this.#start = time;
               }
 
-              this._clockTime = time;
+              this.#clockTime = time;
             }
           }
-          const receiveTime = this._getCurrentTime();
+          const receiveTime = this.#getCurrentTime();
 
-          if (!this._hasReceivedMessage) {
-            this._hasReceivedMessage = true;
-            this._metricsCollector.recordTimeToFirstMsgs();
+          if (!this.#hasReceivedMessage) {
+            this.#hasReceivedMessage = true;
+            this.#metricsCollector.recordTimeToFirstMsgs();
           }
 
-          if (this._parsedTopics.has(topicName)) {
+          if (this.#parsedTopics.has(topicName)) {
             const msg: MessageEvent<unknown> = {
               topic: topicName,
               receiveTime,
@@ -526,13 +528,13 @@ export default class RosbridgePlayer implements Player {
               schemaName,
               sizeInBytes: bytes.byteLength,
             };
-            this._parsedMessages.push(msg);
+            this.#parsedMessages.push(msg);
           }
-          this._problems.removeProblem(problemId);
+          this.#problems.removeProblem(problemId);
 
           // Update the message count for this topic
           let stats = this.#providerTopicsStats.get(topicName);
-          if (this._topicSubscriptions.has(topicName)) {
+          if (this.#topicSubscriptions.has(topicName)) {
             if (!stats) {
               stats = { numMessages: 0 };
               this.#providerTopicsStats.set(topicName, stats);
@@ -540,23 +542,23 @@ export default class RosbridgePlayer implements Player {
             stats.numMessages++;
           }
         } catch (error) {
-          this._problems.addProblem(problemId, {
+          this.#problems.addProblem(problemId, {
             severity: "error",
             message: `Failed to parse message on ${topicName}`,
             error,
           });
         }
 
-        this._emitState();
+        this.#emitState();
       });
-      this._topicSubscriptions.set(topicName, topic);
+      this.#topicSubscriptions.set(topicName, topic);
     }
 
     // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const [topicName, topic] of this._topicSubscriptions) {
+    for (const [topicName, topic] of this.#topicSubscriptions) {
       if (!topicNames.includes(topicName)) {
         topic.unsubscribe();
-        this._topicSubscriptions.delete(topicName);
+        this.#topicSubscriptions.delete(topicName);
 
         // Reset the message count for this topic
         this.#providerTopicsStats.delete(topicName);
@@ -567,12 +569,12 @@ export default class RosbridgePlayer implements Player {
   public setPublishers(publishers: AdvertiseOptions[]): void {
     // Since `setPublishers` is rarely called, we can get away with just throwing away the old
     // Roslib.Topic objects and creating new ones.
-    for (const publisher of this._topicPublishers.values()) {
+    for (const publisher of this.#topicPublishers.values()) {
       publisher.unadvertise();
     }
-    this._topicPublishers.clear();
-    this._advertisements = publishers;
-    this._setupPublishers();
+    this.#topicPublishers.clear();
+    this.#advertisements = publishers;
+    this.#setupPublishers();
   }
 
   public setParameter(_key: string, _value: ParameterValue): void {
@@ -580,9 +582,9 @@ export default class RosbridgePlayer implements Player {
   }
 
   public publish({ topic, msg }: PublishPayload): void {
-    const publisher = this._topicPublishers.get(topic);
+    const publisher = this.#topicPublishers.get(topic);
     if (!publisher) {
-      if (this._advertisements.some((opts) => opts.topic === topic)) {
+      if (this.#advertisements.some((opts) => opts.topic === topic)) {
         // Topic was advertised but the connection is not yet established
         return;
       }
@@ -599,7 +601,7 @@ export default class RosbridgePlayer implements Player {
       throw new Error("Not connected");
     }
 
-    const existing = this._serviceTypeCache.get(service);
+    const existing = this.#serviceTypeCache.get(service);
     if (existing) {
       return await existing;
     }
@@ -609,7 +611,7 @@ export default class RosbridgePlayer implements Player {
       rosClient.getServiceType(service, resolve, reject);
     });
 
-    this._serviceTypeCache.set(service, serviceTypePromise);
+    this.#serviceTypeCache.set(service, serviceTypePromise);
 
     return await serviceTypePromise;
   }
@@ -659,24 +661,24 @@ export default class RosbridgePlayer implements Player {
     // no-op
   }
 
-  private _setupPublishers(): void {
+  #setupPublishers(): void {
     // This function will be called again once a connection is established
     if (!this.#rosClient) {
       return;
     }
 
-    if (this._advertisements.length <= 0) {
+    if (this.#advertisements.length <= 0) {
       return;
     }
 
-    for (const { topic, schemaName: datatype } of this._advertisements) {
+    for (const { topic, schemaName: datatype } of this.#advertisements) {
       const roslibTopic = new roslib.Topic({
         ros: this.#rosClient,
         name: topic,
         messageType: datatype,
         queue_size: 0,
       });
-      this._topicPublishers.set(topic, roslibTopic);
+      this.#topicPublishers.set(topic, roslibTopic);
       roslibTopic.advertise();
     }
   }
@@ -690,8 +692,8 @@ export default class RosbridgePlayer implements Player {
     }
   }
 
-  private _getCurrentTime(): Time {
-    return this._clockTime ?? fromMillis(Date.now());
+  #getCurrentTime(): Time {
+    return this.#clockTime ?? fromMillis(Date.now());
   }
 
   // Refreshes the full system state graph. Runs in the background so we don't
@@ -729,12 +731,12 @@ export default class RosbridgePlayer implements Player {
         item.status === "fulfilled" ? item.value : undefined,
       );
       this.#publishedTopics = collateNodeDetails(fulfilled, "publications");
-      this._subscribedTopics = collateNodeDetails(fulfilled, "subscriptions");
-      this._services = collateNodeDetails(fulfilled, "services");
+      this.#subscribedTopics = collateNodeDetails(fulfilled, "subscriptions");
+      this.#services = collateNodeDetails(fulfilled, "services");
 
-      this._emitState();
+      this.#emitState();
     } catch (error) {
-      this._problems.addProblem("requestTopics:system-state", {
+      this.#problems.addProblem("requestTopics:system-state", {
         severity: "error",
         message: "Failed to fetch node details from rosbridge",
         error,

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -83,16 +83,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 // support raw ROS messages; instead we use the CBOR compression provided by roslibjs, which
 // unmarshalls into plain JS objects.
 export default class RosbridgePlayer implements Player {
-  private _url: string; // WebSocket URL.
-  private _rosClient?: roslib.Ros; // The roslibjs client when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
-  private _isRefreshing = false; // True if currently refreshing the node graph.
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed: boolean = false; // Whether the player has been completely closed using close().
-  private _providerTopics?: TopicWithSchemaName[]; // Topics as published by the WebSocket.
-  private _providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
-  private _providerDatatypes?: RosDatatypes; // Datatypes as published by the WebSocket.
-  private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
+  #url: string; // WebSocket URL.
+  #rosClient?: roslib.Ros; // The roslibjs client when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player.
+  #isRefreshing = false; // True if currently refreshing the node graph.
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed: boolean = false; // Whether the player has been completely closed using close().
+  #providerTopics?: TopicWithSchemaName[]; // Topics as published by the WebSocket.
+  #providerTopicsStats = new Map<string, TopicStats>(); // topic names to topic statistics.
+  #providerDatatypes?: RosDatatypes; // Datatypes as published by the WebSocket.
+  #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
   private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
   private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
   private _messageReadersByDatatype: {
@@ -131,7 +131,7 @@ export default class RosbridgePlayer implements Player {
   }) {
     this._presence = PlayerPresence.INITIALIZING;
     this._metricsCollector = metricsCollector;
-    this._url = url;
+    this.#url = url;
     this._start = fromMillis(Date.now());
     this._metricsCollector.playerConstructed();
     this._sourceId = sourceId;
@@ -139,26 +139,26 @@ export default class RosbridgePlayer implements Player {
   }
 
   private _open = (): void => {
-    if (this._closed) {
+    if (this.#closed) {
       return;
     }
-    if (this._rosClient != undefined) {
+    if (this.#rosClient != undefined) {
       throw new Error(`Attempted to open a second Rosbridge connection`);
     }
     this._problems.removeProblem("rosbridge:connection-failed");
-    log.info(`Opening connection to ${this._url}`);
+    log.info(`Opening connection to ${this.#url}`);
 
     // `workersocket` will open the actual WebSocket connection in a WebWorker.
-    const rosClient = new roslib.Ros({ url: this._url, transportLibrary: "workersocket" });
+    const rosClient = new roslib.Ros({ url: this.#url, transportLibrary: "workersocket" });
 
     rosClient.on("connection", () => {
-      log.info(`Connected to ${this._url}`);
-      if (this._closed) {
+      log.info(`Connected to ${this.#url}`);
+      if (this.#closed) {
         return;
       }
       this._presence = PlayerPresence.PRESENT;
       this._problems.removeProblem("rosbridge:connection-failed");
-      this._rosClient = rosClient;
+      this.#rosClient = rosClient;
 
       this._setupPublishers();
       void this._requestTopics({ forceUpdate: true });
@@ -186,12 +186,12 @@ export default class RosbridgePlayer implements Player {
         this._topicSubscriptions.delete(topicName);
       }
       rosClient.close(); // ensure the underlying worker is cleaned up
-      delete this._rosClient;
+      delete this.#rosClient;
 
       this._problems.addProblem("rosbridge:connection-failed", {
         severity: "error",
         message: "Connection failed",
-        tip: `Check that the rosbridge WebSocket server at ${this._url} is reachable.`,
+        tip: `Check that the rosbridge WebSocket server at ${this.#url} is reachable.`,
       });
 
       this._emitState();
@@ -202,10 +202,10 @@ export default class RosbridgePlayer implements Player {
   };
 
   private _topicsChanged = (newTopics: Topic[]): boolean => {
-    if (!this._providerTopics || newTopics.length !== this._providerTopics.length) {
+    if (!this.#providerTopics || newTopics.length !== this.#providerTopics.length) {
       return true;
     }
-    return !isEqual(this._providerTopics, newTopics);
+    return !isEqual(this.#providerTopics, newTopics);
   };
 
   private async _requestTopics(opt?: { forceUpdate: boolean }): Promise<void> {
@@ -216,8 +216,8 @@ export default class RosbridgePlayer implements Player {
     if (this._requestTopicsTimeout) {
       clearTimeout(this._requestTopicsTimeout);
     }
-    const rosClient = this._rosClient;
-    if (!rosClient || this._closed) {
+    const rosClient = this.#rosClient;
+    if (!rosClient || this.#closed) {
       return;
     }
 
@@ -307,15 +307,15 @@ export default class RosbridgePlayer implements Player {
 
       // Remove stats entries for removed topics
       const topicsSet = new Set<string>(topics.map((topic) => topic.name));
-      for (const topic of this._providerTopicsStats.keys()) {
+      for (const topic of this.#providerTopicsStats.keys()) {
         if (!topicsSet.has(topic)) {
-          this._providerTopicsStats.delete(topic);
+          this.#providerTopicsStats.delete(topic);
         }
       }
 
-      this._providerTopics = sortedTopics;
+      this.#providerTopics = sortedTopics;
 
-      this._providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
+      this.#providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
         ros2: this._rosVersion === 2,
       });
       this._messageReadersByDatatype = messageReaders;
@@ -324,7 +324,7 @@ export default class RosbridgePlayer implements Player {
       this.setSubscriptions(this._requestedSubscriptions);
 
       // Refresh the full graph topology
-      this._refreshSystemState().catch((error) => log.error(error));
+      this.#refreshSystemState().catch((error) => log.error(error));
     } catch (error) {
       log.error(error);
       clearTimeout(topicsStallWarningTimeout);
@@ -346,24 +346,24 @@ export default class RosbridgePlayer implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
     const { _providerTopics, _providerDatatypes, _start } = this;
     if (!_providerTopics || !_providerDatatypes || !_start) {
-      return this._listener({
-        name: this._url,
+      return this.#listener({
+        name: this.#url,
         presence: this._presence,
         progress: {},
         capabilities: CAPABILITIES,
         profile: undefined,
-        playerId: this._id,
+        playerId: this.#id,
         activeData: undefined,
         problems: this._problems.problems(),
         urlState: {
           sourceId: this._sourceId,
-          parameters: { url: this._url },
+          parameters: { url: this.#url },
         },
       });
     }
@@ -380,17 +380,17 @@ export default class RosbridgePlayer implements Player {
     const currentTime = this._getCurrentTime();
     const messages = this._parsedMessages;
     this._parsedMessages = [];
-    return this._listener({
-      name: this._url,
+    return this.#listener({
+      name: this.#url,
       presence: this._presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: this._rosVersion === 2 ? "ros2" : "ros1",
-      playerId: this._id,
+      playerId: this.#id,
       problems: this._problems.problems(),
       urlState: {
         sourceId: this._sourceId,
-        parameters: { url: this._url },
+        parameters: { url: this.#url },
       },
 
       activeData: {
@@ -406,9 +406,9 @@ export default class RosbridgePlayer implements Player {
         lastSeekTime: 1,
         topics: _providerTopics,
         // Always copy topic stats since message counts and timestamps are being updated
-        topicStats: new Map(this._providerTopicsStats),
+        topicStats: new Map(this.#providerTopicsStats),
         datatypes: _providerDatatypes,
-        publishedTopics: this._publishedTopics,
+        publishedTopics: this.#publishedTopics,
         subscribedTopics: this._subscribedTopics,
         services: this._services,
       },
@@ -416,14 +416,14 @@ export default class RosbridgePlayer implements Player {
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
+    this.#listener = listener;
     this._emitState();
   }
 
   public close(): void {
-    this._closed = true;
-    if (this._rosClient) {
-      this._rosClient.close();
+    this.#closed = true;
+    if (this.#rosClient) {
+      this.#rosClient.close();
     }
     if (this._emitTimer != undefined) {
       clearTimeout(this._emitTimer);
@@ -436,17 +436,17 @@ export default class RosbridgePlayer implements Player {
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
     this._requestedSubscriptions = subscriptions;
 
-    if (!this._rosClient || this._closed) {
+    if (!this.#rosClient || this.#closed) {
       return;
     }
 
     // Subscribe to additional topics used by RosbridgePlayer itself
-    this._addInternalSubscriptions(subscriptions);
+    this.#addInternalSubscriptions(subscriptions);
 
     this._parsedTopics = new Set(subscriptions.map(({ topic }) => topic));
 
     // See what topics we actually can subscribe to.
-    const availableTopicsByTopicName = keyBy(this._providerTopics ?? [], ({ name }) => name);
+    const availableTopicsByTopicName = keyBy(this.#providerTopics ?? [], ({ name }) => name);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
@@ -457,7 +457,7 @@ export default class RosbridgePlayer implements Player {
         continue;
       }
       const topic = new roslib.Topic({
-        ros: this._rosClient,
+        ros: this.#rosClient,
         name: topicName,
         compression: "cbor-raw",
       });
@@ -474,7 +474,7 @@ export default class RosbridgePlayer implements Player {
 
       const problemId = `message:${topicName}`;
       topic.subscribe((message) => {
-        if (!this._providerTopics) {
+        if (!this.#providerTopics) {
           return;
         }
         try {
@@ -531,11 +531,11 @@ export default class RosbridgePlayer implements Player {
           this._problems.removeProblem(problemId);
 
           // Update the message count for this topic
-          let stats = this._providerTopicsStats.get(topicName);
+          let stats = this.#providerTopicsStats.get(topicName);
           if (this._topicSubscriptions.has(topicName)) {
             if (!stats) {
               stats = { numMessages: 0 };
-              this._providerTopicsStats.set(topicName, stats);
+              this.#providerTopicsStats.set(topicName, stats);
             }
             stats.numMessages++;
           }
@@ -559,7 +559,7 @@ export default class RosbridgePlayer implements Player {
         this._topicSubscriptions.delete(topicName);
 
         // Reset the message count for this topic
-        this._providerTopicsStats.delete(topicName);
+        this.#providerTopicsStats.delete(topicName);
       }
     }
   }
@@ -594,8 +594,8 @@ export default class RosbridgePlayer implements Player {
   }
 
   // Query the type name for this service. Cache the query to avoid looking it up again.
-  private async getServiceType(service: string): Promise<string> {
-    if (!this._rosClient) {
+  async #getServiceType(service: string): Promise<string> {
+    if (!this.#rosClient) {
       throw new Error("Not connected");
     }
 
@@ -604,7 +604,7 @@ export default class RosbridgePlayer implements Player {
       return await existing;
     }
 
-    const rosClient = this._rosClient;
+    const rosClient = this.#rosClient;
     const serviceTypePromise = new Promise<string>((resolve, reject) => {
       rosClient.getServiceType(service, resolve, reject);
     });
@@ -615,7 +615,7 @@ export default class RosbridgePlayer implements Player {
   }
 
   public async callService(service: string, request: unknown): Promise<unknown> {
-    if (!this._rosClient) {
+    if (!this.#rosClient) {
       throw new Error("Not connected");
     }
 
@@ -623,11 +623,11 @@ export default class RosbridgePlayer implements Player {
       throw new Error("RosbridgePlayer#callService request must be an object");
     }
 
-    const serviceType = await this.getServiceType(service);
+    const serviceType = await this.#getServiceType(service);
 
     // Create a proxy object for dispatching our service call
     const proxy = new roslib.Service({
-      ros: this._rosClient,
+      ros: this.#rosClient,
       name: service,
       serviceType,
     });
@@ -661,7 +661,7 @@ export default class RosbridgePlayer implements Player {
 
   private _setupPublishers(): void {
     // This function will be called again once a connection is established
-    if (!this._rosClient) {
+    if (!this.#rosClient) {
       return;
     }
 
@@ -671,7 +671,7 @@ export default class RosbridgePlayer implements Player {
 
     for (const { topic, schemaName: datatype } of this._advertisements) {
       const roslibTopic = new roslib.Topic({
-        ros: this._rosClient,
+        ros: this.#rosClient,
         name: topic,
         messageType: datatype,
         queue_size: 0,
@@ -681,7 +681,7 @@ export default class RosbridgePlayer implements Player {
     }
   }
 
-  private _addInternalSubscriptions(subscriptions: SubscribePayload[]): void {
+  #addInternalSubscriptions(subscriptions: SubscribePayload[]): void {
     // Always subscribe to /clock if available
     if (subscriptions.find((sub) => sub.topic === "/clock") == undefined) {
       subscriptions.unshift({
@@ -696,21 +696,21 @@ export default class RosbridgePlayer implements Player {
 
   // Refreshes the full system state graph. Runs in the background so we don't
   // block app startup while mapping large node graphs.
-  private async _refreshSystemState(): Promise<void> {
-    if (this._isRefreshing) {
+  async #refreshSystemState(): Promise<void> {
+    if (this.#isRefreshing) {
       return;
     }
 
     try {
-      this._isRefreshing = true;
+      this.#isRefreshing = true;
 
       const nodes = await new Promise<string[]>((resolve, reject) => {
-        this._rosClient?.getNodes((fetchedNodes) => resolve(fetchedNodes), reject);
+        this.#rosClient?.getNodes((fetchedNodes) => resolve(fetchedNodes), reject);
       });
 
       const promises = nodes.map(async (node) => {
         return await new Promise<RosNodeDetails>((resolve, reject) => {
-          this._rosClient?.getNodeDetails(
+          this.#rosClient?.getNodeDetails(
             node,
             (subscriptions, publications, services) => {
               resolve({
@@ -728,7 +728,7 @@ export default class RosbridgePlayer implements Player {
       const fulfilled = filterMap(results, (item) =>
         item.status === "fulfilled" ? item.value : undefined,
       );
-      this._publishedTopics = collateNodeDetails(fulfilled, "publications");
+      this.#publishedTopics = collateNodeDetails(fulfilled, "publications");
       this._subscribedTopics = collateNodeDetails(fulfilled, "subscriptions");
       this._services = collateNodeDetails(fulfilled, "services");
 
@@ -740,7 +740,7 @@ export default class RosbridgePlayer implements Player {
         error,
       });
     } finally {
-      this._isRefreshing = false;
+      this.#isRefreshing = false;
     }
   }
 }

--- a/packages/studio-base/src/players/UserNodePlayer/MemoizedLibGenerator.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/MemoizedLibGenerator.ts
@@ -18,13 +18,13 @@ type LibGeneratorFn = (args: Args) => Promise<string>;
  * generated value from `fn` is returned.
  */
 class MemoizedLibGenerator {
-  private datatypes?: RosDatatypes;
-  private topics?: Topic[];
-  private fn: LibGeneratorFn;
-  private cached?: string;
+  #datatypes?: RosDatatypes;
+  #topics?: Topic[];
+  #fn: LibGeneratorFn;
+  #cached?: string;
 
   public constructor(fn: LibGeneratorFn) {
-    this.fn = fn;
+    this.#fn = fn;
   }
 
   /**
@@ -35,17 +35,17 @@ class MemoizedLibGenerator {
    */
   public async update(args: Args): Promise<{ didUpdate: boolean; lib: string }> {
     if (
-      args.topics === this.topics &&
-      args.datatypes === this.datatypes &&
-      this.cached != undefined
+      args.topics === this.#topics &&
+      args.datatypes === this.#datatypes &&
+      this.#cached != undefined
     ) {
-      return { didUpdate: false, lib: this.cached };
+      return { didUpdate: false, lib: this.#cached };
     }
 
-    const lib = await this.fn(args);
-    this.topics = args.topics;
-    this.datatypes = args.datatypes;
-    this.cached = lib;
+    const lib = await this.#fn(args);
+    this.#topics = args.topics;
+    this.#datatypes = args.datatypes;
+    this.#cached = lib;
     return { didUpdate: true, lib };
   }
 }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -101,23 +101,23 @@ type ProtectedState = {
 };
 
 export default class UserNodePlayer implements Player {
-  private _player: Player;
+  #player: Player;
 
   // Datatypes and topics are derived from nodeRegistrations, but memoized so they only change when needed
-  private _memoizedNodeDatatypes: readonly RosDatatypes[] = [];
-  private _memoizedNodeTopics: readonly Topic[] = [];
+  #memoizedNodeDatatypes: readonly RosDatatypes[] = [];
+  #memoizedNodeTopics: readonly Topic[] = [];
 
-  private _subscriptions: SubscribePayload[] = [];
-  private _nodeSubscriptions: Record<string, SubscribePayload> = {};
+  #subscriptions: SubscribePayload[] = [];
+  #nodeSubscriptions: Record<string, SubscribePayload> = {};
 
   // listener for state updates
-  private _listener?: (arg0: PlayerState) => Promise<void>;
+  #listener?: (arg0: PlayerState) => Promise<void>;
 
   // Not sure if there is perf issue with unused workers (may just go idle) - requires more research
-  private _unusedNodeRuntimeWorkers: Rpc[] = [];
-  private _setUserNodeDiagnostics: (nodeId: string, diagnostics: readonly Diagnostic[]) => void;
-  private _addUserNodeLogs: (nodeId: string, logs: UserNodeLog[]) => void;
-  private _nodeTransformRpc?: Rpc;
+  #unusedNodeRuntimeWorkers: Rpc[] = [];
+  #setUserNodeDiagnostics: (nodeId: string, diagnostics: readonly Diagnostic[]) => void;
+  #addUserNodeLogs: (nodeId: string, logs: UserNodeLog[]) => void;
+  #nodeTransformRpc?: Rpc;
   private _globalVariables: GlobalVariables = {};
   private _userNodeActions: UserNodeActions;
   private _rosLibGenerator: MemoizedLibGenerator;
@@ -165,14 +165,14 @@ export default class UserNodePlayer implements Player {
   };
 
   public constructor(player: Player, userNodeActions: UserNodeActions) {
-    this._player = player;
+    this.#player = player;
     this._userNodeActions = userNodeActions;
     const { setUserNodeDiagnostics, addUserNodeLogs } = userNodeActions;
 
-    this._setUserNodeDiagnostics = (nodeId: string, diagnostics: readonly Diagnostic[]) => {
+    this.#setUserNodeDiagnostics = (nodeId: string, diagnostics: readonly Diagnostic[]) => {
       setUserNodeDiagnostics(nodeId, diagnostics);
     };
-    this._addUserNodeLogs = (nodeId: string, logs: UserNodeLog[]) => {
+    this.#addUserNodeLogs = (nodeId: string, logs: UserNodeLog[]) => {
       if (logs.length > 0) {
         addUserNodeLogs(nodeId, logs);
       }
@@ -262,7 +262,7 @@ export default class UserNodePlayer implements Player {
       const messagePromises = [];
       for (const nodeRegistration of nodeRegistrations) {
         if (
-          this._nodeSubscriptions[nodeRegistration.output.name] &&
+          this.#nodeSubscriptions[nodeRegistration.output.name] &&
           nodeRegistration.inputs.includes(message.topic)
         ) {
           const messagePromise = nodeRegistration.processMessage(message, globalVariables);
@@ -305,7 +305,7 @@ export default class UserNodePlayer implements Player {
     // If no downstream subscriptions want blocks for our output topics we can just pass through
     // the blocks from the underlying player.
     const fullRegistrations = nodeRegistrations.filter(
-      (reg) => this._nodeSubscriptions[reg.output.name]?.preloadType === "full",
+      (reg) => this.#nodeSubscriptions[reg.output.name]?.preloadType === "full",
     );
     if (fullRegistrations.length === 0) {
       return blocks;
@@ -389,7 +389,7 @@ export default class UserNodePlayer implements Player {
       state.nodeRegistrationCache.splice(maxNodeRegistrationCacheCount);
       // This code causes us to reset workers twice because the seeking resets the workers too
       await this._resetWorkersUnlocked(state);
-      this._setSubscriptionsUnlocked(this._subscriptions, state);
+      this._setSubscriptionsUnlocked(this.#subscriptions, state);
     });
   }
 
@@ -441,7 +441,7 @@ export default class UserNodePlayer implements Player {
       return async (msgEvent: MessageEvent<unknown>, globalVariables: GlobalVariables) => {
         // Register the node within a web worker to be executed.
         if (!rpc) {
-          rpc = this._unusedNodeRuntimeWorkers.pop();
+          rpc = this.#unusedNodeRuntimeWorkers.pop();
 
           // initialize a new worker since no unused one is available
           if (!rpc) {
@@ -493,7 +493,7 @@ export default class UserNodePlayer implements Player {
             },
           );
           if (error != undefined) {
-            this._setUserNodeDiagnostics(nodeId, [
+            this.#setUserNodeDiagnostics(nodeId, [
               ...userNodeDiagnostics,
               {
                 source: Sources.Runtime,
@@ -504,7 +504,7 @@ export default class UserNodePlayer implements Player {
             ]);
             return;
           }
-          this._addUserNodeLogs(nodeId, userNodeLogs);
+          this.#addUserNodeLogs(nodeId, userNodeLogs);
         }
 
         // This signals that we have terminated the node registration and we should bail any message
@@ -548,7 +548,7 @@ export default class UserNodePlayer implements Player {
           });
         }
 
-        this._addUserNodeLogs(nodeId, result.userNodeLogs);
+        this.#addUserNodeLogs(nodeId, result.userNodeLogs);
 
         if (allDiagnostics.length > 0) {
           this._problemStore.set(problemKey, {
@@ -557,7 +557,7 @@ export default class UserNodePlayer implements Player {
             tip: "Open the User Scripts panel and check the Problems tab for errors.",
           });
 
-          this._setUserNodeDiagnostics(nodeId, allDiagnostics);
+          this.#setUserNodeDiagnostics(nodeId, allDiagnostics);
           return;
         }
 
@@ -594,7 +594,7 @@ export default class UserNodePlayer implements Player {
       terminateSignal = undefined;
 
       if (rpc) {
-        this._unusedNodeRuntimeWorkers.push(rpc);
+        this.#unusedNodeRuntimeWorkers.push(rpc);
         rpc = undefined;
       }
     };
@@ -613,7 +613,7 @@ export default class UserNodePlayer implements Player {
   }
 
   private _getTransformWorker(): Rpc {
-    if (!this._nodeTransformRpc) {
+    if (!this.#nodeTransformRpc) {
       const worker = UserNodePlayer.CreateNodeTransformWorker();
 
       // The errors below persist for the lifetime of the player.
@@ -655,9 +655,9 @@ export default class UserNodePlayer implements Player {
         void this._emitState();
       });
 
-      this._nodeTransformRpc = rpc;
+      this.#nodeTransformRpc = rpc;
     }
-    return this._nodeTransformRpc;
+    return this.#nodeTransformRpc;
   }
 
   // We need to reset workers in a variety of circumstances:
@@ -682,8 +682,8 @@ export default class UserNodePlayer implements Player {
     }
     state.nodeRegistrations = [];
 
-    const rosLib = await this._getRosLib(state);
-    const typesLib = await this._getTypesLib(state);
+    const rosLib = await this.#getRosLib(state);
+    const typesLib = await this.#getTypesLib(state);
 
     const allNodeRegistrations = await Promise.all(
       Object.entries(state.userNodes).map(
@@ -705,7 +705,7 @@ export default class UserNodePlayer implements Player {
       const { nodeData, nodeId } = nodeRegistration;
 
       if (!nodeData.outputTopic) {
-        this._setUserNodeDiagnostics(nodeId, [
+        this.#setUserNodeDiagnostics(nodeId, [
           ...nodeData.diagnostics,
           {
             severity: DiagnosticSeverity.Error,
@@ -719,7 +719,7 @@ export default class UserNodePlayer implements Player {
 
       // Create diagnostic errors if more than one node outputs to the same topic
       if (state.inputsByOutputTopic.has(nodeData.outputTopic)) {
-        this._setUserNodeDiagnostics(nodeId, [
+        this.#setUserNodeDiagnostics(nodeId, [
           ...nodeData.diagnostics,
           {
             severity: DiagnosticSeverity.Error,
@@ -736,7 +736,7 @@ export default class UserNodePlayer implements Player {
 
       // Create diagnostic errors if node outputs overlap with real topics
       if (playerTopics.has(nodeData.outputTopic)) {
-        this._setUserNodeDiagnostics(nodeId, [
+        this.#setUserNodeDiagnostics(nodeId, [
           ...nodeData.diagnostics,
           {
             severity: DiagnosticSeverity.Error,
@@ -750,7 +750,7 @@ export default class UserNodePlayer implements Player {
 
       // Filter out nodes with compilation errors
       if (hasTransformerErrors(nodeData)) {
-        this._setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
+        this.#setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
         continue;
       }
 
@@ -768,12 +768,12 @@ export default class UserNodePlayer implements Player {
 
     state.nodeRegistrations = validNodeRegistrations;
     const nodeTopics = state.nodeRegistrations.map(({ output }) => output);
-    if (!isEqual(nodeTopics, this._memoizedNodeTopics)) {
-      this._memoizedNodeTopics = nodeTopics;
+    if (!isEqual(nodeTopics, this.#memoizedNodeTopics)) {
+      this.#memoizedNodeTopics = nodeTopics;
     }
     const nodeDatatypes = state.nodeRegistrations.map(({ nodeData: { datatypes } }) => datatypes);
-    if (!isEqual(nodeDatatypes, this._memoizedNodeDatatypes)) {
-      this._memoizedNodeDatatypes = nodeDatatypes;
+    if (!isEqual(nodeDatatypes, this.#memoizedNodeDatatypes)) {
+      this.#memoizedNodeDatatypes = nodeDatatypes;
     }
 
     // We need to set the user node diagnostics, which is a react set state
@@ -790,12 +790,12 @@ export default class UserNodePlayer implements Player {
     // Moving to React 18 should remove the need for this call.
     ReactDOM.unstable_batchedUpdates(() => {
       for (const nodeRegistration of state.nodeRegistrations) {
-        this._setUserNodeDiagnostics(nodeRegistration.nodeId, []);
+        this.#setUserNodeDiagnostics(nodeRegistration.nodeId, []);
       }
     });
   }
 
-  private async _getRosLib(state: ProtectedState): Promise<string> {
+  async #getRosLib(state: ProtectedState): Promise<string> {
     if (!state.lastPlayerStateActiveData) {
       throw new Error("_getRosLib was called before `_lastPlayerStateActiveData` set");
     }
@@ -809,7 +809,7 @@ export default class UserNodePlayer implements Player {
     return lib;
   }
 
-  private async _getTypesLib(state: ProtectedState): Promise<string> {
+  async #getTypesLib(state: ProtectedState): Promise<string> {
     if (!state.lastPlayerStateActiveData) {
       throw new Error("_getTypesLib was called before `_lastPlayerStateActiveData` set");
     }
@@ -824,7 +824,7 @@ export default class UserNodePlayer implements Player {
   }
 
   // invoked when our child player state changes
-  private async _onPlayerState(playerState: PlayerState) {
+  async #onPlayerState(playerState: PlayerState) {
     try {
       const globalVariables = this._globalVariables;
       const { activeData } = playerState;
@@ -843,7 +843,7 @@ export default class UserNodePlayer implements Player {
         if (!state.lastPlayerStateActiveData) {
           state.lastPlayerStateActiveData = activeData;
           await this._resetWorkersUnlocked(state);
-          this._setSubscriptionsUnlocked(this._subscriptions, state);
+          this._setSubscriptionsUnlocked(this.#subscriptions, state);
         } else {
           // Reset node state after seeking
           let shouldReset =
@@ -864,7 +864,7 @@ export default class UserNodePlayer implements Player {
           }
         }
 
-        const allDatatypes = this._getDatatypes(datatypes, this._memoizedNodeDatatypes);
+        const allDatatypes = this._getDatatypes(datatypes, this.#memoizedNodeDatatypes);
 
         /**
          * if nodes have been updated we need to add their previous input messages
@@ -949,7 +949,7 @@ export default class UserNodePlayer implements Player {
           activeData: {
             ...activeData,
             messages: parsedMessages,
-            topics: this._getTopics(topics, this._memoizedNodeTopics),
+            topics: this._getTopics(topics, this.#memoizedNodeTopics),
             datatypes: allDatatypes,
           },
         };
@@ -989,22 +989,22 @@ export default class UserNodePlayer implements Player {
       problems,
     };
 
-    if (this._listener) {
-      await this._listener(playerState);
+    if (this.#listener) {
+      await this.#listener(playerState);
     }
   }
 
   public setListener(listener: NonNullable<UserNodePlayer["_listener"]>): void {
-    this._listener = listener;
+    this.#listener = listener;
 
     // Delay _player.setListener until our setListener is called because setListener in some cases
     // triggers initialization logic and remote requests. This is an unfortunate API behavior and
     // naming choice, but it's better for us not to do trigger this logic in the constructor.
-    this._player.setListener(async (state) => await this._onPlayerState(state));
+    this.#player.setListener(async (state) => await this.#onPlayerState(state));
   }
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._subscriptions = subscriptions;
+    this.#subscriptions = subscriptions;
     this._protectedState
       .runExclusive(async (state) => {
         this._setSubscriptionsUnlocked(subscriptions, state);
@@ -1047,8 +1047,8 @@ export default class UserNodePlayer implements Player {
       }
     }
 
-    this._nodeSubscriptions = nodeSubscriptions;
-    this._player.setSubscriptions(realTopicSubscriptions);
+    this.#nodeSubscriptions = nodeSubscriptions;
+    this.#player.setSubscriptions(realTopicSubscriptions);
   }
 
   public close = (): void => {
@@ -1057,49 +1057,49 @@ export default class UserNodePlayer implements Player {
         nodeRegistration.terminate();
       }
     });
-    this._player.close();
-    if (this._nodeTransformRpc) {
-      void this._nodeTransformRpc.send("close");
+    this.#player.close();
+    if (this.#nodeTransformRpc) {
+      void this.#nodeTransformRpc.send("close");
     }
   };
 
   public setPublishers(publishers: AdvertiseOptions[]): void {
-    this._player.setPublishers(publishers);
+    this.#player.setPublishers(publishers);
   }
 
   public setParameter(key: string, value: ParameterValue): void {
-    this._player.setParameter(key, value);
+    this.#player.setParameter(key, value);
   }
 
   public publish(request: PublishPayload): void {
-    this._player.publish(request);
+    this.#player.publish(request);
   }
 
   public async callService(service: string, request: unknown): Promise<unknown> {
-    return await this._player.callService(service, request);
+    return await this.#player.callService(service, request);
   }
 
   public startPlayback(): void {
-    this._player.startPlayback?.();
+    this.#player.startPlayback?.();
   }
 
   public pausePlayback(): void {
-    this._player.pausePlayback?.();
+    this.#player.pausePlayback?.();
   }
 
   public playUntil(time: Time): void {
-    if (this._player.playUntil) {
-      this._player.playUntil(time);
+    if (this.#player.playUntil) {
+      this.#player.playUntil(time);
       return;
     }
-    this._player.seekPlayback?.(time);
+    this.#player.seekPlayback?.(time);
   }
 
   public setPlaybackSpeed(speed: number): void {
-    this._player.setPlaybackSpeed?.(speed);
+    this.#player.setPlaybackSpeed?.(speed);
   }
 
   public seekPlayback(time: Time, backfillDuration?: Time): void {
-    this._player.seekPlayback?.(time, backfillDuration);
+    this.#player.seekPlayback?.(time, backfillDuration);
   }
 }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -118,25 +118,25 @@ export default class UserNodePlayer implements Player {
   #setUserNodeDiagnostics: (nodeId: string, diagnostics: readonly Diagnostic[]) => void;
   #addUserNodeLogs: (nodeId: string, logs: UserNodeLog[]) => void;
   #nodeTransformRpc?: Rpc;
-  private _globalVariables: GlobalVariables = {};
-  private _userNodeActions: UserNodeActions;
-  private _rosLibGenerator: MemoizedLibGenerator;
-  private _typesLibGenerator: MemoizedLibGenerator;
+  #globalVariables: GlobalVariables = {};
+  #userNodeActions: UserNodeActions;
+  #rosLibGenerator: MemoizedLibGenerator;
+  #typesLibGenerator: MemoizedLibGenerator;
 
   // Player state changes when the child player invokes our player state listener
   // we may also emit state changes on internal errors
-  private _playerState?: PlayerState;
+  #playerState?: PlayerState;
 
   // The store tracks problems for individual userspace nodes
   // a node may set its own problem or clear its problem
-  private _problemStore = new Map<string, PlayerProblem>();
+  #problemStore = new Map<string, PlayerProblem>();
 
   // keep track of last message on all topics to recompute output topic messages when user nodes change
-  private _lastMessageByInputTopic = new Map<string, MessageEvent<unknown>>();
-  private _userNodeIdsNeedUpdate = new Set<string>();
-  private _globalVariablesChanged = false;
+  #lastMessageByInputTopic = new Map<string, MessageEvent<unknown>>();
+  #userNodeIdsNeedUpdate = new Set<string>();
+  #globalVariablesChanged = false;
 
-  private _protectedState = new MutexLocked<ProtectedState>({
+  #protectedState = new MutexLocked<ProtectedState>({
     userNodes: {},
     nodeRegistrations: [],
     nodeRegistrationCache: [],
@@ -166,7 +166,7 @@ export default class UserNodePlayer implements Player {
 
   public constructor(player: Player, userNodeActions: UserNodeActions) {
     this.#player = player;
-    this._userNodeActions = userNodeActions;
+    this.#userNodeActions = userNodeActions;
     const { setUserNodeDiagnostics, addUserNodeLogs } = userNodeActions;
 
     this.#setUserNodeDiagnostics = (nodeId: string, diagnostics: readonly Diagnostic[]) => {
@@ -178,7 +178,7 @@ export default class UserNodePlayer implements Player {
       }
     };
 
-    this._typesLibGenerator = new MemoizedLibGenerator(async (args) => {
+    this.#typesLibGenerator = new MemoizedLibGenerator(async (args) => {
       const lib = generateTypesLib({
         topics: args.topics,
         datatypes: new Map([...basicDatatypes, ...args.datatypes]),
@@ -192,8 +192,8 @@ export default class UserNodePlayer implements Player {
       return lib;
     });
 
-    this._rosLibGenerator = new MemoizedLibGenerator(async (args) => {
-      const transformWorker = this._getTransformWorker();
+    this.#rosLibGenerator = new MemoizedLibGenerator(async (args) => {
+      const transformWorker = this.#getTransformWorker();
       return await transformWorker.send("generateRosLib", {
         topics: args.topics,
         // Include basic datatypes along with any custom datatypes.
@@ -203,11 +203,12 @@ export default class UserNodePlayer implements Player {
     });
   }
 
-  private _getTopics = memoizeWeak(
-    (topics: readonly Topic[], nodeTopics: readonly Topic[]): Topic[] => [...topics, ...nodeTopics],
-  );
+  #getTopics = memoizeWeak((topics: readonly Topic[], nodeTopics: readonly Topic[]): Topic[] => [
+    ...topics,
+    ...nodeTopics,
+  ]);
 
-  private _getDatatypes = memoizeWeak(
+  #getDatatypes = memoizeWeak(
     (datatypes: RosDatatypes, nodeDatatypes: readonly RosDatatypes[]): RosDatatypes => {
       return nodeDatatypes.reduce(
         (allDatatypes, userNodeDatatypes) => new Map([...allDatatypes, ...userNodeDatatypes]),
@@ -216,7 +217,7 @@ export default class UserNodePlayer implements Player {
     },
   );
 
-  private _lastBlockRequest: {
+  #lastBlockRequest: {
     input?: {
       blocks: readonly (MessageBlock | undefined)[];
       globalVariables: GlobalVariables;
@@ -226,18 +227,18 @@ export default class UserNodePlayer implements Player {
   } = { result: [] };
 
   // Basic memoization by remembering the last values passed to getMessages
-  private _lastGetMessagesInput: {
+  #lastGetMessagesInput: {
     parsedMessages: readonly MessageEvent<unknown>[];
     globalVariables: GlobalVariables;
     nodeRegistrations: readonly NodeRegistration[];
   } = { parsedMessages: [], globalVariables: {}, nodeRegistrations: [] };
-  private _lastGetMessagesResult: { parsedMessages: readonly MessageEvent<unknown>[] } = {
+  #lastGetMessagesResult: { parsedMessages: readonly MessageEvent<unknown>[] } = {
     parsedMessages: [],
   };
 
   // Processes input messages through nodes to create messages on output topics
   // Memoized to prevent reprocessing on same input
-  private async _getMessages(
+  async #getMessages(
     parsedMessages: readonly MessageEvent<unknown>[],
     globalVariables: GlobalVariables,
     nodeRegistrations: readonly NodeRegistration[],
@@ -249,13 +250,13 @@ export default class UserNodePlayer implements Player {
       return { parsedMessages };
     }
     if (
-      shallowequal(this._lastGetMessagesInput, {
+      shallowequal(this.#lastGetMessagesInput, {
         parsedMessages,
         globalVariables,
         nodeRegistrations,
       })
     ) {
-      return this._lastGetMessagesResult;
+      return this.#lastGetMessagesResult;
     }
     const parsedMessagesPromises: Promise<MessageEvent<unknown> | undefined>[] = [];
     for (const message of parsedMessages) {
@@ -282,24 +283,24 @@ export default class UserNodePlayer implements Player {
         .concat(nodeParsedMessages)
         .sort((a, b) => compare(a.receiveTime, b.receiveTime)),
     };
-    this._lastGetMessagesInput = { parsedMessages, globalVariables, nodeRegistrations };
-    this._lastGetMessagesResult = result;
+    this.#lastGetMessagesInput = { parsedMessages, globalVariables, nodeRegistrations };
+    this.#lastGetMessagesResult = result;
     return result;
   }
 
-  private async _getBlocks(
+  async #getBlocks(
     blocks: readonly (MessageBlock | undefined)[],
     globalVariables: GlobalVariables,
     nodeRegistrations: readonly NodeRegistration[],
   ): Promise<readonly (MessageBlock | undefined)[]> {
     if (
-      shallowequal(this._lastBlockRequest.input, {
+      shallowequal(this.#lastBlockRequest.input, {
         blocks,
         globalVariables,
         nodeRegistrations,
       })
     ) {
-      return this._lastBlockRequest.result;
+      return this.#lastBlockRequest.result;
     }
 
     // If no downstream subscriptions want blocks for our output topics we can just pass through
@@ -357,7 +358,7 @@ export default class UserNodePlayer implements Player {
       });
     }
 
-    this._lastBlockRequest = {
+    this.#lastBlockRequest = {
       input: { blocks, globalVariables, nodeRegistrations },
       result: outputBlocks,
     };
@@ -366,19 +367,19 @@ export default class UserNodePlayer implements Player {
   }
 
   public setGlobalVariables(globalVariables: GlobalVariables): void {
-    this._globalVariables = globalVariables;
-    this._globalVariablesChanged = true;
+    this.#globalVariables = globalVariables;
+    this.#globalVariablesChanged = true;
   }
 
   // Called when userNode state is updated.
   public async setUserNodes(userNodes: UserNodes): Promise<void> {
-    await this._protectedState.runExclusive(async (state) => {
+    await this.#protectedState.runExclusive(async (state) => {
       for (const nodeId of Object.keys(userNodes)) {
         const prevNode = state.userNodes[nodeId];
         const newNode = userNodes[nodeId];
         if (prevNode && newNode && prevNode.sourceCode !== newNode.sourceCode) {
           // if source code of a userNode changed then we need to mark it for re-processing input messages
-          this._userNodeIdsNeedUpdate.add(nodeId);
+          this.#userNodeIdsNeedUpdate.add(nodeId);
         }
       }
       state.userNodes = userNodes;
@@ -388,13 +389,13 @@ export default class UserNodePlayer implements Player {
       const maxNodeRegistrationCacheCount = Object.keys(userNodes).length + 1;
       state.nodeRegistrationCache.splice(maxNodeRegistrationCacheCount);
       // This code causes us to reset workers twice because the seeking resets the workers too
-      await this._resetWorkersUnlocked(state);
-      this._setSubscriptionsUnlocked(this.#subscriptions, state);
+      await this.#resetWorkersUnlocked(state);
+      this.#setSubscriptionsUnlocked(this.#subscriptions, state);
     });
   }
 
   // Defines the inputs/outputs and worker interface of a user node.
-  private async _createNodeRegistration(
+  async #createNodeRegistration(
     nodeId: string,
     userNode: UserNode,
     state: ProtectedState,
@@ -420,7 +421,7 @@ export default class UserNodePlayer implements Player {
       typesLib,
       datatypes: nodeDatatypes,
     };
-    const transformWorker = this._getTransformWorker();
+    const transformWorker = this.#getTransformWorker();
     const nodeData = await transformWorker.send<NodeData>("transform", transformMessage);
     const { inputTopics, outputTopic, transpiledCode, projectCode, outputDatatype } = nodeData;
 
@@ -450,25 +451,25 @@ export default class UserNodePlayer implements Player {
             worker.onerror = (event) => {
               log.error(event);
 
-              this._problemStore.set(problemKey, {
+              this.#problemStore.set(problemKey, {
                 message: `User script runtime error: ${event.message}`,
                 severity: "error",
               });
 
               // trigger listener updates
-              void this._emitState();
+              void this.#emitState();
             };
 
             const port: MessagePort = worker.port;
             port.onmessageerror = (event) => {
               log.error(event);
 
-              this._problemStore.set(problemKey, {
+              this.#problemStore.set(problemKey, {
                 severity: "error",
                 message: `User script runtime error: ${String(event.data)}`,
               });
 
-              void this._emitState();
+              void this.#emitState();
             };
             port.start();
             rpc = new Rpc(port);
@@ -476,12 +477,12 @@ export default class UserNodePlayer implements Player {
             rpc.receive("error", (msg) => {
               log.error(msg);
 
-              this._problemStore.set(problemKey, {
+              this.#problemStore.set(problemKey, {
                 severity: "error",
                 message: `User script runtime error: ${msg}`,
               });
 
-              void this._emitState();
+              void this.#emitState();
             });
           }
 
@@ -531,7 +532,7 @@ export default class UserNodePlayer implements Player {
         ]);
 
         if (!result) {
-          this._problemStore.set(problemKey, {
+          this.#problemStore.set(problemKey, {
             message: `User Script ${nodeId} timed out`,
             severity: "warn",
           });
@@ -551,7 +552,7 @@ export default class UserNodePlayer implements Player {
         this.#addUserNodeLogs(nodeId, result.userNodeLogs);
 
         if (allDiagnostics.length > 0) {
-          this._problemStore.set(problemKey, {
+          this.#problemStore.set(problemKey, {
             severity: "error",
             message: `User Script ${nodeId} encountered an error.`,
             tip: "Open the User Scripts panel and check the Problems tab for errors.",
@@ -562,7 +563,7 @@ export default class UserNodePlayer implements Player {
         }
 
         if (!result.message) {
-          this._problemStore.set(problemKey, {
+          this.#problemStore.set(problemKey, {
             severity: "warn",
             message: `User Script ${nodeId} did not produce a message.`,
             tip: "Check that all code paths in the user script return a message.",
@@ -572,7 +573,7 @@ export default class UserNodePlayer implements Player {
 
         // At this point we've received a message successfully from the userspace node, therefore
         // we clear any previous problem from this node.
-        this._problemStore.delete(problemKey);
+        this.#problemStore.delete(problemKey);
 
         return {
           topic: outputTopic,
@@ -585,7 +586,7 @@ export default class UserNodePlayer implements Player {
     };
 
     const terminate = () => {
-      this._problemStore.delete(problemKey);
+      this.#problemStore.delete(problemKey);
 
       // Signal any pending in-flight message processing to terminate and clear the state so we can
       // re-initialize when the next message is processed.
@@ -612,7 +613,7 @@ export default class UserNodePlayer implements Player {
     return result;
   }
 
-  private _getTransformWorker(): Rpc {
+  #getTransformWorker(): Rpc {
     if (!this.#nodeTransformRpc) {
       const worker = UserNodePlayer.CreateNodeTransformWorker();
 
@@ -622,24 +623,24 @@ export default class UserNodePlayer implements Player {
       worker.onerror = (event) => {
         log.error(event);
 
-        this._problemStore.set("worker-error", {
+        this.#problemStore.set("worker-error", {
           severity: "error",
           message: `User Script error: ${event.message}`,
         });
 
-        void this._emitState();
+        void this.#emitState();
       };
 
       const port: MessagePort = worker.port;
       port.onmessageerror = (event) => {
         log.error(event);
 
-        this._problemStore.set("worker-error", {
+        this.#problemStore.set("worker-error", {
           severity: "error",
           message: `User Script error: ${String(event.data)}`,
         });
 
-        void this._emitState();
+        void this.#emitState();
       };
       port.start();
       const rpc = new Rpc(port);
@@ -647,12 +648,12 @@ export default class UserNodePlayer implements Player {
       rpc.receive("error", (msg) => {
         log.error(msg);
 
-        this._problemStore.set("worker-error", {
+        this.#problemStore.set("worker-error", {
           severity: "error",
           message: `User Script error: ${msg}`,
         });
 
-        void this._emitState();
+        void this.#emitState();
       });
 
       this.#nodeTransformRpc = rpc;
@@ -664,7 +665,7 @@ export default class UserNodePlayer implements Player {
   // - When a user node is updated, added or deleted
   // - When we seek (in order to reset state)
   // - When a new child player is added
-  private async _resetWorkersUnlocked(state: ProtectedState): Promise<void> {
+  async #resetWorkersUnlocked(state: ProtectedState): Promise<void> {
     if (!state.lastPlayerStateActiveData) {
       return;
     }
@@ -688,7 +689,7 @@ export default class UserNodePlayer implements Player {
     const allNodeRegistrations = await Promise.all(
       Object.entries(state.userNodes).map(
         async ([nodeId, userNode]) =>
-          await this._createNodeRegistration(nodeId, userNode, state, rosLib, typesLib),
+          await this.#createNodeRegistration(nodeId, userNode, state, rosLib, typesLib),
       ),
     );
 
@@ -801,9 +802,9 @@ export default class UserNodePlayer implements Player {
     }
 
     const { topics, datatypes } = state.lastPlayerStateActiveData;
-    const { didUpdate, lib } = await this._rosLibGenerator.update({ topics, datatypes });
+    const { didUpdate, lib } = await this.#rosLibGenerator.update({ topics, datatypes });
     if (didUpdate) {
-      this._userNodeActions.setUserNodeRosLib(lib);
+      this.#userNodeActions.setUserNodeRosLib(lib);
     }
 
     return lib;
@@ -815,9 +816,9 @@ export default class UserNodePlayer implements Player {
     }
 
     const { topics, datatypes } = state.lastPlayerStateActiveData;
-    const { didUpdate, lib } = await this._typesLibGenerator.update({ topics, datatypes });
+    const { didUpdate, lib } = await this.#typesLibGenerator.update({ topics, datatypes });
     if (didUpdate) {
-      this._userNodeActions.setUserNodeTypesLib(lib);
+      this.#userNodeActions.setUserNodeTypesLib(lib);
     }
 
     return lib;
@@ -826,11 +827,11 @@ export default class UserNodePlayer implements Player {
   // invoked when our child player state changes
   async #onPlayerState(playerState: PlayerState) {
     try {
-      const globalVariables = this._globalVariables;
+      const globalVariables = this.#globalVariables;
       const { activeData } = playerState;
       if (!activeData) {
-        this._playerState = playerState;
-        await this._emitState();
+        this.#playerState = playerState;
+        await this.#emitState();
         return;
       }
 
@@ -839,11 +840,11 @@ export default class UserNodePlayer implements Player {
       // If we do not have active player data from a previous call, then our
       // player just spun up, meaning we should re-run our user nodes in case
       // they have inputs that now exist in the current player context.
-      const newPlayerState = await this._protectedState.runExclusive(async (state) => {
+      const newPlayerState = await this.#protectedState.runExclusive(async (state) => {
         if (!state.lastPlayerStateActiveData) {
           state.lastPlayerStateActiveData = activeData;
-          await this._resetWorkersUnlocked(state);
-          this._setSubscriptionsUnlocked(this.#subscriptions, state);
+          await this.#resetWorkersUnlocked(state);
+          this.#setSubscriptionsUnlocked(this.#subscriptions, state);
         } else {
           // Reset node state after seeking
           let shouldReset =
@@ -860,11 +861,11 @@ export default class UserNodePlayer implements Player {
 
           state.lastPlayerStateActiveData = activeData;
           if (shouldReset) {
-            await this._resetWorkersUnlocked(state);
+            await this.#resetWorkersUnlocked(state);
           }
         }
 
-        const allDatatypes = this._getDatatypes(datatypes, this.#memoizedNodeDatatypes);
+        const allDatatypes = this.#getDatatypes(datatypes, this.#memoizedNodeDatatypes);
 
         /**
          * if nodes have been updated we need to add their previous input messages
@@ -873,7 +874,7 @@ export default class UserNodePlayer implements Player {
          */
         const inputTopicsForRecompute = new Set<string>();
 
-        for (const userNodeId of this._userNodeIdsNeedUpdate) {
+        for (const userNodeId of this.#userNodeIdsNeedUpdate) {
           const nodeRegistration = state.nodeRegistrations.find(
             ({ nodeId }) => nodeId === userNodeId,
           );
@@ -889,9 +890,9 @@ export default class UserNodePlayer implements Player {
 
         // if the globalVariables have changed recompute all last messages for the current frame
         // there's no way to know which nodes are affected by the globalVariables change to make this more specific
-        if (this._globalVariablesChanged) {
-          this._globalVariablesChanged = false;
-          for (const inputTopic of this._lastMessageByInputTopic.keys()) {
+        if (this.#globalVariablesChanged) {
+          this.#globalVariablesChanged = false;
+          for (const inputTopic of this.#lastMessageByInputTopic.keys()) {
             inputTopicsForRecompute.add(inputTopic);
           }
         }
@@ -906,21 +907,21 @@ export default class UserNodePlayer implements Player {
 
         const messagesForRecompute: MessageEvent<unknown>[] = [];
         for (const topic of inputTopicsForRecompute) {
-          const messageForRecompute = this._lastMessageByInputTopic.get(topic);
+          const messageForRecompute = this.#lastMessageByInputTopic.get(topic);
           if (messageForRecompute) {
             messagesForRecompute.push(messageForRecompute);
           }
         }
 
-        this._userNodeIdsNeedUpdate.clear();
+        this.#userNodeIdsNeedUpdate.clear();
 
         for (const message of messages) {
-          this._lastMessageByInputTopic.set(message.topic, message);
+          this.#lastMessageByInputTopic.set(message.topic, message);
         }
 
         const messagesToBeParsed =
           messagesForRecompute.length > 0 ? messages.concat(messagesForRecompute) : messages;
-        const { parsedMessages } = await this._getMessages(
+        const { parsedMessages } = await this.#getMessages(
           messagesToBeParsed,
           globalVariables,
           state.nodeRegistrations,
@@ -931,7 +932,7 @@ export default class UserNodePlayer implements Player {
         };
 
         if (playerProgress.messageCache) {
-          const newBlocks = await this._getBlocks(
+          const newBlocks = await this.#getBlocks(
             playerProgress.messageCache.blocks,
             globalVariables,
             state.nodeRegistrations,
@@ -949,43 +950,43 @@ export default class UserNodePlayer implements Player {
           activeData: {
             ...activeData,
             messages: parsedMessages,
-            topics: this._getTopics(topics, this.#memoizedNodeTopics),
+            topics: this.#getTopics(topics, this.#memoizedNodeTopics),
             datatypes: allDatatypes,
           },
         };
       });
 
-      this._playerState = newPlayerState;
+      this.#playerState = newPlayerState;
 
       // clear any previous problem we had from making a new player state
-      this._problemStore.delete("player-state-update");
+      this.#problemStore.delete("player-state-update");
     } catch (err) {
-      this._problemStore.set("player-state-update", {
+      this.#problemStore.set("player-state-update", {
         severity: "error",
         message: err.message,
         error: err,
       });
 
-      this._playerState = playerState;
+      this.#playerState = playerState;
     } finally {
-      await this._emitState();
+      await this.#emitState();
     }
   }
 
-  private async _emitState() {
-    if (!this._playerState) {
+  async #emitState() {
+    if (!this.#playerState) {
       return;
     }
 
     // only augment child problems if we have our own problems
     // if neither child or parent have problems we do nothing
-    let problems = this._playerState.problems;
-    if (this._problemStore.size > 0) {
-      problems = (problems ?? []).concat(Array.from(this._problemStore.values()));
+    let problems = this.#playerState.problems;
+    if (this.#problemStore.size > 0) {
+      problems = (problems ?? []).concat(Array.from(this.#problemStore.values()));
     }
 
     const playerState: PlayerState = {
-      ...this._playerState,
+      ...this.#playerState,
       problems,
     };
 
@@ -994,7 +995,7 @@ export default class UserNodePlayer implements Player {
     }
   }
 
-  public setListener(listener: NonNullable<UserNodePlayer["_listener"]>): void {
+  public setListener(listener: (_: PlayerState) => Promise<void>): void {
     this.#listener = listener;
 
     // Delay _player.setListener until our setListener is called because setListener in some cases
@@ -1005,9 +1006,9 @@ export default class UserNodePlayer implements Player {
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
     this.#subscriptions = subscriptions;
-    this._protectedState
+    this.#protectedState
       .runExclusive(async (state) => {
-        this._setSubscriptionsUnlocked(subscriptions, state);
+        this.#setSubscriptionsUnlocked(subscriptions, state);
       })
       .catch((err) => {
         log.error(err);
@@ -1015,10 +1016,7 @@ export default class UserNodePlayer implements Player {
       });
   }
 
-  private _setSubscriptionsUnlocked(
-    subscriptions: SubscribePayload[],
-    state: ProtectedState,
-  ): void {
+  #setSubscriptionsUnlocked(subscriptions: SubscribePayload[], state: ProtectedState): void {
     const nodeSubscriptions: Record<string, SubscribePayload> = {};
     const realTopicSubscriptions: SubscribePayload[] = [];
 
@@ -1052,7 +1050,7 @@ export default class UserNodePlayer implements Player {
   }
 
   public close = (): void => {
-    void this._protectedState.runExclusive(async (state) => {
+    void this.#protectedState.runExclusive(async (state) => {
       for (const nodeRegistration of state.nodeRegistrations) {
         nodeRegistration.terminate();
       }

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/readers.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/readers.ts
@@ -11,80 +11,80 @@ export interface FieldReader {
 }
 
 export class Float32Reader implements FieldReader {
-  private offset: number;
-  private view: DataView;
+  #offset: number;
+  #view: DataView;
   public constructor(offset: number) {
-    this.offset = offset;
+    this.#offset = offset;
     const buffer = new ArrayBuffer(4);
-    this.view = new DataView(buffer);
+    this.#view = new DataView(buffer);
   }
 
   public read(data: Uint8Array, index: number): number {
-    const base = index + this.offset;
+    const base = index + this.#offset;
     const size = 4;
     if (data.length < base + size) {
       throw new Error("cannot read Float32 from data - not enough data");
     }
-    this.view.setUint8(0, data[base]!);
-    this.view.setUint8(1, data[base + 1]!);
-    this.view.setUint8(2, data[base + 2]!);
-    this.view.setUint8(3, data[base + 3]!);
-    return this.view.getFloat32(0, true);
+    this.#view.setUint8(0, data[base]!);
+    this.#view.setUint8(1, data[base + 1]!);
+    this.#view.setUint8(2, data[base + 2]!);
+    this.#view.setUint8(3, data[base + 3]!);
+    return this.#view.getFloat32(0, true);
   }
 }
 
 export class Int32Reader implements FieldReader {
-  private offset: number;
-  private view: DataView;
+  #offset: number;
+  #view: DataView;
   public constructor(offset: number) {
-    this.offset = offset;
+    this.#offset = offset;
     const buffer = new ArrayBuffer(4);
-    this.view = new DataView(buffer);
+    this.#view = new DataView(buffer);
   }
 
   public read(data: Uint8Array, index: number): number {
-    const base = index + this.offset;
+    const base = index + this.#offset;
     const size = 4;
     if (data.length < base + size) {
       throw new Error("cannot read Int32 from data - not enough data");
     }
-    this.view.setUint8(0, data[base]!);
-    this.view.setUint8(1, data[base + 1]!);
-    this.view.setUint8(2, data[base + 2]!);
-    this.view.setUint8(3, data[base + 3]!);
-    return this.view.getInt32(0, true);
+    this.#view.setUint8(0, data[base]!);
+    this.#view.setUint8(1, data[base + 1]!);
+    this.#view.setUint8(2, data[base + 2]!);
+    this.#view.setUint8(3, data[base + 3]!);
+    return this.#view.getInt32(0, true);
   }
 }
 
 export class Uint16Reader implements FieldReader {
-  private offset: number;
-  private view: DataView;
+  #offset: number;
+  #view: DataView;
   public constructor(offset: number) {
-    this.offset = offset;
+    this.#offset = offset;
     const buffer = new ArrayBuffer(2);
-    this.view = new DataView(buffer);
+    this.#view = new DataView(buffer);
   }
 
   public read(data: Uint8Array, index: number): number {
-    const base = index + this.offset;
+    const base = index + this.#offset;
     const size = 2;
     if (data.length < base + size) {
       throw new Error("cannot read Uint16 from data - not enough data");
     }
-    this.view.setUint8(0, data[base]!);
-    this.view.setUint8(1, data[base + 1]!);
-    return this.view.getUint16(0, true);
+    this.#view.setUint8(0, data[base]!);
+    this.#view.setUint8(1, data[base + 1]!);
+    return this.#view.getUint16(0, true);
   }
 }
 
 export class Uint8Reader implements FieldReader {
-  private offset: number;
+  #offset: number;
   public constructor(offset: number) {
-    this.offset = offset;
+    this.#offset = offset;
   }
 
   public read(data: Uint8Array, index: number): number {
-    const base = index + this.offset;
+    const base = index + this.#offset;
     const size = 1;
     if (data.length < base + size) {
       throw new Error("cannot read Uint8 from data - not enough data");
@@ -94,23 +94,23 @@ export class Uint8Reader implements FieldReader {
 }
 
 export class Int16Reader implements FieldReader {
-  private offset: number;
-  private view: DataView;
+  #offset: number;
+  #view: DataView;
   public constructor(offset: number) {
-    this.offset = offset;
+    this.#offset = offset;
     const buffer = new ArrayBuffer(2);
-    this.view = new DataView(buffer);
+    this.#view = new DataView(buffer);
   }
 
   public read(data: Uint8Array, index: number): number {
-    const base = index + this.offset;
+    const base = index + this.#offset;
     const size = 2;
     if (data.length < base + size) {
       throw new Error("cannot read Int16 from data - not enough data");
     }
-    this.view.setUint8(0, data[base]!);
-    this.view.setUint8(1, data[base + 1]!);
-    return this.view.getInt16(0, true);
+    this.#view.setUint8(0, data[base]!);
+    this.#view.setUint8(1, data[base + 1]!);
+    return this.#view.getInt16(0, true);
   }
 }
 

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -68,17 +68,17 @@ type VelodynePlayerOpts = {
 };
 
 export default class VelodynePlayer implements Player {
-  private _id: string = uuidv4(); // Unique ID for this player
-  private _port: number; // Listening UDP port
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState()
-  private _socket?: UdpSocketRenderer;
-  private _seq = 0;
-  private _totalBytesReceived = 0;
-  private _closed: boolean = false; // Whether the player has been completely closed using close()
-  private _topic: Topic = { ...TOPIC }; // The one topic we are "subscribed" to
-  private _topics = [this._topic]; // Stable list of all topics
-  private _topicStats = new Map<string, TopicStats>(); // Message count and timestamps for our single topic
-  private _start: Time; // The time at which we started playing
+  #id: string = uuidv4(); // Unique ID for this player
+  #port: number; // Listening UDP port
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState()
+  #socket?: UdpSocketRenderer;
+  #seq = 0;
+  #totalBytesReceived = 0;
+  #closed: boolean = false; // Whether the player has been completely closed using close()
+  #topic: Topic = { ...TOPIC }; // The one topic we are "subscribed" to
+  #topics = [this.#topic]; // Stable list of all topics
+  #topicStats = new Map<string, TopicStats>(); // Message count and timestamps for our single topic
+  #start: Time; // The time at which we started playing
   private _packets: RawPacket[] = []; // Queue of packets that will form the next parsed message
   private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call
   private _metricsCollector: PlayerMetricsCollectorInterface;
@@ -90,25 +90,25 @@ export default class VelodynePlayer implements Player {
   private _problemsById = new Map<string, PlayerProblem>();
 
   public constructor({ port, metricsCollector }: VelodynePlayerOpts) {
-    this._port = port ?? DEFAULT_VELODYNE_PORT;
-    log.info(`initializing VelodynePlayer on port ${this._port}`);
+    this.#port = port ?? DEFAULT_VELODYNE_PORT;
+    log.info(`initializing VelodynePlayer on port ${this.#port}`);
     this._metricsCollector = metricsCollector;
-    this._start = fromMillis(Date.now());
+    this.#start = fromMillis(Date.now());
     this._metricsCollector.playerConstructed();
     void this._open();
   }
 
   private _open = async (): Promise<void> => {
-    if (this._closed) {
+    if (this.#closed) {
       return;
     }
     this._presence = PlayerPresence.PRESENT;
     this._emitState();
 
-    if (this._socket == undefined) {
+    if (this.#socket == undefined) {
       const net = await Sockets.Create();
-      this._socket = await net.createUdpSocket();
-      this._socket.on("error", (error) => {
+      this.#socket = await net.createUdpSocket();
+      this.#socket.on("error", (error) => {
         this._addProblem(PROBLEM_SOCKET_ERROR, {
           message: "Networking error listening for Velodyne data",
           severity: "error",
@@ -116,24 +116,24 @@ export default class VelodynePlayer implements Player {
           tip: "Check that your are connected to the same local network (subnet) as the Velodyne sensor",
         });
       });
-      this._socket.on("message", this._handleMessage);
+      this.#socket.on("message", this._handleMessage);
     } else {
       try {
-        await this._socket.close();
+        await this.#socket.close();
       } catch (err) {
         log.error(`Failed to close socket: ${err}`);
       }
     }
 
     try {
-      await this._socket.bind({ address: "0.0.0.0", port: this._port });
-      log.debug(`Bound Velodyne UDP listener socket to port ${this._port}`);
+      await this.#socket.bind({ address: "0.0.0.0", port: this.#port });
+      log.debug(`Bound Velodyne UDP listener socket to port ${this.#port}`);
     } catch (error) {
       this._addProblem(PROBLEM_SOCKET_ERROR, {
         message: "Could not bind to the Velodyne UDP data port",
         severity: "error",
         error,
-        tip: `Check that port ${this._port} is not in use by another application`,
+        tip: `Check that port ${this.#port} is not in use by another application`,
       });
     }
   };
@@ -144,11 +144,11 @@ export default class VelodynePlayer implements Player {
     date.setMinutes(0, 0, 0);
     const topOfHour = fromDate(date);
 
-    this._totalBytesReceived += data.byteLength;
+    this.#totalBytesReceived += data.byteLength;
     this._presence = PlayerPresence.PRESENT;
-    this._clearProblem(PROBLEM_SOCKET_ERROR, { skipEmit: true });
+    this.#clearProblem(PROBLEM_SOCKET_ERROR, { skipEmit: true });
 
-    if (this._seq === 0) {
+    if (this.#seq === 0) {
       this._metricsCollector.recordTimeToFirstMsgs();
     }
 
@@ -164,7 +164,7 @@ export default class VelodynePlayer implements Player {
     this._packets.push(rawPacket);
     if (this._packets.length >= numPackets) {
       const message = {
-        header: { seq: this._seq++, stamp: receiveTime, frame_id: rinfo.address },
+        header: { seq: this.#seq++, stamp: receiveTime, frame_id: rinfo.address },
         packets: this._packets.map((raw) => rawPacketToRos(raw, topOfHour)),
       };
 
@@ -180,10 +180,10 @@ export default class VelodynePlayer implements Player {
       this._packets = [];
 
       // Update the message count
-      let stats = this._topicStats.get(TOPIC_NAME);
+      let stats = this.#topicStats.get(TOPIC_NAME);
       if (!stats) {
         stats = { numMessages: 0 };
-        this._topicStats.set(TOPIC_NAME, stats);
+        this.#topicStats.set(TOPIC_NAME, stats);
       }
       stats.numMessages++;
       stats.firstMessageTime ??= receiveTime;
@@ -205,7 +205,7 @@ export default class VelodynePlayer implements Player {
     }
   }
 
-  private _clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
+  #clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
     if (!this._problemsById.delete(id)) {
       return;
     }
@@ -218,7 +218,7 @@ export default class VelodynePlayer implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
@@ -234,19 +234,19 @@ export default class VelodynePlayer implements Player {
     const currentTime = fromMillis(Date.now());
     const messages = this._parsedMessages;
     this._parsedMessages = [];
-    return this._listener({
+    return this.#listener({
       name: "Velodyne",
       presence: this._presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: "velodyne",
-      playerId: this._id,
+      playerId: this.#id,
       problems: this._problems,
 
       activeData: {
         messages,
-        totalBytesReceived: this._totalBytesReceived,
-        startTime: this._start,
+        totalBytesReceived: this.#totalBytesReceived,
+        startTime: this.#start,
         endTime: currentTime,
         currentTime,
         isPlaying: true,
@@ -254,8 +254,8 @@ export default class VelodynePlayer implements Player {
         // We don't support seeking, so we need to set this to any fixed value. Just avoid 0 so
         // that we don't accidentally hit falsy checks.
         lastSeekTime: 1,
-        topics: this._topics,
-        topicStats: new Map(this._topicStats),
+        topics: this.#topics,
+        topicStats: new Map(this.#topicStats),
         datatypes: DATATYPES,
         publishedTopics: undefined,
         subscribedTopics: undefined,
@@ -266,23 +266,23 @@ export default class VelodynePlayer implements Player {
   });
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
+    this.#listener = listener;
     this._emitState();
   }
 
   public close(): void {
-    this._closed = true;
-    if (this._socket) {
-      void this._socket.dispose();
-      this._socket = undefined;
+    this.#closed = true;
+    if (this.#socket) {
+      void this.#socket.dispose();
+      this.#socket = undefined;
     }
     if (this._emitTimer != undefined) {
       clearTimeout(this._emitTimer);
       this._emitTimer = undefined;
     }
     this._metricsCollector.close();
-    this._totalBytesReceived = 0;
-    this._seq = 0;
+    this.#totalBytesReceived = 0;
+    this.#seq = 0;
     this._packets = [];
     this._parsedMessages = [];
   }

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -79,44 +79,44 @@ export default class VelodynePlayer implements Player {
   #topics = [this.#topic]; // Stable list of all topics
   #topicStats = new Map<string, TopicStats>(); // Message count and timestamps for our single topic
   #start: Time; // The time at which we started playing
-  private _packets: RawPacket[] = []; // Queue of packets that will form the next parsed message
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _emitTimer?: ReturnType<typeof setTimeout>;
+  #packets: RawPacket[] = []; // Queue of packets that will form the next parsed message
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #emitTimer?: ReturnType<typeof setTimeout>;
 
   // track issues within the player
-  private _problems: PlayerProblem[] = [];
-  private _problemsById = new Map<string, PlayerProblem>();
+  #problems: PlayerProblem[] = [];
+  #problemsById = new Map<string, PlayerProblem>();
 
   public constructor({ port, metricsCollector }: VelodynePlayerOpts) {
     this.#port = port ?? DEFAULT_VELODYNE_PORT;
     log.info(`initializing VelodynePlayer on port ${this.#port}`);
-    this._metricsCollector = metricsCollector;
+    this.#metricsCollector = metricsCollector;
     this.#start = fromMillis(Date.now());
-    this._metricsCollector.playerConstructed();
-    void this._open();
+    this.#metricsCollector.playerConstructed();
+    void this.#open();
   }
 
-  private _open = async (): Promise<void> => {
+  #open = async (): Promise<void> => {
     if (this.#closed) {
       return;
     }
-    this._presence = PlayerPresence.PRESENT;
-    this._emitState();
+    this.#presence = PlayerPresence.PRESENT;
+    this.#emitState();
 
     if (this.#socket == undefined) {
       const net = await Sockets.Create();
       this.#socket = await net.createUdpSocket();
       this.#socket.on("error", (error) => {
-        this._addProblem(PROBLEM_SOCKET_ERROR, {
+        this.#addProblem(PROBLEM_SOCKET_ERROR, {
           message: "Networking error listening for Velodyne data",
           severity: "error",
           error,
           tip: "Check that your are connected to the same local network (subnet) as the Velodyne sensor",
         });
       });
-      this.#socket.on("message", this._handleMessage);
+      this.#socket.on("message", this.#handleMessage);
     } else {
       try {
         await this.#socket.close();
@@ -129,7 +129,7 @@ export default class VelodynePlayer implements Player {
       await this.#socket.bind({ address: "0.0.0.0", port: this.#port });
       log.debug(`Bound Velodyne UDP listener socket to port ${this.#port}`);
     } catch (error) {
-      this._addProblem(PROBLEM_SOCKET_ERROR, {
+      this.#addProblem(PROBLEM_SOCKET_ERROR, {
         message: "Could not bind to the Velodyne UDP data port",
         severity: "error",
         error,
@@ -138,18 +138,18 @@ export default class VelodynePlayer implements Player {
     }
   };
 
-  private _handleMessage = (data: Uint8Array, rinfo: UdpRemoteInfo): void => {
+  #handleMessage = (data: Uint8Array, rinfo: UdpRemoteInfo): void => {
     const receiveTime = fromMillis(Date.now());
     const date = toDate(receiveTime);
     date.setMinutes(0, 0, 0);
     const topOfHour = fromDate(date);
 
     this.#totalBytesReceived += data.byteLength;
-    this._presence = PlayerPresence.PRESENT;
+    this.#presence = PlayerPresence.PRESENT;
     this.#clearProblem(PROBLEM_SOCKET_ERROR, { skipEmit: true });
 
     if (this.#seq === 0) {
-      this._metricsCollector.recordTimeToFirstMsgs();
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
 
     const rawPacket = new RawPacket(data);
@@ -161,14 +161,14 @@ export default class VelodynePlayer implements Player {
         : packetRate(rawPacket.inferModel() ?? Model.HDL64E);
     const numPackets = Math.ceil(rate / frequency);
 
-    this._packets.push(rawPacket);
-    if (this._packets.length >= numPackets) {
+    this.#packets.push(rawPacket);
+    if (this.#packets.length >= numPackets) {
       const message = {
         header: { seq: this.#seq++, stamp: receiveTime, frame_id: rinfo.address },
-        packets: this._packets.map((raw) => rawPacketToRos(raw, topOfHour)),
+        packets: this.#packets.map((raw) => rawPacketToRos(raw, topOfHour)),
       };
 
-      const sizeInBytes = this._packets.reduce((acc, packet) => acc + packet.data.byteLength, 0);
+      const sizeInBytes = this.#packets.reduce((acc, packet) => acc + packet.data.byteLength, 0);
       const msg: MessageEvent<unknown> = {
         topic: TOPIC_NAME,
         receiveTime,
@@ -176,8 +176,8 @@ export default class VelodynePlayer implements Player {
         sizeInBytes,
         schemaName: TOPIC.schemaName ?? "",
       };
-      this._parsedMessages.push(msg);
-      this._packets = [];
+      this.#parsedMessages.push(msg);
+      this.#packets = [];
 
       // Update the message count
       let stats = this.#topicStats.get(TOPIC_NAME);
@@ -189,59 +189,59 @@ export default class VelodynePlayer implements Player {
       stats.firstMessageTime ??= receiveTime;
       stats.lastMessageTime = receiveTime;
 
-      this._emitState();
+      this.#emitState();
     }
   };
 
-  private _addProblem(
+  #addProblem(
     id: string,
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
   ): void {
-    this._problemsById.set(id, problem);
-    this._problems = Array.from(this._problemsById.values());
+    this.#problemsById.set(id, problem);
+    this.#problems = Array.from(this.#problemsById.values());
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
   #clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
-    if (!this._problemsById.delete(id)) {
+    if (!this.#problemsById.delete(id)) {
       return;
     }
-    this._problems = Array.from(this._problemsById.values());
+    this.#problems = Array.from(this.#problemsById.values());
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
+  #emitState = debouncePromise(() => {
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
     // Time is always moving forward even if we don't get messages from the device.
     // If we are not connected, don't emit updates since we are not longer getting new data
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
     const currentTime = fromMillis(Date.now());
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
     return this.#listener({
       name: "Velodyne",
-      presence: this._presence,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
       profile: "velodyne",
       playerId: this.#id,
-      problems: this._problems,
+      problems: this.#problems,
 
       activeData: {
         messages,
@@ -267,7 +267,7 @@ export default class VelodynePlayer implements Player {
 
   public setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.#listener = listener;
-    this._emitState();
+    this.#emitState();
   }
 
   public close(): void {
@@ -276,15 +276,15 @@ export default class VelodynePlayer implements Player {
       void this.#socket.dispose();
       this.#socket = undefined;
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
+    this.#metricsCollector.close();
     this.#totalBytesReceived = 0;
     this.#seq = 0;
-    this._packets = [];
-    this._parsedMessages = [];
+    this.#packets = [];
+    this.#parsedMessages = [];
   }
 
   public setSubscriptions(_subscriptions: SubscribePayload[]): void {}

--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -90,12 +90,12 @@ export default class LayoutManager implements ILayoutManager {
     const method = descriptor.value!;
     descriptor.value = async function (...args) {
       try {
-        this.busyCount++;
-        this.emitter.emit("busychange");
+        this.#busyCount++;
+        this.#emitter.emit("busychange");
         return await method.apply(this, args);
       } finally {
-        this.busyCount--;
-        this.emitter.emit("busychange");
+        this.#busyCount--;
+        this.#emitter.emit("busychange");
       }
     };
   }
@@ -592,7 +592,7 @@ export default class LayoutManager implements ILayoutManager {
     operations: readonly (SyncOperation & { local: false })[],
     abortSignal: AbortSignal,
   ): Promise<void> {
-    const { remote } = this;
+    const remote = this.#remote;
     if (!remote) {
       return;
     }

--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -69,14 +69,14 @@ export default class LayoutManager implements ILayoutManager {
    * and then writing a single layout, or writing one and deleting another) from getting
    * interleaved.
    */
-  private local: MutexLocked<NamespacedLayoutStorage>;
-  private remote: IRemoteLayoutStorage | undefined;
+  #local: MutexLocked<NamespacedLayoutStorage>;
+  #remote: IRemoteLayoutStorage | undefined;
 
   public readonly supportsSharing: boolean;
 
-  private emitter = new EventEmitter<LayoutManagerEventTypes>();
+  #emitter = new EventEmitter<LayoutManagerEventTypes>();
 
-  private busyCount = 0;
+  #busyCount = 0;
 
   /**
    * A decorator to emit busy events before and after an async operation so the UI can show that the
@@ -102,7 +102,7 @@ export default class LayoutManager implements ILayoutManager {
 
   // eslint-disable-next-line no-restricted-syntax
   public get isBusy(): boolean {
-    return this.busyCount > 0;
+    return this.#busyCount > 0;
   }
 
   public isOnline = false;
@@ -112,12 +112,12 @@ export default class LayoutManager implements ILayoutManager {
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   public setOnline(online: boolean): void {
     this.isOnline = online;
-    this.emitter.emit("onlinechange");
+    this.#emitter.emit("onlinechange");
   }
 
   public setError(error: undefined | Error): void {
     this.error = error;
-    this.emitter.emit("errorchange");
+    this.#emitter.emit("errorchange");
   }
 
   public constructor({
@@ -127,7 +127,7 @@ export default class LayoutManager implements ILayoutManager {
     local: ILayoutStorage;
     remote: IRemoteLayoutStorage | undefined;
   }) {
-    this.local = new MutexLocked(
+    this.#local = new MutexLocked(
       new NamespacedLayoutStorage(
         new WriteThroughLayoutCache(local),
         remote
@@ -141,7 +141,7 @@ export default class LayoutManager implements ILayoutManager {
         },
       ),
     );
-    this.remote = remote;
+    this.#remote = remote;
     this.supportsSharing = remote != undefined;
   }
 
@@ -149,28 +149,28 @@ export default class LayoutManager implements ILayoutManager {
     name: E,
     listener: EventEmitter.EventListener<LayoutManagerEventTypes, E>,
   ): void {
-    this.emitter.on(name, listener);
+    this.#emitter.on(name, listener);
   }
   public off<E extends EventEmitter.EventNames<LayoutManagerEventTypes>>(
     name: E,
     listener: EventEmitter.EventListener<LayoutManagerEventTypes, E>,
   ): void {
-    this.emitter.off(name, listener);
+    this.#emitter.off(name, listener);
   }
 
-  private notifyChangeListeners(event: LayoutManagerChangeEvent) {
-    queueMicrotask(() => this.emitter.emit("change", event));
+  #notifyChangeListeners(event: LayoutManagerChangeEvent) {
+    queueMicrotask(() => this.#emitter.emit("change", event));
   }
 
   public async getLayouts(): Promise<readonly Layout[]> {
-    return await this.local.runExclusive(async (local) => {
+    return await this.#local.runExclusive(async (local) => {
       const layouts = await local.list();
       return layouts.filter((layout) => !layoutAppearsDeleted(layout));
     });
   }
 
   public async getLayout(id: LayoutID): Promise<Layout | undefined> {
-    const existingLocal = await this.local.runExclusive(async (local) => {
+    const existingLocal = await this.#local.runExclusive(async (local) => {
       return await local.get(id);
     });
 
@@ -188,13 +188,13 @@ export default class LayoutManager implements ILayoutManager {
 
     log.debug(`Attempting to fetch from remote id:${id}`);
     // We couldn't find an existing local layout for our id, so we attempt to load the remote one
-    const remoteLayout = await this.remote?.getLayout(id);
+    const remoteLayout = await this.#remote?.getLayout(id);
     if (!remoteLayout) {
       log.debug(`No remote layout with id:${id}`);
       return undefined;
     }
 
-    return await this.local.runExclusive(async (local) => {
+    return await this.#local.runExclusive(async (local) => {
       // Layout sync may have happened while we fetched the remote layout.
       // We see if we have the layout locally and use that before caching the fetched remote layout.
       const localLayout = await local.get(id);
@@ -227,20 +227,20 @@ export default class LayoutManager implements ILayoutManager {
   }): Promise<Layout> {
     const data = migratePanelsState(unmigratedData);
     if (layoutPermissionIsShared(permission)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot share a layout while offline");
       }
-      const newLayout = await this.remote.saveNewLayout({
+      const newLayout = await this.#remote.saveNewLayout({
         id: uuidv4() as LayoutID,
         name,
         data,
         permission,
         savedAt: new Date().toISOString() as ISO8601Timestamp,
       });
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             id: newLayout.id,
@@ -251,11 +251,11 @@ export default class LayoutManager implements ILayoutManager {
             syncInfo: { status: "tracked", lastRemoteSavedAt: newLayout.savedAt },
           }),
       );
-      this.notifyChangeListeners({ type: "change", updatedLayout: undefined });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
       return result;
     }
 
-    const newLayout = await this.local.runExclusive(
+    const newLayout = await this.#local.runExclusive(
       async (local) =>
         await local.put({
           id: uuidv4() as LayoutID,
@@ -263,10 +263,10 @@ export default class LayoutManager implements ILayoutManager {
           permission,
           baseline: { data, savedAt: new Date().toISOString() as ISO8601Timestamp },
           working: undefined,
-          syncInfo: this.remote ? { status: "new", lastRemoteSavedAt: undefined } : undefined,
+          syncInfo: this.#remote ? { status: "new", lastRemoteSavedAt: undefined } : undefined,
         }),
     );
-    this.notifyChangeListeners({ type: "change", updatedLayout: newLayout });
+    this.#notifyChangeListeners({ type: "change", updatedLayout: newLayout });
     return newLayout;
   }
 
@@ -281,7 +281,7 @@ export default class LayoutManager implements ILayoutManager {
     data: LayoutData | undefined;
   }): Promise<Layout> {
     const now = new Date().toISOString() as ISO8601Timestamp;
-    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
     if (!localLayout) {
       throw new Error(`Cannot update layout ${id} because it does not exist`);
     }
@@ -297,14 +297,14 @@ export default class LayoutManager implements ILayoutManager {
 
     // Renames of shared layouts go directly to the server
     if (name != undefined && layoutIsShared(localLayout)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot update a shared layout while offline");
       }
-      const updatedBaseline = await updateOrFetchLayout(this.remote, { id, name, savedAt: now });
-      const result = await this.local.runExclusive(
+      const updatedBaseline = await updateOrFetchLayout(this.#remote, { id, name, savedAt: now });
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -314,15 +314,15 @@ export default class LayoutManager implements ILayoutManager {
             syncInfo: { status: "tracked", lastRemoteSavedAt: updatedBaseline.savedAt },
           }),
       );
-      this.notifyChangeListeners({ type: "change", updatedLayout: result });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
       return result;
     } else {
       const isRename =
-        this.remote != undefined &&
+        this.#remote != undefined &&
         name != undefined &&
         localLayout.syncInfo != undefined &&
         localLayout.syncInfo.status !== "new";
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -336,30 +336,30 @@ export default class LayoutManager implements ILayoutManager {
               : localLayout.syncInfo,
           }),
       );
-      this.notifyChangeListeners({ type: "change", updatedLayout: result });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
       return result;
     }
   }
 
   @LayoutManager.withBusyStatus
   public async deleteLayout({ id }: { id: LayoutID }): Promise<void> {
-    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
     if (!localLayout) {
       throw new Error(`Cannot update layout ${id} because it does not exist`);
     }
     if (layoutIsShared(localLayout)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (localLayout.syncInfo?.status !== "remotely-deleted") {
         if (!this.isOnline) {
           throw new Error("Cannot delete a shared layout while offline");
         }
-        await this.remote.deleteLayout(id);
+        await this.#remote.deleteLayout(id);
       }
     }
-    await this.local.runExclusive(async (local) => {
-      if (this.remote && !layoutIsShared(localLayout)) {
+    await this.#local.runExclusive(async (local) => {
+      if (this.#remote && !layoutIsShared(localLayout)) {
         await local.put({
           ...localLayout,
           working: {
@@ -376,29 +376,29 @@ export default class LayoutManager implements ILayoutManager {
         await local.delete(id);
       }
     });
-    this.notifyChangeListeners({ type: "delete", layoutId: id });
+    this.#notifyChangeListeners({ type: "delete", layoutId: id });
   }
 
   @LayoutManager.withBusyStatus
   public async overwriteLayout({ id }: { id: LayoutID }): Promise<Layout> {
-    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
     if (!localLayout) {
       throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
     }
     const now = new Date().toISOString() as ISO8601Timestamp;
     if (layoutIsShared(localLayout)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot save a shared layout while offline");
       }
-      const updatedBaseline = await updateOrFetchLayout(this.remote, {
+      const updatedBaseline = await updateOrFetchLayout(this.#remote, {
         id,
         data: localLayout.working?.data ?? localLayout.baseline.data,
         savedAt: now,
       });
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -407,10 +407,10 @@ export default class LayoutManager implements ILayoutManager {
             syncInfo: { status: "tracked", lastRemoteSavedAt: updatedBaseline.savedAt },
           }),
       );
-      this.notifyChangeListeners({ type: "change", updatedLayout: result });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
       return result;
     } else {
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -420,19 +420,19 @@ export default class LayoutManager implements ILayoutManager {
             },
             working: undefined,
             syncInfo:
-              this.remote && localLayout.syncInfo?.status !== "new"
+              this.#remote && localLayout.syncInfo?.status !== "new"
                 ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
                 : localLayout.syncInfo,
           }),
       );
-      this.notifyChangeListeners({ type: "change", updatedLayout: result });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
       return result;
     }
   }
 
   @LayoutManager.withBusyStatus
   public async revertLayout({ id }: { id: LayoutID }): Promise<Layout> {
-    const result = await this.local.runExclusive(async (local) => {
+    const result = await this.#local.runExclusive(async (local) => {
       const layout = await local.get(id);
       if (!layout) {
         throw new Error(`Cannot revert layout id ${id} because it does not exist`);
@@ -442,14 +442,14 @@ export default class LayoutManager implements ILayoutManager {
         working: undefined,
       });
     });
-    this.notifyChangeListeners({ type: "change", updatedLayout: result });
+    this.#notifyChangeListeners({ type: "change", updatedLayout: result });
     return result;
   }
 
   @LayoutManager.withBusyStatus
   public async makePersonalCopy({ id, name }: { id: LayoutID; name: string }): Promise<Layout> {
     const now = new Date().toISOString() as ISO8601Timestamp;
-    const result = await this.local.runExclusive(async (local) => {
+    const result = await this.#local.runExclusive(async (local) => {
       const layout = await local.get(id);
       if (!layout) {
         throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
@@ -465,12 +465,12 @@ export default class LayoutManager implements ILayoutManager {
       await local.put({ ...layout, working: undefined });
       return newLayout;
     });
-    this.notifyChangeListeners({ type: "change", updatedLayout: undefined });
+    this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
     return result;
   }
 
   /** Ensures at most one sync operation is in progress at a time */
-  private currentSync?: Promise<void>;
+  #currentSync?: Promise<void>;
 
   /**
    * Attempt to synchronize the local cache with remote storage. At minimum this incurs a fetch of
@@ -479,16 +479,16 @@ export default class LayoutManager implements ILayoutManager {
    */
   @LayoutManager.withBusyStatus
   public async syncWithRemote(abortSignal: AbortSignal): Promise<void> {
-    if (this.currentSync) {
+    if (this.#currentSync) {
       log.debug("Layout sync is already in progress");
-      return await this.currentSync;
+      return await this.#currentSync;
     }
     const start = performance.now();
     try {
       log.debug("Starting layout sync");
-      this.currentSync = this.syncWithRemoteImpl(abortSignal);
-      await this.currentSync;
-      this.notifyChangeListeners({ type: "change", updatedLayout: undefined });
+      this.#currentSync = this.#syncWithRemoteImpl(abortSignal);
+      await this.#currentSync;
+      this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
       if (this.error) {
         this.setError(undefined);
       }
@@ -496,19 +496,19 @@ export default class LayoutManager implements ILayoutManager {
       this.setError(error);
       throw error;
     } finally {
-      this.currentSync = undefined;
+      this.#currentSync = undefined;
       log.debug(`Completed sync in ${((performance.now() - start) / 1000).toFixed(2)}s`);
     }
   }
 
-  private async syncWithRemoteImpl(abortSignal: AbortSignal): Promise<void> {
-    if (!this.remote || !this.isOnline) {
+  async #syncWithRemoteImpl(abortSignal: AbortSignal): Promise<void> {
+    if (!this.#remote || !this.isOnline) {
       return;
     }
 
     const [localLayouts, remoteLayouts] = await Promise.all([
-      this.local.runExclusive(async (local) => await local.list()),
-      this.remote.getLayouts(),
+      this.#local.runExclusive(async (local) => await local.list()),
+      this.#remote.getLayouts(),
     ]);
     if (abortSignal.aborted) {
       return;
@@ -520,16 +520,16 @@ export default class LayoutManager implements ILayoutManager {
       (op): op is typeof op & { local: true } => op.local,
     );
     await Promise.all([
-      this.performLocalSyncOperations(localOps, abortSignal),
-      this.performRemoteSyncOperations(remoteOps, abortSignal),
+      this.#performLocalSyncOperations(localOps, abortSignal),
+      this.#performRemoteSyncOperations(remoteOps, abortSignal),
     ]);
   }
 
-  private async performLocalSyncOperations(
+  async #performLocalSyncOperations(
     operations: readonly (SyncOperation & { local: true })[],
     abortSignal: AbortSignal,
   ): Promise<void> {
-    await this.local.runExclusive(async (local) => {
+    await this.#local.runExclusive(async (local) => {
       for (const operation of operations) {
         if (abortSignal.aborted) {
           return;
@@ -550,7 +550,7 @@ export default class LayoutManager implements ILayoutManager {
               `Deleting local layout ${operation.localLayout.id}, whose sync status was ${operation.localLayout.syncInfo?.status}`,
             );
             await local.delete(operation.localLayout.id);
-            this.notifyChangeListeners({ type: "delete", layoutId: operation.localLayout.id });
+            this.#notifyChangeListeners({ type: "delete", layoutId: operation.localLayout.id });
             break;
 
           case "add-to-cache": {
@@ -588,7 +588,7 @@ export default class LayoutManager implements ILayoutManager {
     });
   }
 
-  private async performRemoteSyncOperations(
+  async #performRemoteSyncOperations(
     operations: readonly (SyncOperation & { local: false })[],
     abortSignal: AbortSignal,
   ): Promise<void> {
@@ -663,7 +663,7 @@ export default class LayoutManager implements ILayoutManager {
       }),
     );
 
-    await this.local.runExclusive(async (local) => {
+    await this.#local.runExclusive(async (local) => {
       await Promise.all(cleanups.map(async (cleanup) => await cleanup(local)));
     });
   }

--- a/packages/studio-base/src/services/LayoutManager/NamespacedLayoutStorage.ts
+++ b/packages/studio-base/src/services/LayoutManager/NamespacedLayoutStorage.ts
@@ -11,7 +11,7 @@ const log = Logger.getLogger(__filename);
  * A wrapper around ILayoutStorage for a particular namespace.
  */
 export class NamespacedLayoutStorage {
-  private migration: Promise<void>;
+  #migration: Promise<void>;
   public constructor(
     private storage: ILayoutStorage,
     private namespace: string,
@@ -20,7 +20,7 @@ export class NamespacedLayoutStorage {
       importFromNamespace,
     }: { migrateUnnamespacedLayouts: boolean; importFromNamespace: string | undefined },
   ) {
-    this.migration = (async function () {
+    this.#migration = (async function () {
       if (migrateUnnamespacedLayouts) {
         await storage
           .migrateUnnamespacedLayouts?.(namespace)
@@ -39,19 +39,19 @@ export class NamespacedLayoutStorage {
   }
 
   public async list(): Promise<readonly Layout[]> {
-    await this.migration;
+    await this.#migration;
     return await this.storage.list(this.namespace);
   }
   public async get(id: LayoutID): Promise<Layout | undefined> {
-    await this.migration;
+    await this.#migration;
     return await this.storage.get(this.namespace, id);
   }
   public async put(layout: Layout): Promise<Layout> {
-    await this.migration;
+    await this.#migration;
     return await this.storage.put(this.namespace, layout);
   }
   public async delete(id: LayoutID): Promise<void> {
-    await this.migration;
+    await this.#migration;
     await this.storage.delete(this.namespace, id);
   }
 }

--- a/packages/studio-base/src/services/MockLayoutStorage.ts
+++ b/packages/studio-base/src/services/MockLayoutStorage.ts
@@ -6,34 +6,34 @@ import { ILayoutStorage, Layout } from "@foxglove/studio-base/services/ILayoutSt
 
 // ts-prune-ignore-next
 export default class MockLayoutStorage implements ILayoutStorage {
-  private layoutsByIdByNamespace: Map<string, Map<string, Layout>>;
+  #layoutsByIdByNamespace: Map<string, Map<string, Layout>>;
 
   public constructor(namespace: string, layouts: Layout[] = []) {
-    this.layoutsByIdByNamespace = new Map([
+    this.#layoutsByIdByNamespace = new Map([
       [namespace, new Map(layouts.map((layout) => [layout.id, layout]))],
     ]);
   }
 
   public async list(namespace: string): Promise<readonly Layout[]> {
-    return Array.from(this.layoutsByIdByNamespace.get(namespace)?.values() ?? []);
+    return Array.from(this.#layoutsByIdByNamespace.get(namespace)?.values() ?? []);
   }
 
   public async get(namespace: string, id: string): Promise<Layout | undefined> {
-    return this.layoutsByIdByNamespace.get(namespace)?.get(id);
+    return this.#layoutsByIdByNamespace.get(namespace)?.get(id);
   }
 
   public async put(namespace: string, layout: Layout): Promise<Layout> {
-    let layoutsById = this.layoutsByIdByNamespace.get(namespace);
+    let layoutsById = this.#layoutsByIdByNamespace.get(namespace);
     if (!layoutsById) {
       layoutsById = new Map();
-      this.layoutsByIdByNamespace.set(namespace, layoutsById);
+      this.#layoutsByIdByNamespace.set(namespace, layoutsById);
     }
     layoutsById.set(layout.id, layout);
     return layout;
   }
 
   public async delete(namespace: string, id: string): Promise<void> {
-    this.layoutsByIdByNamespace.get(namespace)?.delete(id);
+    this.#layoutsByIdByNamespace.get(namespace)?.delete(id);
   }
 
   public async importLayouts(): Promise<void> {}

--- a/packages/studio-base/src/test/MemoryStorage.ts
+++ b/packages/studio-base/src/test/MemoryStorage.ts
@@ -17,40 +17,40 @@ const DEFAULT_LOCAL_STORAGE__QUOTA = 5000000;
 
 export default class MemoryStorage {
   // Use `__` to mark the fields as internal so we can filter them out in Storage when getting keys using Object.keys(storage).
-  private _internal_items: Record<string, string> = {};
-  private _internal_quota: number;
+  #internal_items: Record<string, string> = {};
+  #internal_quota: number;
   [key: string]: unknown;
 
   public constructor(quota?: number) {
-    this._internal_quota = quota ?? DEFAULT_LOCAL_STORAGE__QUOTA;
+    this.#internal_quota = quota ?? DEFAULT_LOCAL_STORAGE__QUOTA;
   }
 
   public clear(): void {
-    this._internal_items = {};
+    this.#internal_items = {};
   }
 
   public getItem(key: string): string | undefined {
-    return this._internal_items[key];
+    return this.#internal_items[key];
   }
 
-  private _getUsedSize(): number {
-    return Object.keys(this._internal_items).reduce((memo, key) => {
+  #getUsedSize(): number {
+    return Object.keys(this.#internal_items).reduce((memo, key) => {
       return memo + new Blob([this.getItem(key)!]).size;
     }, 0);
   }
 
   public setItem(key: string, value: string): void {
     const valueByteSize = new Blob([value]).size;
-    const newSize = this._getUsedSize() + valueByteSize;
-    if (newSize > this._internal_quota) {
+    const newSize = this.#getUsedSize() + valueByteSize;
+    if (newSize > this.#internal_quota) {
       throw new Error("Exceeded storage limit");
     }
-    this._internal_items[key] = value;
+    this.#internal_items[key] = value;
     this[key] = value;
   }
 
   public removeItem(key: string): void {
-    delete this._internal_items[key];
+    delete this.#internal_items[key];
     delete this[key];
   }
 }

--- a/packages/studio-base/src/test/setup.ts
+++ b/packages/studio-base/src/test/setup.ts
@@ -43,10 +43,10 @@ global.React = require("react");
 
 // Jest does not include ResizeObserver.
 class ResizeObserverMock {
-  private _callback: ResizeObserverCallback;
+  #callback: ResizeObserverCallback;
 
   public constructor(callback: ResizeObserverCallback) {
-    this._callback = callback;
+    this.#callback = callback;
   }
 
   public disconnect() {}
@@ -55,7 +55,7 @@ class ResizeObserverMock {
     const entry = {
       contentRect: { width: 150, height: 150 },
     };
-    this._callback([entry as ResizeObserverEntry], this);
+    this.#callback([entry as ResizeObserverEntry], this);
   }
 
   public unobserve() {}

--- a/packages/studio-base/src/util/BrowserHttpReader.ts
+++ b/packages/studio-base/src/util/BrowserHttpReader.ts
@@ -17,10 +17,10 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 // A file reader that reads from a remote HTTP URL, for usage in the browser (not for node.js).
 export default class BrowserHttpReader implements FileReader {
-  private _url: string;
+  #url: string;
 
   public constructor(url: string) {
-    this._url = url;
+    this.#url = url;
   }
 
   public async open(): Promise<{ size: number; identifier?: string }> {
@@ -36,7 +36,7 @@ export default class BrowserHttpReader implements FileReader {
       // it may add a `range` header to the request, which causes some servers to omit the
       // `accept-ranges` header in the response.
       const controller = new AbortController();
-      response = await fetch(this._url, { signal: controller.signal, cache: "no-store" });
+      response = await fetch(this.#url, { signal: controller.signal, cache: "no-store" });
       controller.abort();
     } catch (error) {
       let errMsg = `Fetching remote file failed. ${error}`;
@@ -50,7 +50,7 @@ export default class BrowserHttpReader implements FileReader {
     }
     if (!response.ok) {
       throw new Error(
-        `Fetching remote file failed. <${this._url}> Status code: ${response.status}.`,
+        `Fetching remote file failed. <${this.#url}> Status code: ${response.status}.`,
       );
     }
     if (response.headers.get("accept-ranges") !== "bytes") {
@@ -66,7 +66,7 @@ export default class BrowserHttpReader implements FileReader {
     }
     const size = response.headers.get("content-length");
     if (size == undefined) {
-      throw new Error(`Remote file is missing file size. <${this._url}>`);
+      throw new Error(`Remote file is missing file size. <${this.#url}>`);
     }
     return {
       size: parseInt(size),
@@ -77,7 +77,7 @@ export default class BrowserHttpReader implements FileReader {
 
   public fetch(offset: number, length: number): FileStream {
     const headers = new Headers({ range: `bytes=${offset}-${offset + (length - 1)}` });
-    const reader = new FetchReader(this._url, { headers });
+    const reader = new FetchReader(this.#url, { headers });
     reader.read();
     return reader;
   }

--- a/packages/studio-base/src/util/CachedFilelike.test.ts
+++ b/packages/studio-base/src/util/CachedFilelike.test.ts
@@ -16,26 +16,26 @@ import delay from "@foxglove/studio-base/util/delay";
 import CachedFilelike, { FileReader, FileStream } from "./CachedFilelike";
 
 class InMemoryFileReader implements FileReader {
-  private _buffer: Uint8Array;
+  #buffer: Uint8Array;
 
   public constructor(bufferObj: Uint8Array) {
-    this._buffer = bufferObj;
+    this.#buffer = bufferObj;
   }
 
   public async open() {
-    return { size: this._buffer.byteLength };
+    return { size: this.#buffer.byteLength };
   }
 
   public fetch(offset: number, length: number): FileStream {
-    if (offset + length > this._buffer.byteLength) {
+    if (offset + length > this.#buffer.byteLength) {
       throw new Error(
-        `Read offset=${offset} length=${length} past buffer length ${this._buffer.byteLength}`,
+        `Read offset=${offset} length=${length} past buffer length ${this.#buffer.byteLength}`,
       );
     }
     return {
       on: (type: "data" | "error", callback: ((_: Uint8Array) => void) & ((_: Error) => void)) => {
         if (type === "data") {
-          setTimeout(() => callback(this._buffer.slice(offset, offset + length)), 0);
+          setTimeout(() => callback(this.#buffer.slice(offset, offset + length)), 0);
         }
       },
       destroy() {

--- a/packages/studio-base/src/util/CachedFilelike.ts
+++ b/packages/studio-base/src/util/CachedFilelike.ts
@@ -72,21 +72,21 @@ interface ILogger {
 }
 
 export default class CachedFilelike implements Filelike {
-  private _fileReader: FileReader;
-  private _cacheSizeInBytes: number = Infinity;
-  private _fileSize?: number;
-  private _virtualBuffer: VirtualLRUBuffer;
-  private _log: ILogger;
-  private _closed: boolean = false;
+  #fileReader: FileReader;
+  #cacheSizeInBytes: number = Infinity;
+  #fileSize?: number;
+  #virtualBuffer: VirtualLRUBuffer;
+  #log: ILogger;
+  #closed: boolean = false;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
-  private _keepReconnectingCallback?: (reconnecting: boolean) => void;
+  #keepReconnectingCallback?: (reconnecting: boolean) => void;
 
   // The current active connection, if there is one. `remainingRange.start` gets updated whenever
   // we receive new data, so it truly is the remaining range that it is going to download.
-  private _currentConnection: { stream: FileStream; remainingRange: Range } | undefined;
+  #currentConnection: { stream: FileStream; remainingRange: Range } | undefined;
 
   // A list of read requests and associated ranges for all read requests, in order.
-  private _readRequests: {
+  #readRequests: {
     range: Range;
     resolve: (_: Uint8Array) => void;
     reject: (_: Error) => void;
@@ -94,7 +94,7 @@ export default class CachedFilelike implements Filelike {
   }[] = [];
 
   // The range.end of the last read request that we resolved. Useful for reading ahead a bit.
-  private _lastResolvedCallbackEnd?: number;
+  #lastResolvedCallbackEnd?: number;
 
   // The last time we've encountered an error;
   private _lastErrorTime?: number;
@@ -106,42 +106,42 @@ export default class CachedFilelike implements Filelike {
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     keepReconnectingCallback?: (reconnecting: boolean) => void;
   }) {
-    this._fileReader = options.fileReader;
-    this._cacheSizeInBytes = options.cacheSizeInBytes ?? this._cacheSizeInBytes;
-    this._keepReconnectingCallback = options.keepReconnectingCallback;
-    this._log = options.log ?? log;
-    this._virtualBuffer = new VirtualLRUBuffer({ size: 0 });
+    this.#fileReader = options.fileReader;
+    this.#cacheSizeInBytes = options.cacheSizeInBytes ?? this.#cacheSizeInBytes;
+    this.#keepReconnectingCallback = options.keepReconnectingCallback;
+    this.#log = options.log ?? log;
+    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
   }
 
   public async open(): Promise<void> {
-    if (this._fileSize != undefined) {
+    if (this.#fileSize != undefined) {
       return;
     }
-    const { size } = await this._fileReader.open();
-    this._fileSize = size;
-    if (this._cacheSizeInBytes >= size) {
+    const { size } = await this.#fileReader.open();
+    this.#fileSize = size;
+    if (this.#cacheSizeInBytes >= size) {
       // If we have a cache limit that exceeds the file size, then we don't need to limit ourselves
       // to small blocks. This way `VirtualLRUBuffer#slice` will be faster since we'll almost always
       // not need to copy from multiple blocks into a new `Buffer` instance.
-      this._virtualBuffer = new VirtualLRUBuffer({ size });
+      this.#virtualBuffer = new VirtualLRUBuffer({ size });
     } else {
-      this._virtualBuffer = new VirtualLRUBuffer({
+      this.#virtualBuffer = new VirtualLRUBuffer({
         size,
         blockSize: CACHE_BLOCK_SIZE,
         // Rather create too many blocks than too few (Math.ceil), and always add one block,
         // to allow for a read range not starting or ending perfectly at a block boundary.
-        numberOfBlocks: Math.ceil(this._cacheSizeInBytes / CACHE_BLOCK_SIZE) + 2,
+        numberOfBlocks: Math.ceil(this.#cacheSizeInBytes / CACHE_BLOCK_SIZE) + 2,
       });
     }
-    this._log.info(`Opening file with size ${bytesToMiB(this._fileSize)}MiB`);
+    this.#log.info(`Opening file with size ${bytesToMiB(this.#fileSize)}MiB`);
   }
 
   // Get the file size. Requires a call to `open()` or `read()` first.
   public size(): number {
-    if (this._fileSize == undefined) {
+    if (this.#fileSize == undefined) {
       throw new Error("CachedFilelike has not been opened");
     }
-    return this._fileSize;
+    return this.#fileSize;
   }
 
   // Potentially performance-sensitive; await can be expensive
@@ -156,8 +156,8 @@ export default class CachedFilelike implements Filelike {
     if (offset < 0 || length < 0) {
       throw new Error("CachedFilelike#read invalid input");
     }
-    if (length > this._cacheSizeInBytes) {
-      throw new Error(`Requested more data than cache size: ${length} > ${this._cacheSizeInBytes}`);
+    if (length > this.#cacheSizeInBytes) {
+      throw new Error(`Requested more data than cache size: ${length} > ${this.#cacheSizeInBytes}`);
     }
 
     // Potentially performance-sensitive; await can be expensive
@@ -170,8 +170,8 @@ export default class CachedFilelike implements Filelike {
             return;
           }
 
-          this._readRequests.push({ range, resolve, reject, requestTime: Date.now() });
-          this._updateState();
+          this.#readRequests.push({ range, resolve, reject, requestTime: Date.now() });
+          this.#updateState();
         })
         .catch((err) => {
           reject(err);
@@ -180,19 +180,19 @@ export default class CachedFilelike implements Filelike {
   }
 
   // Gets called any time our connection or read requests change.
-  private _updateState(): void {
-    if (this._closed) {
+  #updateState(): void {
+    if (this.#closed) {
       return;
     }
 
     // First, see if there are any read requests that we can resolve now.
-    this._readRequests = this._readRequests.filter(({ range, resolve }) => {
-      if (!this._virtualBuffer.hasData(range.start, range.end)) {
+    this.#readRequests = this.#readRequests.filter(({ range, resolve }) => {
+      if (!this.#virtualBuffer.hasData(range.start, range.end)) {
         return true;
       }
 
-      this._lastResolvedCallbackEnd = range.end;
-      const buffer = this._virtualBuffer.slice(range.start, range.end);
+      this.#lastResolvedCallbackEnd = range.end;
+      const buffer = this.#virtualBuffer.slice(range.start, range.end);
 
       resolve(buffer);
       return false;
@@ -202,63 +202,63 @@ export default class CachedFilelike implements Filelike {
 
     // Then see if we need to set a new connection based on the new connection and read requests state.
     const newConnection = getNewConnection({
-      currentRemainingRange: this._currentConnection
-        ? this._currentConnection.remainingRange
+      currentRemainingRange: this.#currentConnection
+        ? this.#currentConnection.remainingRange
         : undefined,
-      readRequestRange: this._readRequests[0] ? this._readRequests[0].range : undefined,
-      downloadedRanges: this._virtualBuffer.getRangesWithData(),
-      lastResolvedCallbackEnd: this._lastResolvedCallbackEnd,
-      maxRequestSize: this._cacheSizeInBytes,
+      readRequestRange: this.#readRequests[0] ? this.#readRequests[0].range : undefined,
+      downloadedRanges: this.#virtualBuffer.getRangesWithData(),
+      lastResolvedCallbackEnd: this.#lastResolvedCallbackEnd,
+      maxRequestSize: this.#cacheSizeInBytes,
       fileSize: size,
       continueDownloadingThreshold: CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION,
     });
     if (newConnection) {
-      this._setConnection(newConnection);
+      this.#setConnection(newConnection);
     }
   }
 
   // Replace the current connection with a new one, spanning a certain range.
-  private _setConnection(range: Range): void {
-    this._log.debug(`Setting new connection @ ${rangeToString(range)}`);
+  #setConnection(range: Range): void {
+    this.#log.debug(`Setting new connection @ ${rangeToString(range)}`);
 
-    if (this._currentConnection) {
+    if (this.#currentConnection) {
       // Destroy the current connection if there is one.
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       currentConnection.stream.destroy();
-      this._log.debug(
+      this.#log.debug(
         `Destroyed current connection @ ${rangeToString(currentConnection.remainingRange)}`,
       );
     }
 
     // Start the stream, and update the current connection state.
-    const stream = this._fileReader.fetch(range.start, range.end - range.start);
-    this._currentConnection = { stream, remainingRange: range };
+    const stream = this.#fileReader.fetch(range.start, range.end - range.start);
+    this.#currentConnection = { stream, remainingRange: range };
 
     stream.on("error", (error: Error) => {
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       if (!currentConnection || stream !== currentConnection.stream) {
         return; // Ignore errors from old streams.
       }
 
-      if (this._keepReconnectingCallback) {
+      if (this.#keepReconnectingCallback) {
         // If this callback is set, just keep retrying.
         if (this._lastErrorTime == undefined) {
           // And if this is the first error, let the callback know.
-          this._keepReconnectingCallback(true);
+          this.#keepReconnectingCallback(true);
         }
       } else {
         // Otherwise, if we get two errors in a short timespan (100ms) then there is probably a
         // serious error, we resolve all remaining callbacks with errors and close out.
         const lastErrorTime = this._lastErrorTime;
         if (lastErrorTime != undefined && Date.now() - lastErrorTime < 100) {
-          this._log.error(
+          this.#log.error(
             `Connection @ ${rangeToString(
               range,
             )} threw another error; closing: ${error.toString()}`,
           );
 
-          this._closed = true;
-          for (const request of this._readRequests) {
+          this.#closed = true;
+          for (const request of this.#readRequests) {
             request.reject(error);
           }
           return;
@@ -267,13 +267,13 @@ export default class CachedFilelike implements Filelike {
 
       // When we encounter an error there is usually a bad connection or timeout or so, so just
       // mark the current connection as destroyed, and try again.
-      this._log.info(
+      this.#log.info(
         `Connection @ ${rangeToString(range)} threw error; trying to continue: ${error.toString()}`,
       );
       this._lastErrorTime = Date.now();
       currentConnection.stream.destroy();
-      delete this._currentConnection;
-      this._updateState();
+      delete this.#currentConnection;
+      this.#updateState();
     });
 
     // Handle the data stream.
@@ -281,7 +281,7 @@ export default class CachedFilelike implements Filelike {
     let bytesRead = 0;
     let lastReportedBytesRead = 0;
     stream.on("data", (chunk: Uint8Array) => {
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       if (!currentConnection || stream !== currentConnection.stream) {
         return; // Ignore data from old streams.
       }
@@ -289,14 +289,14 @@ export default class CachedFilelike implements Filelike {
       if (this._lastErrorTime != undefined) {
         // If we had an error before, then that has clearly been resolved since we received some data.
         this._lastErrorTime = undefined;
-        if (this._keepReconnectingCallback) {
+        if (this.#keepReconnectingCallback) {
           // And if we had a callback, let it know that the issue has been resolved.
-          this._keepReconnectingCallback(false);
+          this.#keepReconnectingCallback(false);
         }
       }
 
       // Copy the data into the VirtualLRUBuffer.
-      this._virtualBuffer.copyFrom(chunk, currentConnection.remainingRange.start);
+      this.#virtualBuffer.copyFrom(chunk, currentConnection.remainingRange.start);
       bytesRead += chunk.byteLength;
 
       // Every now and then, do some logging of the current download speed.
@@ -306,28 +306,28 @@ export default class CachedFilelike implements Filelike {
 
         const mibibytes = bytesToMiB(bytesRead);
         const speed = round(mibibytes / sec, 2);
-        this._log.debug(
+        this.#log.debug(
           `Connection @ ${rangeToString(
             currentConnection.remainingRange,
           )} downloading at ${speed} MiB/s`,
         );
       }
 
-      if (this._virtualBuffer.hasData(range.start, range.end)) {
+      if (this.#virtualBuffer.hasData(range.start, range.end)) {
         // If the requested range has been downloaded, we're done!
-        this._log.info(`Connection @ ${rangeToString(currentConnection.remainingRange)} finished!`);
+        this.#log.info(`Connection @ ${rangeToString(currentConnection.remainingRange)} finished!`);
         stream.destroy();
-        delete this._currentConnection;
+        delete this.#currentConnection;
       } else {
         // Otherwise, update `remainingRange`.
-        this._currentConnection = {
+        this.#currentConnection = {
           stream,
           remainingRange: { start: range.start + bytesRead, end: range.end },
         };
       }
 
       // Always call `_updateState` so it can decide to create new connections, resolve callbacks, etc.
-      this._updateState();
+      this.#updateState();
     });
   }
 }

--- a/packages/studio-base/src/util/CachedFilelike.ts
+++ b/packages/studio-base/src/util/CachedFilelike.ts
@@ -97,7 +97,7 @@ export default class CachedFilelike implements Filelike {
   #lastResolvedCallbackEnd?: number;
 
   // The last time we've encountered an error;
-  private _lastErrorTime?: number;
+  #lastErrorTime?: number;
 
   public constructor(options: {
     fileReader: FileReader;
@@ -242,14 +242,14 @@ export default class CachedFilelike implements Filelike {
 
       if (this.#keepReconnectingCallback) {
         // If this callback is set, just keep retrying.
-        if (this._lastErrorTime == undefined) {
+        if (this.#lastErrorTime == undefined) {
           // And if this is the first error, let the callback know.
           this.#keepReconnectingCallback(true);
         }
       } else {
         // Otherwise, if we get two errors in a short timespan (100ms) then there is probably a
         // serious error, we resolve all remaining callbacks with errors and close out.
-        const lastErrorTime = this._lastErrorTime;
+        const lastErrorTime = this.#lastErrorTime;
         if (lastErrorTime != undefined && Date.now() - lastErrorTime < 100) {
           this.#log.error(
             `Connection @ ${rangeToString(
@@ -270,9 +270,9 @@ export default class CachedFilelike implements Filelike {
       this.#log.info(
         `Connection @ ${rangeToString(range)} threw error; trying to continue: ${error.toString()}`,
       );
-      this._lastErrorTime = Date.now();
+      this.#lastErrorTime = Date.now();
       currentConnection.stream.destroy();
-      delete this.#currentConnection;
+      this.#currentConnection = undefined;
       this.#updateState();
     });
 
@@ -286,9 +286,9 @@ export default class CachedFilelike implements Filelike {
         return; // Ignore data from old streams.
       }
 
-      if (this._lastErrorTime != undefined) {
+      if (this.#lastErrorTime != undefined) {
         // If we had an error before, then that has clearly been resolved since we received some data.
-        this._lastErrorTime = undefined;
+        this.#lastErrorTime = undefined;
         if (this.#keepReconnectingCallback) {
           // And if we had a callback, let it know that the issue has been resolved.
           this.#keepReconnectingCallback(false);
@@ -317,7 +317,7 @@ export default class CachedFilelike implements Filelike {
         // If the requested range has been downloaded, we're done!
         this.#log.info(`Connection @ ${rangeToString(currentConnection.remainingRange)} finished!`);
         stream.destroy();
-        delete this.#currentConnection;
+        this.#currentConnection = undefined;
       } else {
         // Otherwise, update `remainingRange`.
         this.#currentConnection = {

--- a/packages/studio-desktop/src/main/StudioAppUpdater.ts
+++ b/packages/studio-desktop/src/main/StudioAppUpdater.ts
@@ -33,13 +33,13 @@ type EventTypes = {
 };
 
 class StudioAppUpdater extends EventEmitter<EventTypes> {
-  private started: boolean = false;
+  #started: boolean = false;
   // Seconds to wait after app startup to check and download updates.
   // This gives the user time to disable app updates for new installations
-  private initialUpdateDelaySec = 60 * 10;
+  #initialUpdateDelaySec = 60 * 10;
 
   // Seconds to wait after an update check completes before starting a new check
-  private updateCheckIntervalSec = 60 * 60;
+  #updateCheckIntervalSec = 60 * 60;
 
   public canCheckForUpdates(): boolean {
     // Updates are disabled by default in dev mode
@@ -50,16 +50,16 @@ class StudioAppUpdater extends EventEmitter<EventTypes> {
    * Start the update process.
    */
   public start(): void {
-    if (this.started) {
+    if (this.#started) {
       log.info(`StudioAppUpdater already running`);
       return;
     }
-    this.started = true;
+    this.#started = true;
 
     log.info(`Starting update loop`);
     setTimeout(() => {
-      void this.maybeCheckForUpdates();
-    }, this.initialUpdateDelaySec * 1000);
+      void this.#maybeCheckForUpdates();
+    }, this.#initialUpdateDelaySec * 1000);
   }
 
   public async checkNow(): Promise<void> {
@@ -96,7 +96,7 @@ class StudioAppUpdater extends EventEmitter<EventTypes> {
   // Check for updates and download.
   //
   // When using the "default" update mode, the app will continue to check for updates periodically
-  private async maybeCheckForUpdates(): Promise<void> {
+  async #maybeCheckForUpdates(): Promise<void> {
     try {
       // The user may have changed the app update setting so we load it again
       const appUpdatesEnabled = getAppSetting<boolean>(AppSetting.UPDATES_ENABLED);
@@ -113,8 +113,8 @@ class StudioAppUpdater extends EventEmitter<EventTypes> {
       }
     } finally {
       setTimeout(() => {
-        void this.maybeCheckForUpdates();
-      }, this.updateCheckIntervalSec * 1000);
+        void this.#maybeCheckForUpdates();
+      }, this.#updateCheckIntervalSec * 1000);
     }
   }
 

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -450,14 +450,14 @@ class StudioWindow {
   // BrowserWindow.id is not as available
   private static windowsByContentId = new Map<number, StudioWindow>();
 
-  #window: BrowserWindow;
+  #browserWindow: BrowserWindow;
   #menu: Menu;
 
   #inputSources = new Set<string>();
 
   public constructor(deepLinks: string[] = []) {
     const browserWindow = newStudioWindow(deepLinks);
-    this.#window = browserWindow;
+    this.#browserWindow = browserWindow;
     this.#menu = buildMenu(browserWindow);
 
     const id = browserWindow.webContents.id;
@@ -499,7 +499,7 @@ class StudioWindow {
   public load(): void {
     // load after setting windowsById so any ipc handlers with id lookup work
     log.info(`window.loadURL(${rendererPath})`);
-    this.#window
+    this.#browserWindow
       .loadURL(rendererPath)
       .then(() => {
         log.info("window URL loaded");
@@ -535,7 +535,7 @@ class StudioWindow {
     // build new file menu
     this.#rebuildFileMenu(fileMenu);
 
-    this.#window.setMenu(this.#menu);
+    this.#browserWindow.setMenu(this.#menu);
   }
 
   public removeInputSource(name: string): void {
@@ -547,11 +547,11 @@ class StudioWindow {
     }
 
     this.#rebuildFileMenu(fileMenu);
-    this.#window.setMenu(this.#menu);
+    this.#browserWindow.setMenu(this.#menu);
   }
 
   public getBrowserWindow(): BrowserWindow {
-    return this.#window;
+    return this.#browserWindow;
   }
 
   public getMenu(): Menu {
@@ -563,7 +563,7 @@ class StudioWindow {
   }
 
   #rebuildFileMenu(fileMenu: MenuItem): void {
-    const browserWindow = this.#window;
+    const browserWindow = this.#browserWindow;
 
     // https://github.com/electron/electron/issues/8598
     (fileMenu.submenu as ClearableMenu).clear();

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -450,15 +450,15 @@ class StudioWindow {
   // BrowserWindow.id is not as available
   private static windowsByContentId = new Map<number, StudioWindow>();
 
-  private _window: BrowserWindow;
-  private _menu: Menu;
+  #window: BrowserWindow;
+  #menu: Menu;
 
-  private _inputSources = new Set<string>();
+  #inputSources = new Set<string>();
 
   public constructor(deepLinks: string[] = []) {
     const browserWindow = newStudioWindow(deepLinks);
-    this._window = browserWindow;
-    this._menu = buildMenu(browserWindow);
+    this.#window = browserWindow;
+    this.#menu = buildMenu(browserWindow);
 
     const id = browserWindow.webContents.id;
 
@@ -467,7 +467,7 @@ class StudioWindow {
 
     // when a window closes and it is the current application menu, clear the input sources
     browserWindow.once("close", () => {
-      if (Menu.getApplicationMenu() === this._menu) {
+      if (Menu.getApplicationMenu() === this.#menu) {
         const existingMenu = Menu.getApplicationMenu();
         const fileMenu = existingMenu?.getMenuItemById("fileMenu");
         // https://github.com/electron/electron/issues/8598
@@ -499,7 +499,7 @@ class StudioWindow {
   public load(): void {
     // load after setting windowsById so any ipc handlers with id lookup work
     log.info(`window.loadURL(${rendererPath})`);
-    this._window
+    this.#window
       .loadURL(rendererPath)
       .then(() => {
         log.info("window URL loaded");
@@ -517,9 +517,9 @@ class StudioWindow {
       return;
     }
 
-    this._inputSources.add(name);
+    this.#inputSources.add(name);
 
-    const fileMenu = this._menu.getMenuItemById("fileMenu");
+    const fileMenu = this.#menu.getMenuItemById("fileMenu");
     if (!fileMenu) {
       return;
     }
@@ -533,37 +533,37 @@ class StudioWindow {
     }
 
     // build new file menu
-    this.rebuildFileMenu(fileMenu);
+    this.#rebuildFileMenu(fileMenu);
 
-    this._window.setMenu(this._menu);
+    this.#window.setMenu(this.#menu);
   }
 
   public removeInputSource(name: string): void {
-    this._inputSources.delete(name);
+    this.#inputSources.delete(name);
 
-    const fileMenu = this._menu.getMenuItemById("fileMenu");
+    const fileMenu = this.#menu.getMenuItemById("fileMenu");
     if (!fileMenu) {
       return;
     }
 
-    this.rebuildFileMenu(fileMenu);
-    this._window.setMenu(this._menu);
+    this.#rebuildFileMenu(fileMenu);
+    this.#window.setMenu(this.#menu);
   }
 
   public getBrowserWindow(): BrowserWindow {
-    return this._window;
+    return this.#window;
   }
 
   public getMenu(): Menu {
-    return this._menu;
+    return this.#menu;
   }
 
   public static fromWebContentsId(id: number): StudioWindow | undefined {
     return StudioWindow.windowsByContentId.get(id);
   }
 
-  private rebuildFileMenu(fileMenu: MenuItem): void {
-    const browserWindow = this._window;
+  #rebuildFileMenu(fileMenu: MenuItem): void {
+    const browserWindow = this.#window;
 
     // https://github.com/electron/electron/issues/8598
     (fileMenu.submenu as ClearableMenu).clear();
@@ -607,7 +607,7 @@ class StudioWindow {
     fileMenu.submenu?.append(
       new MenuItem({
         label: "Open Connection",
-        submenu: Array.from(this._inputSources).map((name) => ({
+        submenu: Array.from(this.#inputSources).map((name) => ({
           // Electron menus require a preceding & to escape the & char
           label: name.replace(/&/g, "&&"),
           click: async () => {

--- a/packages/studio-desktop/src/renderer/services/DesktopExtensionLoader.ts
+++ b/packages/studio-desktop/src/renderer/services/DesktopExtensionLoader.ts
@@ -10,15 +10,15 @@ import { Desktop } from "../../common/types";
 const log = Logger.getLogger(__filename);
 
 export class DesktopExtensionLoader implements ExtensionLoader {
-  private bridge?: Desktop;
+  #bridge?: Desktop;
   public readonly namespace: ExtensionNamespace = "local";
 
   public constructor(bridge: Desktop) {
-    this.bridge = bridge;
+    this.#bridge = bridge;
   }
 
   public async getExtensions(): Promise<ExtensionInfo[]> {
-    const extensionList = (await this.bridge?.getExtensions()) ?? [];
+    const extensionList = (await this.#bridge?.getExtensions()) ?? [];
     log.debug(`Loaded ${extensionList.length} extension(s)`);
 
     const extensions = extensionList.map<ExtensionInfo>((item) => {
@@ -43,14 +43,14 @@ export class DesktopExtensionLoader implements ExtensionLoader {
   }
 
   public async loadExtension(id: string): Promise<string> {
-    return (await this.bridge?.loadExtension(id)) ?? "";
+    return (await this.#bridge?.loadExtension(id)) ?? "";
   }
 
   public async installExtension(foxeFileData: Uint8Array): Promise<ExtensionInfo> {
-    if (this.bridge == undefined) {
+    if (this.#bridge == undefined) {
       throw new Error(`Cannot install extension without a desktopBridge`);
     }
-    const detail = await this.bridge.installExtension(foxeFileData);
+    const detail = await this.#bridge.installExtension(foxeFileData);
 
     const pkgInfo = detail.packageJson as ExtensionInfo;
 
@@ -71,6 +71,6 @@ export class DesktopExtensionLoader implements ExtensionLoader {
   }
 
   public async uninstallExtension(id: string): Promise<void> {
-    await this.bridge?.uninstallExtension(id);
+    await this.#bridge?.uninstallExtension(id);
   }
 }

--- a/packages/studio-desktop/src/renderer/services/NativeAppMenu.ts
+++ b/packages/studio-desktop/src/renderer/services/NativeAppMenu.ts
@@ -9,21 +9,21 @@ import { NativeMenuBridge } from "../../common/types";
 type Handler = () => void;
 
 export class NativeAppMenu implements INativeAppMenu {
-  private bridge?: NativeMenuBridge;
+  #bridge?: NativeMenuBridge;
 
   public constructor(bridge?: NativeMenuBridge) {
-    this.bridge = bridge;
+    this.#bridge = bridge;
   }
   public addFileEntry(name: string, handler: Handler): void {
-    void this.bridge?.menuAddInputSource(name, handler);
+    void this.#bridge?.menuAddInputSource(name, handler);
   }
   public removeFileEntry(name: string): void {
-    void this.bridge?.menuRemoveInputSource(name);
+    void this.#bridge?.menuRemoveInputSource(name);
   }
   public on(name: NativeAppMenuEvent, listener: Handler): void {
-    this.bridge?.addIpcEventListener(name, listener);
+    this.#bridge?.addIpcEventListener(name, listener);
   }
   public off(name: NativeAppMenuEvent, listener: Handler): void {
-    this.bridge?.removeIpcEventListener(name, listener);
+    this.#bridge?.removeIpcEventListener(name, listener);
   }
 }

--- a/packages/studio-desktop/src/renderer/services/NativeStorageLayoutStorage.ts
+++ b/packages/studio-desktop/src/renderer/services/NativeStorageLayoutStorage.ts
@@ -24,14 +24,14 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
   private static STORE_PREFIX = "layouts-";
   private static LEGACY_STORE_NAME = "layouts";
 
-  private _ctx: Storage;
+  #ctx: Storage;
 
   public constructor(storage: Storage) {
-    this._ctx = storage;
+    this.#ctx = storage;
   }
 
   public async list(namespace: string): Promise<readonly Layout[]> {
-    const items = await this._ctx.all(NativeStorageLayoutStorage.STORE_PREFIX + namespace);
+    const items = await this.#ctx.all(NativeStorageLayoutStorage.STORE_PREFIX + namespace);
 
     const layouts: Layout[] = [];
     for (const item of items) {
@@ -46,7 +46,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
   }
 
   public async get(namespace: string, id: LayoutID): Promise<Layout | undefined> {
-    const item = await this._ctx.get(NativeStorageLayoutStorage.STORE_PREFIX + namespace, id);
+    const item = await this.#ctx.get(NativeStorageLayoutStorage.STORE_PREFIX + namespace, id);
     if (item == undefined) {
       return undefined;
     }
@@ -55,12 +55,12 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
 
   public async put(namespace: string, layout: Layout): Promise<Layout> {
     const content = JSON.stringify(layout) ?? "";
-    await this._ctx.put(NativeStorageLayoutStorage.STORE_PREFIX + namespace, layout.id, content);
+    await this.#ctx.put(NativeStorageLayoutStorage.STORE_PREFIX + namespace, layout.id, content);
     return layout;
   }
 
   public async delete(namespace: string, id: LayoutID): Promise<void> {
-    return await this._ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + namespace, id);
+    return await this.#ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + namespace, id);
   }
 
   public async importLayouts({
@@ -70,10 +70,10 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
     fromNamespace: string;
     toNamespace: string;
   }): Promise<void> {
-    const keys = await this._ctx.list(NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace);
+    const keys = await this.#ctx.list(NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace);
     for (const key of keys) {
       try {
-        const item = await this._ctx.get(
+        const item = await this.#ctx.get(
           NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace,
           key,
         );
@@ -82,7 +82,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
         }
         const layout = parseAndMigrateLayout(item);
         await this.put(toNamespace, layout);
-        await this._ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace, key);
+        await this.#ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace, key);
       } catch (error) {
         log.error(error);
       }
@@ -91,7 +91,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
 
   public async migrateUnnamespacedLayouts(namespace: string): Promise<void> {
     // Layouts were previously stored in a single un-namespaced store named "layouts".
-    const items = await this._ctx.all(NativeStorageLayoutStorage.LEGACY_STORE_NAME);
+    const items = await this.#ctx.all(NativeStorageLayoutStorage.LEGACY_STORE_NAME);
     for (const item of items) {
       if (!(item instanceof Uint8Array)) {
         continue;
@@ -101,12 +101,12 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
         const str = new TextDecoder().decode(item);
         const parsed = JSON.parse(str);
         const layout = migrateLayout(parsed);
-        await this._ctx.put(
+        await this.#ctx.put(
           NativeStorageLayoutStorage.STORE_PREFIX + namespace,
           layout.id,
           JSON.stringify(layout) ?? "",
         );
-        await this._ctx.delete(NativeStorageLayoutStorage.LEGACY_STORE_NAME, layout.id);
+        await this.#ctx.delete(NativeStorageLayoutStorage.LEGACY_STORE_NAME, layout.id);
       } catch (err) {
         log.error(err);
       }

--- a/packages/studio-desktop/src/renderer/services/NativeWindow.ts
+++ b/packages/studio-desktop/src/renderer/services/NativeWindow.ts
@@ -9,39 +9,39 @@ import { Desktop } from "../../common/types";
 type Handler = () => void;
 
 export class NativeWindow implements INativeWindow {
-  private bridge?: Desktop;
+  #bridge?: Desktop;
 
   public constructor(bridge: Desktop) {
-    this.bridge = bridge;
+    this.#bridge = bridge;
   }
 
   public async setRepresentedFilename(path: string | undefined): Promise<void> {
-    await this.bridge?.setRepresentedFilename(path);
+    await this.#bridge?.setRepresentedFilename(path);
   }
   public on(name: NativeWindowEvent, listener: Handler): void {
-    this.bridge?.addIpcEventListener(name, listener);
+    this.#bridge?.addIpcEventListener(name, listener);
   }
   public off(name: NativeWindowEvent, listener: Handler): void {
-    this.bridge?.removeIpcEventListener(name, listener);
+    this.#bridge?.removeIpcEventListener(name, listener);
   }
 
   public handleTitleBarDoubleClick(): void {
-    this.bridge?.handleTitleBarDoubleClick();
+    this.#bridge?.handleTitleBarDoubleClick();
   }
 
   public isMaximized(): boolean {
-    return this.bridge?.isMaximized() ?? false;
+    return this.#bridge?.isMaximized() ?? false;
   }
   public minimize(): void {
-    this.bridge?.minimizeWindow();
+    this.#bridge?.minimizeWindow();
   }
   public maximize(): void {
-    this.bridge?.maximizeWindow();
+    this.#bridge?.maximizeWindow();
   }
   public unmaximize(): void {
-    this.bridge?.unmaximizeWindow();
+    this.#bridge?.unmaximizeWindow();
   }
   public close(): void {
-    this.bridge?.closeWindow();
+    this.#bridge?.closeWindow();
   }
 }

--- a/packages/studio-web/src/services/LocalStorageAppConfiguration.ts
+++ b/packages/studio-web/src/services/LocalStorageAppConfiguration.ts
@@ -8,18 +8,18 @@ export default class LocalStorageAppConfiguration implements IAppConfiguration {
   private static KEY_PREFIX = "studio.app-configuration.";
 
   /** Default values for app configuration items which have never been set by a user */
-  private defaults?: { [key: string]: AppConfigurationValue };
+  #defaults?: { [key: string]: AppConfigurationValue };
 
-  private changeListeners = new Map<string, Set<ChangeHandler>>();
+  #changeListeners = new Map<string, Set<ChangeHandler>>();
 
   public constructor({ defaults }: { defaults?: { [key: string]: AppConfigurationValue } }) {
-    this.defaults = defaults;
+    this.#defaults = defaults;
   }
 
   public get(key: string): AppConfigurationValue {
     const value = localStorage.getItem(LocalStorageAppConfiguration.KEY_PREFIX + key);
     try {
-      return value == undefined ? this.defaults?.[key] : JSON.parse(value);
+      return value == undefined ? this.#defaults?.[key] : JSON.parse(value);
     } catch {
       return undefined;
     }
@@ -33,7 +33,7 @@ export default class LocalStorageAppConfiguration implements IAppConfiguration {
         JSON.stringify(value) ?? "",
       );
     }
-    const listeners = this.changeListeners.get(key);
+    const listeners = this.#changeListeners.get(key);
     if (listeners) {
       // Copy the list of listeners to protect against mutation during iteration
       [...listeners].forEach((listener) => listener(value));
@@ -41,16 +41,16 @@ export default class LocalStorageAppConfiguration implements IAppConfiguration {
   }
 
   public addChangeListener(key: string, cb: ChangeHandler): void {
-    let listeners = this.changeListeners.get(key);
+    let listeners = this.#changeListeners.get(key);
     if (!listeners) {
       listeners = new Set();
-      this.changeListeners.set(key, listeners);
+      this.#changeListeners.set(key, listeners);
     }
     listeners.add(cb);
   }
 
   public removeChangeListener(key: string, cb: ChangeHandler): void {
-    const listeners = this.changeListeners.get(key);
+    const listeners = this.#changeListeners.get(key);
     if (listeners) {
       listeners.delete(cb);
     }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add a lint rule to enforce the use of ES [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) rather than the TypeScript `private` modifier. The new lint rule also includes auto-fix support, which renames the property/method definition and the accesses it can see.

In contrast with `private x`, which is a compile-time-only feature of TypeScript, `#x` is _truly_ private (cannot be accessed at runtime from outside the class using subscript notation) and cannot accidentally interfere with superclass properties.

One downside worth noting is that private fields can interfere with `Proxy` behavior: https://lea.verou.me/2023/04/private-fields-considered-harmful/ / https://github.com/tc39/proposal-class-fields/issues/106

I had to change a couple of `delete this._x;` to `this.#x = undefined;` and a couple of `const { _x } = this;` to `const x = this.#x;`.