### PR TITLE
Improved error message for corrupt and large MCAP files

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -47,7 +47,7 @@ export class McapUnindexedIterableSource implements IIterableSource {
     if (this.#options.size > 1024 * 1024 * 1024) {
       // This provider uses a simple approach of loading everything into memory up front, so we
       // can't handle large files
-      throw new Error("Unable to stream MCAP file; too large");
+      throw new Error("Unable to open unindexed MCAP file; unindexed files are limited to 1GB");
     }
     const decompressHandlers = await loadDecompressHandlers();
 


### PR DESCRIPTION
**User-Facing Changes**

`McapUnindexedIterableSource` handles unindexed mcap files instead of `McapIterableSource`, but the unindexed source has a strict 1GB file limit. Since mcap files shouldn't be limited to size, the current "file too large" error message — without a mention of the file being unindexed — confuses people: https://github.com/foxglove/studio/issues/5733

This PR changes the error message to:

```
Unable to open unindexed MCAP file; unindexed files are limited to 1GB
```