### PR TITLE
[Image Beta] add fit/fill zoom settings

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -74,6 +74,8 @@ export type ImageModeConfig = {
   calibrationTopic?: string;
   /** Annotation topic settings, analogous to {@link RendererConfig.topics} */
   annotations?: ImageAnnotationSubscription[];
+  /** Zoom mode */
+  zoomMode?: "fit" | "fill";
 };
 
 export type RendererConfig = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -27,7 +27,7 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/projections";
 import { makePose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 
-import { ImageModeCamera } from "./ImageModeCamera";
+import { DEFAULT_ZOOM_MODE, ImageModeCamera } from "./ImageModeCamera";
 import { ImageAnnotations } from "./annotations/ImageAnnotations";
 import type { IRenderer } from "../../IRenderer";
 import { PartialMessageEvent, SceneExtension } from "../../SceneExtension";
@@ -130,6 +130,7 @@ export class ImageMode
      */
     this.#camera.quaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI);
     this.#camera.setCanvasSize(canvasSize.width, canvasSize.height);
+    this.#camera.setZoomMode(renderer.config.imageMode.zoomMode ?? "fit");
 
     renderer.settings.errors.on("update", this.#handleErrorChange);
     renderer.settings.errors.on("clear", this.#handleErrorChange);
@@ -378,7 +379,7 @@ export class ImageMode
     fields.zoomMode = {
       label: "Zoom mode",
       input: "toggle",
-      value: config.imageMode.zoomMode ?? "fit",
+      value: config.imageMode.zoomMode ?? DEFAULT_ZOOM_MODE,
       options: [
         { label: "Fit", value: "fit" },
         { label: "Fill", value: "fill" },
@@ -493,7 +494,7 @@ export class ImageMode
       }
 
       if (config.zoomMode !== prevImageModeConfig.zoomMode) {
-        this.#camera.setZoomMode(config.zoomMode ?? "fit");
+        this.#camera.setZoomMode(config.zoomMode ?? DEFAULT_ZOOM_MODE);
         this.resetViewModifications();
         this.renderer.queueAnimationFrame();
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -375,6 +375,15 @@ export class ImageMode
       options: calibrationTopics,
       error: calibrationTopicError,
     };
+    fields.zoomMode = {
+      label: "Zoom mode",
+      input: "toggle",
+      value: config.imageMode.zoomMode ?? "fit",
+      options: [
+        { label: "Fit", value: "fit" },
+        { label: "Fill", value: "fill" },
+      ],
+    };
     // fields.TODO_transformMarkers = {
     //   readonly: true,
     //   input: "boolean",
@@ -481,6 +490,12 @@ export class ImageMode
             draft.imageMode.calibrationTopic = calibrationTopic.name;
           });
         }
+      }
+
+      if (config.zoomMode !== prevImageModeConfig.zoomMode) {
+        this.#camera.setZoomMode(config.zoomMode ?? "fit");
+        this.resetViewModifications();
+        this.renderer.queueAnimationFrame();
       }
 
       this.#updateViewAndRenderables();
@@ -677,10 +692,7 @@ export class ImageMode
     return cameraInfoFrameId ?? imageFrameId;
   }
 
