### PR TITLE
[3D Image] Opt-in button in Image panel settings

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -115,7 +115,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
   const { capabilities, profile: dataSourceProfile } = playerState;
 
-  const { openSiblingPanel } = usePanelContext();
+  const { openSiblingPanel, replacePanel } = usePanelContext();
 
   const [panelId] = useState(() => uuid());
   const isMounted = useSynchronousMountedState();
@@ -302,6 +302,14 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
             assertNever(position, `Unsupported position for addPanel: ${position}`);
         }
       },
+    };
+
+    // Temporarily added to aid Image panel migration.
+    (layout as { INTERNAL_replacePanel?: unknown }).INTERNAL_replacePanel = (
+      type: string,
+      newConfig: Record<string, unknown>,
+    ) => {
+      replacePanel(type, newConfig);
     };
 
     return {
@@ -504,6 +512,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     initialState,
     isMounted,
     openSiblingPanel,
+    replacePanel,
     panelId,
     saveConfig,
     seekPlayback,

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -114,7 +114,10 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
   const panelComponents = useMemo(
     () =>
       new Map(
-        panelCatalog.getPanels().map((panelInfo) => [panelInfo.type, React.lazy(panelInfo.module)]),
+        (panelCatalog.getAllPanels?.() ?? panelCatalog.getPanels()).map((panelInfo) => [
+          panelInfo.type,
+          React.lazy(panelInfo.module),
+        ]),
       ),
     [panelCatalog],
   );

--- a/packages/studio-base/src/context/PanelCatalogContext.ts
+++ b/packages/studio-base/src/context/PanelCatalogContext.ts
@@ -40,8 +40,11 @@ export type PanelInfo = {
 
 /** PanelCatalog describes the interface for getting available panels */
 export interface PanelCatalog {
-  /** get a list of the available panels */
+  /** Get the panels that should appear in the list of available panels */
   getPanels(): readonly PanelInfo[];
+
+  /** Get all panels that can be rendered (may include some experimental new panels not present in `getPanels()`). */
+  getAllPanels?(): readonly PanelInfo[];
 
   /** Get panel information for a specific panel type (i.e. 3d, map, image, etc) */
   getPanelByType(type: string): PanelInfo | undefined;

--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -269,11 +269,11 @@ export function ImageView({ context, enableNewImagePanel }: Props): JSX.Element 
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
-      if (action.action === "perform-node-action" && action.payload.id === "upgradeOptIn") {
-        setShowUpgradeConfirmDialog(true);
+      if (action.action !== "update") {
         return;
       }
-      if (action.action !== "update") {
+      if (action.payload.path[0] === "newImage" && action.payload.value === true) {
+        setShowUpgradeConfirmDialog(true);
         return;
       }
 

--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -11,11 +11,20 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Typography } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
 import { produce } from "immer";
 import { difference, keyBy, set, union } from "lodash";
 import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import ReactDOM from "react-dom";
+import { useLatest } from "react-use";
 import { DeepPartial } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
@@ -113,6 +122,7 @@ export function ImageView({ context }: Props): JSX.Element {
       },
     };
   });
+  const latestConfig = useLatest(config);
 
   const { cameraTopic, enabledMarkerTopics, transformMarkers } = config;
   const topicsByTopicName = useMemo(() => keyBy(topics, ({ name }) => name), [topics]);
@@ -254,9 +264,16 @@ export function ImageView({ context }: Props): JSX.Element {
     [config.cameraTopic, topics],
   );
 
+  const [showUpgradeConfirmDialog, setShowUpgradeConfirmDialog] = useState(false);
+
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
       if (action.action !== "update") {
+        return;
+      }
+
+      if (action.payload.path[0] === "newImage" && action.payload.value === true) {
+        setShowUpgradeConfirmDialog(true);
         return;
       }
 
@@ -281,6 +298,37 @@ export function ImageView({ context }: Props): JSX.Element {
       }
     },
     [onChangeCameraTopic],
