### PR TITLE
[3D] Remove PointClouds and LaserScans renderables when setting visible=false

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -435,12 +435,10 @@ export class RenderObjectHistory<ParentRenderable extends Renderable<RenderObjec
 
   /** Removes all but the last renderable, which would be the current object used in rendering. */
   public clearHistory(): void {
-    for (let i = 1; i < this.#history.length; i++) {
-      const entry = this.#history[i]!;
+    for (const entry of this.#history.splice(0, this.#history.length - 1)) {
       entry.object3d.geometry.dispose();
       this.#renderable.remove(entry.object3d);
     }
-    this.#history.length = 1;
   }
 
   public dispose(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -358,7 +358,7 @@ type RenderObjectHistoryUserData = BaseUserData & {
 type ThreeObject = THREE.Points<DynamicBufferGeometry> | THREE.LineSegments<DynamicBufferGeometry>;
 type HistoryEntry = { receiveTime: bigint; messageTime: bigint; object3d: ThreeObject };
 export class RenderObjectHistory<ParentRenderable extends Renderable<RenderObjectHistoryUserData>> {
-  public history: HistoryEntry[];
+  #history: HistoryEntry[];
   #renderable: ParentRenderable;
   #renderer: IRenderer;
 
@@ -371,29 +371,29 @@ export class RenderObjectHistory<ParentRenderable extends Renderable<RenderObjec
     renderer: IRenderer;
     parentRenderable: ParentRenderable;
   }) {
-    this.history = [initial];
+    this.#history = [initial];
     this.#renderer = renderer;
     this.#renderable = parentRenderable;
   }
 
   public addHistoryEntry(entry: HistoryEntry): void {
-    this.history.push(entry);
+    this.#history.push(entry);
   }
 
   public updateMaterial(material: THREE.Material): void {
-    for (const entry of this.history) {
+    for (const entry of this.#history) {
       entry.object3d.material = material;
     }
   }
 
   public updateHistoryFromCurrentTime(currentTime: bigint): void {
     // Remove expired entries from the history of points when decayTime is enabled
-    const pointsHistory = this.history;
+    const pointsHistory = this.#history;
     const decayTime = this.#renderable.userData.settings.decayTime;
     const expireTime =
       decayTime > 0 ? currentTime - BigInt(Math.round(decayTime * 1e9)) : MAX_DURATION;
     while (pointsHistory.length > 1 && pointsHistory[0]!.receiveTime < expireTime) {
-      const entry = this.history.shift()!;
+      const entry = this.#history.shift()!;
       this.#renderable.remove(entry.object3d);
       entry.object3d.geometry.dispose();
     }
@@ -402,7 +402,7 @@ export class RenderObjectHistory<ParentRenderable extends Renderable<RenderObjec
   public updatePoses(currentTime: bigint, renderFrameId: string, fixedFrameId: string): void {
     // Update the pose on each entry
     let hadTfError = false;
-    for (const entry of this.history) {
+    for (const entry of this.#history) {
       const srcTime = entry.messageTime;
       const frameId = this.#renderable.userData.frameId;
       const updated = updatePose(
@@ -426,22 +426,27 @@ export class RenderObjectHistory<ParentRenderable extends Renderable<RenderObjec
     }
   }
 
-  public latest(): { receiveTime: bigint; messageTime: bigint; object3d: ThreeObject } | undefined {
-    return this.history[this.history.length - 1];
+  public latest(): { receiveTime: bigint; messageTime: bigint; object3d: ThreeObject } {
+    if (this.#history.length === 0) {
+      throw new Error("RenderObjectHistory is empty");
+    }
+    return this.#history[this.#history.length - 1]!;
   }
 
+  /** Removes all but the last renderable, which would be the current object used in rendering. */
   public clearHistory(): void {
-    // removes all but the last element of the array, which would be the current object used in rendering
-    for (const entry of this.history.splice(0, this.history.length - 1)) {
+    for (let i = 1; i < this.#history.length; i++) {
+      const entry = this.#history[i]!;
       entry.object3d.geometry.dispose();
       this.#renderable.remove(entry.object3d);
     }
+    this.#history.length = 1;
   }
 
   public dispose(): void {
-    for (const entry of this.history) {
+    for (const entry of this.#history) {
       entry.object3d.geometry.dispose();
     }
-    this.history.length = 0;
+    this.#history.length = 0;
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where the last scan on a LaserScan topic would remain visible when the topic was hidden.

**Description**
The root cause was that the LaserScans extension did not set `visible=false` when the setting changed. It did call `clearHistory()`, but that method leaves the most recent entry in the array (intentionally).

Changed LaserScans and PointClouds to dispose hidden renderables in startFrame, instead of keeping them around.