-  #getImageModeSettings(): {
-    readonly calibrationTopic?: string;
-    readonly imageTopic?: string;
-  } {
+  #getImageModeSettings() {
     return this.renderer.config.imageMode;
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -496,7 +496,6 @@ export class ImageMode
       if (config.zoomMode !== prevImageModeConfig.zoomMode) {
         this.#camera.setZoomMode(config.zoomMode ?? DEFAULT_ZOOM_MODE);
         this.resetViewModifications();
-        this.renderer.queueAnimationFrame();
       }
 
       this.#updateViewAndRenderables();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -13,11 +13,12 @@ const DEFAULT_CAMERA_STATE = {
 
 const MIN_USER_ZOOM = 0.5;
 const MAX_USER_ZOOM = 50;
+export const DEFAULT_ZOOM_MODE = "fit";
 
 export class ImageModeCamera extends THREE.PerspectiveCamera {
   #model?: PinholeCameraModel;
   #cameraState = DEFAULT_CAMERA_STATE;
-  #zoomMode: "fit" | "fill" | "custom" = "fit";
+  #zoomMode: "fit" | "fill" | "custom" = DEFAULT_ZOOM_MODE;
 
   /** x/y zoom factors derived from image and window aspect ratios and zoom mode */
   #aspectZoom = new THREE.Vector2();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -11,11 +11,15 @@ const DEFAULT_CAMERA_STATE = {
   far: 1000,
 };
 
+const MIN_USER_ZOOM = 0.5;
+const MAX_USER_ZOOM = 50;
+
 export class ImageModeCamera extends THREE.PerspectiveCamera {
   #model?: PinholeCameraModel;
   #cameraState = DEFAULT_CAMERA_STATE;
+  #zoomMode: "fit" | "fill" | "custom" = "fit";
 
-  /** x/y zoom factors derived from image and window aspect ratios */
+  /** x/y zoom factors derived from image and window aspect ratios and zoom mode */
   #aspectZoom = new THREE.Vector2();
   #canvasSize = new THREE.Vector2();
 
@@ -44,8 +48,13 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
     this.#updateProjection();
   }
 
+  public setZoomMode(mode: "fit" | "fill" | "custom"): void {
+    this.#zoomMode = mode;
+    this.#updateProjection();
+  }
+
   public updateZoomFromWheel(ratio: number, cursorCoords: THREE.Vector2): void {
-    const newZoom = THREE.MathUtils.clamp(this.#userZoom * ratio, 0.5, 50);
+    const newZoom = THREE.MathUtils.clamp(this.#userZoom * ratio, MIN_USER_ZOOM, MAX_USER_ZOOM);
     const finalRatio = newZoom / this.#userZoom;
     const halfWidth = this.#canvasSize.width / 2;
     const halfHeight = this.#canvasSize.height / 2;
@@ -145,7 +154,9 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
     const rendererAspect = this.#canvasSize.width / this.#canvasSize.height;
     const imageAspect = imgWidth / fx / (imgHeight / fy);
     // preserve the aspect ratio
-    if (imageAspect > rendererAspect) {
+    const shrinkY =
+      this.#zoomMode === "fit" ? imageAspect > rendererAspect : imageAspect < rendererAspect;
+    if (shrinkY) {
       this.#aspectZoom.y = (this.#aspectZoom.y / imageAspect) * rendererAspect;
     } else {
       this.#aspectZoom.x = (this.#aspectZoom.x / rendererAspect) * imageAspect;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -17,15 +17,15 @@ export const DEFAULT_ZOOM_MODE = "fit";
 
 export class ImageModeCamera extends THREE.PerspectiveCamera {
   #model?: PinholeCameraModel;
-  #cameraState = DEFAULT_CAMERA_STATE;
+  readonly #cameraState = DEFAULT_CAMERA_STATE;
   #zoomMode: "fit" | "fill" | "custom" = DEFAULT_ZOOM_MODE;
 
   /** x/y zoom factors derived from image and window aspect ratios and zoom mode */
-  #aspectZoom = new THREE.Vector2();
-  #canvasSize = new THREE.Vector2();
+  readonly #aspectZoom = new THREE.Vector2();
+  readonly #canvasSize = new THREE.Vector2();
 
   /** Amount the user has panned, measured in screen pixels */
-  #panOffset = new THREE.Vector2(0, 0);
+  readonly #panOffset = new THREE.Vector2(0, 0);
   /** Amount the user has zoomed with the scroll wheel */
   #userZoom = 1;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -169,12 +169,12 @@ const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }): JSX.Ele
   );
 };
 
-export const ImageModeRosRawImage: StoryObj<Parameters<typeof ImageModeRosImage>[0]> = {
+export const ImageModeRosRawImage: StoryObj<React.ComponentProps<typeof ImageModeRosImage>> = {
   render: ImageModeRosImage,
   args: { imageType: "raw" },
 };
 
-export const ImageModeRosPngImage: StoryObj<Parameters<typeof ImageModeRosImage>[0]> = {
+export const ImageModeRosPngImage: StoryObj<React.ComponentProps<typeof ImageModeRosImage>> = {
   render: ImageModeRosImage,
   args: { imageType: "png" },
 };
@@ -328,32 +328,39 @@ const ImageModeFoxgloveImage = ({
   );
 };
 
-export const ImageModeFoxgloveRawImage: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModeFoxgloveRawImage: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
 };
 
-export const ImageModeFoxglovePngImage: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModeFoxglovePngImage: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "png" },
 };
 
-export const ImageModeResizeHandled: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
-  render: ImageModeFoxgloveImage,
-  args: { imageType: "raw" },
+export const ImageModeResizeHandled: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
+  {
+    render: ImageModeFoxgloveImage,
+    args: { imageType: "raw" },
 
-  play: async () => {
-    const canvas = document.querySelector("canvas")!;
-    // Input attaches resize listener to parent element, so we need to resize that.
-    const parentEl = canvas.parentElement!;
-    await delay(30);
-    parentEl.style.width = "50%";
-    canvas.dispatchEvent(new Event("resize"));
-    await delay(30);
-  },
-};
+    play: async () => {
+      const canvas = document.querySelector("canvas")!;
+      // Input attaches resize listener to parent element, so we need to resize that.
+      const parentEl = canvas.parentElement!;
+      await delay(30);
+      parentEl.style.width = "50%";
+      canvas.dispatchEvent(new Event("resize"));
+      await delay(30);
+    },
+  };
 
-export const ImageModeResizeHandledFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModeResizeHandledFill: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
   ...ImageModeResizeHandled,
   args: {
     ...ImageModeResizeHandled.args,
@@ -361,7 +368,7 @@ export const ImageModeResizeHandledFill: StoryObj<Parameters<typeof ImageModeFox
   },
 };
 
-export const ImageModePan: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModePan: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
   play: async () => {
@@ -372,7 +379,7 @@ export const ImageModePan: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]
   },
 };
 
