### PR TITLE
Fix Display Frame Error on refresh

### DIFF
--- a/packages/studio-base/src/i18n/en/threeDee.ts
+++ b/packages/studio-base/src/i18n/en/threeDee.ts
@@ -18,7 +18,7 @@ export const threeDee = {
   followModeHelp: "Change the camera behavior during playback to follow the display frame or not.",
   pose: "Pose",
   fixed: "Fixed",
-  frameNotFound: "Frame {{followFrameId}} not found",
+  frameNotFound: "Frame {{frameId}} not found",
   noCoordinateFramesFound: "No coordinate frames found",
   enablePreloading: "Enable preloading",
   lineColor: "Line color",

--- a/packages/studio-base/src/i18n/ja/threeDee.ts
+++ b/packages/studio-base/src/i18n/ja/threeDee.ts
@@ -21,7 +21,7 @@ export const threeDee: Partial<TypeOptions["resources"]["threeDee"]> = {
     "再生中のカメラの動作を変更し、表示フレームをフォローするかどうかを選択できます。",
   pose: "ポーズ",
   fixed: "固定",
-  frameNotFound: "フレーム {{followFrameId}} が見つかりません",
+  frameNotFound: "フレーム {{frameId}} が見つかりません",
   noCoordinateFramesFound: "座標フレームが見つかりません",
   enablePreloading: "事前の読み込みを有効にする",
   lineColor: "ラインの色",

--- a/packages/studio-base/src/i18n/zh/threeDee.ts
+++ b/packages/studio-base/src/i18n/zh/threeDee.ts
@@ -19,7 +19,7 @@ export const threeDee: Partial<TypeOptions["resources"]["threeDee"]> = {
   followModeHelp: "更改回放期间相机的行为，是否跟踪显示坐标系。",
   pose: "姿态",
   fixed: "固定",
-  frameNotFound: "未找到参考系 {{followFrameId}}",
+  frameNotFound: "未找到参考系 {{frameId}}",
   noCoordinateFramesFound: "未找到坐标系",
   enablePreloading: "启用预加载",
   lineColor: "线颜色",

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -206,12 +206,12 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
   transformTree: TransformTree;
   coordinateFrameList: SelectEntry[];
   currentTime: bigint;
-  /* Root frame of the follow frame */
+  /** Coordinate frame that transforms are applied through to the follow frame. Should be unchanging. */
   fixedFrameId: string | undefined;
   /**
    * The frameId that we _want_ to follow and render in if it exists.
    */
-  followFrameId: string | undefined;
+  readonly followFrameId: string | undefined;
 
   labelPool: LabelPool;
   markerPool: MarkerPool;
@@ -303,7 +303,7 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
 
   addMessageEvent(messageEvent: Readonly<MessageEvent<unknown>>): void;
 
-  /* Set desired render/display frame, will render using fallback if id is undefined or frame does not exist */
+  /**  Set desired render/display frame, will render using fallback if id is undefined or frame does not exist */
   setFollowFrameId(frameId: string | undefined): void;
 
   /** Match the behavior of `tf::Transformer` by stripping leading slashes from

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -206,8 +206,11 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
   transformTree: TransformTree;
   coordinateFrameList: SelectEntry[];
   currentTime: bigint;
+  /* Root frame of the follow frame */
   fixedFrameId: string | undefined;
-  renderFrameId: string | undefined;
+  /**
+   * The frameId that we _want_ to follow and render in if it exists.
+   */
   followFrameId: string | undefined;
 
   labelPool: LabelPool;

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -45,6 +45,7 @@ export type RendererEvents = {
     variables: ReadonlyMap<string, VariableValue> | undefined,
     renderer: IRenderer,
   ) => void;
+  /** Fired when the structure of the transform tree changes ie: new frame added/removed or frame assigned new parent */
   transformTreeUpdated: (renderer: IRenderer) => void;
   settingsTreeChange: (renderer: IRenderer) => void;
   configChange: (renderer: IRenderer) => void;

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -303,6 +303,9 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
 
   addMessageEvent(messageEvent: Readonly<MessageEvent<unknown>>): void;
 
+  /* Set desired render/display frame, will render using fallback if id is undefined or frame does not exist */
+  setFollowFrameId(frameId: string | undefined): void;
+
   /** Match the behavior of `tf::Transformer` by stripping leading slashes from
    * frame_ids. This preserves compatibility with earlier versions of ROS while
    * not breaking any current versions where:

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -992,7 +992,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   public setFollowFrameId(frameId: string | undefined): void {
     this.followFrameId = frameId;
-    log.debug(`Setting render frame to ${frameId}`);
+    log.debug(`Setting followFrameId to ${frameId}`);
   }
 
   #frameHandler = (currentTime: bigint): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -997,7 +997,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   #frameHandler = (currentTime: bigint): void => {
     this.currentTime = currentTime;
-    this.#checkFollowFrame();
+    this.#updateFrameErrors();
     this.#updateFixedFrameId();
     this.#updateResolution();
 
@@ -1239,8 +1239,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     return { renderable, instanceIndex };
   }
 
-  // update fixed frame to be the root of the render frame
-  #checkFollowFrame(): void {
+  #updateFrameErrors(): void {
     if (this.followFrameId == undefined) {
       // No frames available
       this.settings.errors.add(

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -217,10 +217,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   public currentTime = 0n;
   public fixedFrameId: string | undefined;
   public followFrameId: string | undefined;
-  /**
-   * The frameId that we are actually rendering in
-   */
-  #renderFrameId: string | undefined;
 
   public labelPool = new LabelPool({ fontFamily: fonts.MONOSPACE });
   public markerPool = new MarkerPool(this);
@@ -994,6 +990,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
+  public setFollowFrameId(frameId: string | undefined): void {
+    this.followFrameId = frameId;
+    log.debug(`Setting render frame to ${frameId}`);
+  }
+
   #frameHandler = (currentTime: bigint): void => {
     this.currentTime = currentTime;
     this.#checkFollowFrame();
@@ -1008,8 +1009,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.#selectionBackdrop.visible = this.#selectedRenderable != undefined;
 
     // use the FALLBACK_FRAME_ID if renderFrame is undefined and there are no options for transforms
-    log.debug(`Setting render frame to ${this.followFrameId}`);
-    const renderFrameId = this.followFrameId ?? CoordinateFrame.FALLBACK_FRAME_ID;
+    const renderFrameId =
+      this.followFrameId && this.transformTree.frame(this.followFrameId)
+        ? this.followFrameId
+        : CoordinateFrame.FALLBACK_FRAME_ID;
     const fixedFrameId = this.fixedFrameId ?? CoordinateFrame.FALLBACK_FRAME_ID;
 
     for (const sceneExtension of this.sceneExtensions.values()) {
@@ -1263,8 +1266,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
           frameId: this.followFrameId,
         }),
       );
-      this.#renderFrameId = undefined;
-      this.fixedFrameId = undefined;
       return;
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -128,14 +128,11 @@ const DARK_BACKDROP = new THREE.Color(dark.background?.default);
 const LAYER_DEFAULT = 0;
 const LAYER_SELECTED = 1;
 
-// Coordinate frames named in [REP-105](https://www.ros.org/reps/rep-0105.html)
-const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
-
 const FOLLOW_TF_PATH = ["general", "followTf"];
 const NO_FRAME_SELECTED = "NO_FRAME_SELECTED";
-const FRAME_NOT_FOUND = "FRAME_NOT_FOUND";
 const TF_OVERFLOW = "TF_OVERFLOW";
 const CYCLE_DETECTED = "CYCLE_DETECTED";
+const FOLLOW_FRAME_NOT_FOUND = "FOLLOW_FRAME_NOT_FOUND";
 
 // An extensionId for creating the top-level settings nodes such as "Topics" and
 // "Custom Layers"
@@ -219,8 +216,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   public coordinateFrameList: SelectEntry[] = [];
   public currentTime = 0n;
   public fixedFrameId: string | undefined;
-  public renderFrameId: string | undefined;
   public followFrameId: string | undefined;
+  /**
+   * The frameId that we are actually rendering in
+   */
+  #renderFrameId: string | undefined;
 
   public labelPool = new LabelPool({ fontFamily: fonts.MONOSPACE });
   public markerPool = new MarkerPool(this);
@@ -312,8 +312,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.#selectionBackdrop = new ScreenOverlay(this);
     this.#selectionBackdrop.visible = false;
     this.#scene.add(this.#selectionBackdrop);
-
-    this.followFrameId = config.followTf;
 
     const samples = msaaSamples(this.gl.capabilities);
     const renderSize = this.gl.getDrawingBufferSize(tempVec2);
@@ -729,42 +727,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     this.settings.setNodesForKey(RENDERER_ID, [topics, customLayers]);
   }
