### PR TITLE
Expose our own Immutable type in @foxglove/studio

### DIFF
--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -2,11 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
 import { chain } from "lodash";
 import memoizeWeak from "memoize-weak";
 
-import { SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+import { Immutable, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 
 import { Config } from "./types";

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
-
 import { filterMap } from "@foxglove/den/collection";
 import { isTime, subtract, Time, toSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import { format } from "@foxglove/studio-base/util/formatTime";
 import { darkColor, getLineColor, lightColor } from "@foxglove/studio-base/util/plotColors";
 import { formatTimeRaw, TimestampMethod } from "@foxglove/studio-base/util/time";

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -2,12 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable as Im } from "immer";
 import { assignWith, last, isEmpty } from "lodash";
 import memoizeWeak from "memoize-weak";
 
 import { filterMap } from "@foxglove/den/collection";
 import { Time, isLessThan, isGreaterThan, compare as compareTimes } from "@foxglove/rostime";
+import { Immutable as Im } from "@foxglove/studio";
 import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksByTopic";
 import { MessageDataItemsByPath } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { PlotDataByPath, PlotDataItem } from "@foxglove/studio-base/panels/Plot/internalTypes";

--- a/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
@@ -2,11 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
 import { groupBy, isEmpty, pick } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { isLessThan, isTimeInRangeInclusive, subtract } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import { useBlocksByTopic, useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import parseRosPath, {
   getTopicsFromPaths,

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -3,15 +3,21 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import EventEmitter from "eventemitter3";
-import { Immutable } from "immer";
 import * as THREE from "three";
 
-import { MessageEvent, ParameterValue, SettingsIcon, Topic, VariableValue } from "@foxglove/studio";
+import {
+  Immutable,
+  MessageEvent,
+  ParameterValue,
+  SettingsIcon,
+  Topic,
+  VariableValue,
+} from "@foxglove/studio";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";
 import { LabelPool } from "@foxglove/three-text";
 
 import { Input } from "./Input";
-import { ModelCache, MeshUpAxis } from "./ModelCache";
+import { MeshUpAxis, ModelCache } from "./ModelCache";
 import { PickedRenderable } from "./Picker";
 import { SceneExtension } from "./SceneExtension";
 import { SettingsManager } from "./SettingsManager";

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
 import { cloneDeep, isEqual, merge } from "lodash";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
@@ -13,6 +12,7 @@ import { useDebouncedCallback } from "use-debounce";
 import Logger from "@foxglove/log";
 import { Time, toNanoSec } from "@foxglove/rostime";
 import {
+  Immutable,
   LayoutActions,
   MessageEvent,
   PanelExtensionContext,
@@ -28,12 +28,12 @@ import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import type {
-  RendererConfig,
-  RendererSubscription,
   FollowMode,
-  RendererEvents,
   IRenderer,
   ImageModeConfig,
+  RendererConfig,
+  RendererEvents,
+  RendererSubscription,
 } from "./IRenderer";
 import type { PickedRenderable } from "./Picker";
 import { SELECTED_ID_VARIABLE } from "./Renderable";
@@ -42,11 +42,11 @@ import { RendererContext, useRendererEvent } from "./RendererContext";
 import { RendererOverlay } from "./RendererOverlay";
 import { CameraState, DEFAULT_CAMERA_STATE } from "./camera";
 import {
+  PublishRos1Datatypes,
+  PublishRos2Datatypes,
   makePointMessage,
   makePoseEstimateMessage,
   makePoseMessage,
-  PublishRos1Datatypes,
-  PublishRos2Datatypes,
 } from "./publish";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent } from "./renderables/PublishClickTool";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -3,13 +3,17 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { t } from "i18next";
-import { Immutable } from "immer";
 import * as THREE from "three";
 import { Line2 } from "three/examples/jsm/lines/Line2";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 
-import { SettingsTreeAction, SettingsTreeChildren, SettingsTreeFields } from "@foxglove/studio";
+import {
+  Immutable,
+  SettingsTreeAction,
+  SettingsTreeChildren,
+  SettingsTreeFields,
+} from "@foxglove/studio";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 import { Label } from "@foxglove/three-text";
 
@@ -22,7 +26,7 @@ import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { getLuminance, stringToRgb } from "../color";
 import { BaseSettings, fieldSize, PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
-import { Duration, Transform, makePose, CoordinateFrame, MAX_DURATION } from "../transforms";
+import { CoordinateFrame, Duration, makePose, MAX_DURATION, Transform } from "../transforms";
 
 export type LayerSettingsTransform = BaseSettings & {
   xyzOffset: Readonly<[number | undefined, number | undefined, number | undefined]>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -3,13 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { t } from "i18next";
-import { Immutable } from "immer";
 import * as THREE from "three";
 
 import { TwoKeyMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas";
-import { MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
+import { Immutable, MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
 import { normalizeAnnotations } from "@foxglove/studio-base/panels/Image/lib/normalizeAnnotations";
 import {
   ImageMarker as RosImageMarker,

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -19,6 +19,7 @@
     "prepack": "tsc -b tsconfig.json"
   },
   "devDependencies": {
+    "immer": "10.0.2",
     "typescript": "5.0.4"
   }
 }

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+export type { Immutable } from "immer";
+
 // Valid types for parameter data (such as rosparams)
 export type ParameterValue =
   | undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,6 +2741,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/studio@workspace:packages/studio"
   dependencies:
+    immer: 10.0.2
     typescript: 5.0.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Expose our own Immutable type in @foxglove/studio. Immutability is an important concept for correctness, performance, and for clarity of intentions in API definitions. It's worth having our own internal type for this.

Once this is merged we should take advantage of it in our public APIs to make it clearer what data we don't expect extensions to modify.

In this PR I'm just re-exporting the definition from immerjs but if we want it to be standalone I think we could also just copy over the definition itself with the MIT license and an attribution in the header or grab an equivalent type from ts-essentials.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
