### PR TITLE
Implement topic mapping extensions

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -12,7 +12,14 @@
 //   You may not use this file except in compliance with the License.
 
 import { useSnackbar } from "notistack";
-import { PropsWithChildren, useCallback, useLayoutEffect, useMemo, useState } from "react";
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useLatest, useMountedState } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
@@ -24,6 +31,10 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  ExtensionCatalog,
+  useExtensionCatalog,
+} from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { useNativeWindow } from "@foxglove/studio-base/context/NativeWindowContext";
 import PlayerSelectionContext, {
@@ -36,6 +47,7 @@ import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables"
 import useIndexedDbRecents, { RecentRecord } from "@foxglove/studio-base/hooks/useIndexedDbRecents";
 import useWarnImmediateReRender from "@foxglove/studio-base/hooks/useWarnImmediateReRender";
 import AnalyticsMetricsCollector from "@foxglove/studio-base/players/AnalyticsMetricsCollector";
+import { TopicMappingPlayer } from "@foxglove/studio-base/players/TopicMappingPlayer/TopicMappingPlayer";
 import UserNodePlayer from "@foxglove/studio-base/players/UserNodePlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import { UserNodes } from "@foxglove/studio-base/types/panels";
@@ -53,6 +65,7 @@ const userNodesSelector = (state: LayoutState) =>
   state.selectedLayout?.data?.userNodes ?? EMPTY_USER_NODES;
 const globalVariablesSelector = (state: LayoutState) =>
   state.selectedLayout?.data?.globalVariables ?? EMPTY_GLOBAL_VARIABLES;
+const selectTopicMappers = (catalog: ExtensionCatalog) => catalog.installedTopicMappers;
 
 export default function PlayerManager(props: PropsWithChildren<PlayerManagerProps>): JSX.Element {
   const { children, playerSources } = props;
@@ -83,6 +96,9 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   const userNodes = useCurrentLayoutSelector(userNodesSelector);
   const globalVariables = useCurrentLayoutSelector(globalVariablesSelector);
 
+  const topicMappers = useExtensionCatalog(selectTopicMappers);
+  const [initialTopicMappers] = useState(topicMappers);
+
   const { recents, addRecent } = useIndexedDbRecents();
 
   // We don't want to recreate the player when the these variables change, but we do want to
@@ -93,15 +109,34 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   // the message pipeline
   const globalVariablesRef = useLatest(globalVariables);
 
-  const player = useMemo(() => {
+  // Initialize the topic mapping player with the mappers we have at first load. Any
+  // changes in mappers caused by dynamically loaded extensions have to be set separately
+  // because we can only construct the wrapping player once since the underlying player
+  // doesn't allow us set a new listener after the initial listener is set.
+  const topicMapper = useMemo(() => {
     if (!basePlayer) {
       return undefined;
     }
 
-    const userNodePlayer = new UserNodePlayer(basePlayer, userNodeActions);
+    return new TopicMappingPlayer(basePlayer, initialTopicMappers ?? []);
+  }, [basePlayer, initialTopicMappers]);
+
+  // Topic mappers can change if we hot load a new extension with new mappers.
+  useEffect(() => {
+    if (topicMappers !== initialTopicMappers) {
+      topicMapper?.setMappers(topicMappers ?? []);
+    }
+  }, [initialTopicMappers, topicMapper, topicMappers]);
+
+  const player = useMemo(() => {
+    if (!topicMapper) {
+      return undefined;
+    }
+
+    const userNodePlayer = new UserNodePlayer(topicMapper, userNodeActions);
     userNodePlayer.setGlobalVariables(globalVariablesRef.current);
     return userNodePlayer;
-  }, [basePlayer, globalVariablesRef, userNodeActions]);
+  }, [globalVariablesRef, topicMapper, userNodeActions]);
 
   useLayoutEffect(() => void player?.setUserNodes(userNodes), [player, userNodes]);
 

--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -5,7 +5,11 @@
 import { createContext } from "react";
 import { StoreApi, useStore } from "zustand";
 
-import { ExtensionPanelRegistration, RegisterMessageConverterArgs } from "@foxglove/studio";
+import {
+  ExtensionPanelRegistration,
+  RegisterMessageConverterArgs,
+  RegisterTopicMapperArgs,
+} from "@foxglove/studio";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 import { ExtensionInfo, ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
 
@@ -27,6 +31,7 @@ export type ExtensionCatalog = {
   installedExtensions: undefined | ExtensionInfo[];
   installedPanels: undefined | Record<string, RegisteredPanel>;
   installedMessageConverters: undefined | readonly RegisterMessageConverterArgs<unknown>[];
+  installedTopicMappers: undefined | readonly RegisterTopicMapperArgs[];
 };
 
 export const ExtensionCatalogContext = createContext<undefined | StoreApi<ExtensionCatalog>>(

--- a/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.stories.tsx
@@ -32,7 +32,7 @@ const TOPICS: Topic[] = [
   { schemaName: "visualization_msgs/MarkerArray", name: "/markers/annotations" },
   { schemaName: "sensor_msgs/Imu", name: "/imu" },
   { schemaName: "diagnostic_msgs/DiagnosticArray", name: "/diagnostics" },
-  { schemaName: "nav_msgs/Odometry", name: "/odom" },
+  { schemaName: "nav_msgs/Odometry", name: "/odom", mappedFromName: "/old_odom_name" },
 ];
 
 export const Default: StoryObj = {

--- a/packages/studio-base/src/panels/DataSourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Divider } from "@mui/material";
+import { Divider, Typography } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
@@ -77,6 +77,11 @@ function TopicRow({ topic }: { topic: Topic }): JSX.Element {
           iconSize="small"
           getText={() => topic.name}
         />
+        {topic.mappedFromName && (
+          <Typography variant="subtitle2" fontSize="0.5rem">
+            from {topic.mappedFromName}
+          </Typography>
+        )}
       </td>
       <td>
         {topic.schemaName == undefined ? (

--- a/packages/studio-base/src/players/TopicMappingPlayer/TopicMappingPlayer.ts
+++ b/packages/studio-base/src/players/TopicMappingPlayer/TopicMappingPlayer.ts
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable as Im } from "immer";
+
+import { Time } from "@foxglove/rostime";
+import { ParameterValue, RegisterTopicMapperArgs } from "@foxglove/studio";
+import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
+import {
+  AdvertiseOptions,
+  Player,
+  PlayerState,
+  PublishPayload,
+  SubscribePayload,
+} from "@foxglove/studio-base/players/types";
+
+import { MappingInputs, mapPlayerState, mapSubscriptions } from "./mapping";
+
+export class TopicMappingPlayer implements Player {
+  readonly #player: Player;
+
+  #inputs: Im<MappingInputs>;
+  #pendingSubscriptions: undefined | SubscribePayload[];
+  #skipMapping: boolean;
+
+  #listener?: (state: PlayerState) => Promise<void>;
+
+  public constructor(player: Player, mappers: readonly RegisterTopicMapperArgs[]) {
+    this.#player = player;
+    this.#skipMapping = mappers.length === 0;
+    this.#inputs = {
+      mappers,
+      topics: undefined,
+    };
+  }
+
+  public setListener(listener: (playerState: PlayerState) => Promise<void>): void {
+    this.#listener = listener;
+
+    this.#player.setListener(async (state) => await this.#onPlayerState(state));
+  }
+
+  public setMappers(mappers: readonly RegisterTopicMapperArgs[]): void {
+    this.#inputs = { mappers, topics: this.#inputs.topics };
+    this.#skipMapping = mappers.length === 0;
+  }
+
+  public close(): void {
+    this.#player.close();
+  }
+
+  public setSubscriptions(subscriptions: SubscribePayload[]): void {
+    if (this.#skipMapping) {
+      this.#player.setSubscriptions(subscriptions);
+    } else {
+      // If we have mappers but haven't yet recieved a topic list from an active state
+      // from the wrapped player yet we have to delay setSubscriptions until we have the
+      // topic list to set up the mappings.
+      if (this.#inputs.topics != undefined) {
+        const mappedSubscriptions = mapSubscriptions(this.#inputs, subscriptions);
+        this.#player.setSubscriptions(mappedSubscriptions);
+        this.#pendingSubscriptions = undefined;
+      } else {
+        this.#pendingSubscriptions = subscriptions;
+      }
+    }
+  }
+
+  public setPublishers(publishers: AdvertiseOptions[]): void {
+    this.#player.setPublishers(publishers);
+  }
+
+  public setParameter(key: string, value: ParameterValue): void {
+    this.#player.setParameter(key, value);
+  }
+
+  public publish(request: PublishPayload): void {
+    this.#player.publish(request);
+  }
+
+  public async callService(service: string, request: unknown): Promise<unknown> {
+    return await this.#player.callService(service, request);
+  }
+
+  public startPlayback?(): void {
+    this.#player.startPlayback?.();
+  }
+
+  public pausePlayback?(): void {
+    this.#player.pausePlayback?.();
+  }
+
+  public seekPlayback?(time: Time, backfillDuration?: Time | undefined): void {
+    this.#player.seekPlayback?.(time, backfillDuration);
+  }
+
+  public playUntil?(time: Time): void {
+    this.#player.playUntil?.(time);
+  }
+
+  public setPlaybackSpeed?(speedFraction: number): void {
+    this.#player.setPlaybackSpeed?.(speedFraction);
+  }
+
+  public setGlobalVariables(globalVariables: GlobalVariables): void {
+    this.#player.setGlobalVariables(globalVariables);
+  }
+
+  async #onPlayerState(playerState: PlayerState) {
+    if (this.#skipMapping) {
+      await this.#listener?.(playerState);
+      return;
+    }
+
+    if (playerState.activeData?.topics !== this.#inputs.topics) {
+      this.#inputs = { ...this.#inputs, topics: playerState.activeData?.topics };
+    }
+
+    const newState = mapPlayerState(this.#inputs, playerState);
+    await this.#listener?.(newState);
+
+    if (this.#pendingSubscriptions && this.#inputs.topics) {
+      this.setSubscriptions(this.#pendingSubscriptions);
+    }
+  }
+}

--- a/packages/studio-base/src/players/TopicMappingPlayer/mapping.test.ts
+++ b/packages/studio-base/src/players/TopicMappingPlayer/mapping.test.ts
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  MappingInputs,
+  mapPlayerState,
+} from "@foxglove/studio-base/players/TopicMappingPlayer/mapping";
+import {
+  PlayerPresence,
+  PlayerState,
+  PlayerStateActiveData,
+  Topic,
+} from "@foxglove/studio-base/players/types";
+
+function fakePlayerState(
+  overrides?: Partial<PlayerState>,
+  dataOverrides?: Partial<PlayerStateActiveData>,
+): PlayerState {
+  return {
+    activeData: {
+      messages: [],
+      currentTime: { sec: 0, nsec: 0 },
+      endTime: { sec: 0, nsec: 0 },
+      lastSeekTime: 1,
+      topics: [],
+      speed: 1,
+      isPlaying: false,
+      topicStats: new Map(),
+      startTime: { sec: 0, nsec: 0 },
+      datatypes: new Map(),
+      totalBytesReceived: 0,
+      ...dataOverrides,
+    },
+    capabilities: [],
+    presence: PlayerPresence.PRESENT,
+    profile: undefined,
+    playerId: "1",
+    progress: {
+      fullyLoadedFractionRanges: [],
+      messageCache: undefined,
+    },
+    ...overrides,
+  };
+}
+
+describe("mapPlayerState", () => {
+  it("maps blocks", () => {
+    const topics: Topic[] = [
+      { name: "/topic_1", schemaName: "whatever" },
+      { name: "/topic_2", schemaName: "whatever" },
+    ];
+    const state = fakePlayerState(
+      {
+        progress: {
+          fullyLoadedFractionRanges: [],
+          messageCache: {
+            startTime: { sec: 0, nsec: 1 },
+            blocks: [
+              {
+                messagesByTopic: {
+                  "/topic_1": [
+                    {
+                      topic: "/topic_1",
+                      receiveTime: { sec: 0, nsec: 0 },
+                      message: undefined,
+                      schemaName: "whatever",
+                      sizeInBytes: 0,
+                    },
+                  ],
+                  "/topic_2": [
+                    {
+                      topic: "/topic_2",
+                      receiveTime: { sec: 0, nsec: 0 },
+                      message: undefined,
+                      schemaName: "whatever",
+                      sizeInBytes: 0,
+                    },
+                  ],
+                },
+                sizeInBytes: 0,
+              },
+            ],
+          },
+        },
+      },
+      {
+        topics,
+      },
+    );
+    const inputs: MappingInputs = {
+      mappers: [() => new Map([["/topic_1", "/renamed_topic_1"]])],
+      topics,
+    };
+    const mapped = mapPlayerState(inputs, state);
+    expect(mapped.progress).toEqual({
+      fullyLoadedFractionRanges: [],
+      messageCache: {
+        startTime: { sec: 0, nsec: 1 },
+        blocks: [
+          {
+            messagesByTopic: {
+              "/renamed_topic_1": [
+                {
+                  topic: "/renamed_topic_1",
+                  receiveTime: { sec: 0, nsec: 0 },
+                  message: undefined,
+                  schemaName: "whatever",
+                  sizeInBytes: 0,
+                },
+              ],
+              "/topic_2": [
+                {
+                  topic: "/topic_2",
+                  receiveTime: { sec: 0, nsec: 0 },
+                  message: undefined,
+                  schemaName: "whatever",
+                  sizeInBytes: 0,
+                },
+              ],
+            },
+            sizeInBytes: 0,
+          },
+        ],
+      },
+    });
+  });
+
+  it("maps messages", () => {
+    const topics: Topic[] = [
+      { name: "/topic_1", schemaName: "whatever" },
+      { name: "/topic_2", schemaName: "whatever" },
+    ];
+    const state = fakePlayerState(undefined, {
+      topics,
+      messages: [
+        {
+          topic: "/topic_1",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: undefined,
+          schemaName: "whatever",
+          sizeInBytes: 0,
+        },
+        {
+          topic: "/topic_2",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: undefined,
+          schemaName: "whatever",
+          sizeInBytes: 0,
+        },
+      ],
+    });
+    const inputs: MappingInputs = {
+      mappers: [() => new Map([["/topic_1", "/renamed_topic_1"]])],
+      topics,
+    };
+    const mapped = mapPlayerState(inputs, state);
+    expect(mapped.activeData?.messages).toEqual([
+      expect.objectContaining({ topic: "/renamed_topic_1" }),
+      expect.objectContaining({ topic: "/topic_2" }),
+    ]);
+  });
+
+  it("maps published topics", () => {
+    const topics: Topic[] = [
+      { name: "/topic_1", schemaName: "whatever" },
+      { name: "/topic_2", schemaName: "whatever" },
+    ];
+    const state = fakePlayerState(undefined, {
+      topics,
+      publishedTopics: new Map([
+        ["1", new Set(["/topic_1", "/topic_2"])],
+        ["2", new Set(["/topic_2"])],
+      ]),
+    });
+    const inputs: MappingInputs = {
+      mappers: [() => new Map([["/topic_1", "/renamed_topic_1"]])],
+      topics,
+    };
+    const mapped = mapPlayerState(inputs, state);
+    expect(mapped.activeData?.publishedTopics).toEqual(
+      new Map([
+        ["1", new Set(["/renamed_topic_1", "/topic_2"])],
+        ["2", new Set(["/topic_2"])],
+      ]),
+    );
+  });
+
+  it("maps subscribed topics", () => {
+    const topics: Topic[] = [
+      { name: "/topic_1", schemaName: "whatever" },
+      { name: "/topic_2", schemaName: "whatever" },
+    ];
+    const state = fakePlayerState(undefined, {
+      topics,
+      subscribedTopics: new Map([
+        ["1", new Set(["/topic_1", "/topic_2"])],
+        ["2", new Set(["/topic_2"])],
+      ]),
+    });
+    const inputs: MappingInputs = {
+      mappers: [() => new Map([["/topic_1", "/renamed_topic_1"]])],
+      topics,
+    };
+    const mapped = mapPlayerState(inputs, state);
+    expect(mapped.activeData?.subscribedTopics).toEqual(
+      new Map([
+        ["1", new Set(["/renamed_topic_1", "/topic_2"])],
+        ["2", new Set(["/topic_2"])],
+      ]),
+    );
+  });
+
+  it("maps topics", () => {
+    const topics: Topic[] = [
+      { name: "/topic_1", schemaName: "whatever" },
+      { name: "/topic_2", schemaName: "whatever" },
+    ];
+    const state = fakePlayerState(undefined, { topics });
+    const inputs: MappingInputs = {
+      mappers: [() => new Map([["/topic_1", "/renamed_topic_1"]])],
+      topics,
+    };
+    const mapped = mapPlayerState(inputs, state);
+    expect(mapped.activeData?.topics).toEqual([
+      { name: "/renamed_topic_1", schemaName: "whatever", mappedFromName: "/topic_1" },
+      { name: "/topic_2", schemaName: "whatever" },
+    ]);
+  });
+});

--- a/packages/studio-base/src/players/TopicMappingPlayer/mapping.ts
+++ b/packages/studio-base/src/players/TopicMappingPlayer/mapping.ts
@@ -1,0 +1,245 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable as Im } from "immer";
+import { transform, uniq } from "lodash";
+import memoizeWeak from "memoize-weak";
+
+import { MessageEvent, RegisterTopicMapperArgs } from "@foxglove/studio";
+import {
+  MessageBlock,
+  PlayerState,
+  Progress,
+  SubscribePayload,
+  Topic,
+} from "@foxglove/studio-base/players/types";
+
+export type TopicMapping = Map<string, string[]>;
+export type MessageBlocks = readonly (undefined | MessageBlock)[];
+export const EmptyMapping: Im<TopicMapping> = new Map();
+
+export type MappingInputs = {
+  mappers: RegisterTopicMapperArgs[];
+  topics: undefined | Topic[];
+};
+
+function mapBlocks(blocks: MessageBlocks, mapping: Im<TopicMapping>): MessageBlocks {
+  if (mapping === EmptyMapping) {
+    return blocks;
+  }
+
+  return blocks.map((block) => {
+    return block
+      ? {
+          ...block,
+          messagesByTopic: transform(
+            block.messagesByTopic,
+            (acc, messages, topic) => {
+              const mappings = mapping.get(topic);
+              if (mappings) {
+                for (const mappedTopic of mappings) {
+                  acc[mappedTopic] = messages.map((msg) => ({
+                    ...msg,
+                    topic: mappedTopic,
+                  }));
+                }
+              } else {
+                acc[topic] = messages;
+              }
+            },
+            {} as Record<string, MessageEvent<unknown>[]>,
+          ),
+        }
+      : undefined;
+  });
+}
+
+function mapMessages(
+  messages: readonly MessageEvent<unknown>[],
+  mapping: Im<TopicMapping>,
+): readonly MessageEvent<unknown>[] {
+  if (mapping === EmptyMapping) {
+    return messages;
+  }
+
+  return messages.flatMap((msg) => {
+    const mappings = mapping.get(msg.topic);
+    if (mappings) {
+      return mappings.map((topic) => ({
+        ...msg,
+        topic,
+      }));
+    } else {
+      return msg;
+    }
+  });
+}
+
+function mapKeyedTopics(
+  topics: Map<string, Set<string>>,
+  mapping: Im<TopicMapping>,
+): Map<string, Set<string>> {
+  if (mapping === EmptyMapping) {
+    return topics;
+  }
+
+  const mappedTopics = new Map<string, Set<string>>();
+  for (const [key, values] of topics) {
+    const mappedValues = [...values].flatMap((value) => mapping.get(value) ?? value);
+    mappedTopics.set(key, new Set(mappedValues));
+  }
+  return mappedTopics;
+}
+
+function mapProgress(progress: Progress, mapping: Im<TopicMapping>): Progress {
+  if (mapping === EmptyMapping || progress.messageCache == undefined) {
+    return progress;
+  }
+  const newProgress: Progress = {
+    ...progress,
+    messageCache: {
+      ...progress.messageCache,
+      blocks: memoMapBlocks(progress.messageCache.blocks, mapping),
+    },
+  };
+  return newProgress;
+}
+
+function mapTopics(topics: Topic[], mapping: Im<TopicMapping>): Topic[] {
+  if (mapping === EmptyMapping) {
+    return topics;
+  }
+
+  return topics.flatMap((topic) => {
+    const mappings = mapping.get(topic.name);
+    if (mappings) {
+      return mappings.map((name) => ({
+        ...topic,
+        name,
+        mappedFromName: topic.name,
+      }));
+    } else {
+      return topic;
+    }
+  });
+}
+
+// Inverts a mapping, used to reverse map incoming subscriptions to subscriptions we pass
+// through to the wrapped player.
+function invertMapping(mapping: Im<TopicMapping>): Im<TopicMapping> {
+  if (mapping === EmptyMapping) {
+    return EmptyMapping;
+  }
+
+  const inverted: TopicMapping = new Map();
+  for (const [key, values] of mapping.entries()) {
+    for (const value of values) {
+      const newValues = inverted.get(value) ?? [];
+      newValues.push(key);
+      inverted.set(value, newValues);
+    }
+  }
+  return inverted;
+}
+
+// Merges multiple mappings into a single unified mappings. Note that a single topic name
+// can map to more than one renamed topic if multiple extensions provide a mapping for it.
+function mergeMappings(maps: Im<Map<string, string>[]>): TopicMapping {
+  const merged: TopicMapping = new Map();
+  for (const map of maps) {
+    for (const [key, value] of map.entries()) {
+      const mergedValues = uniq((merged.get(key) ?? []).concat(value));
+      merged.set(key, mergedValues);
+    }
+  }
+  return merged;
+}
+
+// Applies our topic mappers to the input topics to generate an active set of name =>
+// renamed topic mappings.
+function buildMapping(inputs: Im<MappingInputs>): Im<TopicMapping> {
+  const mappings = inputs.mappers.map((mapper) => mapper(inputs.topics ?? []));
+  const anyMappings = mappings.some((map) => [...map.entries()].length > 0);
+  return anyMappings ? mergeMappings(mappings) : EmptyMapping;
+}
+
+// Memoize our mapping functions to avoid redundant work and also to preserve downstream
+// referential transparency for React components.
+const memoBuildMapping = memoizeWeak(buildMapping);
+const memoMapBlocks = memoizeWeak(mapBlocks);
+const memoMapKeyedTopics = memoizeWeak(mapKeyedTopics);
+const memoMapMessages = memoizeWeak(mapMessages);
+const memoMapTopics = memoizeWeak(mapTopics);
+const memoMapProgress = memoizeWeak(mapProgress);
+
+/**
+ * Maps a player state to a new player state with all topic name mappings applied.
+ *
+ * @param inputs the mapping inputs to the mapping function
+ * @param playerState the player state containing topics to map
+ * @returns a mapped player state with all mapped topic names replaced with their mapped
+ * value.
+ */
+export function mapPlayerState(inputs: Im<MappingInputs>, playerState: PlayerState): PlayerState {
+  const newState = {
+    ...playerState,
+    activeData: playerState.activeData ? { ...playerState.activeData } : undefined,
+  };
+
+  const mapping = memoBuildMapping(inputs);
+
+  if (newState.activeData) {
+    newState.activeData.topics = memoMapTopics(newState.activeData.topics, mapping);
+    newState.activeData.messages = memoMapMessages(newState.activeData.messages, mapping);
+    if (newState.activeData.publishedTopics) {
+      newState.activeData.publishedTopics = memoMapKeyedTopics(
+        newState.activeData.publishedTopics,
+        mapping,
+      );
+    }
+    if (newState.activeData.subscribedTopics) {
+      newState.activeData.subscribedTopics = memoMapKeyedTopics(
+        newState.activeData.subscribedTopics,
+        mapping,
+      );
+    }
+  }
+
+  if (newState.progress.messageCache) {
+    newState.progress = memoMapProgress(newState.progress, mapping);
+  }
+
+  return newState;
+}
+
+/**
+ * Maps an array of subscriptions to a new array with all topic mappings applied.
+ *
+ * @param inputs the inputs to the mapping function
+ * @param subscriptions the subscription payloads to map
+ * @returns a new array of subscription payloads with mapped topic names
+ */
+export const mapSubscriptions = memoizeWeak(
+  (inputs: Im<MappingInputs>, subcriptions: SubscribePayload[]): SubscribePayload[] => {
+    const mapping = memoBuildMapping(inputs);
+
+    if (mapping === EmptyMapping) {
+      return subcriptions;
+    }
+
+    const inverseMapping = invertMapping(mapping);
+
+    return subcriptions.flatMap((sub) => {
+      const mappings = inverseMapping.get(sub.topic);
+      if (mappings) {
+        return mappings.map((topic) => ({
+          ...sub,
+          topic,
+        }));
+      } else {
+        return sub;
+      }
+    });
+  },
+);

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -205,6 +205,8 @@ export type Topic = {
   name: string;
   // Name of the datatype (see `type PlayerStateActiveData` for details).
   schemaName: string | undefined;
+  // Name of the topic before topic mapping, if any.
+  mappedFromName?: string;
 };
 
 export type TopicWithSchemaName = Topic & { schemaName: string };

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
@@ -184,4 +184,39 @@ describe("ExtensionCatalogProvider", () => {
       },
     ]);
   });
+
+  it("should register a topic mapper", async () => {
+    const source = `
+        module.exports = {
+            activate: function(ctx) {
+                ctx.registerTopicMapper(() => {
+                    return new Map();
+                })
+            }
+        }
+    `;
+
+    const loadExtension = jest.fn().mockResolvedValue(source);
+    const mockPrivateLoader: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "org", name: "sample", version: "1" })]),
+      loadExtension,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result, waitFor } = renderHook(() => useExtensionCatalog((state) => state), {
+      initialProps: {},
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[mockPrivateLoader]}>
+          {children}
+        </ExtensionCatalogProvider>
+      ),
+    });
+
+    await waitFor(() => expect(loadExtension).toHaveBeenCalledTimes(1));
+    expect(result.current.installedTopicMappers).toEqual([expect.any(Function)]);
+  });
 });

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -410,6 +410,10 @@ export type RegisterMessageConverterArgs<Src> = {
   converter: (msg: Src) => unknown;
 };
 
