### PR TITLE
[Image Beta] Add missing setHasCalibrationTopic(true)

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -268,6 +268,9 @@ export class ImageMode
         draft.imageMode.calibrationTopic = matchingCalibrationTopic.name;
       }
     });
+    if (matchingCalibrationTopic) {
+      this.#setHasCalibrationTopic(true);
+    }
   };
 
   /** Choose a calibration topic that best matches the given `imageTopic`. */
@@ -480,6 +483,7 @@ export class ImageMode
           this.renderer.updateConfig((draft) => {
             draft.imageMode.calibrationTopic = calibrationTopic.name;
           });
+          this.#setHasCalibrationTopic(true);
         }
       }
 


### PR DESCRIPTION
**User-Facing Changes**
None (beta)

**Description**
Follow-up to #5941 
Ensures that 3D topics can be enabled immediately after a panel is added if there was an auto-selected calibration topic.