### PR TITLE
[3D Image] Support CircleAnnotation by rendering as a polygon

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
@@ -105,9 +105,18 @@ export class RenderableTopicAnnotations extends THREE.Object3D {
 
     for (const annotation of this.#annotations) {
       switch (annotation.type) {
-        case "circle":
-          // not yet implemented
+        case "circle": {
+          let line = unusedLines.pop();
+          if (!line) {
+            line = new RenderableLineAnnotation();
+            line.setScale(this.#scale, this.#canvasWidth, this.#canvasHeight, this.#pixelRatio);
+            line.setCameraModel(this.#cameraModel);
+            this.add(line);
+          }
+          this.#lines.push(line);
+          line.setAnnotationFromCircle(annotation);
           break;
+        }
 
         case "points":
           switch (annotation.style) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -101,7 +101,7 @@ export const Annotations: StoryObj = {
             position: { x: 25, y: 5 },
             diameter: 4,
             thickness: 1,
-            fill_color: { r: 1, g: 0, b: 1, a: 1 },
+            fill_color: { r: 1, g: 0, b: 1, a: 0.5 },
             outline_color: { r: 0, g: 0, b: 0, a: 0 },
           },
           {
@@ -110,7 +110,7 @@ export const Annotations: StoryObj = {
             diameter: 4,
             thickness: 0.5,
             fill_color: { r: 1, g: 1, b: 0, a: 0 },
-            outline_color: { r: 0, g: 1, b: 1, a: 1 },
+            outline_color: { r: 0, g: 1, b: 1, a: 0.5 },
           },
         ],
         points: [

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -87,6 +87,32 @@ export const Annotations: StoryObj = {
       topic: "annotations",
       receiveTime: { sec: 10, nsec: 0 },
       message: {
+        circles: [
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 20, y: 5 },
+            diameter: 4,
+            thickness: 1,
+            fill_color: { r: 1, g: 0, b: 1, a: 1 },
+            outline_color: { r: 1, g: 1, b: 0, a: 1 },
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 25, y: 5 },
+            diameter: 4,
+            thickness: 1,
+            fill_color: { r: 1, g: 0, b: 1, a: 1 },
+            outline_color: { r: 0, g: 0, b: 0, a: 0 },
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 30, y: 5 },
+            diameter: 4,
+            thickness: 0.5,
+            fill_color: { r: 1, g: 1, b: 0, a: 0 },
+            outline_color: { r: 0, g: 1, b: 1, a: 1 },
+          },
+        ],
         points: [
           {
             timestamp: { sec: 0, nsec: 0 },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Render circles using RenderableLineAnnotation.
For now just hard-coded 32 segments.