-export const ImageModePanFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModePanFill: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   ...ImageModePan,
   args: {
     ...ImageModePan.args,
@@ -380,7 +387,7 @@ export const ImageModePanFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage
   },
 };
 
-export const ImageModeZoomThenPan: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModeZoomThenPan: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
   play: async () => {
@@ -393,7 +400,9 @@ export const ImageModeZoomThenPan: StoryObj<Parameters<typeof ImageModeFoxgloveI
   },
 };
 
-export const ImageModeZoomThenPanFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModeZoomThenPanFill: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
   ...ImageModeZoomThenPan,
   args: {
     ...ImageModeZoomThenPan.args,
@@ -401,7 +410,7 @@ export const ImageModeZoomThenPanFill: StoryObj<Parameters<typeof ImageModeFoxgl
   },
 };
 
-export const ImageModePanThenZoom: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModePanThenZoom: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
   play: async () => {
@@ -414,7 +423,9 @@ export const ImageModePanThenZoom: StoryObj<Parameters<typeof ImageModeFoxgloveI
   },
 };
 
-export const ImageModePanThenZoomFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModePanThenZoomFill: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
   ...ImageModePanThenZoom,
   args: {
     ...ImageModePanThenZoom.args,
@@ -422,7 +433,9 @@ export const ImageModePanThenZoomFill: StoryObj<Parameters<typeof ImageModeFoxgl
   },
 };
 
-export const ImageModePanThenZoomReset: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModePanThenZoomReset: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
   play: async (ctx) => {
@@ -431,16 +444,17 @@ export const ImageModePanThenZoomReset: StoryObj<Parameters<typeof ImageModeFoxg
   },
 };
 
-export const ImageModePanThenZoomResetFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> =
-  {
-    ...ImageModePanThenZoomReset,
-    args: {
-      ...ImageModePanThenZoomReset.args,
-      zoomMode: "fill",
-    },
-  };
+export const ImageModePanThenZoomResetFill: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
+  ...ImageModePanThenZoomReset,
+  args: {
+    ...ImageModePanThenZoomReset.args,
+    zoomMode: "fill",
+  },
+};
 
-export const ImageModePick: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+export const ImageModePick: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -27,7 +27,7 @@ export default {
   parameters: { colorScheme: "light" },
 };
 
