### PR TITLE
URL param to allow importing layout from a URL

### DIFF
--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -30,6 +30,7 @@ import {
 } from "./actions";
 
 export type LayoutID = string & { __brand: "LayoutID" };
+export type LayoutURL = string & { __brand: "LayoutURL" };
 
 export type LayoutState = Readonly<{
   selectedLayout:

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
@@ -17,6 +17,7 @@ import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialD
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 import { Player } from "@foxglove/studio-base/players/types";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import LayoutManagerProvider from "@foxglove/studio-base/providers/LayoutManagerProvider";
 import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 
 jest.mock("@foxglove/studio-base/hooks/useSessionStorageValue");

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -112,12 +112,12 @@ function useSyncLayoutFromUrl(
       data: layoutData,
       permission: "CREATOR_WRITE",
     });
-    unappliedLayoutArgs.layoutId = newLayout.id;
-  }, [layoutManager, unappliedLayoutArgs]);
+    setSelectedLayoutId(newLayout.id);
+  }, [layoutManager, unappliedLayoutArgs, setSelectedLayoutId]);
 
   // Select layout from URL.
   useEffect(() => {
-    if (!unappliedLayoutArgs?.layoutId && !unappliedLayoutArgs?.layoutUrl) {
+    if (!unappliedLayoutArgs?.layoutUrl && !unappliedLayoutArgs?.layoutId) {
       return;
     }
 
@@ -128,14 +128,16 @@ function useSyncLayoutFromUrl(
       return;
     }
 
-    // Only fetch the layout from URL if layout ID is not available.
-    // if (!unappliedLayoutArgs.layoutId && unappliedLayoutArgs.layoutUrl) {
-    if (!unappliedLayoutArgs.layoutId && unappliedLayoutArgs.layoutUrl) {
+    // Only fetch layout from URL if no ID is selected.
+    if (unappliedLayoutArgs.layoutUrl && !unappliedLayoutArgs.layoutId) {
+      log.debug(`Fetching layout from layoutUrl: ${unappliedLayoutArgs.layoutUrl}`);
       void fetchLayoutFromUrl();
     }
+    else if (unappliedLayoutArgs.layoutId) {
+      log.debug(`Selecting layout from layoutId: ${unappliedLayoutArgs.layoutId}`);
+      setSelectedLayoutId(unappliedLayoutArgs.layoutId);
+    }
 
-    log.debug(`Initializing layout from url: ${unappliedLayoutArgs.layoutId}`);
-    setSelectedLayoutId(unappliedLayoutArgs.layoutId);
     setUnappliedLayoutArgs({ layoutId: undefined, layoutUrl: undefined });
   }, [
     currentUserRequired,

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -21,7 +21,7 @@ export type {
 } from "./context/AppConfigurationContext";
 export { AppContext } from "./context/AppContext";
 export type { IAppContext } from "./context/AppContext";
-export type { LayoutID } from "./context/CurrentLayoutContext";
+export type { LayoutID, LayoutURL} from "./context/CurrentLayoutContext";
 export type { Layout, ISO8601Timestamp, ILayoutStorage } from "./services/ILayoutStorage";
 export { migrateLayout } from "./services/migrateLayout";
 export type { INativeAppMenu, NativeAppMenuEvent } from "./context/NativeAppMenuContext";

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Time, toRFC3339String } from "@foxglove/rostime";
-import { LayoutID } from "@foxglove/studio-base/index";
+import { LayoutID, LayoutURL} from "@foxglove/studio-base/index";
 import {
   AppURLState,
   updateAppURLState,
@@ -34,6 +34,18 @@ describe("app state url parser", () => {
       const url = urlBuilder();
       url.searchParams.append("layoutId", "1234");
       expect(parseAppURLState(url)?.layoutId).toBe("1234");
+    });
+
+    it("parses urls with only a relative layoutUrl", () => {
+      const url = urlBuilder();
+      url.searchParams.append("layoutUrl", "/bar.json");
+      expect(parseAppURLState(url)?.layoutUrl).toBe("/bar.json");
+    });
+
+    it("parses urls with only a absolute layoutUrl", () => {
+      const url = urlBuilder();
+      url.searchParams.append("layoutUrl", "https://foo.com/bar.json");
+      expect(parseAppURLState(url)?.layoutUrl).toBe("https://foo.com/bar.json");
     });
 
     it("parses rosbag data state urls", () => {
@@ -90,6 +102,16 @@ describe("app state encoding", () => {
       }).href,
     ).toEqual(
       "http://example.com/?ds=ros1-remote-bagfile&ds.url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag&layoutId=123",
+    );
+  });
+
+  it("encodes layout url", () => {
+    expect(
+      updateAppURLState(baseURL(), {
+        layoutUrl: "https://foo.com/bar.json" as LayoutURL
+      }).href,
+    ).toEqual(
+      "http://example.com/?layoutUrl=https%3A%2F%2Ffoo.com%2Fbar.json",
     );
   });
 

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -123,3 +123,18 @@ export function windowAppURLState(): AppURLState | undefined {
     return undefined;
   }
 }
+
+/**
+ * Tries to return app url from the window's current location.
+ */
+export function windowAppURL(): URL | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  try {
+    return new URL(window.location.href);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -5,12 +5,13 @@
 import { isEmpty, omitBy } from "lodash";
 
 import { fromRFC3339String, toRFC3339String, Time } from "@foxglove/rostime";
-import { LayoutID } from "@foxglove/studio-base/index";
+import { LayoutID, LayoutURL } from "@foxglove/studio-base/index";
 
 export type AppURLState = {
   ds?: string;
   dsParams?: Record<string, string>;
   layoutId?: LayoutID;
+  layoutUrl?: LayoutURL;
   time?: Time;
 };
 
@@ -29,6 +30,14 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
       newURL.searchParams.set("layoutId", urlState.layoutId);
     } else {
       newURL.searchParams.delete("layoutId");
+    }
+  }
+
+  if ("layoutUrl" in urlState) {
+    if (urlState.layoutUrl) {
+      newURL.searchParams.set("layoutUrl", urlState.layoutUrl);
+    } else {
+      newURL.searchParams.delete("layoutUrl");
     }
   }
 
@@ -75,6 +84,7 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
 export function parseAppURLState(url: URL): AppURLState | undefined {
   const ds = url.searchParams.get("ds") ?? undefined;
   const layoutId = url.searchParams.get("layoutId");
+  const layoutUrl = url.searchParams.get("layoutUrl");
   const timeString = url.searchParams.get("time");
   const time = timeString == undefined ? undefined : fromRFC3339String(timeString);
   const dsParams: Record<string, string> = {};
@@ -88,6 +98,7 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
   const state: AppURLState = omitBy(
     {
       layoutId: layoutId ? (layoutId as LayoutID) : undefined,
+      layoutUrl: layoutUrl ? (layoutUrl as LayoutURL) : undefined,
       time,
       ds,
       dsParams: isEmpty(dsParams) ? undefined : dsParams,


### PR DESCRIPTION
**User-Facing Changes**

Added a new URL param to import layout from a remote URL: `layoutUrl`.
Example: `...&layoutUrl=/foxglove_layout.json`

**Description**

This adds an optional property `layoutUrl` to the `AppURLState` type to provide a URL parameter, as well as updates the `useSyncLayoutFromUrl` function, to load layouts using URLs. This parameter takes lower priority with respect to `layoutId` when loading specified layouts. However, when `layoutUrl` is explicitly specified and `layoutId` is left unspecified, `layoutUrl` is then used to fetch the layout json file from the URL path, save the new layout, then select it using the resulting new layout ID. This allows the updated `AppURLState` to specify the new layout, without redownloading it, even when the `layoutUrl` parameter is persisted across subsequent page loads.

Fixes:
 - https://github.com/orgs/foxglove/discussions/217
