### PR TITLE
Remove muiStyled from PanelLayout

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -177,7 +177,6 @@ overrides:
       - "packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx"
       - "packages/studio-base/src/components/ExpandingToolbar.tsx"
       - "packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx"
-      - "packages/studio-base/src/components/PanelLayout.tsx"
       - "packages/studio-base/src/components/ShareJsonModal.tsx"
       - "packages/studio-base/src/components/TextHighlight.tsx"
       - "packages/studio-base/src/panels/Image/components/Toolbar.tsx"

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -21,7 +21,7 @@ import {
   MosaicWindow,
   MosaicWithoutDragDropContext,
 } from "react-mosaic-component";
-import { withStyles } from "tss-react/mui";
+import { makeStyles } from "tss-react/mui";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { EmptyPanelLayout } from "@foxglove/studio-base/components/EmptyPanelLayout";
@@ -60,8 +60,8 @@ type Props = {
 // place the dropped item as a sibling of the Tab), as well as the "root drop targets" inside the
 // nested mosaic (that would place the dropped item as a direct child of the Tab). Makes it easier
 // to drop panels into a tab layout.
-const HideTopLevelDropTargets = withStyles("div", {
-  root: {
+const useStyles = makeStyles()({
+  hideTopLevelDropTargets: {
     margin: 0,
 
     ".mosaic-root + .drop-target-container": {
@@ -77,6 +77,7 @@ const HideTopLevelDropTargets = withStyles("div", {
 // drop target. This allows a panel to know which mosaic it was dropped in regardless of nesting
 // level.
 function TabMosaicWrapper({ tabId, children }: PropsWithChildren<{ tabId?: string }>) {
+  const { classes, cx } = useStyles();
   const [, drop] = useDrop<unknown, MosaicDropResult, never>({
     accept: MosaicDragType.WINDOW,
     drop: (_item, monitor) => {
@@ -90,9 +91,9 @@ function TabMosaicWrapper({ tabId, children }: PropsWithChildren<{ tabId?: strin
     },
   });
   return (
-    <HideTopLevelDropTargets className="mosaic-tile" ref={drop}>
+    <div className={cx(classes.hideTopLevelDropTargets, "mosaic-tile")} ref={drop}>
       {children}
-    </HideTopLevelDropTargets>
+    </div>
   );
 }
 

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { CircularProgress, Link, styled as muiStyled, Typography } from "@mui/material";
+import { CircularProgress, Link, Typography } from "@mui/material";
 import React, { PropsWithChildren, Suspense, useCallback, useMemo } from "react";
 import { useDrop } from "react-dnd";
 import {
@@ -21,6 +21,7 @@ import {
   MosaicWindow,
   MosaicWithoutDragDropContext,
 } from "react-mosaic-component";
+import { withStyles } from "tss-react/mui";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { EmptyPanelLayout } from "@foxglove/studio-base/components/EmptyPanelLayout";
@@ -59,16 +60,18 @@ type Props = {
 // place the dropped item as a sibling of the Tab), as well as the "root drop targets" inside the
 // nested mosaic (that would place the dropped item as a direct child of the Tab). Makes it easier
 // to drop panels into a tab layout.
-const HideTopLevelDropTargets = muiStyled("div")`
-  margin: 0;
+const HideTopLevelDropTargets = withStyles("div", {
+  root: {
+    margin: 0,
 
-  .mosaic-root + .drop-target-container {
-    display: none !important;
-  }
-  & > .mosaic-window > .drop-target-container {
-    display: none !important;
-  }
-`;
+    ".mosaic-root + .drop-target-container": {
+      display: "none !important",
+    },
+    "& > .mosaic-window > .drop-target-container": {
+      display: "none !important",
+    },
+  },
+});
 
 // This wrapper makes the tabId available in the drop result when something is dropped into a nested
 // drop target. This allows a panel to know which mosaic it was dropped in regardless of nesting


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Removes muiStyled from HideTopLevelDropTargets in favor of tss-react
