### PR TITLE
Support global variables in plot panel series paths

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/grammar.ne
+++ b/packages/studio-base/src/components/MessagePathSyntax/grammar.ne
@@ -44,8 +44,9 @@ value -> integer  {% (d) => d[0] %}
 topicName -> slashID:+     {% (d) => ({ value: d[0].join(""), repr: d[0].join("") }) %}
            | id slashID:*  {% (d) => ({ value: d[0] + d[1].join(""), repr: d[0] + d[1].join("") }) %}
            | quotedString  {% id %}
-slashID -> "/" id:?
-  {% (d) => d.join("") %}
+
+slashID -> "/" id:?     {% (d) => d.join("") %}
+         | "/" "$" id:? {% (d) => d.join("") %}
 
 quotedString ->
   "\""

--- a/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.test.ts
@@ -146,6 +146,15 @@ describe("parseRosPath", () => {
     expect(parseRosPath(String.raw`/foo."x.baz`)).toBeUndefined();
   });
 
+  it("parses global variables in topics", () => {
+    expect(parseRosPath("/$first_var/$second_var.foo")).toEqual({
+      topicName: "/$first_var/$second_var",
+      topicNameRepr: "/$first_var/$second_var",
+      messagePath: [{ type: "name", name: "foo", repr: "foo" }],
+      modifier: MISSING,
+    });
+  });
+
   it("parses slices", () => {
     expect(parseRosPath("/topic.foo[0].bar")).toEqual({
       topicName: "/topic",

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -35,6 +35,7 @@ import PanelToolbar, {
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { ChartDefaultView } from "@foxglove/studio-base/components/TimeBasedChart";
+import { useMappedTopics } from "@foxglove/studio-base/panels/Plot/useMappedTopics";
 import { usePlotPanelMessageData } from "@foxglove/studio-base/panels/Plot/usePlotPanelMessageData";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -183,18 +184,27 @@ function Plot(props: Props) {
     showSingleCurrentMessage,
   });
 
+  const topicMappings = useMappedTopics(allPaths);
+
+  const mappedYPaths = useMemo(() => {
+    return yAxisPaths.map((path) => ({
+      ...path,
+      value: topicMappings.resolvedPaths[path.value] ?? path.value,
+    }));
+  }, [topicMappings, yAxisPaths]);
+
   // Keep disabled paths when passing into getDatasets, because we still want
   // easy access to the history when turning the disabled paths back on.
   const { datasets, pathsWithMismatchedDataLengths } = useMemo(() => {
     return getDatasets({
-      paths: yAxisPaths,
+      paths: mappedYPaths,
       itemsByPath: combinedPlotData,
       startTime: startTime ?? ZERO_TIME,
       xAxisVal,
       xAxisPath,
       invertedTheme: theme.palette.mode === "dark",
     });
-  }, [yAxisPaths, combinedPlotData, startTime, xAxisVal, xAxisPath, theme.palette.mode]);
+  }, [mappedYPaths, combinedPlotData, startTime, xAxisVal, xAxisPath, theme.palette.mode]);
 
   const messagePipeline = useMessagePipelineGetter();
   const onClick = useCallback<NonNullable<ComponentProps<typeof PlotChart>["onClick"]>>(

--- a/packages/studio-base/src/panels/Plot/useMappedTopics.ts
+++ b/packages/studio-base/src/panels/Plot/useMappedTopics.ts
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable } from "immer";
+import { groupBy } from "lodash";
+import { useMemo } from "react";
+
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+import useGlobalVariables, {
+  GlobalVariables,
+} from "@foxglove/studio-base/hooks/useGlobalVariables";
+
+type MappedTopics = Immutable<{
+  topics: string[];
+  pathsToTopic: Record<string, string>;
+  resolvedPaths: Record<string, string>;
+  topicsToPaths: Record<string, string[]>;
+}>;
+
+function resolveVariablesInPath(path: string, variables: GlobalVariables): string {
+  //   return path.replace(/\$\{([^}]+)\}/g, (_, name) => String(variables[name] ?? ""));
+  return path.replace(/\$([^/.]+)/g, (_, name) => String(variables[name] ?? ""));
+}
+
+export function useMappedTopics(paths: readonly string[]): MappedTopics {
+  const { globalVariables } = useGlobalVariables();
+
+  const resolvedPaths = useMemo(() => {
+    return Object.fromEntries(
+      paths.map((path) => [path, resolveVariablesInPath(path, globalVariables)]),
+    );
+  }, [paths, globalVariables]);
+
+  const topicsToPaths = useMemo(
+    () =>
+      groupBy(paths, (path) => {
+        const resolvedPath = resolveVariablesInPath(path, globalVariables);
+        return parseRosPath(resolvedPath)?.topicName;
+      }),
+    [globalVariables, paths],
+  );
+
+  const pathsToTopic = useMemo(
+    () =>
+      Object.fromEntries(
+        paths.map((path) => {
+          const resolvedPath = resolvedPaths[path] ?? path;
+          return [path, parseRosPath(resolvedPath)?.topicName ?? path];
+        }),
+      ),
+    [paths, resolvedPaths],
+  );
+
+  return useMemo(
+    () => ({
+      pathsToTopic,
+      resolvedPaths,
+      topics: Object.keys(topicsToPaths),
+      topicsToPaths,
+    }),
+    [pathsToTopic, resolvedPaths, topicsToPaths],
+  );
+}


### PR DESCRIPTION
**User-Facing Changes**
Support global variables in message paths.

**Description**
Support global variables in message paths. This is a POC limited to the plot panel only. I haven't done anything to make the message path input aware of this yet but you can enter paths with variables and plot them.

I've taken this path instead of changing anything in the message pipeline because there's no way to do this without having some awareness of a mapping in the panel so I decided to localize it to the panel, in a way we could generalize to other panels without too much difficulty.

I'm posting this in this state so we can play with it and see how we feel about the UX.

<img width="1049" alt="Screenshot 2023-05-08 at 8 04 45 AM" src="https://user-images.githubusercontent.com/93935560/236712838-1d7cee37-0b97-4cbb-9ef4-46e8ca163143.png">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