+  );
+
+  const upgradeConfirmDialog = useMemo(
+    () => (
+      <Dialog open={showUpgradeConfirmDialog} onClose={() => setShowUpgradeConfirmDialog(false)}>
+        <DialogTitle>Upgrade to the new Image panel?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            To undo this change, you will need to re-configure this Image panel.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button variant="outlined" onClick={() => setShowUpgradeConfirmDialog(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              (
+                context.layout as {
+                  INTERNAL_replacePanel?: (type: string, config: unknown) => void;
+                }
+              ).INTERNAL_replacePanel?.("Image", latestConfig.current);
+            }}
+          >
+            Replace panel
+          </Button>
+        </DialogActions>
+      </Dialog>
+    ),
+    [latestConfig, context, showUpgradeConfirmDialog],
   );
 
   const markerTopics = useMemo(() => {
@@ -391,6 +439,7 @@ export function ImageView({ context }: Props): JSX.Element {
 
   return (
     <ThemeProvider isDark={colorScheme === "dark"}>
+      {upgradeConfirmDialog}
       <Stack
         flex="auto"
         overflow="hidden"

--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -53,6 +53,7 @@ import type { Config, PixelData, RawMarkerData } from "./types";
 
 type Props = {
   context: PanelExtensionContext;
+  enableNewImagePanel: boolean;
 };
 
 const SUPPORTED_IMAGE_SCHEMAS = new Set(NORMALIZABLE_IMAGE_DATATYPES);
@@ -105,7 +106,7 @@ const useStyles = makeStyles<void, "timestamp">()((theme, _params, classes) => (
   },
 }));
 
-export function ImageView({ context }: Props): JSX.Element {
+export function ImageView({ context, enableNewImagePanel }: Props): JSX.Element {
   const { classes, cx } = useStyles();
   const [renderDone, setRenderDone] = useState(() => () => {});
   const [topics, setTopics] = useState<readonly Topic[]>([]);
@@ -345,6 +346,7 @@ export function ImageView({ context }: Props): JSX.Element {
         markerTopics,
         enabledMarkerTopics,
         relatedMarkerTopics,
+        enableNewImagePanel,
       }),
     });
   }, [
@@ -355,6 +357,7 @@ export function ImageView({ context }: Props): JSX.Element {
     markerTopics,
     relatedMarkerTopics,
     context,
+    enableNewImagePanel,
   ]);
 
   const lastImageMessageRef = useRef(image);