-const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }) => {
+const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }): JSX.Element => {
   const topics: Topic[] = [
     { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
     { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
@@ -169,15 +169,23 @@ const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }) => {
   );
 };
 
-export const ImageModeRosRawImage: StoryObj = {
-  render: () => <ImageModeRosImage imageType="raw" />,
+export const ImageModeRosRawImage: StoryObj<Parameters<typeof ImageModeRosImage>[0]> = {
+  render: ImageModeRosImage,
+  args: { imageType: "raw" },
 };
 
-export const ImageModeRosPngImage: StoryObj = {
-  render: () => <ImageModeRosImage imageType="png" />,
+export const ImageModeRosPngImage: StoryObj<Parameters<typeof ImageModeRosImage>[0]> = {
+  render: ImageModeRosImage,
+  args: { imageType: "png" },
 };
 
-const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => {
+const ImageModeFoxgloveImage = ({
+  imageType,
+  zoomMode = "fit",
+}: {
+  imageType: "raw" | "png";
+  zoomMode?: "fit" | "fill";
+}): JSX.Element => {
   const topics: Topic[] = [
     { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
     { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
@@ -300,6 +308,7 @@ const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => 
           imageMode: {
             calibrationTopic: imageType === "raw" ? "/cam2/info" : "/cam1/info",
             imageTopic: imageType === "raw" ? "/cam2/raw" : "/cam1/png",
+            zoomMode,
           },
           cameraState: {
             distance: 1.5,
@@ -319,16 +328,19 @@ const ImageModeFoxgloveImage = ({ imageType }: { imageType: "raw" | "png" }) => 
   );
 };
 
-export const ImageModeFoxgloveRawImage: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModeFoxgloveRawImage: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
 };
 
-export const ImageModeFoxglovePngImage: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="png" />,
+export const ImageModeFoxglovePngImage: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "png" },
 };
 
-export const ImageModeResizeHandled: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModeResizeHandled: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
 
   play: async () => {
     const canvas = document.querySelector("canvas")!;
@@ -341,8 +353,17 @@ export const ImageModeResizeHandled: StoryObj = {
   },
 };
 
-export const ImageModePan: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModeResizeHandledFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  ...ImageModeResizeHandled,
+  args: {
+    ...ImageModeResizeHandled.args,
+    zoomMode: "fill",
+  },
+};
+
+export const ImageModePan: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
   play: async () => {
     const canvas = document.querySelector("canvas")!;
     fireEvent.mouseDown(canvas, { clientX: 200, clientY: 200 });
@@ -351,8 +372,17 @@ export const ImageModePan: StoryObj = {
   },
 };
 
-export const ImageModeZoomThenPan: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModePanFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  ...ImageModePan,
+  args: {
+    ...ImageModePan.args,
+    zoomMode: "fill",
+  },
+};
+
+export const ImageModeZoomThenPan: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
   play: async () => {
     const canvas = document.querySelector("canvas")!;
     fireEvent.wheel(canvas, { deltaY: -30, clientX: 400, clientY: 400 });
@@ -363,8 +393,17 @@ export const ImageModeZoomThenPan: StoryObj = {
   },
 };
 
-export const ImageModePanThenZoom: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModeZoomThenPanFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  ...ImageModeZoomThenPan,
+  args: {
+    ...ImageModeZoomThenPan.args,
+    zoomMode: "fill",
+  },
+};
+
+export const ImageModePanThenZoom: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
   play: async () => {
     const canvas = document.querySelector("canvas")!;
     fireEvent.mouseDown(canvas, { clientX: 200, clientY: 200 });
@@ -375,16 +414,35 @@ export const ImageModePanThenZoom: StoryObj = {
   },
 };
 
-export const ImageModePanThenZoomReset: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModePanThenZoomFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  ...ImageModePanThenZoom,
+  args: {
+    ...ImageModePanThenZoom.args,
+    zoomMode: "fill",
+  },
+};
+
+export const ImageModePanThenZoomReset: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
   play: async (ctx) => {
     await ImageModePanThenZoom.play?.(ctx);
     userEvent.click(await screen.findByTestId("reset-view"));
   },
 };
 
-export const ImageModePick: StoryObj = {
-  render: () => <ImageModeFoxgloveImage imageType="raw" />,
+export const ImageModePanThenZoomResetFill: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> =
+  {
+    ...ImageModePanThenZoomReset,
+    args: {
+      ...ImageModePanThenZoomReset.args,
+      zoomMode: "fill",
+    },
+  };
+
+export const ImageModePick: StoryObj<Parameters<typeof ImageModeFoxgloveImage>[0]> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
 
   play: async () => {
     const canvas = document.querySelector("canvas")!;


### PR DESCRIPTION
**User-Facing Changes**
- [Image (Beta)] Added "Zoom mode: Fit / Fill" to settings

**Description**
Partially implements FG-3258
Omitting the custom zoom percentage for now. I am not convinced we actually need this and I don't want to deal with the math required to get 100% to correctly equal "actual size".