### PR TITLE
Offset fullscreen panel for app bar

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.test.tsx
+++ b/packages/studio-base/src/components/PanelLayout.test.tsx
@@ -4,10 +4,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { render, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 import Panel from "@foxglove/studio-base/components/Panel";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
@@ -15,6 +17,7 @@ import PanelCatalogContext, {
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
 
 import { UnconnectedPanelLayout } from "./PanelLayout";
 
@@ -63,16 +66,20 @@ describe("UnconnectedPanelLayout", () => {
       />,
       {
         wrapper: function Wrapper({ children }: React.PropsWithChildren<unknown>) {
+          const [config] = useState(() => makeMockAppConfiguration());
+
           return (
             <DndProvider backend={HTML5Backend}>
               <WorkspaceContextProvider>
-                <MockCurrentLayoutProvider>
-                  <PanelStateContextProvider>
-                    <PanelCatalogContext.Provider value={panelCatalog}>
-                      {children}
-                    </PanelCatalogContext.Provider>
-                  </PanelStateContextProvider>
-                </MockCurrentLayoutProvider>
+                <AppConfigurationContext.Provider value={config}>
+                  <MockCurrentLayoutProvider>
+                    <PanelStateContextProvider>
+                      <PanelCatalogContext.Provider value={panelCatalog}>
+                        {children}
+                      </PanelCatalogContext.Provider>
+                    </PanelStateContextProvider>
+                  </MockCurrentLayoutProvider>
+                </AppConfigurationContext.Provider>
               </WorkspaceContextProvider>
             </DndProvider>
           );

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -8,6 +8,7 @@ import { TransitionStatus } from "react-transition-group";
 import { makeStyles } from "tss-react/mui";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { APP_BAR_HEIGHT } from "@foxglove/studio-base/components/AppBar/constants";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 
 export const PANEL_ROOT_CLASS_NAME = "FoxglovePanelRoot-root";
@@ -70,7 +71,7 @@ export const usePanelRootStyles = makeStyles<
     entered: {
       borderWidth: 4,
       position: "fixed",
-      top: appBarEnabled ? 44 : 0, // offset by app bar height if enabled
+      top: appBarEnabled ? APP_BAR_HEIGHT : 0, // offset by app bar height if enabled
       left: 0,
       right: 0,
       bottom: 77, // match PlaybackBar height

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -7,6 +7,9 @@ import { forwardRef, HTMLAttributes, PropsWithChildren } from "react";
 import { TransitionStatus } from "react-transition-group";
 import { makeStyles } from "tss-react/mui";
 
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
+
 export const PANEL_ROOT_CLASS_NAME = "FoxglovePanelRoot-root";
 
 type PanelRootProps = {
@@ -17,10 +20,10 @@ type PanelRootProps = {
 } & HTMLAttributes<HTMLDivElement>;
 
 export const usePanelRootStyles = makeStyles<
-  Omit<PanelRootProps, "fullscreenState" | "selected">
+  Omit<PanelRootProps, "fullscreenState" | "selected"> & { appBarEnabled: boolean }
 >()((theme, props) => {
   const { palette, transitions } = theme;
-  const { sourceRect, hasFullscreenDescendant } = props;
+  const { appBarEnabled, sourceRect, hasFullscreenDescendant } = props;
   const duration = transitions.duration.shorter;
 
   return {
@@ -67,7 +70,7 @@ export const usePanelRootStyles = makeStyles<
     entered: {
       borderWidth: 4,
       position: "fixed",
-      top: sourceRect?.top ?? 0,
+      top: appBarEnabled ? 44 : 0, // offset by app bar height if enabled
       left: 0,
       right: 0,
       bottom: 77, // match PlaybackBar height
@@ -104,9 +107,15 @@ export const usePanelRootStyles = makeStyles<
 
 export const PanelRoot = forwardRef<HTMLDivElement, PropsWithChildren<PanelRootProps>>(
   function PanelRoot(props, ref): JSX.Element {
+    const [appBarEnabled = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
+
     const { fullscreenState, selected, sourceRect, hasFullscreenDescendant, className, ...rest } =
       props;
-    const { classes, cx } = usePanelRootStyles({ sourceRect, hasFullscreenDescendant });
+    const { classes, cx } = usePanelRootStyles({
+      appBarEnabled,
+      sourceRect,
+      hasFullscreenDescendant,
+    });
 
     const classNames = cx(PANEL_ROOT_CLASS_NAME, className, classes.root, {
       [classes.entering]: fullscreenState === "entering",

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -67,7 +67,7 @@ export const usePanelRootStyles = makeStyles<
     entered: {
       borderWidth: 4,
       position: "fixed",
-      top: 0,
+      top: sourceRect?.top ?? 0,
       left: 0,
       right: 0,
       bottom: 77, // match PlaybackBar height


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Offset position of fullscreen panel by app bar height so it doesn't cover the app bar.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