+export type RegisterTopicMapperArgs = (
+  topics: ReadonlyArray<{ name: string; schemaName?: string }>,
+) => ReadonlyMap<string, string>;
+
 export interface ExtensionContext {
   /** The current _mode_ of the application. */
   readonly mode: "production" | "development" | "test";
@@ -417,6 +421,8 @@ export interface ExtensionContext {
   registerPanel(params: ExtensionPanelRegistration): void;
 
   registerMessageConverter<Src>(args: RegisterMessageConverterArgs<Src>): void;
+
+  registerTopicMapper(args: RegisterTopicMapperArgs): void;
 }
 
 export interface ExtensionActivate {


### PR DESCRIPTION
**User-Facing Changes**
Implement topic mapping extensions that allow topics to be renamed programatically. 

**Description**
Implement topic mapping extensions that allow topics to be renamed programatically. This adds a new extension type that extensions can register like this:

```typescript
type RegisterTopicMapperArgs = (
  topics: ReadonlyArray<{ name: string; schemaName?: string }>,
) => ReadonlyMap<string, string>;

registerTopicMapper: (args: RegisterTopicMapperArgs);
```

These extensions are single functions that take as input an array of topics and return a `Map<string,string>` that will be used to rename the topics after they are emitted from the core player but before any of the rest of the application uses them. This is accomplished by inserting a new `TopicMappingPlayer` between the core player and the `UserNodePlayer`. The advantage of this approach is that downstream users of player data can use the mapped topics without any changes or awareness that the mapping is going on. If the topic list changes extensions will run again on the new topic list and have a change to update they mappings dynamically.

I've tried hard here to have no overhead for users that don't have any mapping extensions installed.  This could also have been implemented as something attached to a layout but that would make the mappings difficult to update and reuse across an organization.

This PR could also use some design input for indications to the user that a topic was renamed. I'm showing the original topic name, if any, in small type in the data source info panel but we could probably improve this.

One somewhat unsatisfactory aspect of this implementation is that we have to wait until the player emits a topic list to calculate the mappings but in an existing layout we try to call `setSubscriptions` on the player before this happens. I've tried to solve this by storing the requested subscriptions and then applying them once we do have a topic list but this seems like the most fragile element of this approach.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
