### PR TITLE
Improve Flatbuffer deserialization performance

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -36,7 +36,7 @@
     "@mcap/core": "1.2.1",
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "23.5.9",
-    "flatbuffers_reflection": "github:jkuszmaul/flatbuffers_reflection#68697e2d489f6e589b0ccc67389dfda1bc349037",
+    "flatbuffers_reflection": "0.0.5",
     "protobufjs": "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
   }
 }

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -36,7 +36,7 @@
     "@mcap/core": "1.2.1",
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "23.5.9",
-    "flatbuffers_reflection": "0.0.4",
+    "flatbuffers_reflection": "github:jkuszmaul/flatbuffers_reflection#68697e2d489f6e589b0ccc67389dfda1bc349037",
     "protobufjs": "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
   }
 }

--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -191,6 +191,7 @@ export function parseFlatbufferSchema(
     }
   }
   const parser = new Parser(rawSchema);
+  const toObject = parser.toObjectLambda(typeIndex);
   const deserialize = (buffer: ArrayBufferView) => {
     const byteBuffer = new ByteBuffer(
       new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),
@@ -200,8 +201,7 @@ export function parseFlatbufferSchema(
       typeIndex,
       byteBuffer.readInt32(byteBuffer.position()) + byteBuffer.position(),
     );
-    const obj = parser.toObject(table);
-    return obj;
+    return toObject(table);
   };
   return { datatypes, deserialize };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,7 +2342,7 @@ __metadata:
     "@protobufjs/base64": 1.1.2
     "@types/protobufjs": "workspace:*"
     flatbuffers: 23.5.9
-    flatbuffers_reflection: "github:jkuszmaul/flatbuffers_reflection#68697e2d489f6e589b0ccc67389dfda1bc349037"
+    flatbuffers_reflection: 0.0.5
     protobufjs: "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
     typescript: 5.0.4
   languageName: unknown
@@ -11477,10 +11477,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatbuffers_reflection@github:jkuszmaul/flatbuffers_reflection#68697e2d489f6e589b0ccc67389dfda1bc349037":
-  version: 0.0.4
-  resolution: "flatbuffers_reflection@https://github.com/jkuszmaul/flatbuffers_reflection.git#commit=68697e2d489f6e589b0ccc67389dfda1bc349037"
-  checksum: af582d9842d1add110a6cc2ff749c1dd36bceb0e0ec87f6b510493f0474bb4df041eccc3ce3360feb68d55af1834cdc3f6275b4a74f070ba1455a1d6aa96e1aa
+"flatbuffers_reflection@npm:0.0.5":
+  version: 0.0.5
+  resolution: "flatbuffers_reflection@npm:0.0.5"
+  checksum: 34c15174aba37caf37e0f433442e04df2a224ed460d39a0c7098f8c1dcf0436d3779ab5489edbcbdd231866183554e9e69308b847061f8bad9fecdc736b8694d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,7 +2342,7 @@ __metadata:
     "@protobufjs/base64": 1.1.2
     "@types/protobufjs": "workspace:*"
     flatbuffers: 23.5.9
-    flatbuffers_reflection: 0.0.4
+    flatbuffers_reflection: "github:jkuszmaul/flatbuffers_reflection#68697e2d489f6e589b0ccc67389dfda1bc349037"
     protobufjs: "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
     typescript: 5.0.4
   languageName: unknown
@@ -11477,10 +11477,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatbuffers_reflection@npm:0.0.4":
+"flatbuffers_reflection@github:jkuszmaul/flatbuffers_reflection#68697e2d489f6e589b0ccc67389dfda1bc349037":
   version: 0.0.4
-  resolution: "flatbuffers_reflection@npm:0.0.4"
-  checksum: 88353e0bcee4ff781083a681d533a84f95533a4b57aba42b03beb788be2592d21b40fa996e641eadd4f312a7fca7eb7da4a298e0443cc3ae1fcb8dcd630a5cf9
+  resolution: "flatbuffers_reflection@https://github.com/jkuszmaul/flatbuffers_reflection.git#commit=68697e2d489f6e589b0ccc67389dfda1bc349037"
+  checksum: af582d9842d1add110a6cc2ff749c1dd36bceb0e0ec87f6b510493f0474bb4df041eccc3ce3360feb68d55af1834cdc3f6275b4a74f070ba1455a1d6aa96e1aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Improved performance when loading FlatBuffer data.

**Description**
Use the new `toObjectLambda` method from https://github.com/jkuszmaul/flatbuffers_reflection/pull/59 to avoid re-parsing the schema for each message.

Resolves FG-3158