### PR TITLE
Remove "select a layout" fallback from PanelSettings

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -2,9 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Divider, Link, Typography } from "@mui/material";
+import { Divider, Typography } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useTranslation, Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useUnmount } from "react-use";
 
 import { SettingsTree } from "@foxglove/studio";
@@ -27,13 +27,10 @@ import {
   PanelStateStore,
   usePanelStateStore,
 } from "@foxglove/studio-base/context/PanelStateContext";
-import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
-
-const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 
 const singlePanelIdSelector = (state: LayoutState) =>
   typeof state.selectedLayout?.data?.layout === "string"
@@ -72,7 +69,6 @@ export default function PanelSettings({
   selectedPanelIdsForTests?: readonly string[];
 }>): JSX.Element {
   const { t } = useTranslation("panelSettings");
-  const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
   const singlePanelId = useCurrentLayoutSelector(singlePanelIdSelector);
   const {
     selectedPanelIds: originalSelectedPanelIds,
@@ -90,7 +86,6 @@ export default function PanelSettings({
     }
   }, [selectAllPanels, selectedPanelIds, singlePanelId]);
 
-  const { openLayoutBrowser } = useWorkspaceActions();
   const selectedPanelId = useMemo(
     () => (selectedPanelIds.length === 1 ? selectedPanelIds[0] : undefined),
     [selectedPanelIds],
@@ -158,20 +153,6 @@ export default function PanelSettings({
       incrementSequenceNumber(selectedPanelId);
     }
   }, [incrementSequenceNumber, savePanelConfigs, selectedPanelId]);
-
-  if (selectedLayoutId == undefined) {
-    return (
-      <EmptyWrapper>
-        <Trans
-          t={t}
-          i18nKey="noLayoutSelected"
-          components={{
-            selectLayoutLink: <Link variant="inherit" onClick={openLayoutBrowser} />,
-          }}
-        />
-      </EmptyWrapper>
-    );
-  }
 
   if (selectedPanelId == undefined) {
     return <EmptyWrapper>{t("selectAPanelToEditItsSettings")}</EmptyWrapper>;

--- a/packages/studio-base/src/i18n/en/panelSettings.ts
+++ b/packages/studio-base/src/i18n/en/panelSettings.ts
@@ -13,5 +13,4 @@ export const panelSettings = {
   panelName: "{{title}} panel",
   panelDoesNotHaveSettings: "This panel does not have any settings",
   unknown: "Unknown",
-  noLayoutSelected: "<selectLayoutLink>Select a layout</selectLayoutLink> to get started!",
 };

--- a/packages/studio-base/src/i18n/ja/panelSettings.ts
+++ b/packages/studio-base/src/i18n/ja/panelSettings.ts
@@ -15,5 +15,4 @@ export const panelSettings: Partial<TypeOptions["resources"]["panelSettings"]> =
   panelName: "{{title}}パネル",
   panelDoesNotHaveSettings: "このパネルには設定がありません。",
   unknown: "不明",
-  noLayoutSelected: "<selectLayoutLink>レイアウトを選択</selectLayoutLink>して開始してください！",
 };

--- a/packages/studio-base/src/i18n/zh/panelSettings.ts
+++ b/packages/studio-base/src/i18n/zh/panelSettings.ts
@@ -15,5 +15,4 @@ export const panelSettings: Partial<TypeOptions["resources"]["panelSettings"]> =
   panelDoesNotHaveSettings: "此面板没有任何设置",
   resetToDefaults: "重置为默认值",
   unknown: "未知",
-  noLayoutSelected: "<selectLayoutLink>选择一个布局</selectLayoutLink> 开始使用！",
 };


### PR DESCRIPTION

**User-Facing Changes**
None

Even though there is a different user experience here I don't think it is worth calling out in the release notes because you are still prompted to select a layout.

**Description**
When there is no layout selected, the main workspace area already directs the user to select a layout or create a new layout. We don't also need the panel settings area to also tell the user the same thing.

<img width="849" alt="Screenshot 2023-05-11 at 8 18 04 PM" src="https://github.com/foxglove/studio/assets/84792/baf77b10-41f2-42cf-9bb1-97f7a0150996">