-
-  #defaultFrameId(): string | undefined {
-    if (this.interfaceMode === "image") {
-      return undefined;
-    }
-    const allFrames = this.transformTree.frames();
-    if (allFrames.size === 0) {
-      return undefined;
-    }
-
-    // Top priority is the followFrameId
-    if (this.followFrameId != undefined) {
-      return this.transformTree.hasFrame(this.followFrameId) ? this.followFrameId : undefined;
-    }
-
-    // Prefer frames from [REP-105](https://www.ros.org/reps/rep-0105.html)
-    for (const frameId of DEFAULT_FRAME_IDS) {
-      const frame = this.transformTree.frame(frameId);
-      if (frame) {
-        return frame.id;
-      }
-    }
-
-    // Choose the root frame with the most children
-    const rootsToCounts = new Map<string, number>();
-    for (const frame of allFrames.values()) {
-      const root = frame.root();
-      const rootId = root.id;
-
-      rootsToCounts.set(rootId, (rootsToCounts.get(rootId) ?? 0) + 1);
-    }
-    const rootsArray = Array.from(rootsToCounts.entries());
-    const rootId = rootsArray.sort((a, b) => b[1] - a[1])[0]?.[0];
-    return rootId;
-  }
-
   /** Enable or disable object selection mode */
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   public setPickingEnabled(enabled: boolean): void {
@@ -1034,7 +996,8 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   #frameHandler = (currentTime: bigint): void => {
     this.currentTime = currentTime;
-    this.#updateFrames();
+    this.#checkFollowFrame();
+    this.#updateFixedFrameId();
     this.#updateResolution();
 
     this.gl.clear();
@@ -1045,7 +1008,8 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.#selectionBackdrop.visible = this.#selectedRenderable != undefined;
 
     // use the FALLBACK_FRAME_ID if renderFrame is undefined and there are no options for transforms
-    const renderFrameId = this.renderFrameId ?? CoordinateFrame.FALLBACK_FRAME_ID;
+    log.debug(`Setting render frame to ${this.followFrameId}`);
+    const renderFrameId = this.followFrameId ?? CoordinateFrame.FALLBACK_FRAME_ID;
     const fixedFrameId = this.fixedFrameId ?? CoordinateFrame.FALLBACK_FRAME_ID;
 
     for (const sceneExtension of this.sceneExtensions.values()) {
@@ -1065,6 +1029,26 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     this.gl.info.reset();
   };
+
+  #updateFixedFrameId(): void {
+    const frame =
+      this.followFrameId != undefined ? this.transformTree.frame(this.followFrameId) : undefined;
+
+    if (frame == undefined) {
+      this.fixedFrameId = undefined;
+      return;
+    }
+    const fixedFrame = frame.root();
+    const fixedFrameId = fixedFrame.id;
+    if (this.fixedFrameId !== fixedFrameId) {
+      if (this.fixedFrameId == undefined) {
+        log.debug(`Setting fixed frame to ${fixedFrameId}`);
+      } else {
+        log.debug(`Changing fixed frame from "${this.fixedFrameId}" to "${fixedFrameId}"`);
+      }
+      this.fixedFrameId = fixedFrameId;
+    }
+  }
 
   #resizeHandler = (size: THREE.Vector2): void => {
     this.gl.setPixelRatio(window.devicePixelRatio);
