### PR TITLE
Avoid showing the welcome dialog when using file -> open local file

### DIFF
--- a/packages/studio-base/src/components/DataSourceDialog/DataSourceDialog.tsx
+++ b/packages/studio-base/src/components/DataSourceDialog/DataSourceDialog.tsx
@@ -69,14 +69,19 @@ export function DataSourceDialog(props: DataSourceDialogProps): JSX.Element {
   useLayoutEffect(() => {
     if (activeView === "file") {
       openFile()
-        .catch((err) => {
-          console.error(err);
-        })
-        .finally(() => {
-          // set the view back to start so the user can click to open file again
-          if (isMounted()) {
+        .then((didOpen) => {
+          // If no file was selected we go back to the start screen.
+          // There is quirk here where if the user cancels the open file dialog they launched
+          // through the file -> open local file menu they will still see the start screen
+          //
+          // This is because we are using the dialog to handle logic which could move to workspace
+          // actions.
+          if (!didOpen && isMounted()) {
             dialogActions.dataSource.open("start");
           }
+        })
+        .catch((err) => {
+          console.error(err);
         });
     } else if (activeView === "demo" && firstSampleSource) {
       selectSource(firstSampleSource.id);
@@ -115,6 +120,12 @@ export function DataSourceDialog(props: DataSourceDialogProps): JSX.Element {
         };
     }
   }, [activeView]);
+
+  // If the active view is "file", we don't need to render anything and instead will show the system
+  // file dialog.
+  if (activeView === "file") {
+    return <></>;
+  }
 
   return (
     <Dialog

--- a/packages/studio-base/src/components/DataSourceDialog/useOpenFile.tsx
+++ b/packages/studio-base/src/components/DataSourceDialog/useOpenFile.tsx
@@ -11,7 +11,13 @@ import {
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import showOpenFilePicker from "@foxglove/studio-base/util/showOpenFilePicker";
 
-export function useOpenFile(sources: IDataSourceFactory[]): () => Promise<void> {
+/**
+ * Return a function to open a file picker and select the appropriate source for the selected file.
+ *
+ * The returned function resolves to a promise which returns true if a file was selected and
+ * false if the user cancelled the file picker.
+ */
+export function useOpenFile(sources: IDataSourceFactory[]): () => Promise<boolean> {
   const { selectSource } = usePlayerSelection();
 
   const allExtensions = useMemo(() => {
@@ -34,7 +40,7 @@ export function useOpenFile(sources: IDataSourceFactory[]): () => Promise<void> 
       ],
     });
     if (!fileHandle) {
-      return;
+      return false;
     }
 
     const file = await fileHandle.getFile();
@@ -59,5 +65,6 @@ export function useOpenFile(sources: IDataSourceFactory[]): () => Promise<void> 
     }
 
     selectSource(foundSource.id, { type: "file", handle: fileHandle });
+    return true;
   }, [allExtensions, selectSource, sources]);
 }


### PR DESCRIPTION

**User-Facing Changes**
Fixes an issue where the user is first shown the welcome dialog when using File -> Open local file and then shown the file picker.

**Description**
Update the DataSourceDialog to hide itself when the active view is "file". This avoids showing the dialog when a user wants to select a file using the new app menu.

A quirk of the way we are leveraging the dialog for workspace actions is that if the user cancels the file picker they will be brought back to the welcome dialog.

Another quirk with this change is that if you click "Open local file" in the welcome dialog, the dialog goes away for a moment while the open file logic itself runs and you see the file picker. The real solution here is to stop using the dialog as the business logic and move the selection and state transition logic to workspace actions. I view this as a quick-fix to the currently annoying behavior with `File -> Open local file` for new nav users and not a reason to avoid doing the more appropriate code refactor.