### PR TITLE
Support math modifiers on settings panel message path inputs

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -287,6 +287,7 @@ function FieldInput({
             path={field.value ?? ""}
             disabled={field.disabled}
             readOnly={field.readonly}
+            supportsMathModifiers={field.supportsMathModifiers}
             onChange={(value) =>
               actionHandler({
                 action: "update",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -79,6 +79,8 @@ const BasicSettings: SettingsTreeNodes = {
       messagepath: {
         label: "Message Path",
         input: "messagepath",
+        value: "/some_topic/state.foo_id.@abs",
+        supportsMathModifiers: true,
       },
       topic: {
         label: "Topic",

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -37,6 +37,7 @@ const makeSeriesNode = memoizeWeak(
           input: "messagepath",
           value: path.value,
           validTypes: plotableRosTypes,
+          supportsMathModifiers: true,
         },
         label: {
           input: "string",

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -497,7 +497,13 @@ export type SettingsTreeFieldValue =
       hideClearButton?: boolean;
     }
   | { input: "gradient"; value?: [string, string] }
-  | { input: "messagepath"; value?: string; validTypes?: string[] }
+  | {
+      input: "messagepath";
+      value?: string;
+      validTypes?: string[];
+      /** True if the input should allow math modifiers like @abs. */
+      supportsMathModifiers?: boolean;
+    }
   | {
       input: "number";
       value?: number;


### PR DESCRIPTION
**User-Facing Changes**
Support math modifiers on settings panel message path inputs

**Description**
Support math modifiers on settings panel message path inputs. Adds a `supportsMathModifiers` field to the message path settings input type.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
