### PR TITLE
[3D Image] Add pan & zoom support

### DIFF
--- a/packages/studio-base/src/i18n/en/threeDee.ts
+++ b/packages/studio-base/src/i18n/en/threeDee.ts
@@ -75,4 +75,5 @@ export const threeDee = {
 
   // Image annotations
   imageAnnotations: "Image annotations",
+  resetView: "Reset view",
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -50,6 +50,7 @@ export type RendererEvents = {
   configChange: (renderer: IRenderer) => void;
   schemaHandlersChanged: (renderer: IRenderer) => void;
   topicHandlersChanged: (renderer: IRenderer) => void;
+  resetViewChanged: (renderer: IRenderer) => void;
 };
 
 export type FollowMode = "follow-pose" | "follow-position" | "follow-none";
@@ -289,6 +290,11 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
   setCameraState(cameraState: CameraState): void;
 
   getCameraState(): CameraState | undefined;
+
+  /** Whether the view has been modified and a reset button should be shown (image mode only). */
+  canResetView(): boolean;
+  /** Reset any manual view modifications (image mode only). */
+  resetView(): void;
 
   setSelectedRenderable(selection: PickedRenderable | undefined): void;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -337,6 +337,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
           },
         });
         this.cameraHandler = this.#imageModeExtension;
+        this.#imageModeExtension.addEventListener("hasModifiedViewChanged", () => {
+          this.emit("resetViewChanged", this);
+        });
         this.#addSceneExtension(this.cameraHandler);
         break;
       case "3d":
