### PR TITLE
Use automerge-action to automerge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "pascalgn/automerge-action@v0.15.6"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: ""
+          MERGE_METHOD: squash
+          MERGE_FORKS: false
+          MERGE_FILTER_AUTHOR: dependabot


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Uses [@pascalgn/automerge-action](https://github.com/pascalgn/automerge-action) to auto-merge PRs from dependabot.