### PR TITLE
Add text anchor point setting to image panel

### DIFF
--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -114,7 +114,7 @@ export function ImageView({ context }: Props): JSX.Element {
     };
   });
 
-  const { cameraTopic, enabledMarkerTopics, transformMarkers } = config;
+  const { cameraTopic, enabledMarkerTopics, transformMarkers, showTextAnchorPoints } = config;
   const topicsByTopicName = useMemo(() => keyBy(topics, ({ name }) => name), [topics]);
   const cameraTopicFullObject = useMemo(
     () => topicsByTopicName[cameraTopic],
@@ -367,12 +367,13 @@ export function ImageView({ context }: Props): JSX.Element {
   const rawMarkerData: RawMarkerData = useMemo(() => {
     return {
       markers: annotations,
+      showTextAnchorPoints,
       transformMarkers,
       // Convert to plain object before sending to web worker
       cameraInfo:
         (cameraInfo as { toJSON?: () => CameraInfo } | undefined)?.toJSON?.() ?? cameraInfo,
     };
-  }, [annotations, cameraInfo, transformMarkers]);
+  }, [annotations, cameraInfo, transformMarkers, showTextAnchorPoints]);
   const saveConfigWithMerging = useCallback(
     (newConfig: Partial<Config>) => setConfig((oldConfig) => ({ ...oldConfig, ...newConfig })),
     [setConfig],
@@ -447,4 +448,5 @@ export const defaultConfig: Config = {
   synchronize: false,
   transformMarkers: false,
   zoom: 1,
+  showTextAnchorPoints: false,
 };

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -6,7 +6,16 @@ import { StoryObj } from "@storybook/react";
 import { useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
-import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import {
+  CameraCalibration,
+  ImageAnnotations,
+  PointsAnnotationType,
+  RawImage,
+  TextAnnotation,
+} from "@foxglove/schemas";
+import { MessageEvent } from "@foxglove/studio";
+import { makeImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
+import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
 import ImageView from "./index";
 
@@ -53,6 +62,273 @@ export const WithSettings: StoryObj = {
     return (
       <PanelSetup includeSettings>
         <ImageView />
+      </PanelSetup>
+    );
+  },
+
+  parameters: {
+    colorScheme: "light",
+  },
+};
+
+// TODO: REMOVE BEFORE LANDING
+export const WithSettingsAndData: StoryObj = {
+  render: function Story() {
+    const width = 60;
+    const height = 45;
+
+    const { calibrationMessage, cameraMessage } = makeImageAndCalibration({
+      width,
+      height,
+      frameId: "camera",
+      imageTopic: "camera",
+      calibrationTopic: "calibration",
+    });
+
+    const annotationsMessage: MessageEvent<Partial<ImageAnnotations>> = {
+      topic: "annotations",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        circles: [
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 20, y: 5 },
+            diameter: 4,
+            thickness: 1,
+            fill_color: { r: 1, g: 0, b: 1, a: 1 },
+            outline_color: { r: 1, g: 1, b: 0, a: 1 },
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 25, y: 5 },
+            diameter: 4,
+            thickness: 1,
+            fill_color: { r: 1, g: 0, b: 1, a: 0.5 },
+            outline_color: { r: 0, g: 0, b: 0, a: 0 },
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 30, y: 5 },
+            diameter: 4,
+            thickness: 0.5,
+            fill_color: { r: 1, g: 1, b: 0, a: 0 },
+            outline_color: { r: 0, g: 1, b: 1, a: 0.5 },
+          },
+        ],
+        points: [
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.POINTS,
+            points: [
+              { x: 0, y: 0 },
+              { x: 0, y: 8 },
+              { x: 2, y: 6 },
+              { x: 5, y: 2 },
+            ],
+            outline_color: { r: 1, g: 0, b: 0, a: 1 },
+            outline_colors: [],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 1,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.POINTS,
+            points: [
+              { x: 10 + 0, y: 0 },
+              { x: 10 + 0, y: 8 },
+              { x: 10 + 2, y: 6 },
+              { x: 10 + 5, y: 2 },
+            ],
+            outline_color: { r: 0, g: 0, b: 0, a: 1 },
+            outline_colors: [
+              { r: 1, g: 0, b: 0, a: 1 },
+              { r: 0, g: 1, b: 0, a: 1 },
+              { r: 0, g: 0, b: 1, a: 1 },
+              { r: 0, g: 1, b: 1, a: 1 },
+            ],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 2,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_LIST,
+            points: [
+              { x: 0, y: 10 + 0 },
+              { x: 0, y: 10 + 8 },
+              { x: 2, y: 10 + 6 },
+              { x: 5, y: 10 + 2 },
+            ],
+            outline_color: { r: 1, g: 0, b: 0, a: 1 },
+            outline_colors: [],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 1,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_LIST,
+            points: [
+              { x: 10 + 0, y: 10 + 0 },
+              { x: 10 + 0, y: 10 + 8 },
+              { x: 10 + 2, y: 10 + 6 },
+              { x: 10 + 5, y: 10 + 2 },
+            ],
+            outline_color: { r: 0, g: 0, b: 0, a: 1 },
+            outline_colors: [
+              // 1 color per point
+              { r: 1, g: 0, b: 0, a: 1 },
+              { r: 0, g: 1, b: 0, a: 1 },
+              { r: 0, g: 0, b: 1, a: 1 },
+              { r: 0, g: 1, b: 1, a: 1 },
+            ],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 2,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_LIST,
+            points: [
+              { x: 20 + 0, y: 10 + 0 },
+              { x: 20 + 0, y: 10 + 8 },
+              { x: 20 + 2, y: 10 + 6 },
+              { x: 20 + 5, y: 10 + 2 },
+            ],
+            outline_color: { r: 0, g: 0, b: 0, a: 1 },
+            outline_colors: [
+              // 1 color per line
+              { r: 1, g: 0, b: 0, a: 1 },
+              { r: 0, g: 1, b: 0, a: 1 },
+            ],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 2,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_STRIP,
+            points: [
+              { x: 0, y: 20 + 0 },
+              { x: 0, y: 20 + 8 },
+              { x: 2, y: 20 + 6 },
+              { x: 5, y: 20 + 2 },
+            ],
+            outline_color: { r: 1, g: 0, b: 0, a: 1 },
+            outline_colors: [],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 1,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_STRIP,
+            points: [
+              { x: 10 + 0, y: 20 + 0 },
+              { x: 10 + 0, y: 20 + 8 },
+              { x: 10 + 2, y: 20 + 6 },
+              { x: 10 + 5, y: 20 + 2 },
+            ],
+            outline_color: { r: 1, g: 1, b: 0, a: 1 },
+            outline_colors: [],
+            fill_color: { r: 1, g: 0, b: 1, a: 1 },
+            thickness: 0.5,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_LOOP,
+            points: [
+              { x: 0, y: 30 + 0 },
+              { x: 0, y: 30 + 8 },
+              { x: 2, y: 30 + 6 },
+              { x: 5, y: 30 + 2 },
+            ],
+            outline_color: { r: 1, g: 0, b: 0, a: 1 },
+            outline_colors: [],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 1,
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_LOOP,
+            points: [
+              { x: 10 + 0, y: 30 + 0 },
+              { x: 10 + 0, y: 30 + 8 },
+              { x: 10 + 2, y: 30 + 6 },
+              { x: 10 + 5, y: 30 + 2 },
+            ],
+            outline_color: { r: 1, g: 1, b: 0, a: 1 },
+            outline_colors: [],
+            fill_color: { r: 1, g: 0, b: 1, a: 1 },
+            thickness: 0.5,
+          },
+        ],
+        texts: [
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 20, y: 30 },
+            text: "Hi",
+            font_size: 5,
+            text_color: { r: 1, g: 0, b: 0, a: 1 },
+            background_color: { r: 1, g: 1, b: 0, a: 1 },
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 20, y: 32 },
+            text: "hello",
+            font_size: 3,
+            text_color: { r: 0.3, g: 0.5, b: 0.5, a: 0.8 },
+            background_color: { r: 1, g: 1, b: 1, a: 0.2 },
+          },
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            position: { x: 40, y: 10 },
+            text: "I'm but a measly single a pixel tall!",
+            font_size: 1,
+            text_color: { r: 1, g: 0.5, b: 0.5, a: 0.8 },
+            background_color: { r: 1, g: 1, b: 1, a: 0.8 },
+          },
+        ],
+      },
+
+      schemaName: "foxglove.ImageAnnotations",
+      sizeInBytes: 0,
+    };
+
+    const numRandomTextAnnotations = 10;
+    for (let i = 0; i < numRandomTextAnnotations; i++) {
+      const x = Math.random() * width;
+      const y = Math.random() * height;
+      const size = Math.random() * 5;
+      const randomTextAnnotation: TextAnnotation = {
+        timestamp: { sec: 0, nsec: 0 },
+        position: { x, y },
+        text: `size: ${size.toFixed(2)} @ ${x.toFixed(2)}, ${y.toFixed(2)}`,
+        font_size: 1,
+        text_color: { r: 1, g: 0, b: size / 5, a: 0.8 },
+        background_color: { r: Math.random(), g: 1, b: 0, a: 0.8 },
+      };
+      annotationsMessage.message.texts!.push(randomTextAnnotation);
+    }
+    const fixture: Fixture = {
+      topics: [
+        { name: "calibration", schemaName: "foxglove.CameraCalibration" },
+        { name: "camera", schemaName: "foxglove.RawImage" },
+        { name: "annotations", schemaName: "foxglove.ImageAnnotations" },
+      ],
+      frame: {
+        calibration: [calibrationMessage],
+        camera: [cameraMessage],
+        annotations: [annotationsMessage],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    };
+    return (
+      <PanelSetup includeSettings fixture={fixture}>
+        <ImageView
+          overrideConfig={{
+            enabledMarkerTopics: ["annotations"],
+            showTextAnchorPoints: true,
+          }}
+        />
       </PanelSetup>
     );
   },

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -162,6 +162,7 @@ export const FoxgloveAnnotations: StoryObj = {
           markers: normalizeAnnotations(foxgloveAnnotations, "foxglove.ImageAnnotations")!,
           cameraInfo,
           transformMarkers: false,
+          showTextAnchorPoints: true,
         },
       });
     }, [imageMessage]);

