### PR TITLE
Fix: Diagnostics summary panel flickering

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -21,12 +21,12 @@ import {
   Select,
   InputBase,
   IconButton,
-  List,
 } from "@mui/material";
 import { produce } from "immer";
 import { compact, set, uniq } from "lodash";
-import { useCallback, useEffect, useMemo } from "react";
+import { CSSProperties, useCallback, useEffect, useMemo } from "react";
 import { AutoSizer } from "react-virtualized";
+import { FixedSizeList as List } from "react-window";
 
 import { filterMap } from "@foxglove/den/collection";
 import { SettingsTreeAction } from "@foxglove/studio";
@@ -132,6 +132,7 @@ const NodeRow = React.memo(function NodeRow(props: NodeRowProps) {
           secondaryTypographyProps={{
             color: MESSAGE_COLORS[levelName ?? "stale"],
           }}
+          style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
         />
       </StyledListItemButton>
     </ListItem>
@@ -178,6 +179,24 @@ function DiagnosticSummary(props: Props): JSX.Element {
       });
     },
     [topicToRender, openSiblingPanel],
+  );
+
+  const renderRow = useCallback(
+    (renderProps: { data: DiagnosticInfo[]; index: number; style: CSSProperties }) => {
+      const item = renderProps.data[renderProps.index]!;
+      return (
+        <div style={{ ...renderProps.style }}>
+          <NodeRow
+            key={item.id}
+            info={item}
+            isPinned={pinnedIds.includes(item.id)}
+            onClick={showDetails}
+            onClickPin={togglePinned}
+          />
+        </div>
+      );
+    },
+    [pinnedIds, showDetails, togglePinned],
   );
 
   // Filter down all topics to those that conform to our supported datatypes
@@ -238,31 +257,22 @@ function DiagnosticSummary(props: Props): JSX.Element {
     }
     return (
       <AutoSizer>
-        {({ width, height }) => (
-          <List style={{ overflow: "scroll", width, height }}>
-            {nodes.map((item) => (
-              <NodeRow
-                key={item.id}
-                info={item}
-                isPinned={pinnedIds.includes(item.id)}
-                onClick={showDetails}
-                onClickPin={togglePinned}
-              />
-            ))}
+        {({ height, width }) => (
+          <List
+            width={width}
+            height={height}
+            style={{ outline: "none" }}
+            itemSize={30}
+            itemData={nodes}
+            itemCount={nodes.length}
+            overscanCount={10}
+          >
+            {renderRow}
           </List>
         )}
       </AutoSizer>
     );
-  }, [
-    diagnostics,
-    hardwareIdFilter,
-    pinnedIds,
-    showDetails,
-    togglePinned,
-    sortByLevel,
-    minLevel,
-    topicToRender,
-  ]);
+  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, minLevel, topicToRender]);
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -21,11 +21,12 @@ import {
   Select,
   InputBase,
   IconButton,
+  List,
 } from "@mui/material";
 import { produce } from "immer";
 import { compact, set, uniq } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
-import { List, AutoSizer, ListRowProps } from "react-virtualized";
+import { AutoSizer } from "react-virtualized";
 
 import { filterMap } from "@foxglove/den/collection";
 import { SettingsTreeAction } from "@foxglove/studio";
@@ -179,22 +180,6 @@ function DiagnosticSummary(props: Props): JSX.Element {
     [topicToRender, openSiblingPanel],
   );
 
-  const renderRow = useCallback(
-    // eslint-disable-next-line react/no-unused-prop-types
-    ({ item, key }: ListRowProps & { item: DiagnosticInfo }) => {
-      return (
-        <NodeRow
-          key={key}
-          info={item}
-          isPinned={pinnedIds.includes(item.id)}
-          onClick={showDetails}
-          onClickPin={togglePinned}
-        />
-      );
-    },
-    [pinnedIds, showDetails, togglePinned],
-  );
-
   // Filter down all topics to those that conform to our supported datatypes
   const availableTopics = useMemo(() => {
     const filtered = topics
@@ -253,20 +238,31 @@ function DiagnosticSummary(props: Props): JSX.Element {
     }
     return (
       <AutoSizer>
-        {({ height, width }) => (
-          <List
-            width={width}
-            height={height}
-            style={{ outline: "none" }}
-            rowHeight={30}
-            rowRenderer={(rowProps) => renderRow({ ...rowProps, item: nodes[rowProps.index]! })}
-            rowCount={nodes.length}
-            overscanRowCount={10}
-          />
+        {({ width, height }) => (
+          <List style={{ overflow: "scroll", width, height }}>
+            {nodes.map((item) => (
+              <NodeRow
+                key={item.id}
+                info={item}
+                isPinned={pinnedIds.includes(item.id)}
+                onClick={showDetails}
+                onClickPin={togglePinned}
+              />
+            ))}
+          </List>
         )}
       </AutoSizer>
     );
-  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, minLevel, topicToRender]);
+  }, [
+    diagnostics,
+    hardwareIdFilter,
+    pinnedIds,
+    showDetails,
+    togglePinned,
+    sortByLevel,
+    minLevel,
+    topicToRender,
+  ]);
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {


### PR DESCRIPTION
**User-Facing Changes**

Fixes a bug where the DiagnosticSummary panel starts flickering if the list is too long.

The flickering was caused by the `List` component we used from `react-virtualized`, inside the `AutoSizer`; it kept re-rendering the list for no apparent reason. Having replaced it with the List from `react-window` solved the problem, and it's also consistent with the codebase as it's used in the log panel.

Note that the original list came with a fixed height where items are neatly stacked, and this PR does not change that. A diagnostic summary with long items and open item-details might look something like this:

<img width="499" alt="fix" src="https://user-images.githubusercontent.com/349687/236043391-bad75c68-5e7a-4f92-a39d-b733fbac8003.png">
