### PR TITLE
Add @emotion/* packages to constraints

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -59,6 +59,8 @@ version_group(Dep, storybook) :-
   has_prefix('@storybook/', Dep), Dep \= '@storybook/testing-library'.
 version_group(Dep, typescript_eslint) :-
   has_prefix('@typescript-eslint/', Dep).
+version_group(Dep, emotion) :-
+  has_prefix('@emotion/', Dep).
 
 % Enforce the requirements defined on version groups above.
 gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, DependencyType) :-


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Originally I didn't add these because I thought they weren't published at the same time, but based on https://github.com/foxglove/studio/pull/5945 & #5952  it seems like we want to keep them in sync.