### PR TITLE
Fix Renderables not clearing when seeking back to beginning of file

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -480,6 +480,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     for (const extension of this.sceneExtensions.values()) {
       extension.removeAllRenderables();
     }
+    this.queueAnimationFrame();
   }
 
   #allFramesCursor: {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix Renderables not clearing when seeking back to beginning of file

**Description**
It wasn't just images that were the problem. We weren't rendering again after clearing. 


<!-- link relevant GitHub issues -->
FG-3118
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