--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -268,12 +268,11 @@ export function ImageView({ context }: Props): JSX.Element {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
-      if (action.action !== "update") {
+      if (action.action === "perform-node-action" && action.payload.id === "upgradeOptIn") {
+        setShowUpgradeConfirmDialog(true);
         return;
       }
-
-      if (action.payload.path[0] === "newImage" && action.payload.value === true) {
-        setShowUpgradeConfirmDialog(true);
+      if (action.action !== "update") {
         return;
       }
 

--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -306,7 +306,8 @@ export function ImageView({ context, enableNewImagePanel }: Props): JSX.Element 
         <DialogTitle>Upgrade to the new Image panel?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            To undo this change, you will need to re-configure this Image panel.
+            This change will modify your layout. To revert to the old Image panel, you will need to
+            manually replace this panel or add a new one.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -300,36 +300,33 @@ export function ImageView({ context, enableNewImagePanel }: Props): JSX.Element 
     [onChangeCameraTopic],
   );
 
-  const upgradeConfirmDialog = useMemo(
-    () => (
-      <Dialog open={showUpgradeConfirmDialog} onClose={() => setShowUpgradeConfirmDialog(false)}>
-        <DialogTitle>Upgrade to the new Image panel?</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            This change will modify your layout. To revert to the old Image panel, you will need to
-            manually replace this panel or add a new one.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button variant="outlined" onClick={() => setShowUpgradeConfirmDialog(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            onClick={() => {
-              (
-                context.layout as {
-                  INTERNAL_replacePanel?: (type: string, config: unknown) => void;
-                }
-              ).INTERNAL_replacePanel?.("Image", latestConfig.current);
-            }}
-          >
-            Replace panel
-          </Button>
-        </DialogActions>
-      </Dialog>
-    ),
-    [latestConfig, context, showUpgradeConfirmDialog],
+  const upgradeConfirmDialog = showUpgradeConfirmDialog && (
+    <Dialog open onClose={() => setShowUpgradeConfirmDialog(false)}>
+      <DialogTitle>Upgrade to the new Image panel?</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This change will modify your layout. To revert to the old Image panel, you will need to
+          manually replace this panel or add a new one.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="outlined" onClick={() => setShowUpgradeConfirmDialog(false)}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => {
+            (
+              context.layout as {
+                INTERNAL_replacePanel?: (type: string, config: unknown) => void;
+              }
+            ).INTERNAL_replacePanel?.("Image", latestConfig.current);
+          }}
+        >
+          Replace panel
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 
   const markerTopics = useMemo(() => {

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -7,19 +7,27 @@ import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { defaultConfig, ImageView } from "./ImageView";
 import { Config } from "./types";
 
-function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
+function initPanel(
+  {
+    crash,
+    enableNewImagePanel,
+  }: { crash: ReturnType<typeof useCrash>; enableNewImagePanel: boolean },
+  context: PanelExtensionContext,
+) {
   ReactDOM.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
-        <ImageView context={context} />
+        <ImageView context={context} enableNewImagePanel={enableNewImagePanel} />
       </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
@@ -36,7 +44,13 @@ type Props = {
 
 function ImagePanelAdapter(props: Props) {
   const crash = useCrash();
-  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
+  const [enableNewImagePanel = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_NEW_IMAGE_PANEL,
+  );
+  const boundInitPanel = useMemo(
+    () => initPanel.bind(undefined, { crash, enableNewImagePanel }),
+    [crash, enableNewImagePanel],
+  );
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -38,15 +38,19 @@ export function buildSettingsTree({
   markerTopics,
   enabledMarkerTopics,
   relatedMarkerTopics,
+  enableNewImagePanel,
 }: {
   config: Immutable<Config>;
   imageTopics: readonly Topic[];
   markerTopics: readonly string[];
   enabledMarkerTopics: readonly string[];
   relatedMarkerTopics: readonly string[];
+  enableNewImagePanel: boolean;
 }): SettingsTreeNodes {
-  return {
-    newImage: {
+  const nodes: SettingsTreeNodes = {};
+
+  if (enableNewImagePanel) {
+    nodes.newImage = {
       label: "Try the new Image panel",
       actions: [
         {
@@ -57,69 +61,73 @@ export function buildSettingsTree({
           label: "Upgrade",
         },
       ],
-    },
-    general: {
-      label: "General",
-      fields: {
-        cameraTopic: {
-          label: "Topic",
-          input: "select",
-          value: config.cameraTopic,
-          options: imageTopics.map((topic) => ({ label: topic.name, value: topic.name })),
-        },
-        transformMarkers: {
-          input: "boolean",
-          label: "Transform markers",
-          value: config.transformMarkers,
-          help: config.transformMarkers
-            ? "Markers are being transformed by Foxglove Studio based on the camera model. Click to turn it off."
-            : `Markers can be transformed by Foxglove Studio based on the camera model. Click to turn it on.`,
-        },
-        synchronize: {
-          input: "boolean",
-          label: "Synchronize timestamps",
-          value: config.synchronize,
-        },
-        smooth: {
-          input: "boolean",
-          label: "Bilinear smoothing",
-          value: config.smooth ?? false,
-        },
-        flipHorizontal: {
-          input: "boolean",
-          label: "Flip horizontal",
-          value: config.flipHorizontal ?? false,
-        },
-        flipVertical: {
-          input: "boolean",
-          label: "Flip vertical",
-          value: config.flipVertical ?? false,
-        },
-        rotation: {
-          input: "select",
-          label: "Rotation",
-          value: config.rotation ?? 0,
-          options: [
-            { label: "0°", value: 0 },
-            { label: "90°", value: 90 },
-            { label: "180°", value: 180 },
-            { label: "270°", value: 270 },
-          ],
-        },
-        minValue: {
-          input: "number",
-          label: "Min (depth images)",
-          placeholder: "0",
-          value: config.minValue,
-        },
-        maxValue: {
-          input: "number",
-          label: "Max (depth images)",
-          placeholder: "10000",
-          value: config.maxValue,
-        },
+    };
+  }
+
+  nodes.general = {
+    label: "General",
+    fields: {
+      cameraTopic: {
+        label: "Topic",
+        input: "select",
+        value: config.cameraTopic,
+        options: imageTopics.map((topic) => ({ label: topic.name, value: topic.name })),
+      },
+      transformMarkers: {
+        input: "boolean",
+        label: "Transform markers",
+        value: config.transformMarkers,
+        help: config.transformMarkers
+          ? "Markers are being transformed by Foxglove Studio based on the camera model. Click to turn it off."
+          : `Markers can be transformed by Foxglove Studio based on the camera model. Click to turn it on.`,
+      },
+      synchronize: {
+        input: "boolean",
+        label: "Synchronize timestamps",
+        value: config.synchronize,
+      },
+      smooth: {
+        input: "boolean",
+        label: "Bilinear smoothing",
+        value: config.smooth ?? false,
+      },
+      flipHorizontal: {
+        input: "boolean",
+        label: "Flip horizontal",
+        value: config.flipHorizontal ?? false,
+      },
+      flipVertical: {
+        input: "boolean",
+        label: "Flip vertical",
+        value: config.flipVertical ?? false,
+      },
+      rotation: {
+        input: "select",
+        label: "Rotation",
+        value: config.rotation ?? 0,
+        options: [
+          { label: "0°", value: 0 },
+          { label: "90°", value: 90 },
+          { label: "180°", value: 180 },
+          { label: "270°", value: 270 },
+        ],
+      },
+      minValue: {
+        input: "number",
+        label: "Min (depth images)",
+        placeholder: "0",
+        value: config.minValue,
+      },
+      maxValue: {
+        input: "number",
+        label: "Max (depth images)",
+        placeholder: "10000",
+        value: config.maxValue,
       },
     },
-    markers: memoBuildMarkersNode(markerTopics, enabledMarkerTopics, relatedMarkerTopics),
   };
+
+  nodes.markers = memoBuildMarkersNode(markerTopics, enabledMarkerTopics, relatedMarkerTopics);
+
+  return nodes;
 }

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -52,15 +52,13 @@ export function buildSettingsTree({
   if (enableNewImagePanel) {
     nodes.newImage = {
       label: "Try the new Image panel",
-      actions: [
-        {
-          type: "action",
-          id: "upgradeOptIn",
-          display: "inline",
-          icon: "Star",
-          label: "Upgrade",
+      fields: {
+        newImage: {
+          input: "boolean",
+          label: "Enable new panel",
+          value: false,
         },
-      ],
+      },
     };
   }
 

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -48,13 +48,15 @@ export function buildSettingsTree({
   return {
     newImage: {
       label: "Try the new Image panel",
-      fields: {
-        newImage: {
-          input: "boolean",
-          label: "Enable new panel",
-          value: false,
+      actions: [
+        {
+          type: "action",
+          id: "upgradeOptIn",
+          display: "inline",
+          icon: "Star",
+          label: "Upgrade",
         },
-      },
+      ],
     },
     general: {
       label: "General",

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -46,6 +46,16 @@ export function buildSettingsTree({
   relatedMarkerTopics: readonly string[];
 }): SettingsTreeNodes {
   return {
+    newImage: {
+      label: "Try the new Image panel",
+      fields: {
+        newImage: {
+          input: "boolean",
+          label: "Enable new panel",
+          value: false,
+        },
+      },
+    },
     general: {
       label: "General",
       fields: {

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -104,11 +104,14 @@ export default function PanelCatalogProvider(
       getPanels() {
         return visiblePanels;
       },
+      getAllPanels() {
+        return allPanels;
+      },
       getPanelByType(type: string) {
         return panelsByType.get(type);
       },
     };
-  }, [panelsByType, visiblePanels]);
+  }, [allPanels, panelsByType, visiblePanels]);
 
   return (
     <PanelCatalogContext.Provider value={provider}>{props.children}</PanelCatalogContext.Provider>


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
When the new image panel is enabled, display a button in the **old** image panel to upgrade to the new panel. The button displays a confirmation dialog before doing the upgrade. Clicking "Replace panel" swaps in a new image panel.

The new panel does not have an option to toggle this back to "off". Instead the user has to click "Change panel" or add a new (legacy) Image panel.

<img width="332" alt="image" src="https://user-images.githubusercontent.com/14237/236074418-d6894557-10dc-4a7b-af4e-025e996439af.png">

<img width="648" alt="image" src="https://user-images.githubusercontent.com/14237/236072087-c5d86714-5d98-4088-9a05-e468feecf5d6.png">

Resolves FG-3213