### PR TITLE
Pass original message event to message converters

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -40,7 +40,7 @@ export function convertMessage(
   const key = converterKey(messageEvent.topic, messageEvent.schemaName);
   const matchedConverters = converters.get(key);
   for (const converter of matchedConverters ?? []) {
-    const convertedMessage = converter.converter(messageEvent.message);
+    const convertedMessage = converter.converter(messageEvent.message, messageEvent);
     convertedMessages.push({
       topic: messageEvent.topic,
       schemaName: converter.toSchemaName,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -351,7 +351,7 @@ export const MessageConverterSupport: StoryObj = {
         {
           fromSchemaName: "foxglove.ImageAnnotations",
           toSchemaName: "foxglove_msgs/ImageAnnotations",
-          converter: (_msg): Partial<ImageAnnotations> => ({
+          converter: (_msg: unknown): Partial<ImageAnnotations> => ({
             points: [
               {
                 timestamp: { sec: 0, nsec: 0 },
@@ -374,7 +374,7 @@ export const MessageConverterSupport: StoryObj = {
         {
           fromSchemaName: "MyCustomSchema",
           toSchemaName: "foxglove_msgs/ImageAnnotations",
-          converter: (_msg): Partial<ImageAnnotations> => ({
+          converter: (_msg: unknown): Partial<ImageAnnotations> => ({
             points: [
               {
                 timestamp: { sec: 0, nsec: 0 },
@@ -402,7 +402,7 @@ export const MessageConverterSupport: StoryObj = {
         {
           fromSchemaName: "MyCustomSchema",
           toSchemaName: "foxglove_msgs/msg/ImageAnnotations",
-          converter: (_msg): Partial<ImageAnnotations> => ({
+          converter: (_msg: unknown): Partial<ImageAnnotations> => ({
             points: [
               {
                 timestamp: { sec: 0, nsec: 0 },
@@ -425,7 +425,7 @@ export const MessageConverterSupport: StoryObj = {
         {
           fromSchemaName: "MyCustomSchema",
           toSchemaName: "foxglove.SceneUpdate",
-          converter: (msg) => msg,
+          converter: (msg: unknown) => msg,
         },
       ],
     };

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -411,7 +411,7 @@ export type ExtensionPanelRegistration = {
 export type RegisterMessageConverterArgs<Src> = {
   fromSchemaName: string;
   toSchemaName: string;
-  converter: ((msg: Src) => unknown) | ((msg: Src, event: Immutable<MessageEvent<Src>>) => unknown);
+  converter: (msg: Src, event: Immutable<MessageEvent<Src>>) => unknown;
 };
 
 export interface ExtensionContext {

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -411,7 +411,7 @@ export type ExtensionPanelRegistration = {
 export type RegisterMessageConverterArgs<Src> = {
   fromSchemaName: string;
   toSchemaName: string;
-  converter: (msg: Src) => unknown;
+  converter: ((msg: Src) => unknown) | ((msg: Src, event: Immutable<MessageEvent<Src>>) => unknown);
 };
 
 export interface ExtensionContext {


### PR DESCRIPTION
**User-Facing Changes**
Pass the original message event to message converters to provide access to publishTime and other properties of the original event.

**Description**
Provide extra fields of the MessageEvent by passing the full MessageEvent as a second argument to message converters.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
