### PR TITLE
Support for user defined custom Http headers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-16"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,3 +20,9 @@
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }
+
+// TODO: Add setup commands for:
+// sudo corepack enable
+// sudo apt update
+// sudo apt install git-lfs -y
+// git lfs install

--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
@@ -55,7 +55,8 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
         defaultValue: "{}",
         validate: (newValue: string): Error | undefined => {
           try {
-            const headers = JSON.parse(newValue);
+            const headers = new Map<string, string>(
+              Object.entries(JSON.parse(newValue) as { [s: string]: string }));
             if (typeof headers !== "object") {
               return new Error("Invalid JSON object");
             }
@@ -75,7 +76,8 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
     }
 
     const headerStr = args.params?.headers as string;
-    const headers = JSON.parse(headerStr);
+    const headers = new Map<string, string>(
+      Object.entries(JSON.parse(headerStr) as { [s: string]: string }));
 
     return new FoxgloveWebSocketPlayer({
       url,

--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
@@ -49,6 +49,22 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
           }
         },
       },
+      {
+        id: "headers",
+        label: "HTTP headers",
+        defaultValue: "{}",
+        validate: (newValue: string): Error | undefined => {
+          try {
+            const headers = JSON.parse(newValue);
+            if (typeof headers !== "object") {
+              return new Error("Invalid JSON object");
+            }
+            return undefined;
+          } catch (err) {
+            return new Error("Enter a valid JSON object");
+          }
+        },
+      },
     ],
   };
 
@@ -58,8 +74,12 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
       return;
     }
 
+    const headerStr = args.params?.headers as string;
+    const headers = JSON.parse(headerStr);
+
     return new FoxgloveWebSocketPlayer({
       url,
+      headers,
       metricsCollector: args.metricsCollector,
       sourceId: this.id,
     });

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
@@ -16,10 +16,10 @@ export default class WorkerSocketAdapter implements IWebSocket {
   public onclose: ((event: unknown) => void) | undefined = undefined;
   public onmessage: ((event: unknown) => void) | undefined = undefined;
 
-  public constructor(wsUrl: string, protocols?: string[] | string) {
+  public constructor(wsUrl: string, wsHeaders: Map<string, string>, protocols?: string[] | string) {
     // foxglove-depcheck-used: babel-plugin-transform-import-meta
     this.worker = new Worker(new URL("./worker", import.meta.url));
-    this.sendToWorker({ type: "open", data: { wsUrl, protocols } });
+    this.sendToWorker({ type: "open", data: { wsUrl, wsHeaders, protocols } });
 
     this.worker.onerror = (ev) => {
       if (this.onerror) {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -175,7 +175,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this._client = new FoxgloveClient({
       ws:
         typeof Worker !== "undefined"
-          ? new WorkerSocketAdapter(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
+          ? new WorkerSocketAdapter(this._url, this._headers, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
           : new WebSocket(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
     });
 

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -77,6 +77,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private readonly _sourceId: string;
 
   private _url: string; // WebSocket URL.
+  private _headers: unknown; // HTTP headers.
   private _name: string;
   private _client?: FoxgloveClient; // The client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player session.
@@ -133,15 +134,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
   public constructor({
     url,
+    headers,
     metricsCollector,
     sourceId,
   }: {
     url: string;
+    headers: unknown;
     metricsCollector: PlayerMetricsCollectorInterface;
     sourceId: string;
   }) {
     this._metricsCollector = metricsCollector;
     this._url = url;
+    this._headers = headers;
     this._name = url;
     this._metricsCollector.playerConstructed();
     this._sourceId = sourceId;

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -77,7 +77,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private readonly _sourceId: string;
 
   private _url: string; // WebSocket URL.
-  private _headers: unknown; // HTTP headers.
+  private _headers: Map<string, string>; // HTTP headers.
   private _name: string;
   private _client?: FoxgloveClient; // The client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player session.
@@ -139,7 +139,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     sourceId,
   }: {
     url: string;
-    headers: unknown;
+    headers: Map<string, string>;
     metricsCollector: PlayerMetricsCollectorInterface;
     sourceId: string;
   }) {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export type ToWorkerMessage =
-  | { type: "open"; data: { wsUrl: string; protocols?: string[] | string } }
+  | { type: "open"; data: { wsUrl: string; wsHeaders: Map<string, string>; protocols?: string[] | string } }
   | { type: "close"; data: undefined }
   | { type: "data"; data: string | ArrayBuffer | ArrayBufferView };
 


### PR DESCRIPTION
**User-Facing Changes**

Adds an additional input field for users to specify custom Http headers to include for the websocket connection, such as headers including authentication tokens to access websocket backends behind reverse proxy servers that enforce access control restrictions for secure and private port forwarding, such as GitHub Codespaces.

-  https://docs.github.com/en/codespaces/developing-in-codespaces/forwarding-ports-in-your-codespace#using-command-line-tools-and-rest-clients-to-access-ports

**Description**

This adds a new `headers` input field in formConfig for FoxgloveWebSocketDataSourceFactory that accepts Http headers, as key value string pairs encoded in json, to include in the websocket connection request. After input validation, these headers are then passed along with the user specified websocket URL down to where they can be used in the call sight for the creation of the websocket connection.
