### PR TITLE
Showing object id on Image panel

### DIFF
--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -360,6 +360,15 @@ export function ImageView({ context }: Props): JSX.Element {
             rotation: ((oldConfig.rotation ?? 0) + 90) % 360,
           })),
       },
+      {
+        type: "item",
+        label: "ShowId",
+        onclick: () =>
+          setConfig((oldConfig) => ({
+            ...oldConfig,
+            isIdShowen: oldConfig.isIdShowen ?? false,
+          })),
+      },
     ],
     [doDownloadImage],
   );
@@ -447,4 +456,5 @@ export const defaultConfig: Config = {
   synchronize: false,
   transformMarkers: false,
   zoom: 1,
+  isIdShowen: false,
 };

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -271,6 +271,7 @@ export function ImageCanvas(props: Props): JSX.Element {
         geometry: {
           flipHorizontal: config.flipHorizontal ?? false,
           flipVertical: config.flipVertical ?? false,
+          isIdShowen: config.isIdShowen ?? false,
           panZoom: computedViewbox,
           rotation: config.rotation ?? 0,
           viewport: { width: targetWidth, height: targetHeight },
@@ -287,6 +288,7 @@ export function ImageCanvas(props: Props): JSX.Element {
     canvas,
     config.flipHorizontal,
     config.flipVertical,
+    config.isIdShowen,
     config.rotation,
     devicePixelRatio,
     doRenderImage,

--- a/packages/studio-base/src/panels/Image/lib/downloadImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/downloadImage.ts
@@ -21,6 +21,7 @@ export async function downloadImage(
     geometry: {
       flipHorizontal: config.flipHorizontal ?? false,
       flipVertical: config.flipVertical ?? false,
+      isIdShowen: config.isIdShowen ?? false,
       panZoom: { x: 0, y: 0, scale: 1 },
       rotation: config.rotation ?? 0,
       viewport: { width: 1, height: 1 }, // We'll just use the intrinsic image dimensions.

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -80,6 +80,7 @@ function normalizeFoxgloveImageAnnotations(
       radius: circle.diameter / 2.0,
       thickness: circle.thickness,
       position: circle.position,
+      object_id: circle.object_id,
     });
   }
   for (const point of message.points ?? []) {
@@ -97,6 +98,7 @@ function normalizeFoxgloveImageAnnotations(
       outlineColor: mightActuallyBePartial(point).outline_color ?? { r: 1, g: 1, b: 1, a: 1 },
       thickness: mightActuallyBePartial(point).thickness ?? 1,
       fillColor: point.fill_color,
+      object_id: point.object_id,
     });
   }
   for (const text of message.texts ?? []) {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -44,6 +44,7 @@ export const MarkersWithHitmap: StoryObj = {
         geometry: {
           flipHorizontal: false,
           flipVertical: false,
+          isIdShowen: false,
           panZoom: { x: 0, y: 0, scale: 1 },
           rotation: 0,
           viewport: { width, height },
@@ -100,6 +101,7 @@ export const MarkersWithRotations: StoryObj = {
           geometry: {
             flipHorizontal: false,
             flipVertical: false,
+            isIdShowen: false,
             panZoom: { x: 0, y: 0, scale: 1 },
             rotation: 0,
             viewport: { width, height },
@@ -152,6 +154,7 @@ export const FoxgloveAnnotations: StoryObj = {
         geometry: {
           flipHorizontal: false,
           flipVertical: false,
+          isIdShowen: false,
           panZoom: { x: 0, y: 0, scale: 1 },
           rotation: 0,
           viewport: { width, height },

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -83,6 +83,11 @@ export function buildSettingsTree({
           label: "Flip vertical",
           value: config.flipVertical ?? false,
         },
+        isIdShowen: {
+          input: "boolean",
+          label: "Show id",
+          value: config.isIdShowen ?? false,
+        },
         rotation: {
           input: "select",
           label: "Rotation",

--- a/packages/studio-base/src/panels/Image/types.ts
+++ b/packages/studio-base/src/panels/Image/types.ts
@@ -26,6 +26,7 @@ export type Config = DefaultConfig & {
   transformMarkers: boolean;
   zoom?: number;
   zoomPercentage?: number;
+  isIdShowen?: boolean;
 };
 
 export type UseImagePanelMessagesParams = {
@@ -82,6 +83,7 @@ export type RenderGeometry = {
   rotation: number;
   viewport: Dimensions;
   zoomMode: ZoomMode;
+  isIdShowen: boolean;
 };
 
 export type RenderArgs = {
@@ -118,6 +120,7 @@ export type CircleAnnotation = {
   radius: number;
   thickness: number;
   position: Point2D;
+  object_id?: string;
 };
 
 export type PointsAnnotation = {
@@ -129,13 +132,14 @@ export type PointsAnnotation = {
   outlineColor?: Color;
   thickness: number;
   fillColor?: Color;
+  object_id?: string;
 };
 
 export type TextAnnotation = {
   type: "text";
   stamp: Time;
   position: Point2D;
-  text: string;
+  text: string | undefined;
   textColor: Color;
   backgroundColor?: Color;
   fontSize: number;


### PR DESCRIPTION

Addition for this PR https://github.com/foxglove/schemas/pull/107#issue-1697653251 
**Description**
I added object_id to be visible on Image panel in order to recognize objects on Image panel easier. And option button to turn on/off  this option. It is possible for PointsAnnotation and CircleAnnotation as well. I get object_id from protobuf message which changes  i requested in PR above (schema repo).