--- a/packages/studio-base/src/panels/Image/lib/util.ts
+++ b/packages/studio-base/src/panels/Image/lib/util.ts
@@ -168,8 +168,8 @@ function getAnchorPointsForTextAnnotations(texts: TextAnnotation[]): CircleAnnot
     stamp: text.stamp,
     position: text.position,
     outlineColor: text.textColor,
-    radius: 2,
-    thickness: 1,
+    radius: 2 * (text.fontSize / 12),
+    thickness: 1 * (text.fontSize / 12),
     fillColor: text.backgroundColor,
   }));
 }

--- a/packages/studio-base/src/panels/Image/lib/util.ts
+++ b/packages/studio-base/src/panels/Image/lib/util.ts
@@ -14,7 +14,14 @@
 import { CameraInfo, PinholeCameraModel } from "@foxglove/den/image";
 import { Topic } from "@foxglove/studio-base/players/types";
 
-import { Dimensions, MarkerData, RawMarkerData, ZoomMode } from "../types";
+import {
+  CircleAnnotation,
+  Dimensions,
+  MarkerData,
+  RawMarkerData,
+  TextAnnotation,
+  ZoomMode,
+} from "../types";
 
 export function calculateZoomScale(
   bitmap: Dimensions,
@@ -121,7 +128,7 @@ export function getCameraNamespace(topicName: string): string | undefined {
 }
 
 export function buildMarkerData(rawMarkerData: RawMarkerData): MarkerData | undefined {
-  const { markers, transformMarkers, cameraInfo } = rawMarkerData;
+  const { markers, transformMarkers, cameraInfo, showTextAnchorPoints } = rawMarkerData;
   if (markers.length === 0) {
     return {
       markers,
@@ -138,10 +145,31 @@ export function buildMarkerData(rawMarkerData: RawMarkerData): MarkerData | unde
     cameraModel = new PinholeCameraModel(cameraInfo as CameraInfo);
   }
 
+  let markersToRender = markers;
+  if (showTextAnchorPoints === true) {
+    const textAnnotations = markers.filter((marker) => marker.type === "text") as TextAnnotation[];
+    const anchorPoints = getAnchorPointsForTextAnnotations(textAnnotations);
+    if (anchorPoints.length > 0) {
+      markersToRender = markers.concat(anchorPoints);
+    }
+  }
+
   return {
-    markers,
+    markers: markersToRender,
     cameraModel,
     originalWidth: cameraInfo?.width,
     originalHeight: cameraInfo?.height,
   };
+}
+
+function getAnchorPointsForTextAnnotations(texts: TextAnnotation[]): CircleAnnotation[] {
+  return texts.map((text) => ({
+    type: "circle",
+    stamp: text.stamp,
+    position: text.position,
+    outlineColor: text.textColor,
+    radius: 2,
+    thickness: 1,
+    fillColor: text.backgroundColor,
+  }));
 }

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -106,6 +106,11 @@ export function buildSettingsTree({
           placeholder: "10000",
           value: config.maxValue,
         },
+        showTextAnchorPoints: {
+          input: "boolean",
+          label: "Show text anchor points",
+          value: config.showTextAnchorPoints ?? false,
+        },
       },
     },
     markers: memoBuildMarkersNode(markerTopics, enabledMarkerTopics, relatedMarkerTopics),

--- a/packages/studio-base/src/panels/Image/types.ts
+++ b/packages/studio-base/src/panels/Image/types.ts
@@ -26,6 +26,7 @@ export type Config = DefaultConfig & {
   transformMarkers: boolean;
   zoom?: number;
   zoomPercentage?: number;
+  showTextAnchorPoints?: boolean;
 };
 
 export type UseImagePanelMessagesParams = {
@@ -62,6 +63,7 @@ export type Dimensions = { width: number; height: number };
 export type RawMarkerData = {
   markers: readonly Annotation[];
   transformMarkers: boolean;
+  showTextAnchorPoints?: boolean;
   cameraInfo?: CameraInfo;
 };
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Add option in image panel to show text anchor points 

**Description**
Add option in image panel to show text anchor points in the bottom left of the annotation using a circle of radius 2 with an outline of 1 using the background text color as the fill and the text color as the outline.
Example from story:
<img width="407" alt="image" src="https://user-images.githubusercontent.com/10187776/236260477-4a7aec7b-b168-4f48-a8e9-612e94d51241.png">


<!-- link relevant GitHub issues -->
FG-2994
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
