### PR TITLE
Mark `subscribe(topics[])` as deprecated.

### DIFF
--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -309,11 +309,19 @@ export type PanelExtensionContext = {
    * array will unsubscribe from all topics.
    *
    * Calling subscribe with an empty array of topics is analagous to unsubscribeAll.
+   *
+   * @deprecated Use `subscribe` with an array of Subscription objects instead.
    */
   subscribe(topics: string[]): void;
 
   /**
    * Subscribe to an array of topics with additional options for each subscription.
+   *
+   * Subscribe will update the current subscriptions to the new list of Subscriptions and
+   * unsubscribe from any previously subscribed topics no longer in the Subscription list. Passing
+   * an empty array will unsubscribe from all topics.
+   *
+   * Calling subscribe with an empty array is analagous to unsubscribeAll.
    */
   subscribe(subscriptions: Subscription[]): void;
 


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Subscribing to an array of topics does not allow for controlling whether you want partial or full subscriptions and instead assumes full subscriptions which is often more than you want to subscribe to. By deprecating this form of subscribe we lead users to the more flexible form with subscriber options.

Related: https://github.com/foxglove/studio/pull/5267