@@ -1252,79 +1236,39 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     return { renderable, instanceIndex };
   }
 
-  /** Tracks the number of frames so we can recompute the defaultFrameId when frames are added. */
-  #lastTransformFrameCount = 0;
-
-  #updateFrames(): void {
-    if (
-      this.followFrameId != undefined &&
-      this.renderFrameId !== this.followFrameId &&
-      this.transformTree.hasFrame(this.followFrameId)
-    ) {
-      // followFrameId is set and is a valid frame, use it
-      this.renderFrameId = this.followFrameId;
-    } else if (
-      this.renderFrameId == undefined ||
-      this.transformTree.frames().size !== this.#lastTransformFrameCount ||
-      !this.transformTree.hasFrame(this.renderFrameId)
-    ) {
-      // No valid renderFrameId set, or new frames have been added, fall back to selecting the
-      // heuristically most valid frame (if any frames are present)
-      this.renderFrameId = this.#defaultFrameId();
-      this.#lastTransformFrameCount = this.transformTree.frames().size;
-
-      if (this.renderFrameId == undefined) {
-        if (this.followFrameId != undefined) {
-          this.settings.errors.add(
-            FOLLOW_TF_PATH,
-            FRAME_NOT_FOUND,
-            i18next.t("threeDee:frameNotFound", {
-              followFrameId: this.followFrameId,
-            }),
-          );
-        } else {
-          this.settings.errors.add(
-            FOLLOW_TF_PATH,
-            NO_FRAME_SELECTED,
-            i18next.t("threeDee:noCoordinateFramesFound"),
-          );
-        }
-        this.fixedFrameId = undefined;
-        return;
-      } else {
-        log.debug(`Setting render frame to ${this.renderFrameId}`);
-        this.settings.errors.remove(FOLLOW_TF_PATH, NO_FRAME_SELECTED);
-      }
-    }
-
-    const frame = this.transformTree.frame(this.renderFrameId);
-    if (!frame) {
-      this.renderFrameId = undefined;
-      this.fixedFrameId = undefined;
+  // update fixed frame to be the root of the render frame
+  #checkFollowFrame(): void {
+    if (this.followFrameId == undefined) {
+      // No frames available
       this.settings.errors.add(
         FOLLOW_TF_PATH,
-        FRAME_NOT_FOUND,
-        i18next.t("threeDee:frameNotFound", {
-          followFrameId: this.renderFrameId,
-        }),
+        NO_FRAME_SELECTED,
+        i18next.t("threeDee:noCoordinateFramesFound"),
       );
       return;
-    } else {
-      this.settings.errors.remove(FOLLOW_TF_PATH, FRAME_NOT_FOUND);
     }
 
-    const fixedFrame = frame.root();
-    const fixedFrameId = fixedFrame.id;
-    if (this.fixedFrameId !== fixedFrameId) {
-      if (this.fixedFrameId == undefined) {
-        log.debug(`Setting fixed frame to ${fixedFrameId}`);
-      } else {
-        log.debug(`Changing fixed frame from "${this.fixedFrameId}" to "${fixedFrameId}"`);
-      }
-      this.fixedFrameId = fixedFrameId;
+    this.settings.errors.remove(FOLLOW_TF_PATH, NO_FRAME_SELECTED);
+
+    const frame = this.transformTree.frame(this.followFrameId);
+
+    // The follow frame id should be chosen from a frameId that exists, but
+    // we still need to watch out for the case that the transform tree was
+    // cleared before that could be updated
+    if (!frame) {
+      this.settings.errors.add(
+        FOLLOW_TF_PATH,
+        FOLLOW_FRAME_NOT_FOUND,
+        i18next.t("threeDee:frameNotFound", {
+          frameId: this.followFrameId,
+        }),
+      );
+      this.#renderFrameId = undefined;
+      this.fixedFrameId = undefined;
+      return;
     }
 
-    this.settings.errors.clearPath(FOLLOW_TF_PATH);
+    this.settings.errors.remove(FOLLOW_TF_PATH, FOLLOW_FRAME_NOT_FOUND);
   }
 
   #updateResolution(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -186,9 +186,6 @@ export function ThreeDeeRender(props: {
     () => new Map(),
   );
 
