### PR TITLE
Fall back to using english font-feature-settings if locale is unset

### DIFF
--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -32,7 +32,7 @@ export default function ThemeProvider({
 
   const { i18n } = useTranslation();
   const muiTheme = useMemo(
-    () => createMuiTheme(isDark ? "dark" : "light", i18n.language as Language),
+    () => createMuiTheme(isDark ? "dark" : "light", i18n.language as Language | undefined),
     [i18n.language, isDark],
   );
 

--- a/packages/studio-base/src/theme/createMuiTheme.ts
+++ b/packages/studio-base/src/theme/createMuiTheme.ts
@@ -14,7 +14,7 @@ type ThemePreference = "dark" | "light";
 
 export function createMuiTheme(
   themePreference: ThemePreference,
-  locale: Language,
+  locale: Language | undefined,
 ): Theme & { name: ThemePreference } {
   const theme = createTheme({
     palette: palette[themePreference],

--- a/packages/studio-base/src/theme/muiTypography.ts
+++ b/packages/studio-base/src/theme/muiTypography.ts
@@ -16,15 +16,20 @@ declare module "@mui/material/styles/createTypography" {
   }
 }
 
-export function muiTypography({ locale }: { locale: Language }): MuiThemeOptions["typography"] {
+export function muiTypography({
+  locale,
+}: {
+  locale: Language | undefined;
+}): MuiThemeOptions["typography"] {
   let fontFeatureSettings: string;
   switch (locale) {
-    case "en":
-      fontFeatureSettings = fonts.SANS_SERIF_FEATURE_SETTINGS;
-      break;
     case "zh":
     case "ja":
       fontFeatureSettings = fonts.SANS_SERIF_FEATURE_SETTINGS_CJK;
+      break;
+    case "en":
+    default:
+      fontFeatureSettings = fonts.SANS_SERIF_FEATURE_SETTINGS;
       break;
   }
   const baseFontStyles: TypographyStyle = {

--- a/packages/studio-web/src/VersionBanner.tsx
+++ b/packages/studio-web/src/VersionBanner.tsx
@@ -68,7 +68,7 @@ const VersionBanner = function ({
   const [showBanner, setShowBanner] = useState(true);
   const { i18n } = useTranslation();
   const muiTheme = useMemo(
-    () => createMuiTheme("dark", i18n.language as Language),
+    () => createMuiTheme("dark", i18n.language as Language | undefined),
     [i18n.language],
   );
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Follow-up from #5878 
This shouldn't happen in the real app, but can happen in certain stories if `disableI18n` is true, or if `initI18n` is not called (`i18n.language` can be `undefined` in this case).
Relates to FG-3153