### PR TITLE
Restyle version banner and open in portal

### DIFF
--- a/packages/studio-web/package.json
+++ b/packages/studio-web/package.json
@@ -7,8 +7,8 @@
     "@foxglove/studio-base": "workspace:*"
   },
   "devDependencies": {
+    "@fluentui/react-icons": "2.0.201",
     "@foxglove/log": "workspace:*",
-    "@mui/icons-material": "5.11.16",
     "@mui/material": "5.12.3",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@storybook/react": "7.0.9",

--- a/packages/studio-web/src/VersionBanner.stories.tsx
+++ b/packages/studio-web/src/VersionBanner.stories.tsx
@@ -25,6 +25,10 @@ export const UnsupportedBrowser: StoryObj = {
 
 export const Undismissable: StoryObj = {
   render: () => {
-    return <VersionBanner isChrome={false} currentVersion={42} isDismissable={false} />;
+    return (
+      <div style={{ height: "100vh" }}>
+        <VersionBanner isChrome={false} currentVersion={42} isDismissable={false} />
+      </div>
+    );
   },
 };

--- a/packages/studio-web/src/VersionBanner.stories.tsx
+++ b/packages/studio-web/src/VersionBanner.stories.tsx
@@ -22,3 +22,9 @@ export const UnsupportedBrowser: StoryObj = {
     return <VersionBanner isChrome={false} currentVersion={42} isDismissable />;
   },
 };
+
+export const Undismissable: StoryObj = {
+  render: () => {
+    return <VersionBanner isChrome={false} currentVersion={42} isDismissable={false} />;
+  },
+};

--- a/packages/studio-web/src/VersionBanner.tsx
+++ b/packages/studio-web/src/VersionBanner.tsx
@@ -2,8 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Warning24Filled } from "@fluentui/react-icons";
-import CloseIcon from "@mui/icons-material/Close";
+import { Warning24Filled, Dismiss24Regular } from "@fluentui/react-icons";
 import {
   IconButton,
   Typography,
@@ -136,7 +135,7 @@ function VersionBannerBase({
 
         {isDismissable && (
           <IconButton edge="end" color="inherit" size="small" onClick={onDismiss}>
-            <CloseIcon />
+            <Dismiss24Regular />
           </IconButton>
         )}
       </Stack>

--- a/packages/studio-web/src/VersionBanner.tsx
+++ b/packages/studio-web/src/VersionBanner.tsx
@@ -144,7 +144,7 @@ function VersionBannerBase({
   );
 }
 
-const VersionBanner = function ({
+export default function VersionBanner({
   isChrome,
   currentVersion,
   isDismissable,
@@ -177,6 +177,4 @@ const VersionBanner = function ({
       <div className={classes.spacer} />
     </MuiThemeProvider>
   );
-};
-
-export default VersionBanner;
+}

--- a/packages/studio-web/src/VersionBanner.tsx
+++ b/packages/studio-web/src/VersionBanner.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles<void, "button" | "icon">()((theme, _params, classes
     justifyContent: "center",
     backgroundColor: theme.palette.background.paper,
     color: theme.palette.text.primary,
+    textAlign: "center",
   },
   icon: {
     color: theme.palette.primary.dark,
@@ -96,7 +97,7 @@ function VersionBannerBase({
 
   return (
     <div className={cx(classes.root, { [classes.fullscreen]: !isDismissable })}>
-      <Stack direction="row" alignItems="center" gap={2}>
+      <Stack direction={!isDismissable ? "column" : "row"} alignItems="center" gap={2}>
         <Warning24Filled className={classes.icon} />
 
         <div>

--- a/packages/studio-web/src/VersionBanner.tsx
+++ b/packages/studio-web/src/VersionBanner.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Warning24Filled } from "@fluentui/react-icons";
 import CloseIcon from "@mui/icons-material/Close";
 import {
   IconButton,
@@ -9,52 +10,139 @@ import {
   Link,
   Button,
   ThemeProvider as MuiThemeProvider,
-  useTheme,
+  Portal,
 } from "@mui/material";
-import { useState, useMemo, ReactElement, PropsWithChildren, CSSProperties } from "react";
+import { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { withStyles } from "tss-react/mui";
+import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Language } from "@foxglove/studio-base/i18n";
 import { createMuiTheme } from "@foxglove/studio-base/theme";
 
 const MINIMUM_CHROME_VERSION = 76;
+const BANNER_HEIGHT = 54;
+const BANNER_MOBILE_HEIGHT = 100;
 
-const BannerContainer = (props: PropsWithChildren<{ isDismissable: boolean }>) => {
-  const { isDismissable, children } = props;
-
-  const theme = useTheme();
-  const style: CSSProperties = {
+const useStyles = makeStyles<void, "button" | "icon">()((theme, _params, classes) => ({
+  root: {
     display: "flex",
-    flexDirection: "column",
     alignItems: "center",
-    justifyContent: "center",
+    justifyContent: "space-between",
     width: "100%",
+    minHeight: BANNER_HEIGHT,
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
-    zIndex: 100,
-    ...(!isDismissable && {
-      position: "fixed",
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      height: "100vh",
-    }),
-  };
-
-  return <div style={style}>{children}</div>;
-};
-
-const DismissButton = withStyles(IconButton, (theme) => ({
-  root: {
-    position: "absolute",
-    margin: theme.spacing(1),
-    right: 0,
+    boxSizing: "border-box",
+    padding: theme.spacing(1, 1.5),
+    zIndex: theme.zIndex.modal + 1,
+    gap: theme.spacing(1),
+    position: "fixed",
     top: 0,
+    right: 0,
+    left: 0,
+
+    [theme.breakpoints.down("md")]: {
+      [`.${classes.icon}`]: {
+        display: "none",
+      },
+    },
+    [theme.breakpoints.down("sm")]: {
+      height: BANNER_MOBILE_HEIGHT,
+
+      [`.${classes.button}`]: {
+        display: "none",
+      },
+    },
+  },
+  fullscreen: {
+    flexDirection: "column",
+    bottom: 0,
+    minHeight: "100vh",
+    justifyContent: "center",
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+  },
+  icon: {
+    color: theme.palette.primary.dark,
+  },
+  button: {
+    whiteSpace: "nowrap",
+  },
+  spacer: {
+    height: BANNER_HEIGHT,
+    flex: "none",
+
+    [theme.breakpoints.down("md")]: {
+      minHeight: BANNER_MOBILE_HEIGHT,
+    },
   },
 }));
+
+function VersionBannerBase({
+  isChrome,
+  isDismissable,
+  onDismiss,
+}: {
+  isChrome: boolean;
+  isDismissable: boolean;
+  onDismiss: () => void;
+}): JSX.Element {
+  const { classes, cx } = useStyles();
+
+  const prompt = isChrome
+    ? "You’re using an outdated version of Chrome."
+    : "You’re using an unsupported browser.";
+  const fixText = isChrome ? "Update Chrome" : "Download Chrome";
+
+  return (
+    <div className={cx(classes.root, { [classes.fullscreen]: !isDismissable })}>
+      <Stack direction="row" alignItems="center" gap={2}>
+        <Warning24Filled className={classes.icon} />
+
+        <div>
+          <Typography variant="subtitle2">
+            {prompt} Foxglove Studio currently requires Chrome v{MINIMUM_CHROME_VERSION}+.
+          </Typography>
+
+          {!isChrome && (
+            <Typography variant="body2">
+              Check out our cross-browser support progress in GitHub discussion{" "}
+              <Link
+                color="inherit"
+                href="https://github.com/orgs/foxglove/discussions/174"
+                target="_blank"
+              >
+                #174
+              </Link>
+              .
+            </Typography>
+          )}
+        </div>
+      </Stack>
+
+      <Stack direction="row" gap={1} alignItems="center">
+        <Button
+          href="https://www.google.com/chrome/"
+          target="_blank"
+          rel="noreferrer"
+          color="inherit"
+          variant="outlined"
+          size="small"
+          className={classes.button}
+        >
+          {fixText}
+        </Button>
+
+        {isDismissable && (
+          <IconButton edge="end" color="inherit" size="small" onClick={onDismiss}>
+            <CloseIcon />
+          </IconButton>
+        )}
+      </Stack>
+    </div>
+  );
+}
 
 const VersionBanner = function ({
   isChrome,
@@ -64,64 +152,29 @@ const VersionBanner = function ({
   isChrome: boolean;
   currentVersion: number;
   isDismissable: boolean;
-}): ReactElement | ReactNull {
-  const [showBanner, setShowBanner] = useState(true);
+}): JSX.Element | ReactNull {
+  const { classes } = useStyles();
   const { i18n } = useTranslation();
   const muiTheme = useMemo(
     () => createMuiTheme("dark", i18n.language as Language | undefined),
     [i18n.language],
   );
+  const [showBanner, setShowBanner] = useState(true);
 
   if (!showBanner || currentVersion >= MINIMUM_CHROME_VERSION) {
     return ReactNull;
   }
 
-  const prompt = isChrome
-    ? "You’re using an outdated version of Chrome."
-    : "You’re using an unsupported browser.";
-  const fixText = isChrome ? "Update Chrome" : "Download Chrome";
-
   return (
     <MuiThemeProvider theme={muiTheme}>
-      <BannerContainer isDismissable={isDismissable}>
-        <Stack padding={2} gap={1.5} alignItems="center">
-          {isDismissable && (
-            <DismissButton color="inherit" onClick={() => setShowBanner(false)}>
-              <CloseIcon />
-            </DismissButton>
-          )}
-
-          <div>
-            <Typography align="center" variant="h6">
-              {prompt} Foxglove Studio currently requires Chrome v{MINIMUM_CHROME_VERSION}+.
-            </Typography>
-
-            {!isChrome && (
-              <Typography align="center" variant="subtitle1">
-                Check out our cross-browser support progress in GitHub discussion{" "}
-                <Link
-                  color="inherit"
-                  href="https://github.com/orgs/foxglove/discussions/174"
-                  target="_blank"
-                >
-                  #174
-                </Link>
-                .
-              </Typography>
-            )}
-          </div>
-
-          <Button
-            href="https://www.google.com/chrome/"
-            target="_blank"
-            rel="noreferrer"
-            color="inherit"
-            variant="outlined"
-          >
-            {fixText}
-          </Button>
-        </Stack>
-      </BannerContainer>
+      <Portal>
+        <VersionBannerBase
+          isChrome={isChrome}
+          isDismissable={isDismissable}
+          onDismiss={() => setShowBanner(false)}
+        />
+      </Portal>
+      <div className={classes.spacer} />
     </MuiThemeProvider>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2744,9 +2744,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/studio-web@workspace:packages/studio-web"
   dependencies:
+    "@fluentui/react-icons": 2.0.201
     "@foxglove/log": "workspace:*"
     "@foxglove/studio-base": "workspace:*"
-    "@mui/icons-material": 5.11.16
     "@mui/material": 5.12.3
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.10
     "@storybook/react": 7.0.9


### PR DESCRIPTION
### User-Facing Changes
Restyle version banner to be shorter and denser and change to render above Data Source Dialog
 
### Description

**Desktop**
<img width="1012" alt="Screen Shot 2023-05-08 at 2 11 12 pm" src="https://user-images.githubusercontent.com/924528/236733291-c0801a6c-2c94-43ea-b3fe-80e30f647c63.png">

**Mobile**
<img width="358" alt="Screen Shot 2023-05-08 at 2 23 52 pm" src="https://user-images.githubusercontent.com/924528/236733464-356f2bf3-5bf6-4eea-b691-244bb673d3d4.png">

**Non-dismissable**
<img width="995" alt="Screen Shot 2023-05-08 at 2 34 19 pm" src="https://user-images.githubusercontent.com/924528/236734977-34519e91-44d6-4dab-9370-5d9321331935.png">