@@ -842,6 +845,15 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   public getCameraState(): CameraState | undefined {
     return this.cameraHandler.getCameraState();
+  }
+
+  public canResetView(): boolean {
+    return this.#imageModeExtension?.hasModifiedView() ?? false;
+  }
+
+  public resetView(): void {
+    this.#imageModeExtension?.resetViewModifications();
+    this.queueAnimationFrame();
   }
 
   public setSelectedRenderable(selection: PickedRenderable | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -19,6 +19,9 @@ import { useLongPress } from "react-use";
 import { makeStyles } from "tss-react/mui";
 
 import { LayoutActions } from "@foxglove/studio";
+import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
+import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
+import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
@@ -26,10 +29,15 @@ import type { PickedRenderable } from "./Picker";
 import { Renderable } from "./Renderable";
 import { useRenderer, useRendererEvent } from "./RendererContext";
 import { Stats } from "./Stats";
-import { PublishClickIcons } from "./ThreeDeeRender";
 import { MouseEventObject } from "./camera";
 import { PublishClickType } from "./renderables/PublishClickTool";
 import { InterfaceMode } from "./types";
+
+const PublishClickIcons: Record<PublishClickType, React.ReactNode> = {
+  pose: <PublishGoalIcon fontSize="inherit" />,
+  point: <PublishPointIcon fontSize="inherit" />,
+  pose_estimate: <PublishPoseEstimateIcon fontSize="inherit" />,
+};
 
 const useStyles = makeStyles()((theme) => ({
   iconButton: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -64,7 +64,7 @@ const useStyles = makeStyles()((theme) => ({
     position: "absolute",
     bottom: 0,
     right: 0,
-    marginBottom: theme.spacing(4),
+    marginBottom: theme.spacing(1),
     marginRight: theme.spacing(1),
   },
 }));

--- a/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -1,0 +1,338 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Ruler24Filled } from "@fluentui/react-icons";
+import {
+  Button,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Paper,
+  useTheme,
+} from "@mui/material";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useLongPress } from "react-use";
+import { makeStyles } from "tss-react/mui";
+
+import { LayoutActions } from "@foxglove/studio";
+import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
+import type { PickedRenderable } from "./Picker";
+import { Renderable } from "./Renderable";
+import { useRenderer, useRendererEvent } from "./RendererContext";
+import { Stats } from "./Stats";
+import { PublishClickIcons } from "./ThreeDeeRender";
+import { MouseEventObject } from "./camera";
+import { PublishClickType } from "./renderables/PublishClickTool";
+import { InterfaceMode } from "./types";
+
+const useStyles = makeStyles()((theme) => ({
+  iconButton: {
+    position: "relative",
+    fontSize: "1rem !important",
+    pointerEvents: "auto",
+    aspectRatio: "1",
+
+    "& svg:not(.MuiSvgIcon-root)": {
+      fontSize: "1rem !important",
+    },
+  },
+  rulerIcon: {
+    transform: "rotate(45deg)",
+  },
+  threeDeeButton: {
+    fontFamily: fonts.MONOSPACE,
+    fontFeatureSettings: theme.typography.caption.fontFeatureSettings,
+    fontSize: theme.typography.caption.fontSize,
+    fontWeight: theme.typography.fontWeightBold,
+    lineHeight: "1em",
+  },
+  resetViewButton: {
+    position: "absolute",
+    bottom: 0,
+    right: 0,
+    marginBottom: theme.spacing(4),
+    marginRight: theme.spacing(1),
+  },
+}));
+
+/**
+ * Provides DOM overlay elements on top of the 3D scene (e.g. stats, debug GUI).
+ */
+export function RendererOverlay(props: {
+  interfaceMode: InterfaceMode;
+  canvas: HTMLCanvasElement | ReactNull;
+  addPanel: LayoutActions["addPanel"];
+  enableStats: boolean;
+  perspective: boolean;
+  onTogglePerspective: () => void;
+  measureActive: boolean;
+  onClickMeasure: () => void;
+  canPublish: boolean;
+  publishActive: boolean;
+  publishClickType: PublishClickType;
+  onChangePublishClickType: (_: PublishClickType) => void;
+  onClickPublish: () => void;
+  timezone: string | undefined;
+}): JSX.Element {
+  const { t } = useTranslation("threeDee");
+  const { classes } = useStyles();
+  const [clickedPosition, setClickedPosition] = useState<{ clientX: number; clientY: number }>({
+    clientX: 0,
+    clientY: 0,
+  });
+  const [selectedRenderables, setSelectedRenderables] = useState<PickedRenderable[]>([]);
+  const [selectedRenderable, setSelectedRenderable] = useState<PickedRenderable | undefined>(
+    undefined,
+  );
+  const [interactionsTabType, setInteractionsTabType] = useState<TabType | undefined>(undefined);
+  const renderer = useRenderer();
+
+  // Toggle object selection mode on/off in the renderer
+  useEffect(() => {
+    if (renderer) {
+      renderer.setPickingEnabled(interactionsTabType != undefined);
+    }
+  }, [interactionsTabType, renderer]);
+
+  useRendererEvent("renderablesClicked", (selections, cursorCoords) => {
+    const rect = props.canvas!.getBoundingClientRect();
+    setClickedPosition({ clientX: rect.left + cursorCoords.x, clientY: rect.top + cursorCoords.y });
+    setSelectedRenderables(selections);
+    setSelectedRenderable(selections.length === 1 ? selections[0] : undefined);
+  });
+
+  const [showResetViewButton, setShowResetViewButton] = useState(renderer?.canResetView() ?? false);
+  useRendererEvent(
+    "resetViewChanged",
+    useCallback(() => {
+      setShowResetViewButton(renderer?.canResetView() ?? false);
+    }, [renderer]),
+  );
+  const onResetView = useCallback(() => {
+    renderer?.resetView();
+  }, [renderer]);
+
+  const stats = props.enableStats ? (
+    <div id="stats" style={{ position: "absolute", top: "10px", left: "10px" }}>
+      <Stats />
+    </div>
+  ) : undefined;
+
+  // Convert the list of selected renderables (if any) into MouseEventObjects
+  // that can be passed to <InteractionContextMenu>, which shows a context menu
+  // of candidate objects to select
+  const clickedObjects = useMemo<MouseEventObject[]>(
+    () =>
+      selectedRenderables.map((selection) => ({
+        object: {
+          pose: selection.renderable.pose,
+          scale: selection.renderable.scale,
+          color: undefined,
+          interactionData: {
+            topic: selection.renderable.name,
+            highlighted: undefined,
+            renderable: selection.renderable,
+          },
+        },
+        instanceIndex: selection.instanceIndex,
+      })),
+    [selectedRenderables],
+  );
+
+  // Once a single renderable is selected, convert it to the SelectionObject
+  // format to populate the object inspection dialog (<Interactions>)
+  const selectedObject = useMemo<SelectionObject | undefined>(
+    () =>
+      selectedRenderable
+        ? {
+            object: {
+              pose: selectedRenderable.renderable.pose,
+              interactionData: {
+                topic: selectedRenderable.renderable.topic,
+                highlighted: true,
+                originalMessage: selectedRenderable.renderable.details(),
+                instanceDetails:
+                  selectedRenderable.instanceIndex != undefined
+                    ? selectedRenderable.renderable.instanceDetails(
+                        selectedRenderable.instanceIndex,
+                      )
+                    : undefined,
+              },
+            },
+            instanceIndex: selectedRenderable.instanceIndex,
+          }
+        : undefined,
+    [selectedRenderable],
+  );
+
+  // Inform the Renderer when a renderable is selected
+  useEffect(() => {
+    renderer?.setSelectedRenderable(selectedRenderable);
+  }, [renderer, selectedRenderable]);
+
+  const publickClickButtonRef = useRef<HTMLButtonElement>(ReactNull);
+  const [publishMenuExpanded, setPublishMenuExpanded] = useState(false);
+  const selectedPublishClickIcon = PublishClickIcons[props.publishClickType];
+
+  const onLongPressPublish = useCallback(() => {
+    setPublishMenuExpanded(true);
+  }, []);
+  const longPressPublishEvent = useLongPress(onLongPressPublish);
+
+  const theme = useTheme();
+
+  // Publish control is only available if the canPublish prop is true and we have a fixed frame in the renderer
+  const showPublishControl =
+    props.interfaceMode === "3d" && props.canPublish && renderer?.fixedFrameId != undefined;
+  const publishControls = showPublishControl && (
+    <>
+      <IconButton
+        {...longPressPublishEvent}
+        color={props.publishActive ? "info" : "inherit"}
+        title={props.publishActive ? "Click to cancel" : "Click to publish"}
+        ref={publickClickButtonRef}
+        onClick={props.onClickPublish}
+        data-testid="publish-button"
+        style={{ fontSize: "1rem", pointerEvents: "auto" }}
+      >
+        {selectedPublishClickIcon}
+        <div
+          style={{
+            borderBottom: "6px solid currentColor",
+            borderRight: "6px solid transparent",
+            bottom: 0,
+            left: 0,
+            height: 0,
+            width: 0,
+            margin: theme.spacing(0.25),
+            position: "absolute",
+          }}
+        />
+      </IconButton>
+      <Menu
+        id="publish-menu"
+        anchorEl={publickClickButtonRef.current}
+        anchorOrigin={{ vertical: "top", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        open={publishMenuExpanded}
+        onClose={() => setPublishMenuExpanded(false)}
+      >
+        <MenuItem
+          selected={props.publishClickType === "pose_estimate"}
+          onClick={() => {
+            props.onChangePublishClickType("pose_estimate");
+            setPublishMenuExpanded(false);
+          }}
+        >
+          <ListItemIcon>{PublishClickIcons.pose_estimate}</ListItemIcon>
+          <ListItemText>Publish pose estimate</ListItemText>
+        </MenuItem>
+        <MenuItem
+          selected={props.publishClickType === "pose"}
+          onClick={() => {
+            props.onChangePublishClickType("pose");
+            setPublishMenuExpanded(false);
+          }}
+        >
+          <ListItemIcon>{PublishClickIcons.pose}</ListItemIcon>
+          <ListItemText>Publish pose</ListItemText>
+        </MenuItem>
+        <MenuItem
+          selected={props.publishClickType === "point"}
+          onClick={() => {
+            props.onChangePublishClickType("point");
+            setPublishMenuExpanded(false);
+          }}
+        >
+          <ListItemIcon>{PublishClickIcons.point}</ListItemIcon>
+          <ListItemText>Publish point</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+
+  const resetViewButton = showResetViewButton && (
+    <Button
+      className={classes.resetViewButton}
+      variant="contained"
+      color="secondary"
+      onClick={onResetView}
+      data-testid="reset-view"
+    >
+      {t("resetView")}
+    </Button>
+  );
+
+  return (
+    <>
+      <div
+        style={{
+          position: "absolute",
+          top: "10px",
+          right: "10px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          gap: 10,
+          pointerEvents: "none",
+        }}
+      >
+        <Interactions
+          addPanel={props.addPanel}
+          selectedObject={selectedObject}
+          interactionsTabType={interactionsTabType}
+          setInteractionsTabType={setInteractionsTabType}
+          timezone={props.timezone}
+        />
+        {props.interfaceMode === "3d" && (
+          <Paper square={false} elevation={4} style={{ display: "flex", flexDirection: "column" }}>
+            <IconButton
+              className={classes.iconButton}
+              color={props.perspective ? "info" : "inherit"}
+              title={props.perspective ? "Switch to 2D camera" : "Switch to 3D camera"}
+              onClick={props.onTogglePerspective}
+            >
+              <span className={classes.threeDeeButton}>3D</span>
+            </IconButton>
+            <IconButton
+              data-testid="measure-button"
+              className={classes.iconButton}
+              color={props.measureActive ? "info" : "inherit"}
+              title={props.measureActive ? "Cancel measuring" : "Measure distance"}
+              onClick={props.onClickMeasure}
+            >
+              <Ruler24Filled className={classes.rulerIcon} />
+            </IconButton>
+
+            {publishControls}
+          </Paper>
+        )}
+      </div>
+      {clickedObjects.length > 1 && !selectedObject && (
+        <InteractionContextMenu
+          onClose={() => setSelectedRenderables([])}
+          clickedPosition={clickedPosition}
+          clickedObjects={clickedObjects}
+          selectObject={(selection) => {
+            if (selection) {
+              const renderable = (
+                selection.object as unknown as { interactionData: { renderable: Renderable } }
+              ).interactionData.renderable;
+              const instanceIndex = selection.instanceIndex;
+              setSelectedRenderables([]);
+              setSelectedRenderable({ renderable, instanceIndex });
+            }
+          }}
+        />
+      )}
+      {stats}
+      {resetViewButton}
+    </>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -25,9 +25,6 @@ import {
   VariableValue,
 } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
-import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
-import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
-import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import type {
@@ -52,7 +49,7 @@ import {
   PublishRos2Datatypes,
 } from "./publish";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
-import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
+import { PublishClickEvent } from "./renderables/PublishClickTool";
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/PublishSettings";
 import { InterfaceMode } from "./types";
 
@@ -69,12 +66,6 @@ const PANEL_STYLE: React.CSSProperties = {
   height: "100%",
   display: "flex",
   position: "relative",
-};
-
-export const PublishClickIcons: Record<PublishClickType, React.ReactNode> = {
-  pose: <PublishGoalIcon fontSize="inherit" />,
-  point: <PublishPointIcon fontSize="inherit" />,
-  pose_estimate: <PublishPoseEstimateIcon fontSize="inherit" />,
 };
 
 function useRendererProperty<K extends keyof IRenderer>(

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -2,23 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Ruler24Filled } from "@fluentui/react-icons";
-import {
-  IconButton,
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-  Paper,
-  useTheme,
-} from "@mui/material";
 import { Immutable } from "immer";
 import { cloneDeep, isEqual, merge } from "lodash";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
-import { useLatest, useLongPress } from "react-use";
+import { useLatest } from "react-use";
 import { DeepPartial } from "ts-essentials";
-import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
 
 import Logger from "@foxglove/log";
@@ -40,7 +29,6 @@ import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
 import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
-import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import type {
   RendererConfig,
@@ -50,13 +38,12 @@ import type {
   IRenderer,
   ImageModeConfig,
 } from "./IRenderer";
-import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
 import type { PickedRenderable } from "./Picker";
-import { Renderable, SELECTED_ID_VARIABLE } from "./Renderable";
+import { SELECTED_ID_VARIABLE } from "./Renderable";
 import { LegacyImageConfig, Renderer } from "./Renderer";
-import { RendererContext, useRenderer, useRendererEvent } from "./RendererContext";
-import { Stats } from "./Stats";
-import { CameraState, DEFAULT_CAMERA_STATE, MouseEventObject } from "./camera";
+import { RendererContext, useRendererEvent } from "./RendererContext";
+import { RendererOverlay } from "./RendererOverlay";
+import { CameraState, DEFAULT_CAMERA_STATE } from "./camera";
 import {
   makePointMessage,
   makePoseEstimateMessage,
@@ -84,285 +71,11 @@ const PANEL_STYLE: React.CSSProperties = {
   position: "relative",
 };
 
-const PublishClickIcons: Record<PublishClickType, React.ReactNode> = {
+export const PublishClickIcons: Record<PublishClickType, React.ReactNode> = {
   pose: <PublishGoalIcon fontSize="inherit" />,
   point: <PublishPointIcon fontSize="inherit" />,
   pose_estimate: <PublishPoseEstimateIcon fontSize="inherit" />,
 };
-
-const useStyles = makeStyles()((theme) => ({
-  iconButton: {
-    position: "relative",
-    fontSize: "1rem !important",
-    pointerEvents: "auto",
-    aspectRatio: "1",
-
-    "& svg:not(.MuiSvgIcon-root)": {
-      fontSize: "1rem !important",
-    },
-  },
-  rulerIcon: {
-    transform: "rotate(45deg)",
-  },
-  threeDeeButton: {
-    fontFamily: fonts.MONOSPACE,
-    fontFeatureSettings: theme.typography.caption.fontFeatureSettings,
-    fontSize: theme.typography.caption.fontSize,
-    fontWeight: theme.typography.fontWeightBold,
-    lineHeight: "1em",
-  },
-}));
-
-/**
- * Provides DOM overlay elements on top of the 3D scene (e.g. stats, debug GUI).
- */
-function RendererOverlay(props: {
-  interfaceMode: InterfaceMode;
-  canvas: HTMLCanvasElement | ReactNull;
-  addPanel: LayoutActions["addPanel"];
-  enableStats: boolean;
-  perspective: boolean;
-  onTogglePerspective: () => void;
-  measureActive: boolean;
-  onClickMeasure: () => void;
-  canPublish: boolean;
-  publishActive: boolean;
-  publishClickType: PublishClickType;
-  onChangePublishClickType: (_: PublishClickType) => void;
-  onClickPublish: () => void;
-  timezone: string | undefined;
-}): JSX.Element {
-  const { classes } = useStyles();
-  const [clickedPosition, setClickedPosition] = useState<{ clientX: number; clientY: number }>({
-    clientX: 0,
-    clientY: 0,
-  });
-  const [selectedRenderables, setSelectedRenderables] = useState<PickedRenderable[]>([]);
-  const [selectedRenderable, setSelectedRenderable] = useState<PickedRenderable | undefined>(
-    undefined,
-  );
-  const [interactionsTabType, setInteractionsTabType] = useState<TabType | undefined>(undefined);
-  const renderer = useRenderer();
-
-  // Toggle object selection mode on/off in the renderer
-  useEffect(() => {
-    if (renderer) {
-      renderer.setPickingEnabled(interactionsTabType != undefined);
-    }
-  }, [interactionsTabType, renderer]);
-
-  useRendererEvent("renderablesClicked", (selections, cursorCoords) => {
-    const rect = props.canvas!.getBoundingClientRect();
-    setClickedPosition({ clientX: rect.left + cursorCoords.x, clientY: rect.top + cursorCoords.y });
-    setSelectedRenderables(selections);
-    setSelectedRenderable(selections.length === 1 ? selections[0] : undefined);
-  });
-
-  const stats = props.enableStats ? (
-    <div id="stats" style={{ position: "absolute", top: "10px", left: "10px" }}>
-      <Stats />
-    </div>
-  ) : undefined;
-
-  // Convert the list of selected renderables (if any) into MouseEventObjects
-  // that can be passed to <InteractionContextMenu>, which shows a context menu
-  // of candidate objects to select
-  const clickedObjects = useMemo<MouseEventObject[]>(
-    () =>
-      selectedRenderables.map((selection) => ({
-        object: {
-          pose: selection.renderable.pose,
-          scale: selection.renderable.scale,
-          color: undefined,
-          interactionData: {
-            topic: selection.renderable.name,
-            highlighted: undefined,
-            renderable: selection.renderable,
-          },
-        },
-        instanceIndex: selection.instanceIndex,
-      })),
-    [selectedRenderables],
-  );
-
-  // Once a single renderable is selected, convert it to the SelectionObject
-  // format to populate the object inspection dialog (<Interactions>)
-  const selectedObject = useMemo<SelectionObject | undefined>(
-    () =>
-      selectedRenderable
-        ? {
-            object: {
-              pose: selectedRenderable.renderable.pose,
-              interactionData: {
-                topic: selectedRenderable.renderable.topic,
-                highlighted: true,
-                originalMessage: selectedRenderable.renderable.details(),
-                instanceDetails:
-                  selectedRenderable.instanceIndex != undefined
-                    ? selectedRenderable.renderable.instanceDetails(
-                        selectedRenderable.instanceIndex,
-                      )
-                    : undefined,
-              },
-            },
-            instanceIndex: selectedRenderable.instanceIndex,
-          }
-        : undefined,
-    [selectedRenderable],
-  );
-
-  // Inform the Renderer when a renderable is selected
-  useEffect(() => {
-    renderer?.setSelectedRenderable(selectedRenderable);
-  }, [renderer, selectedRenderable]);
-
-  const publickClickButtonRef = useRef<HTMLButtonElement>(ReactNull);
-  const [publishMenuExpanded, setPublishMenuExpanded] = useState(false);
-  const selectedPublishClickIcon = PublishClickIcons[props.publishClickType];
-
-  const onLongPressPublish = useCallback(() => {
-    setPublishMenuExpanded(true);
-  }, []);
-  const longPressPublishEvent = useLongPress(onLongPressPublish);
-
-  const theme = useTheme();
-
-  // Publish control is only available if the canPublish prop is true and we have a fixed frame in the renderer
-  const showPublishControl =
-    props.interfaceMode === "3d" && props.canPublish && renderer?.fixedFrameId != undefined;
-  const publishControls = showPublishControl && (
-    <>
-      <IconButton
-        {...longPressPublishEvent}
-        color={props.publishActive ? "info" : "inherit"}
-        title={props.publishActive ? "Click to cancel" : "Click to publish"}
-        ref={publickClickButtonRef}
-        onClick={props.onClickPublish}
-        data-testid="publish-button"
-        style={{ fontSize: "1rem", pointerEvents: "auto" }}
-      >
-        {selectedPublishClickIcon}
-        <div
-          style={{
-            borderBottom: "6px solid currentColor",
-            borderRight: "6px solid transparent",
-            bottom: 0,
-            left: 0,
-            height: 0,
-            width: 0,
-            margin: theme.spacing(0.25),
-            position: "absolute",
-          }}
-        />
-      </IconButton>
-      <Menu
-        id="publish-menu"
-        anchorEl={publickClickButtonRef.current}
-        anchorOrigin={{ vertical: "top", horizontal: "left" }}
-        transformOrigin={{ vertical: "top", horizontal: "right" }}
-        open={publishMenuExpanded}
-        onClose={() => setPublishMenuExpanded(false)}
-      >
-        <MenuItem
-          selected={props.publishClickType === "pose_estimate"}
-          onClick={() => {
-            props.onChangePublishClickType("pose_estimate");
-            setPublishMenuExpanded(false);
-          }}
-        >
-          <ListItemIcon>{PublishClickIcons.pose_estimate}</ListItemIcon>
-          <ListItemText>Publish pose estimate</ListItemText>
-        </MenuItem>
-        <MenuItem
-          selected={props.publishClickType === "pose"}
-          onClick={() => {
-            props.onChangePublishClickType("pose");
-            setPublishMenuExpanded(false);
-          }}
-        >
-          <ListItemIcon>{PublishClickIcons.pose}</ListItemIcon>
-          <ListItemText>Publish pose</ListItemText>
-        </MenuItem>
-        <MenuItem
-          selected={props.publishClickType === "point"}
-          onClick={() => {
-            props.onChangePublishClickType("point");
-            setPublishMenuExpanded(false);
-          }}
-        >
-          <ListItemIcon>{PublishClickIcons.point}</ListItemIcon>
-          <ListItemText>Publish point</ListItemText>
-        </MenuItem>
-      </Menu>
-    </>
-  );
-
-  return (
-    <React.Fragment>
-      <div
-        style={{
-          position: "absolute",
-          top: "10px",
-          right: "10px",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "flex-end",
-          gap: 10,
-          pointerEvents: "none",
-        }}
-      >
-        <Interactions
-          addPanel={props.addPanel}
-          selectedObject={selectedObject}
-          interactionsTabType={interactionsTabType}
-          setInteractionsTabType={setInteractionsTabType}
-          timezone={props.timezone}
-        />
-        {props.interfaceMode === "3d" && (
-          <Paper square={false} elevation={4} style={{ display: "flex", flexDirection: "column" }}>
-            <IconButton
-              className={classes.iconButton}
-              color={props.perspective ? "info" : "inherit"}
-              title={props.perspective ? "Switch to 2D camera" : "Switch to 3D camera"}
-              onClick={props.onTogglePerspective}
-            >
-              <span className={classes.threeDeeButton}>3D</span>
-            </IconButton>
-            <IconButton
-              data-testid="measure-button"
-              className={classes.iconButton}
-              color={props.measureActive ? "info" : "inherit"}
-              title={props.measureActive ? "Cancel measuring" : "Measure distance"}
-              onClick={props.onClickMeasure}
-            >
-              <Ruler24Filled className={classes.rulerIcon} />
-            </IconButton>
-
-            {publishControls}
-          </Paper>
-        )}
-      </div>
-      {clickedObjects.length > 1 && !selectedObject && (
-        <InteractionContextMenu
-          onClose={() => setSelectedRenderables([])}
-          clickedPosition={clickedPosition}
-          clickedObjects={clickedObjects}
-          selectObject={(selection) => {
-            if (selection) {
-              const renderable = (
-                selection.object as unknown as { interactionData: { renderable: Renderable } }
-              ).interactionData.renderable;
-              const instanceIndex = selection.instanceIndex;
-              setSelectedRenderables([]);
-              setSelectedRenderable({ renderable, instanceIndex });
-            }
-          }}
-        />
-      )}
-      {stats}
-    </React.Fragment>
-  );
-}
 
 function useRendererProperty<K extends keyof IRenderer>(
   renderer: IRenderer | undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -64,7 +64,12 @@ const CAMERA_MODEL = "CameraModel";
 const DEFAULT_FOCAL_LENGTH = 500;
 const DEFAULT_IMAGE_WIDTH = 512;
 
-export class ImageMode extends SceneExtension<ImageRenderable> implements ICameraHandler {
+type ImageModeEvent = { type: "hasModifiedViewChanged" };
+
+export class ImageMode
+  extends SceneExtension<ImageRenderable, ImageModeEvent>
+  implements ICameraHandler
+{
   #camera: ImageModeCamera;
   #cameraModel:
     | {
@@ -76,6 +81,10 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
   #annotations: ImageAnnotations;
 
   #imageRenderable: ImageRenderable | undefined;
+
+  #dragStartPanOffset = new THREE.Vector2();
+  #dragStartMouseCoords = new THREE.Vector2();
+  #hasModifiedView = false;
 
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   #setHasCalibrationTopic: (hasCalibrationTopic: boolean) => void;
@@ -131,6 +140,42 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
       labelPool: renderer.labelPool,
     });
     this.add(this.#annotations);
+
+    renderer.input.on("mousedown", (mouseDownCursorCoords) => {
+      this.#camera.getPanOffset(this.#dragStartPanOffset);
+      this.#dragStartMouseCoords.copy(mouseDownCursorCoords);
+
+      renderer.input.trackDrag((mouseMoveCursorCoords) => {
+        this.#camera.setPanOffset(
+          mouseMoveCursorCoords
+            .clone()
+            .sub(this.#dragStartMouseCoords)
+            .add(this.#dragStartPanOffset),
+        );
+        this.#hasModifiedView = true;
+        this.dispatchEvent({ type: "hasModifiedViewChanged" });
+        this.renderer.queueAnimationFrame();
+      });
+    });
+
+    renderer.input.on("wheel", (cursorCoords, _worldSpaceCursorCoords, event) => {
+      this.#camera.updateZoomFromWheel(event.deltaY, cursorCoords);
+      this.#updateAnnotationsScale();
+      this.#hasModifiedView = true;
+      this.dispatchEvent({ type: "hasModifiedViewChanged" });
+      this.renderer.queueAnimationFrame();
+    });
+  }
+
+  public hasModifiedView(): boolean {
+    return this.#hasModifiedView;
+  }
+
+  public resetViewModifications(): void {
+    this.#hasModifiedView = false;
+    this.#camera.resetModifications();
+    this.#updateAnnotationsScale();
+    this.dispatchEvent({ type: "hasModifiedViewChanged" });
   }
 
   public override addSubscriptionsToRenderer(): void {
@@ -601,12 +646,7 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     this.renderer.followFrameId = this.#getCurrentFrameId();
     if (this.#cameraModel?.model) {
       this.#camera.updateCamera(this.#cameraModel.model);
-      this.#annotations.updateScale(
-        this.#camera.getEffectiveScale(),
-        this.renderer.input.canvasSize.width,
-        this.renderer.input.canvasSize.height,
-        this.renderer.getPixelRatio(),
-      );
+      this.#updateAnnotationsScale();
       const imageRenderable = this.#imageRenderable;
       if (imageRenderable) {
         imageRenderable.userData.cameraInfo = this.#cameraModel.info;
@@ -659,9 +699,18 @@ export class ImageMode extends SceneExtension<ImageRenderable> implements ICamer
     return this.#camera;
   }
 
-  public handleResize(width: number, height: number, pixelRatio: number): void {
+  public handleResize(width: number, height: number, _pixelRatio: number): void {
     this.#camera.setCanvasSize(width, height);
-    this.#annotations.updateScale(this.#camera.getEffectiveScale(), width, height, pixelRatio);
+    this.#updateAnnotationsScale();
+  }
+
+  #updateAnnotationsScale(): void {
+    this.#annotations.updateScale(
+      this.#camera.getEffectiveScale(),
+      this.renderer.input.canvasSize.width,
+      this.renderer.input.canvasSize.height,
+      this.renderer.getPixelRatio(),
+    );
   }
 
   public setCameraState(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -159,7 +159,11 @@ export class ImageMode
     });
 
     renderer.input.on("wheel", (cursorCoords, _worldSpaceCursorCoords, event) => {
-      this.#camera.updateZoomFromWheel(event.deltaY, cursorCoords);
+      this.#camera.updateZoomFromWheel(
+        // Clamp wheel deltas which can vary wildly across different operating systems, browsers, and input devices.
+        1 - 0.01 * THREE.MathUtils.clamp(event.deltaY, -30, 30),
+        cursorCoords,
+      );
       this.#updateAnnotationsScale();
       this.#hasModifiedView = true;
       this.dispatchEvent({ type: "hasModifiedViewChanged" });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -44,15 +44,15 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
     this.#updateProjection();
   }
 
-  public updateZoomFromWheel(deltaY: number, cursorCoords: THREE.Vector2): void {
-    const newZoom = Math.max(0.5, Math.min(this.#userZoom * (1 - 0.01 * deltaY), 50));
-    const zoomRatio = newZoom / this.#userZoom;
+  public updateZoomFromWheel(ratio: number, cursorCoords: THREE.Vector2): void {
+    const newZoom = THREE.MathUtils.clamp(this.#userZoom * ratio, 0.5, 50);
+    const finalRatio = newZoom / this.#userZoom;
     const halfWidth = this.#canvasSize.width / 2;
     const halfHeight = this.#canvasSize.height / 2;
     // Adjust pan offset so the zoom is centered around the mouse location
     this.#panOffset.set(
-      (halfWidth + this.#panOffset.x - cursorCoords.x) * zoomRatio - halfWidth + cursorCoords.x,
-      (halfHeight + this.#panOffset.y - cursorCoords.y) * zoomRatio - halfHeight + cursorCoords.y,
+      (halfWidth + this.#panOffset.x - cursorCoords.x) * finalRatio - halfWidth + cursorCoords.x,
+      (halfHeight + this.#panOffset.y - cursorCoords.y) * finalRatio - halfHeight + cursorCoords.y,
     );
     this.#userZoom = newZoom;
     this.#updateProjection();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -19,8 +19,42 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
   #aspectZoom = new THREE.Vector2();
   #canvasSize = new THREE.Vector2();
 
+  /** Amount the user has panned, measured in screen pixels */
+  #panOffset = new THREE.Vector2(0, 0);
+  /** Amount the user has zoomed with the scroll wheel */
+  #userZoom = 1;
+
   public updateCamera(cameraModel: PinholeCameraModel | undefined): void {
     this.#model = cameraModel;
+    this.#updateProjection();
+  }
+
+  public setPanOffset(offset: THREE.Vector2): void {
+    this.#panOffset.copy(offset);
+    this.#updateProjection();
+  }
+
+  public getPanOffset(out: THREE.Vector2): void {
+    out.copy(this.#panOffset);
+  }
+
+  public resetModifications(): void {
+    this.#panOffset.set(0, 0);
+    this.#userZoom = 1;
+    this.#updateProjection();
+  }
+
+  public updateZoomFromWheel(deltaY: number, cursorCoords: THREE.Vector2): void {
+    const newZoom = Math.max(0.5, Math.min(this.#userZoom * (1 - 0.01 * deltaY), 50));
+    const zoomRatio = newZoom / this.#userZoom;
+    const halfWidth = this.#canvasSize.width / 2;
+    const halfHeight = this.#canvasSize.height / 2;
+    // Adjust pan offset so the zoom is centered around the mouse location
+    this.#panOffset.set(
+      (halfWidth + this.#panOffset.x - cursorCoords.x) * zoomRatio - halfWidth + cursorCoords.x,
+      (halfHeight + this.#panOffset.y - cursorCoords.y) * zoomRatio - halfHeight + cursorCoords.y,
+    );
+    this.#userZoom = newZoom;
     this.#updateProjection();
   }
 
@@ -53,8 +87,9 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
     const fy = model.P[5];
     // (cx, cy) image center in pixel coordinates
     // for panning we can take offsets from this in pixel coordinates
-    const cx = model.P[2];
-    const cy = model.P[6];
+    const scale = this.getEffectiveScale();
+    const cx = model.P[2] + this.#panOffset.x / scale;
+    const cy = model.P[6] + this.#panOffset.y / scale;
     const { width, height } = model;
 
     const zoom = this.#aspectZoom;
@@ -101,7 +136,7 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
       return;
     }
     // Adapted from https://github.com/ros2/rviz/blob/ee44ccde8a7049073fd1901dd36c1fb69110f726/rviz_default_plugins/src/rviz_default_plugins/displays/camera/camera_display.cpp#L568
-    this.#aspectZoom.set(1.0, 1.0);
+    this.#aspectZoom.set(this.#userZoom, this.#userZoom);
 
     const { width: imgWidth, height: imgHeight } = model;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -335,14 +335,23 @@ export const ImageModeResizeHandled: StoryObj = {
   },
 };
 
-export const ImageModePanAndZoom: StoryObj = {
+export const ImageModePan: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="raw" />,
   play: async () => {
     const canvas = document.querySelector("canvas")!;
     fireEvent.mouseDown(canvas, { clientX: 200, clientY: 200 });
     fireEvent.mouseMove(canvas, { clientX: 400, clientY: 200 });
     fireEvent.mouseUp(canvas, { clientX: 400, clientY: 200 });
-    fireEvent.wheel(canvas, { deltaY: 100, clientX: 200, clientY: 0 });
+  },
+};
+
+export const ImageModePanAndZoom: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  play: async (ctx) => {
+    await ImageModePan.play?.(ctx);
+    const canvas = document.querySelector("canvas")!;
+    fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
+    fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
   },
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
-import { screen, userEvent } from "@storybook/testing-library";
+import { fireEvent, screen, userEvent } from "@storybook/testing-library";
 
 import { CompressedImage, RawImage } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
@@ -18,6 +18,7 @@ import { PNG_TEST_IMAGE, rad2deg, SENSOR_FRAME_ID } from "../common";
 export default {
   title: "panels/ThreeDeeRender/Images",
   component: ThreeDeePanel,
+  parameters: { colorScheme: "light" },
 };
 
 const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }) => {
@@ -164,12 +165,10 @@ const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }) => {
 
 export const ImageModeRosRawImage: StoryObj = {
   render: () => <ImageModeRosImage imageType="raw" />,
-  parameters: { colorScheme: "light" },
 };
 
 export const ImageModeRosPngImage: StoryObj = {
   render: () => <ImageModeRosImage imageType="png" />,
-  parameters: { colorScheme: "light" },
 };
 
 const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => {
@@ -316,17 +315,14 @@ const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => 
 
 export const ImageModeFoxgloveRawImage: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="raw" />,
-  parameters: { colorScheme: "light" },
 };
 
 export const ImageModeFoxglovePngImage: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="png" />,
-  parameters: { colorScheme: "light" },
 };
 
 export const ImageModeResizeHandled: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="raw" />,
-  parameters: { colorScheme: "light" },
 
   play: async () => {
     const canvas = document.querySelector("canvas")!;
@@ -339,9 +335,27 @@ export const ImageModeResizeHandled: StoryObj = {
   },
 };
 
+export const ImageModePanAndZoom: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  play: async () => {
+    const canvas = document.querySelector("canvas")!;
+    fireEvent.mouseDown(canvas, { clientX: 200, clientY: 200 });
+    fireEvent.mouseMove(canvas, { clientX: 400, clientY: 200 });
+    fireEvent.mouseUp(canvas, { clientX: 400, clientY: 200 });
+    fireEvent.wheel(canvas, { deltaY: 100, clientX: 200, clientY: 0 });
+  },
+};
+
+export const ImageModePanAndZoomReset: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  play: async (ctx) => {
+    await ImageModePanAndZoom.play?.(ctx);
+    userEvent.click(await screen.findByTestId("reset-view"));
+  },
+};
+
 export const ImageModePick: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="raw" />,
-  parameters: { colorScheme: "light" },
 
   play: async () => {
     const canvas = document.querySelector("canvas")!;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -345,20 +345,34 @@ export const ImageModePan: StoryObj = {
   },
 };
 
-export const ImageModePanAndZoom: StoryObj = {
+export const ImageModeZoomThenPan: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="raw" />,
-  play: async (ctx) => {
-    await ImageModePan.play?.(ctx);
+  play: async () => {
     const canvas = document.querySelector("canvas")!;
+    fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
+    fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
+    fireEvent.mouseDown(canvas, { clientX: 200, clientY: 200 });
+    fireEvent.mouseMove(canvas, { clientX: 400, clientY: 200 });
+    fireEvent.mouseUp(canvas, { clientX: 400, clientY: 200 });
+  },
+};
+
+export const ImageModePanThenZoom: StoryObj = {
+  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+  play: async () => {
+    const canvas = document.querySelector("canvas")!;
+    fireEvent.mouseDown(canvas, { clientX: 200, clientY: 200 });
+    fireEvent.mouseMove(canvas, { clientX: 400, clientY: 200 });
+    fireEvent.mouseUp(canvas, { clientX: 400, clientY: 200 });
     fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
     fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
   },
 };
 
-export const ImageModePanAndZoomReset: StoryObj = {
+export const ImageModePanThenZoomReset: StoryObj = {
   render: () => <ImageModeFoxgloveImage imageType="raw" />,
   play: async (ctx) => {
-    await ImageModePanAndZoom.play?.(ctx);
+    await ImageModePanThenZoom.play?.(ctx);
     userEvent.click(await screen.findByTestId("reset-view"));
   },
 };


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds pan & zoom support to new Image panel.
Also adds a "Reset view" button that can be used to reset manually adjusted pan/zoom.

Moved RendererOverlay to its own file.

https://user-images.githubusercontent.com/14237/236349003-ca92b246-1b4e-4ac4-a5c5-50dda4881a4b.mov

