### PR TITLE
[3D Image] Keep default panel title in sync with selected image topic

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -603,6 +603,13 @@ export function ThreeDeeRender(props: {
   );
   useEffect(() => throttledSave(config), [config, throttledSave]);
 
+  // Keep default panel title up to date with selected image topic in image mode
+  useEffect(() => {
+    if (interfaceMode === "image") {
+      context.setDefaultPanelTitle(config.imageMode.imageTopic);
+    }
+  }, [interfaceMode, context, config.imageMode.imageTopic]);
+
   // Establish a connection to the message pipeline with context.watch and context.onRender
   useLayoutEffect(() => {
     context.onRender = (renderState: RenderState, done) => {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Matches old panel behavior
<img width="394" alt="image" src="https://user-images.githubusercontent.com/14237/236351698-1554af6c-302a-4a44-aca5-79fef0b077c3.png">