-  // The frame we care about for syncing purposes can be either of these.
-  const effectiveRendererFrameId = renderer?.followFrameId;
-
   // Config cameraState
   useEffect(() => {
     const listener = () => {
@@ -206,14 +203,14 @@ export function ThreeDeeRender(props: {
           context.setSharedPanelState({
             cameraState: newCameraState,
             followMode: config.followMode,
-            followTf: effectiveRendererFrameId,
+            followTf: renderer.followFrameId,
           });
         }
       }
     };
     renderer?.addListener("cameraMove", listener);
     return () => void renderer?.removeListener("cameraMove", listener);
-  }, [config.scene.syncCamera, config.followMode, context, effectiveRendererFrameId, renderer]);
+  }, [config.scene.syncCamera, config.followMode, context, renderer?.followFrameId, renderer]);
 
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
@@ -542,7 +539,7 @@ export function ThreeDeeRender(props: {
       renderer.setCameraSyncError(
         `Follow mode must be ${sharedPanelState.followMode} to sync camera.`,
       );
-    } else if (sharedPanelState.followTf !== effectiveRendererFrameId) {
+    } else if (sharedPanelState.followTf !== renderer.followFrameId) {
       renderer.setCameraSyncError(
         `Display frame must be ${sharedPanelState.followTf} to sync camera.`,
       );
@@ -559,8 +556,8 @@ export function ThreeDeeRender(props: {
   }, [
     config.scene.syncCamera,
     config.followMode,
-    effectiveRendererFrameId,
     renderer,
+    renderer?.followFrameId,
     sharedPanelState,
   ]);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -187,7 +187,7 @@ export function ThreeDeeRender(props: {
   );
 
   // The frame we care about for syncing purposes can be either of these.
-  const effectiveRendererFrameId = renderer?.followFrameId ?? renderer?.renderFrameId;
+  const effectiveRendererFrameId = renderer?.followFrameId;
 
   // Config cameraState
   useEffect(() => {
@@ -643,7 +643,7 @@ export function ThreeDeeRender(props: {
   useEffect(() => {
     const onStart = () => setPublishActive(true);
     const onSubmit = (event: PublishClickEvent & { type: "foxglove.publish-submit" }) => {
-      const frameId = renderer?.renderFrameId;
+      const frameId = renderer?.followFrameId;
       if (frameId == undefined) {
         log.warn("Unable to publish, renderFrameId is not set");
         return;
@@ -698,7 +698,7 @@ export function ThreeDeeRender(props: {
     context,
     latestPublishConfig,
     publishTopics,
-    renderer?.renderFrameId,
+    renderer?.followFrameId,
     renderer?.publishClickTool,
   ]);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -406,7 +406,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
 
     const followTfFrameExists = followTf != undefined && transformTree.hasFrame(followTf);
     if (followTfFrameExists) {
-      this.renderer.followFrameId = followTf;
+      this.renderer.setFollowFrameId(followTf);
       return;
     }
 
@@ -418,7 +418,8 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     // No valid renderFrameId set, or new frames have been added, fall back to selecting the
     // heuristically most valid frame (if any frames are present)
     const followFrameId = transformTree.getMostValidFollowFrameId();
-    this.renderer.followFrameId = followFrameId;
+    this.renderer.setFollowFrameId(followFrameId);
+
     this.#lastTransformFrameCount = newTransformFrameCount;
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -209,7 +209,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     let followTfOptions = this.renderer.coordinateFrameList;
     const followFrameId = this.renderer.followFrameId;
 
-    this.#checkFollowTf();
+    this.#updateFollowTfError();
 
     // always show current config value if it exists
     const followTfValue = config.followTf ?? followFrameId;
@@ -399,7 +399,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   #updateFollowFrameId() {
     const { followTf } = this.renderer.config;
     const { transformTree } = this.renderer;
-    this.#checkFollowTf();
+    this.#updateFollowTfError();
 
     const followTfFrameExists = followTf != undefined && transformTree.hasFrame(followTf);
     if (followTfFrameExists) {
@@ -413,7 +413,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     this.renderer.setFollowFrameId(followFrameId);
   }
 
-  #checkFollowTf = (): void => {
+  #updateFollowTfError = (): void => {
     const { followTf } = this.renderer.config;
     const { transformTree } = this.renderer;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import i18next, { t } from "i18next";
+import { t } from "i18next";
 import { cloneDeep, set } from "lodash";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
@@ -417,7 +417,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
 
     // No valid renderFrameId set, or new frames have been added, fall back to selecting the
     // heuristically most valid frame (if any frames are present)
-    const followFrameId = transformTree.getMostValidFollowFrameId();
+    const followFrameId = transformTree.getDefaultFollowFrameId();
     this.renderer.setFollowFrameId(followFrameId);
 
     this.#lastTransformFrameCount = newTransformFrameCount;
@@ -435,7 +435,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
         this.renderer.settings.errors.add(
           FOLLOW_TF_PATH,
           DISPLAY_FRAME_NOT_FOUND,
-          i18next.t("threeDee:frameNotFound", {
+          t("threeDee:frameNotFound", {
             frameId: followTf,
           }),
         );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { t } from "i18next";
+import i18next, { t } from "i18next";
 import { cloneDeep, set } from "lodash";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
@@ -21,7 +21,9 @@ import type { FollowMode, IRenderer } from "../IRenderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { CameraState, DEFAULT_CAMERA_STATE } from "../camera";
-import { PRECISION_DEGREES, PRECISION_DISTANCE, SelectEntry } from "../settings";
+import { PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
+
+const DISPLAY_FRAME_NOT_FOUND = "DISPLAY_FRAME_NOT_FOUND";
 
 const UNIT_X = new THREE.Vector3(1, 0, 0);
 const UNIT_Z = new THREE.Vector3(0, 0, 1);
@@ -206,17 +208,18 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     // anyways. A settings node error will be displayed
     let followTfOptions = this.renderer.coordinateFrameList;
     const followFrameId = this.renderer.followFrameId;
-    if (followFrameId != undefined && !this.renderer.transformTree.hasFrame(followFrameId)) {
+
+    this.#checkFollowTf();
+
+    // always show current config value if it exists
+    const followTfValue = config.followTf ?? followFrameId;
+    if (followTfValue != undefined && !this.renderer.transformTree.hasFrame(followTfValue)) {
       followTfOptions = [
-        { label: CoordinateFrame.DisplayName(followFrameId), value: followFrameId },
+        { label: CoordinateFrame.DisplayName(followTfValue), value: followTfValue },
         ...followTfOptions,
       ];
     }
 
-    const followTfValue = selectBest(
-      [this.renderer.followFrameId, config.followTf, this.renderer.renderFrameId],
-      followTfOptions,
-    );
     const followTfError = this.renderer.settings.errors.errors.errorAtPath(FOLLOW_TF_PATH);
 
     const followModeOptions = [
@@ -252,7 +255,6 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
       },
     };
   }
-
   public override handleSettingsAction = (action: SettingsTreeAction): void => {
     if (action.action === "perform-node-action" && action.payload.id === "reset-camera") {
       this.renderer.updateConfig((draft) => {
@@ -290,7 +292,7 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
           draft.followTf = followTf;
         });
 
-        this.renderer.followFrameId = followTf;
+        this.#updateFollowFrameId();
         this.renderer.settings.errors.clearPath(["general", "followTf"]);
       } else if (path[1] === "followMode") {
         const followMode = value as FollowMode;
@@ -388,9 +390,58 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
   #handleCameraMove = (): void => {
     this.updateSettingsTree();
   };
+
   #handleTransformTreeUpdated = (): void => {
+    this.#updateFollowFrameId();
     this.updateSettingsTree();
   };
+
+  /** Tracks the number of frames so we can recompute the defaultFrameId when frames are added. */
+  #lastTransformFrameCount = 0;
+
+  #updateFollowFrameId() {
+    const { followTf } = this.renderer.config;
+    const { transformTree } = this.renderer;
+    this.#checkFollowTf();
+
+    const followTfFrameExists = followTf != undefined && transformTree.hasFrame(followTf);
+    if (followTfFrameExists) {
+      this.renderer.followFrameId = followTf;
+      return;
+    }
+
+    const newTransformFrameCount = transformTree.frames().size;
+    if (this.#lastTransformFrameCount === newTransformFrameCount) {
+      return;
+    }
+
+    // No valid renderFrameId set, or new frames have been added, fall back to selecting the
+    // heuristically most valid frame (if any frames are present)
+    const followFrameId = transformTree.getMostValidFollowFrameId();
+    this.renderer.followFrameId = followFrameId;
+    this.#lastTransformFrameCount = newTransformFrameCount;
+  }
+
+  #checkFollowTf = (): void => {
+    const { followTf } = this.renderer.config;
+    const { transformTree } = this.renderer;
+
+    if (followTf != undefined) {
+      const followTfFrameExists = transformTree.hasFrame(followTf);
+      if (followTfFrameExists) {
+        this.renderer.settings.errors.remove(FOLLOW_TF_PATH, DISPLAY_FRAME_NOT_FOUND);
+      } else {
+        this.renderer.settings.errors.add(
+          FOLLOW_TF_PATH,
+          DISPLAY_FRAME_NOT_FOUND,
+          i18next.t("threeDee:frameNotFound", {
+            frameId: followTf,
+          }),
+        );
+      }
+    }
+  };
+
   #handleErrorChange = (): void => {
     this.updateSettingsTree();
   };
@@ -507,14 +558,4 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
       this.#orthographicCamera.updateProjectionMatrix();
     }
   }
-}
-
-function selectBest(
-  choices: ReadonlyArray<string | undefined>,
-  validEntries: ReadonlyArray<SelectEntry>,
-): string | undefined {
-  const validChoices = choices.filter((choice) =>
-    validEntries.some((entry) => entry.value === choice),
-  );
-  return validChoices[0];
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CameraStateSettings.ts
@@ -396,9 +396,6 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
     this.updateSettingsTree();
   };
 
-  /** Tracks the number of frames so we can recompute the defaultFrameId when frames are added. */
-  #lastTransformFrameCount = 0;
-
   #updateFollowFrameId() {
     const { followTf } = this.renderer.config;
     const { transformTree } = this.renderer;
@@ -410,17 +407,10 @@ export class CameraStateSettings extends SceneExtension implements ICameraHandle
       return;
     }
 
-    const newTransformFrameCount = transformTree.frames().size;
-    if (this.#lastTransformFrameCount === newTransformFrameCount) {
-      return;
-    }
-
     // No valid renderFrameId set, or new frames have been added, fall back to selecting the
     // heuristically most valid frame (if any frames are present)
     const followFrameId = transformTree.getDefaultFollowFrameId();
     this.renderer.setFollowFrameId(followFrameId);
-
-    this.#lastTransformFrameCount = newTransformFrameCount;
   }
 
   #checkFollowTf = (): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -647,7 +647,7 @@ export class ImageMode
     }
 
     // set the render frame id to the camera info's frame id
-    this.renderer.followFrameId = this.#getCurrentFrameId();
+    this.renderer.setFollowFrameId(this.#getCurrentFrameId());
     if (this.#cameraModel?.model) {
       this.#camera.updateCamera(this.#cameraModel.model);
       this.#updateAnnotationsScale();

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -15,6 +15,9 @@ export enum AddTransformResult {
   CYCLE_DETECTED,
 }
 
+// Coordinate frames named in [REP-105](https://www.ros.org/reps/rep-0105.html)
+const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
+
 /**
  * TransformTree is a collection of coordinate frames with convenience methods
  * for getting and creating frames and adding transforms between frames.
@@ -245,6 +248,35 @@ export class TransformTree {
 
     return output;
   }
+
+  /** Get heuristically most valid follow frame Id */
+  public getMostValidFollowFrameId(): string | undefined {
+    const allFrames = this.frames();
+    if (allFrames.size === 0) {
+      return undefined;
+    }
+
+    // Prefer frames from [REP-105](https://www.ros.org/reps/rep-0105.html)
+    for (const frameId of DEFAULT_FRAME_IDS) {
+      const frame = this.frame(frameId);
+      if (frame) {
+        return frame.id;
+      }
+    }
+
+    // Choose the root frame with the most children
+    const rootsToCounts = new Map<string, number>();
+    for (const frame of allFrames.values()) {
+      const root = frame.root();
+      const rootId = root.id;
+
+      rootsToCounts.set(rootId, (rootsToCounts.get(rootId) ?? 0) + 1);
+    }
+    const rootsArray = Array.from(rootsToCounts.entries());
+    const rootId = rootsArray.sort((a, b) => b[1] - a[1])[0]?.[0];
+    return rootId;
+  }
+
   #checkParentForCycle(frameId: string, parentFrameId: string): boolean {
     if (frameId === parentFrameId) {
       return true;

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -250,7 +250,7 @@ export class TransformTree {
   }
 
   /** Get heuristically most valid follow frame Id */
-  public getMostValidFollowFrameId(): string | undefined {
+  public getDefaultFollowFrameId(): string | undefined {
     const allFrames = this.frames();
     if (allFrames.size === 0) {
       return undefined;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - [3D Panel] Fix Display Frame Error on refresh sometimes


**Description**

The issue was that the Renderer was setting `this.renderFrameId` using `getDefaultFrame` and it was going to render fine, but the settings nodes weren't getting regenerated so it wasn't clearing the error anymore. So any change to the settings (like moving the camera) would remove the error. 

I updated frame fallback conditions to hopefully be a bit clearer. The display frame settings will only ever display the value of followTf if it exists and if not it will show the followFrameId. The setting of the followFrameId is handled in CameraStateSettings so that it can be updated with the settings node and on transform tree changes. I've removed `renderFrameId` from the renderer to clear up 


<!-- link relevant GitHub issues -->
FG-2985
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
