### PR TITLE
feat: marker datatypes support scale

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -24,11 +24,15 @@ import {
 import { Marker, MarkerArray, MARKER_ARRAY_DATATYPES, MARKER_DATATYPES } from "../ros";
 import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
+import { PRECISION_DISTANCE } from "../settings";
+
+const DEFAULT_SCALE: THREE.Vector3Tuple = [0.01, 0, 0];
 
 const DEFAULT_SETTINGS: LayerSettingsMarker = {
   visible: false,
   showOutlines: true,
   color: undefined,
+  scale: DEFAULT_SCALE,
   selectedIdVariable: undefined,
   namespaces: {},
 };
@@ -62,6 +66,14 @@ export class Markers extends SceneExtension<TopicMarkers> {
         order: topic.name.toLocaleLowerCase(),
         fields: {
           color: { label: "Color", input: "rgba", value: config.color },
+          scale: {
+            label: "Scale",
+            input: "vec3",
+            labels: ["X", "Y", "Z"],
+            step: 0.1,
+            precision: PRECISION_DISTANCE,
+            value: config.scale ?? DEFAULT_SCALE,
+          },
           showOutlines: { label: "Show outline", input: "boolean", value: config.showOutlines },
           selectedIdVariable: {
             label: "Selection Variable",

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -22,9 +22,9 @@ import {
   normalizeVector3s,
 } from "../normalizeMessages";
 import { Marker, MarkerArray, MARKER_ARRAY_DATATYPES, MARKER_DATATYPES } from "../ros";
+import { PRECISION_DISTANCE } from "../settings";
 import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
-import { PRECISION_DISTANCE } from "../settings";
 
 const DEFAULT_SCALE: THREE.Vector3Tuple = [0.01, 0, 0];
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -13,6 +13,7 @@ import { updatePose } from "../updatePose";
 
 export type LayerSettingsMarker = BaseSettings & {
   color: string | undefined;
+  scale: [number, number, number];
   showOutlines: boolean | undefined;
   selectedIdVariable: string | undefined;
   namespaces: Record<string, LayerSettingsMarkerNamespace>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
@@ -118,14 +118,21 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
       | Partial<LayerSettingsMarker>
       | undefined;
     const colorStr = settings?.color;
-
-    if (colorStr == undefined) {
-      return marker;
-    }
+    const scale = settings?.scale;
+    let newMarker = marker;
 
     // Create a clone of the marker with the color overridden
-    const color = stringToRgba(makeRgba(), colorStr);
-    const newMarker = { ...marker, color, colors: [] };
+    if (colorStr) {
+      const color = stringToRgba(makeRgba(), colorStr);
+      newMarker = { ...newMarker, color, colors: [] };
+    }
+
+    // Create a clone of the marker with the scale overridden
+    if (scale) {
+      const [x, y, z] = scale;
+      newMarker = { ...newMarker, scale: { x, y, z } };
+    }
+
     return newMarker;
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->


**Description**
`visualization_msgs/Marker` and `visualization_msgs/MarkerArray` support scale.

Before: 
![image](https://user-images.githubusercontent.com/23401125/236993486-ae28e399-f4dc-4d6d-a34e-35458e133a47.png)

After: 
![image](https://user-images.githubusercontent.com/23401125/236993525-f47b8747-e49a-4cc8-b533-27653fb1468f.png)



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
