### PR TITLE
Rename split panel text for sanity

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -147,16 +147,16 @@ export function PanelActionsDropdown({ isUnknownPanel }: Props): JSX.Element {
     if (!isUnknownPanel) {
       items.push(
         {
-          key: "hsplit",
-          text: "Split horizontal",
-          icon: <SplitHorizontal20Regular />,
-          onClick: () => split(panelContext?.id, "column"),
-        },
-        {
           key: "vsplit",
-          text: "Split vertical",
+          text: "Split right",
           icon: <SplitVertical20Regular />,
           onClick: () => split(panelContext?.id, "row"),
+        },
+        {
+          key: "hsplit",
+          text: "Split down",
+          icon: <SplitHorizontal20Regular />,
+          onClick: () => split(panelContext?.id, "column"),
         },
       );
     }


### PR DESCRIPTION
**User-Facing Changes**
Rename:
- `Split horizontal` -> `Split down`
- `Split vertical` -> `Split right`

Despite years of computering, I am incapable of remembering the difference between vertical/horizontal splits in my head. I constantly click `Split vertical` when I want vertically stacked panels, but I end up with horizontally stacked panels.

I even got these backwards when I tried to make this PR, despite having fallen for it 30 seconds earlier in the UI.

No more! We shall follow VSCode into the glorious new world of `Split right` and `Split down`. Maybe one day we can even add `Split up` and `Split left`.

<img width="179" alt="image" src="https://user-images.githubusercontent.com/637671/235580819-23d0808e-3511-4da2-8eb0-b7a1c243a583.png">
