### PR TITLE
Handle incremental subscriptions in message converters

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.test.ts
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { forEachSortedArrays } from "./messageProcessing";
+
+describe("forEachSortedArrays", () => {
+  it("should not call forEach for empty arrays", () => {
+    const forEach = jest.fn();
+    const arr: number[] = [];
+    forEachSortedArrays([arr, arr], (a, b) => a - b, forEach);
+    expect(forEach).not.toHaveBeenCalled();
+  });
+  it("merges arrays with exclusive ranges", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [1, 2, 3];
+    const arr2 = [4, 5, 6];
+
+    forEachSortedArrays([arr1, arr2], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+  it("merges two interleaved arrays", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [1, 3, 5];
+    const arr2 = [2, 4, 6];
+
+    forEachSortedArrays([arr1, arr2], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+  it("merges three interleaved arrays", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [1, 4, 7];
+    const arr2 = [2, 5, 8];
+    const arr3 = [3, 6, 9];
+
+    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+  it("merges three exclusive arrays", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [4, 5, 6];
+    const arr2 = [1, 2, 3];
+    const arr3 = [7, 8, 9];
+
+    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+  it("merges three identical arrays", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [1, 2, 3];
+    const arr2 = [1, 2, 3];
+    const arr3 = [1, 2, 3];
+
+    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
+  });
+  it("merges two identical arrays and one empty array", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [1, 2, 3];
+    const arr2 = [1, 2, 3];
+    const arr3: number[] = [];
+
+    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 1, 2, 2, 3, 3]);
+  });
+  it("merge arrays of all the same number and a sequence of numbers", () => {
+    const acc: number[] = [];
+    const forEach = (item: number) => acc.push(item);
+    const arr1 = [3, 3, 3];
+    const arr2 = [1, 2, 3, 4];
+    const arr3: number[] = [];
+
+    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
+    expect(acc).toEqual([1, 2, 3, 3, 3, 3, 4]);
+  });
+});

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -49,7 +49,7 @@ export function convertMessage(
 }
 
 /**
- * Returns a new map consisting of all items in a not present in b.
+ * Returns a new map consisting of all items in `a` not present in `b`.
  */
 export function mapDifference<K, V>(a: Map<K, V[]>, b: undefined | Map<K, V[]>): Map<K, V[]> {
   const result = new Map<K, V[]>();

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -1,0 +1,199 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { difference } from "lodash";
+import { DeepReadonly } from "ts-essentials";
+
+import { MessageEvent, RegisterMessageConverterArgs, Subscription } from "@foxglove/studio";
+import { Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
+
+// Branded string to ensure that users go through the `converterKey` function to compute a lookup key
+type Brand<K, T> = K & { __brand: T };
+type ConverterKey = Brand<string, "ConverterKey">;
+
+type MessageConverter = RegisterMessageConverterArgs<unknown>;
+
+type TopicSchemaConverterMap = Map<ConverterKey, MessageConverter[]>;
+
+// Create a string lookup key from a message event
+//
+// The string key uses a newline delimeter to avoid producting the same key for topic/schema name
+// values that might concatenate to the same string. i.e. "topic" "schema" and "topics" "chema".
+function converterKey(topic: string, schema: string): ConverterKey {
+  return (topic + "\n" + schema) as ConverterKey;
+}
+
+/**
+ * Convert message into convertedMessages using the keyed converters. Modifies
+ * convertedMessages in place for efficiency.
+ */
+export function convertMessage(
+  messageEvent: DeepReadonly<MessageEvent<unknown>>,
+  converters: DeepReadonly<TopicSchemaConverterMap>,
+  convertedMessages: MessageEvent<unknown>[],
+): void {
+  const key = converterKey(messageEvent.topic, messageEvent.schemaName);
+  const matchedConverters = converters.get(key);
+  for (const converter of matchedConverters ?? []) {
+    const convertedMessage = converter.converter(messageEvent.message);
+    convertedMessages.push({
+      topic: messageEvent.topic,
+      schemaName: converter.toSchemaName,
+      receiveTime: messageEvent.receiveTime,
+      message: convertedMessage,
+      originalMessageEvent: messageEvent,
+      sizeInBytes: messageEvent.sizeInBytes,
+    });
+  }
+}
+
+/**
+ * Returns a new map consisting of all items in a not present in b.
+ */
+export function mapDifference<K, V>(a: Map<K, V[]>, b: undefined | Map<K, V[]>): Map<K, V[]> {
+  const result = new Map<K, V[]>();
+  for (const [key, value] of a.entries()) {
+    const newValues = difference(value, b?.get(key) ?? []);
+    if (newValues.length > 0) {
+      result.set(key, newValues);
+    }
+  }
+  return result;
+}
+
+export type TopicSchemaConversions = {
+  // Topics which we are subscribed without a conversion, these are topics we
+  // want to receive the original message.
+  unconvertedSubscriptionTopics: Set<string>;
+
+  // When a subscription with a convertTo exists, we use this map to lookup a
+  // converter which can produce the desired output message schema. The keys for
+  // the map are `topic + input schema`.
+  //
+  // This allows the runtime message event handler logic which builds
+  // currentFrame and allFrames to lookup whether the incoming message event has
+  // converters to run by looking up the topic + schema of the message event in
+  // this map.
+  topicSchemaConverters: TopicSchemaConverterMap;
+};
+
+/**
+ * Builds a set of topics we can render without conversion and a map of
+ * converterKey -> converter arguments we use to produce converted messages.
+ *
+ * This will be memoized for performance so the inputs should be stable.
+ */
+export function collateTopicSchemaConversions(
+  subscriptions: readonly Subscription[],
+  sortedTopics: readonly PlayerTopic[],
+  messageConverters: undefined | readonly MessageConverter[],
+): TopicSchemaConversions {
+  const topicSchemaConverters: TopicSchemaConverterMap = new Map();
+  const unconvertedSubscriptionTopics: Set<string> = new Set();
+
+  // Bin the subscriptions into two sets: those which want a conversion and those that do not.
+  //
+  // For the subscriptions that want a conversion, if the topic schemaName matches the requested
+  // convertTo, then we don't need to do a conversion.
+  for (const subscription of subscriptions) {
+    if (!subscription.convertTo) {
+      unconvertedSubscriptionTopics.add(subscription.topic);
+      continue;
+    }
+
+    // If the convertTo is the same as the original schema for the topic then we don't need to
+    // perform a conversion.
+    const noConversion = sortedTopics.find(
+      (topic) => topic.name === subscription.topic && topic.schemaName === subscription.convertTo,
+    );
+    if (noConversion) {
+      unconvertedSubscriptionTopics.add(noConversion.name);
+      continue;
+    }
+
+    // Since we don't have an existing topic with out destination schema we need to find
+    // a converter that will convert from the topic to the desired schema
+    const subscriberTopic = sortedTopics.find((topic) => topic.name === subscription.topic);
+    if (!subscriberTopic) {
+      continue;
+    }
+
+    const key = converterKey(subscription.topic, subscriberTopic.schemaName ?? "<no-schema>");
+    let existingConverters = topicSchemaConverters.get(key);
+
+    // We've already stored a converter for this topic to convertTo
+    const haveConverter = existingConverters?.find(
+      (conv) => conv.toSchemaName === subscription.convertTo,
+    );
+    if (haveConverter) {
+      continue;
+    }
+
+    // Find a converter that can go from the original topic schema to the target schema
+    // Note: We only support one converter per unique from/to pair so this _find_ only needs to
+    //       find one converter rather than multiple converters.
+    const converter = messageConverters?.find(
+      (conv) =>
+        conv.fromSchemaName === subscriberTopic.schemaName &&
+        conv.toSchemaName === subscription.convertTo,
+    );
+
+    if (converter) {
+      existingConverters ??= [];
+      existingConverters.push(converter);
+      topicSchemaConverters.set(key, existingConverters);
+    }
+  }
+
+  return { unconvertedSubscriptionTopics, topicSchemaConverters };
+}
+
+/**
+ * Function to iterate and call function over multiple sorted arrays in sorted order across all items in all arrays.
+ * Time complexity is O(t*n) where t is the number of arrays and n is the total number of items in all arrays.
+ * Space complexity is O(t) where t is the number of arrays.
+ * @param arrays - sorted arrays to iterate over
+ * @param compareFn - function called to compare items in arrays. Returns a positive value if left is larger than right,
+ *  a negative value if right is larger than left, or zero if both are equal
+ * @param forEach - callback to be executed on all items in the arrays to iterate over in sorted order across all arrays
+ */
+export function forEachSortedArrays<Item>(
+  arrays: Item[][],
+  compareFn: (a: Item, b: Item) => number,
+  forEach: (item: Item) => void,
+): void {
+  const cursors: number[] = Array(arrays.length).fill(0);
+  if (arrays.length === 0) {
+    return;
+  }
+  for (;;) {
+    let minCursorIndex = undefined;
+    for (let i = 0; i < cursors.length; i++) {
+      const cursor = cursors[i]!;
+      const array = arrays[i]!;
+      if (cursor >= array.length) {
+        continue;
+      }
+      const item = array[cursor]!;
+      if (minCursorIndex == undefined) {
+        minCursorIndex = i;
+      } else {
+        const minItem = arrays[minCursorIndex]![cursors[minCursorIndex]!]!;
+        if (compareFn(item, minItem) < 0) {
+          minCursorIndex = i;
+        }
+      }
+    }
+    if (minCursorIndex == undefined) {
+      break;
+    }
+    const minItem = arrays[minCursorIndex]![cursors[minCursorIndex]!];
+    if (minItem != undefined) {
+      forEach(minItem);
+      cursors[minCursorIndex]++;
+    } else {
+      break;
+    }
+  }
+}

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -52,7 +52,10 @@ function makeInitialState(): BuilderRenderStateInput {
     globalVariables: {},
     hoverValue: undefined,
     sharedPanelState: {},
-    sortedTopics: [{ name: "test", schemaName: "schema" }],
+    sortedTopics: [
+      { name: "test", schemaName: "schema" },
+      { name: "test2", schemaName: "schema2" },
+    ],
     subscriptions: [{ topic: "test" }, { topic: "test", convertTo: "otherSchema", preload: true }],
     messageConverters: [
       {
@@ -766,69 +769,33 @@ describe("renderState", () => {
     const initialState = makeInitialState();
     const state1 = buildRenderState(initialState);
 
-    const expectedState1 = {
-      topics: [
-        {
-          name: "test",
-          schemaName: "schema",
-          datatype: "schema",
-          convertibleTo: ["otherSchema", "anotherSchema"],
-        },
+    expect(state1).toMatchObject({
+      currentFrame: [
+        { topic: "test", schemaName: "schema" },
+        { topic: "test", schemaName: "otherSchema" },
       ],
+      allFrames: [
+        { topic: "test", schemaName: "schema" },
+        { topic: "test", schemaName: "otherSchema" },
+      ],
+    });
+
+    // emit another state with different messages but same converters
+    buildRenderState({
+      ...initialState,
       currentFrame: [
         {
-          topic: "test",
-          schemaName: "schema",
+          topic: "test2",
+          schemaName: "schema2",
           message: { from: "currentFrame" },
           receiveTime: { sec: 0, nsec: 0 },
           sizeInBytes: 1,
         },
-        {
-          topic: "test",
-          schemaName: "otherSchema",
-          message: 1,
-          receiveTime: { sec: 0, nsec: 0 },
-          sizeInBytes: 1,
-          originalMessageEvent: {
-            topic: "test",
-            schemaName: "schema",
-            message: { from: "currentFrame" },
-            receiveTime: { sec: 0, nsec: 0 },
-            sizeInBytes: 1,
-          },
-        },
       ],
-      allFrames: [
-        {
-          message: { from: "allFrames" },
-          receiveTime: { nsec: 0, sec: 1 },
-          schemaName: "schema",
-          sizeInBytes: 1,
-          topic: "test",
-        },
-        {
-          message: 1,
-          originalMessageEvent: {
-            message: { from: "allFrames" },
-            receiveTime: { nsec: 0, sec: 1 },
-            schemaName: "schema",
-            sizeInBytes: 1,
-            topic: "test",
-          },
-          receiveTime: { nsec: 0, sec: 1 },
-          schemaName: "otherSchema",
-          sizeInBytes: 1,
-          topic: "test",
-        },
-      ],
-    };
+    });
 
-    expect(state1).toEqual(expectedState1);
-
-    // snapshot first state current frame
-    const state1CurrentFrame = state1?.currentFrame;
-
-    const state2 = buildRenderState({
+    // and a third state with no new messages but an added converter
+    const state3 = buildRenderState({
       ...initialState,
       currentFrame: undefined,
       subscriptions: [
@@ -837,42 +804,12 @@ describe("renderState", () => {
       ],
     });
 
-    expect(state2?.currentFrame).not.toEqual(state1CurrentFrame);
-
-    expect(state2).toEqual({
-      topics: expectedState1.topics,
-      currentFrame: [
-        {
-          topic: "test",
-          schemaName: "anotherSchema",
-          message: 2,
-          receiveTime: { sec: 0, nsec: 0 },
-          sizeInBytes: 1,
-          originalMessageEvent: {
-            topic: "test",
-            schemaName: "schema",
-            message: { from: "currentFrame" },
-            receiveTime: { sec: 0, nsec: 0 },
-            sizeInBytes: 1,
-          },
-        },
-      ],
+    expect(state3).toMatchObject({
+      currentFrame: [{ topic: "test", schemaName: "anotherSchema" }],
       allFrames: [
-        ...expectedState1.allFrames,
-        {
-          message: 2,
-          originalMessageEvent: {
-            message: { from: "allFrames" },
-            receiveTime: { nsec: 0, sec: 1 },
-            schemaName: "schema",
-            sizeInBytes: 1,
-            topic: "test",
-          },
-          receiveTime: { nsec: 0, sec: 1 },
-          schemaName: "anotherSchema",
-          sizeInBytes: 1,
-          topic: "test",
-        },
+        { topic: "test", schemaName: "schema" },
+        { topic: "test", schemaName: "otherSchema" },
+        { topic: "test", schemaName: "anotherSchema" },
       ],
     });
   });
@@ -889,6 +826,11 @@ describe("renderState", () => {
           schemaName: "schema",
           datatype: "schema",
           convertibleTo: ["otherSchema", "anotherSchema"],
+        },
+        {
+          name: "test2",
+          schemaName: "schema2",
+          datatype: "schema2",
         },
       ],
       currentFrame: expect.any(Array),

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -2,9 +2,76 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { produce } from "immer";
+
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 
-import { forEachSortedArrays, initRenderStateBuilder } from "./renderState";
+import { BuilderRenderStateInput, initRenderStateBuilder } from "./renderState";
+
+function makeInitialState(): BuilderRenderStateInput {
+  return {
+    watchedFields: new Set(["topics", "currentFrame", "allFrames"]),
+    playerState: {
+      presence: PlayerPresence.INITIALIZING,
+      capabilities: [],
+      profile: undefined,
+      playerId: "test",
+      progress: {
+        messageCache: {
+          startTime: { sec: 0, nsec: 0 },
+          blocks: [
+            {
+              sizeInBytes: 0,
+              messagesByTopic: {
+                test: [
+                  {
+                    topic: "test",
+                    schemaName: "schema",
+                    receiveTime: { sec: 1, nsec: 0 },
+                    sizeInBytes: 1,
+                    message: { from: "allFrames" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+    appSettings: undefined,
+    currentFrame: [
+      {
+        topic: "test",
+        schemaName: "schema",
+        receiveTime: { sec: 0, nsec: 0 },
+        sizeInBytes: 1,
+        message: { from: "currentFrame" },
+      },
+    ],
+    colorScheme: undefined,
+    globalVariables: {},
+    hoverValue: undefined,
+    sharedPanelState: {},
+    sortedTopics: [{ name: "test", schemaName: "schema" }],
+    subscriptions: [{ topic: "test" }, { topic: "test", convertTo: "otherSchema", preload: true }],
+    messageConverters: [
+      {
+        fromSchemaName: "schema",
+        toSchemaName: "otherSchema",
+        converter: () => {
+          return 1;
+        },
+      },
+      {
+        fromSchemaName: "schema",
+        toSchemaName: "anotherSchema",
+        converter: () => {
+          return 2;
+        },
+      },
+    ],
+  };
+}
 
 describe("renderState", () => {
   it("should include convertibleTo when there are message converters", () => {
@@ -694,8 +761,208 @@ describe("renderState", () => {
     });
   });
 
+  it("should deliver new message when a second converter from the same topic is enabled", () => {
+    const buildRenderState = initRenderStateBuilder();
+    const initialState = makeInitialState();
+    const state1 = buildRenderState(initialState);
+
+    const expectedState1 = {
+      topics: [
+        {
+          name: "test",
+          schemaName: "schema",
+          datatype: "schema",
+          convertibleTo: ["otherSchema", "anotherSchema"],
+        },
+      ],
+      currentFrame: [
+        {
+          topic: "test",
+          schemaName: "schema",
+          message: { from: "currentFrame" },
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+        },
+        {
+          topic: "test",
+          schemaName: "otherSchema",
+          message: 1,
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+          originalMessageEvent: {
+            topic: "test",
+            schemaName: "schema",
+            message: { from: "currentFrame" },
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 1,
+          },
+        },
+      ],
+      allFrames: [
+        {
+          message: { from: "allFrames" },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "schema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+        {
+          message: 1,
+          originalMessageEvent: {
+            message: { from: "allFrames" },
+            receiveTime: { nsec: 0, sec: 1 },
+            schemaName: "schema",
+            sizeInBytes: 1,
+            topic: "test",
+          },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "otherSchema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+      ],
+    };
+
+    expect(state1).toEqual(expectedState1);
+
+    // snapshot first state current frame
+    const state1CurrentFrame = state1?.currentFrame;
+
+    const state2 = buildRenderState({
+      ...initialState,
+      currentFrame: undefined,
+      subscriptions: [
+        ...initialState.subscriptions,
+        { topic: "test", convertTo: "anotherSchema", preload: true },
+      ],
+    });
+
+    expect(state2?.currentFrame).not.toEqual(state1CurrentFrame);
+
+    expect(state2).toEqual({
+      topics: expectedState1.topics,
+      currentFrame: [
+        {
+          topic: "test",
+          schemaName: "anotherSchema",
+          message: 2,
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+          originalMessageEvent: {
+            topic: "test",
+            schemaName: "schema",
+            message: { from: "currentFrame" },
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 1,
+          },
+        },
+      ],
+      allFrames: [
+        ...expectedState1.allFrames,
+        {
+          message: 2,
+          originalMessageEvent: {
+            message: { from: "allFrames" },
+            receiveTime: { nsec: 0, sec: 1 },
+            schemaName: "schema",
+            sizeInBytes: 1,
+            topic: "test",
+          },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "anotherSchema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+      ],
+    });
+  });
+
+  it("should deliver new allframes when a second converter from the same topic is enabled", () => {
+    const buildRenderState = initRenderStateBuilder();
+    const initialState = makeInitialState();
+    const state1 = buildRenderState(initialState);
+
+    const expectedState1 = {
+      topics: [
+        {
+          name: "test",
+          schemaName: "schema",
+          datatype: "schema",
+          convertibleTo: ["otherSchema", "anotherSchema"],
+        },
+      ],
+      currentFrame: expect.any(Array),
+      allFrames: [
+        {
+          message: { from: "allFrames" },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "schema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+        {
+          message: 1,
+          originalMessageEvent: {
+            message: { from: "allFrames" },
+            receiveTime: { nsec: 0, sec: 1 },
+            schemaName: "schema",
+            sizeInBytes: 1,
+            topic: "test",
+          },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "otherSchema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+      ],
+    };
+
+    expect(state1).toEqual(expectedState1);
+
+    // snapshot first state current frame
+    const state1CurrentFrame = state1?.currentFrame;
+
+    const state2 = buildRenderState(
+      produce(initialState, (draft) => {
+        draft.currentFrame = undefined;
+        draft.playerState!.progress.messageCache = undefined;
+        draft.subscriptions.push({ topic: "test", convertTo: "anotherSchema", preload: true });
+      }),
+    );
+
+    expect(state2?.currentFrame).not.toEqual(state1CurrentFrame);
+
+    expect(state2).toEqual({
+      topics: expectedState1.topics,
+      currentFrame: expect.any(Array),
+      allFrames: [
+        ...expectedState1.allFrames,
+        {
+          message: 2,
+          originalMessageEvent: {
+            message: { from: "allFrames" },
+            receiveTime: { nsec: 0, sec: 1 },
+            schemaName: "schema",
+            sizeInBytes: 1,
+            topic: "test",
+          },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "anotherSchema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+      ],
+    });
+  });
+
   it("should correctly avoid rendering when current frame stops changing", () => {
     const buildRenderState = initRenderStateBuilder();
+
+    const stableConversionInputs = {
+      sortedTopics: [],
+      subscriptions: [{ topic: "test" }],
+      messageConverters: [],
+    };
 
     // The first render with a current frame produces a state with the current frame
     {
@@ -716,9 +983,7 @@ describe("renderState", () => {
         globalVariables: {},
         hoverValue: undefined,
         sharedPanelState: {},
-        sortedTopics: [],
-        subscriptions: [{ topic: "test" }],
-        messageConverters: [],
+        ...stableConversionInputs,
       });
 
       expect(state).toEqual({
@@ -745,9 +1010,7 @@ describe("renderState", () => {
         globalVariables: {},
         hoverValue: undefined,
         sharedPanelState: {},
-        sortedTopics: [],
-        subscriptions: [{ topic: "test" }],
-        messageConverters: [],
+        ...stableConversionInputs,
       });
 
       expect(state).toEqual({
@@ -766,89 +1029,10 @@ describe("renderState", () => {
         globalVariables: {},
         hoverValue: undefined,
         sharedPanelState: {},
-        sortedTopics: [],
-        subscriptions: [{ topic: "test" }],
-        messageConverters: [],
+        ...stableConversionInputs,
       });
 
       expect(state).toEqual(undefined);
     }
-  });
-});
-
-describe("forEachSortedArrays", () => {
-  it("should not call forEach for empty arrays", () => {
-    const forEach = jest.fn();
-    const arr: number[] = [];
-    forEachSortedArrays([arr, arr], (a, b) => a - b, forEach);
-    expect(forEach).not.toHaveBeenCalled();
-  });
-  it("merges arrays with exclusive ranges", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [1, 2, 3];
-    const arr2 = [4, 5, 6];
-
-    forEachSortedArrays([arr1, arr2], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 2, 3, 4, 5, 6]);
-  });
-  it("merges two interleaved arrays", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [1, 3, 5];
-    const arr2 = [2, 4, 6];
-
-    forEachSortedArrays([arr1, arr2], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 2, 3, 4, 5, 6]);
-  });
-  it("merges three interleaved arrays", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [1, 4, 7];
-    const arr2 = [2, 5, 8];
-    const arr3 = [3, 6, 9];
-
-    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  });
-  it("merges three exclusive arrays", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [4, 5, 6];
-    const arr2 = [1, 2, 3];
-    const arr3 = [7, 8, 9];
-
-    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-  });
-  it("merges three identical arrays", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [1, 2, 3];
-    const arr2 = [1, 2, 3];
-    const arr3 = [1, 2, 3];
-
-    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
-  });
-  it("merges two identical arrays and one empty array", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [1, 2, 3];
-    const arr2 = [1, 2, 3];
-    const arr3: number[] = [];
-
-    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 1, 2, 2, 3, 3]);
-  });
-  it("merge arrays of all the same number and a sequence of numbers", () => {
-    const acc: number[] = [];
-    const forEach = (item: number) => acc.push(item);
-    const arr1 = [3, 3, 3];
-    const arr2 = [1, 2, 3, 4];
-    const arr3: number[] = [];
-
-    forEachSortedArrays([arr1, arr2, arr3], (a, b) => a - b, forEach);
-    expect(acc).toEqual([1, 2, 3, 3, 3, 3, 4]);
   });
 });

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -71,6 +71,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
   let prevSharedPanelState: BuilderRenderStateInput["sharedPanelState"];
   let prevCurrentFrame: RenderState["currentFrame"];
   let prevCollatedConversions: undefined | TopicSchemaConversions;
+  const lastMessageByTopic: Map<string, MessageEvent> = new Map();
 
   // Pull these memoized versions into the closure so they are scoped to the lifetime of
   // the panel.
@@ -114,6 +115,10 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       topicSchemaConverters,
       prevCollatedConversions?.topicSchemaConverters,
     );
+
+    if (prevSeekTime !== activeData?.lastSeekTime) {
+      lastMessageByTopic.clear();
+    }
 
     if (watchedFields.has("didSeek")) {
       const didSeek = prevSeekTime !== activeData?.lastSeekTime;
@@ -195,14 +200,15 @@ function initRenderStateBuilder(): BuildRenderStateFn {
             postProcessedFrame.push(messageEvent);
           }
           convertMessage(messageEvent, topicSchemaConverters, postProcessedFrame);
+          lastMessageByTopic.set(messageEvent.topic, messageEvent);
         }
         renderState.currentFrame = postProcessedFrame;
         shouldRender = true;
       } else if (conversionsChanged) {
         // If we don't have a new frame but our conversions have changed, run
-        // only the new conversions on our most recent available frame.
+        // only the new conversions on our most recent message on each topic.
         const postProcessedFrame: MessageEvent<unknown>[] = [];
-        for (const messageEvent of currentFrame ?? prevCurrentFrame ?? []) {
+        for (const messageEvent of lastMessageByTopic.values()) {
           convertMessage(messageEvent, newConverters, postProcessedFrame);
         }
         renderState.currentFrame = postProcessedFrame;

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import memoizeWeak from "memoize-weak";
+
 import { filterMap } from "@foxglove/den/collection";
 import { compare, toSec } from "@foxglove/rostime";
 import {
@@ -17,12 +19,24 @@ import {
   EMPTY_GLOBAL_VARIABLES,
   GlobalVariables,
 } from "@foxglove/studio-base/hooks/useGlobalVariables";
-import { PlayerState, Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
+import {
+  MessageBlock,
+  PlayerState,
+  Topic as PlayerTopic,
+} from "@foxglove/studio-base/players/types";
 import { HoverValue } from "@foxglove/studio-base/types/hoverValue";
+
+import {
+  collateTopicSchemaConversions,
+  convertMessage,
+  forEachSortedArrays,
+  mapDifference,
+  TopicSchemaConversions,
+} from "./messageProcessing";
 
 const EmptyParameters = new Map<string, ParameterValue>();
 
-type BuilderRenderStateInput = {
+export type BuilderRenderStateInput = {
   appSettings: Map<string, AppSettingValue> | undefined;
   colorScheme: RenderState["colorScheme"] | undefined;
   currentFrame: MessageEvent[] | undefined;
@@ -38,17 +52,6 @@ type BuilderRenderStateInput = {
 
 type BuildRenderStateFn = (input: BuilderRenderStateInput) => Readonly<RenderState> | undefined;
 
-// Branded string to ensure that users go through the `converterKey` function to compute a lookup key
-type ConverterKey = string & { __brand: "ConverterKey" };
-
-// Create a string lookup key from a message event
-//
-// The string key uses a newline delimeter to avoid producting the same key for topic/schema name
-// values that might concatenate to the same string. i.e. "topic" "schema" and "topics" "chema".
-function converterKey(topic: string, schema: string): ConverterKey {
-  return (topic + "\n" + schema) as ConverterKey;
-}
-
 /**
  * initRenderStateBuilder creates a function that transforms render state input into a new
  * RenderState
@@ -61,27 +64,18 @@ function converterKey(topic: string, schema: string): ConverterKey {
  */
 function initRenderStateBuilder(): BuildRenderStateFn {
   let prevVariables: GlobalVariables = EMPTY_GLOBAL_VARIABLES;
-  let prevBlocks: unknown;
+  let prevBlocks: undefined | readonly (undefined | MessageBlock)[];
   let prevSeekTime: number | undefined;
-  let prevSubscriptions: BuilderRenderStateInput["subscriptions"];
   let prevSortedTopics: BuilderRenderStateInput["sortedTopics"] | undefined;
   let prevMessageConverters: BuilderRenderStateInput["messageConverters"] | undefined;
   let prevSharedPanelState: BuilderRenderStateInput["sharedPanelState"];
   let prevCurrentFrame: RenderState["currentFrame"];
+  let prevCollatedConversions: undefined | TopicSchemaConversions;
 
-  // Topics which we are subscribed without a conversion, these are topics we want to receive the
-  // original message
-  const unconvertedSubscriptionTopics: Set<string> = new Set();
-
-  // When a subscription with a convertTo exists, we lookup a converter which can produce the
-  // desired output message schema and store it in this map. The keys for the map are `topic + input
-  // schema`.
-  //
-  // This allows the runtime message event handler logic which builds currentFrame and allFrames to
-  // lookup whether the incoming message event has converters to run by looking up the topic +
-  // schema of the message event in this map.
-  const topicSchemaConverters: Map<ConverterKey, RegisterMessageConverterArgs<unknown>[]> =
-    new Map();
+  // Pull these memoized versions into the closure so they are scoped to the lifetime of
+  // the panel.
+  const memoMapDifference = memoizeWeak(mapDifference);
+  const memoCollateTopicSchemaConversions = memoizeWeak(collateTopicSchemaConversions);
 
   const prevRenderState: RenderState = {};
 
@@ -109,79 +103,17 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     // The render state starts with the previous render state and changes are applied as detected
     const renderState: RenderState = prevRenderState;
 
-    // If the player has loaded all the blocks, the blocks reference won't change so our message
-    // pipeline handler for allFrames won't create a new set of all frames for the newly
-    // subscribed topic. To ensure a new set of allFrames with the newly subscribed topic is
-    // created, we unset the blocks ref which will force re-creating allFrames.
-    if (subscriptions !== prevSubscriptions) {
-      prevBlocks = undefined;
-    }
-
-    // If topics, message converters, or subscriptions change, recalculate the
-    if (
-      prevSubscriptions !== subscriptions ||
-      prevSortedTopics !== sortedTopics ||
-      prevMessageConverters !== messageConverters
-    ) {
-      // reset which topics have subscriptions and which need converting
-      unconvertedSubscriptionTopics.clear();
-      topicSchemaConverters.clear();
-
-      // Bin the subscriptions into two sets: those which want a conversion and those that do not.
-      //
-      // For the subscriptions that want a conversion, if the topic schemaName matches the requested
-      // convertTo, then we don't need to do a conversion.
-      for (const subscription of subscriptions) {
-        if (!subscription.convertTo) {
-          unconvertedSubscriptionTopics.add(subscription.topic);
-          continue;
-        }
-
-        // If the convertTo is the same as the original schema for the topic then we don't need to
-        // perform a conversion.
-        const noConversion = sortedTopics.find(
-          (topic) =>
-            topic.name === subscription.topic && topic.schemaName === subscription.convertTo,
-        );
-        if (noConversion) {
-          unconvertedSubscriptionTopics.add(noConversion.name);
-          continue;
-        }
-
-        // Since we don't have an existing topic with out destination schema we need to find
-        // a converter that will convert from the topic to the desired schema
-        const subscriberTopic = sortedTopics.find((topic) => topic.name === subscription.topic);
-        if (!subscriberTopic) {
-          continue;
-        }
-
-        const key = converterKey(subscription.topic, subscriberTopic.schemaName ?? "<no-schema>");
-        let existingConverters = topicSchemaConverters.get(key);
-
-        // We've already stored a converter for this topic to convertTo
-        const haveConverter = existingConverters?.find(
-          (conv) => conv.toSchemaName === subscription.convertTo,
-        );
-        if (haveConverter) {
-          continue;
-        }
-
-        // Find a converter that can go from the original topic schema to the target schema
-        // Note: We only support one converter per unique from/to pair so this _find_ only needs to
-        //       find one converter rather than multiple converters.
-        const converter = messageConverters?.find(
-          (conv) =>
-            conv.fromSchemaName === subscriberTopic.schemaName &&
-            conv.toSchemaName === subscription.convertTo,
-        );
-
-        if (converter) {
-          existingConverters ??= [];
-          existingConverters.push(converter);
-          topicSchemaConverters.set(key, existingConverters);
-        }
-      }
-    }
+    const collatedConversions = memoCollateTopicSchemaConversions(
+      subscriptions,
+      sortedTopics,
+      messageConverters,
+    );
+    const { unconvertedSubscriptionTopics, topicSchemaConverters } = collatedConversions;
+    const conversionsChanged = prevCollatedConversions !== collatedConversions;
+    const newConverters = memoMapDifference(
+      topicSchemaConverters,
+      prevCollatedConversions?.topicSchemaConverters,
+    );
 
     if (watchedFields.has("didSeek")) {
       const didSeek = prevSeekTime !== activeData?.lastSeekTime;
@@ -254,51 +186,44 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     }
 
     if (watchedFields.has("currentFrame")) {
-      if (prevCurrentFrame !== currentFrame) {
-        prevCurrentFrame = currentFrame;
-        shouldRender = true;
-
-        if (currentFrame) {
-          const postProcessedFrame: MessageEvent[] = [];
-
-          for (const messageEvent of currentFrame) {
-            if (unconvertedSubscriptionTopics.has(messageEvent.topic)) {
-              postProcessedFrame.push(messageEvent);
-            }
-
-            // Get the converters that need to be run for this message event
-            // See the comment for topicSchemaConverters on the use of the key
-            const converters = topicSchemaConverters.get(
-              converterKey(messageEvent.topic, messageEvent.schemaName),
-            );
-            if (converters) {
-              for (const converter of converters) {
-                const convertedMessage = converter.converter(messageEvent.message);
-                postProcessedFrame.push({
-                  topic: messageEvent.topic,
-                  schemaName: converter.toSchemaName,
-                  receiveTime: messageEvent.receiveTime,
-                  message: convertedMessage,
-                  originalMessageEvent: messageEvent,
-                  sizeInBytes: messageEvent.sizeInBytes,
-                });
-              }
-            }
+      if (currentFrame && currentFrame !== prevCurrentFrame) {
+        // If we have a new frame, emit that frame and process all messages on that frame.
+        // Unconverted messages are only processed on a new frame.
+        const postProcessedFrame: MessageEvent<unknown>[] = [];
+        for (const messageEvent of currentFrame) {
+          if (unconvertedSubscriptionTopics.has(messageEvent.topic)) {
+            postProcessedFrame.push(messageEvent);
           }
-
-          renderState.currentFrame = postProcessedFrame;
-        } else {
-          renderState.currentFrame = undefined;
+          convertMessage(messageEvent, topicSchemaConverters, postProcessedFrame);
         }
+        renderState.currentFrame = postProcessedFrame;
+        shouldRender = true;
+      } else if (conversionsChanged) {
+        // If we don't have a new frame but our conversions have changed, run
+        // only the new conversions on our most recent available frame.
+        const postProcessedFrame: MessageEvent<unknown>[] = [];
+        for (const messageEvent of currentFrame ?? prevCurrentFrame ?? []) {
+          convertMessage(messageEvent, newConverters, postProcessedFrame);
+        }
+        renderState.currentFrame = postProcessedFrame;
+        shouldRender = true;
+      } else if (currentFrame !== prevCurrentFrame) {
+        // Otherwise if we're replacing a non-empty frame with an empty frame and
+        // conversions haven't changed, include the empty frame in the new render state.
+        renderState.currentFrame = currentFrame;
+        shouldRender = true;
       }
+
+      prevCurrentFrame = currentFrame;
     }
 
     if (watchedFields.has("allFrames")) {
-      // see comment for prevBlocksRef on why extended message store updates are gated this way
+      // Rebuild allFrames if we have new blocks or if our conversions have changed.
       const newBlocks = playerState?.progress.messageCache?.blocks;
-      if (newBlocks && prevBlocks !== newBlocks) {
+      if ((newBlocks && prevBlocks !== newBlocks) || conversionsChanged) {
         shouldRender = true;
-        const frames: MessageEvent[] = (renderState.allFrames = []);
+        const blocksToProcess = newBlocks ?? prevBlocks ?? [];
+        const frames: MessageEvent<unknown>[] = (renderState.allFrames = []);
         // only populate allFrames with topics that the panel wants to preload
         const topicsToPreloadForPanel = Array.from(
           new Set<string>(
@@ -306,41 +231,27 @@ function initRenderStateBuilder(): BuildRenderStateFn {
           ),
         );
 
-        for (const block of newBlocks) {
+        for (const block of blocksToProcess) {
           if (!block) {
             continue;
           }
 
-          // Given that messagesByTopic should be in order by receiveTime
-          // We need to combine all of the messages into a single array and sorted by receive time
+          // Given that messagesByTopic should be in order by receiveTime, we need to
+          // combine all of the messages into a single array and sorted by receive time.
           forEachSortedArrays(
             topicsToPreloadForPanel.map((topic) => block.messagesByTopic[topic] ?? []),
             (a, b) => compare(a.receiveTime, b.receiveTime),
             (messageEvent) => {
-              // Message blocks may contain topics that we are not subscribed to so we need to filter those out.
-              // We use the topicNoConversions and topicConversions to determine if we should include the message event
-
+              // Message blocks may contain topics that we are not subscribed to so we
+              // need to filter those out. We use unconvertedSubscriptionTopics to
+              // determine if we should include the message event. Clients expect
+              // allFrames to be a complete set of messages for all subscribed topics so
+              // we include all unconverted and converted messages, unlike in
+              // currentFrame.
               if (unconvertedSubscriptionTopics.has(messageEvent.topic)) {
                 frames.push(messageEvent);
               }
-
-              // Get the converters available for this topic and schema
-              const converters = topicSchemaConverters.get(
-                converterKey(messageEvent.topic, messageEvent.schemaName),
-              );
-              if (converters) {
-                for (const converter of converters) {
-                  const convertedMessage = converter.converter(messageEvent.message);
-                  frames.push({
-                    topic: messageEvent.topic,
-                    schemaName: converter.toSchemaName,
-                    receiveTime: messageEvent.receiveTime,
-                    message: convertedMessage,
-                    originalMessageEvent: messageEvent,
-                    sizeInBytes: messageEvent.sizeInBytes,
-                  });
-                }
-              }
+              convertMessage(messageEvent, topicSchemaConverters, frames);
             },
           );
         }
@@ -402,8 +313,8 @@ function initRenderStateBuilder(): BuildRenderStateFn {
 
     // Update the prev fields with the latest values at the end of all the watch steps
     // Several of the watch steps depend on the comparison against prev and new values
-    prevSubscriptions = subscriptions;
     prevMessageConverters = messageConverters;
+    prevCollatedConversions = collatedConversions;
 
     if (!shouldRender) {
       return undefined;
@@ -414,52 +325,3 @@ function initRenderStateBuilder(): BuildRenderStateFn {
 }
 
 export { initRenderStateBuilder };
-
-/**
- * Function to iterate and call function over multiple sorted arrays in sorted order across all items in all arrays.
- * Time complexity is O(t*n) where t is the number of arrays and n is the total number of items in all arrays.
- * Space complexity is O(t) where t is the number of arrays.
- * @param arrays - sorted arrays to iterate over
- * @param compareFn - function called to compare items in arrays. Returns a positive value if left is larger than right,
- *  a negative value if right is larger than left, or zero if both are equal
- * @param forEach - callback to be executed on all items in the arrays to iterate over in sorted order across all arrays
- */
-export function forEachSortedArrays<Item>(
-  arrays: Item[][],
-  compareFn: (a: Item, b: Item) => number,
-  forEach: (item: Item) => void,
-): void {
-  const cursors: number[] = Array(arrays.length).fill(0);
-  if (arrays.length === 0) {
-    return;
-  }
-  for (;;) {
-    let minCursorIndex = undefined;
-    for (let i = 0; i < cursors.length; i++) {
-      const cursor = cursors[i]!;
-      const array = arrays[i]!;
-      if (cursor >= array.length) {
-        continue;
-      }
-      const item = array[cursor]!;
-      if (minCursorIndex == undefined) {
-        minCursorIndex = i;
-      } else {
-        const minItem = arrays[minCursorIndex]![cursors[minCursorIndex]!]!;
-        if (compareFn(item, minItem) < 0) {
-          minCursorIndex = i;
-        }
-      }
-    }
-    if (minCursorIndex == undefined) {
-      break;
-    }
-    const minItem = arrays[minCursorIndex]![cursors[minCursorIndex]!];
-    if (minItem != undefined) {
-      forEach(minItem);
-      cursors[minCursorIndex]++;
-    } else {
-      break;
-    }
-  }
-}


### PR DESCRIPTION
**User-Facing Changes**
Fixes a bug with message converters and extension panels.

**Description**
Fixes incremental updates to subscribed topics and message converters by extracting the calculation of the active conversions into a separate, memoized function and using changes in the results of that function to trigger currentFrame  and allFrames updates.

The strategy is as follows:
1. If we receive a new `currentFrame` or `allFrames`, emit all converted and unconverted messages.
2. If we receive a new set of converters, emit a new `allFrames` containing all converted and unconverted messages, as well as a s new `currentFrame` containing only the results of running new converters on the last message received on all topics.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
