### PR TITLE
[Image Beta] Add flip horizontal/vertical settings

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -78,6 +78,8 @@ export type ImageModeConfig = {
   zoomMode?: "fit" | "fill";
   /** Rotation */
   rotation?: 0 | 90 | 180 | 270;
+  flipHorizontal?: boolean;
+  flipVertical?: boolean;
 };
 
 export type RendererConfig = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -126,6 +126,8 @@ export class ImageMode
     this.#camera.setCanvasSize(canvasSize.width, canvasSize.height);
     this.#camera.setZoomMode(renderer.config.imageMode.zoomMode ?? "fit");
     this.#camera.setRotation(renderer.config.imageMode.rotation ?? 0);
+    this.#camera.setFlipHorizontal(renderer.config.imageMode.flipHorizontal ?? false);
+    this.#camera.setFlipVertical(renderer.config.imageMode.flipVertical ?? false);
 
     renderer.settings.errors.on("update", this.#handleErrorChange);
     renderer.settings.errors.on("clear", this.#handleErrorChange);
@@ -353,9 +355,6 @@ export class ImageMode
     // const transformMarkers: boolean = false;
     // const synchronize: boolean = false;
     // const smooth: boolean = false;
-    // const flipHorizontal: boolean = false;
-    // const flipVertical: boolean = false;
-    // const rotation = 0;
     // const minValue: number | undefined = undefined;
     // const maxValue: number | undefined = undefined;
 
@@ -404,18 +403,16 @@ export class ImageMode
     //   label: "🚧 Bilinear smoothing",
     //   value: smooth,
     // };
-    // fields.TODO_flipHorizontal = {
-    //   readonly: true,
-    //   input: "boolean",
-    //   label: "🚧 Flip horizontal",
-    //   value: flipHorizontal,
-    // };
-    // fields.TODO_flipVertical = {
-    //   readonly: true,
-    //   input: "boolean",
-    //   label: "🚧 Flip vertical",
-    //   value: flipVertical,
-    // };
+    fields.flipHorizontal = {
+      input: "boolean",
+      label: "Flip horizontal",
+      value: config.imageMode.flipHorizontal ?? false,
+    };
+    fields.flipVertical = {
+      input: "boolean",
+      label: "Flip vertical",
+      value: config.imageMode.flipVertical ?? false,
+    };
     fields.rotation = {
       input: "select",
       label: "Rotation",
@@ -499,6 +496,16 @@ export class ImageMode
       if (config.rotation !== prevImageModeConfig.rotation) {
         this.#imageRenderable?.setRotation(config.rotation ?? 0);
         this.#camera.setRotation(config.rotation ?? 0);
+      }
+
+      if (config.flipHorizontal !== prevImageModeConfig.flipHorizontal) {
+        this.#imageRenderable?.setFlipHorizontal(config.flipHorizontal ?? false);
+        this.#camera.setFlipHorizontal(config.flipHorizontal ?? false);
+      }
+
+      if (config.flipVertical !== prevImageModeConfig.flipVertical) {
+        this.#imageRenderable?.setFlipVertical(config.flipVertical ?? false);
+        this.#camera.setFlipVertical(config.flipVertical ?? false);
       }
 
       this.#updateViewAndRenderables();
@@ -652,6 +659,8 @@ export class ImageMode
       cameraModel: undefined,
       image,
       rotation: this.renderer.config.imageMode.rotation ?? 0,
+      flipHorizontal: this.renderer.config.imageMode.flipHorizontal ?? false,
+      flipVertical: this.renderer.config.imageMode.flipVertical ?? false,
       texture: undefined,
       material: undefined,
       geometry: undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -439,6 +439,8 @@ export class Images extends SceneExtension<ImageRenderable> {
       cameraModel: undefined,
       image,
       rotation: 0,
+      flipHorizontal: false,
+      flipVertical: false,
       texture: undefined,
       material: undefined,
       geometry: undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -45,6 +45,8 @@ export type ImageUserData = BaseUserData & {
   cameraModel: PinholeCameraModel | undefined;
   image: AnyImage | undefined;
   rotation: 0 | 90 | 180 | 270;
+  flipHorizontal: boolean;
+  flipVertical: boolean;
   texture: THREE.Texture | undefined;
   material: THREE.MeshBasicMaterial | undefined;
   geometry: THREE.PlaneGeometry | undefined;
@@ -142,6 +144,18 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   /** Set the rotation (used only for downloading) */
   public setRotation(rotation: 0 | 90 | 180 | 270): void {
     this.userData.rotation = rotation;
+  }
+
+  /** Set the horizontal flip (used only for downloading) */
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  public setFlipHorizontal(flipHorizontal: boolean): void {
+    this.userData.flipHorizontal = flipHorizontal;
+  }
+
+  /** Set the vertical flip (used only for downloading) */
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  public setFlipVertical(flipVertical: boolean): void {
+    this.userData.flipVertical = flipVertical;
   }
 
   public setBitmap(bitmap: ImageBitmap): void {
@@ -299,7 +313,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     | undefined {
     // re-render the image onto a new canvas to download the original image
     return async () => {
-      const { topic, image, rotation } = this.userData;
+      const { topic, image, rotation, flipHorizontal, flipVertical } = this.userData;
       if (!image) {
         return;
       }
@@ -326,6 +340,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
       // Draw the image in the selected orientation so it aligns with the canvas viewport
       ctx.translate(width / 2, height / 2);
+      ctx.scale(flipHorizontal ? -1 : 1, flipVertical ? -1 : 1);
       ctx.rotate((rotation / 180) * Math.PI);
       ctx.translate(-bitmap.width / 2, -bitmap.height / 2);
       ctx.drawImage(bitmap, 0, 0);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -394,6 +394,24 @@ export const DownloadPngImage: StoryObj<React.ComponentProps<typeof ImageModeFox
   args: { imageType: "png" },
 };
 
+export const DownloadPngImageFlipH: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
+  {
+    ...DownloadRawImage,
+    args: { imageType: "png", flipHorizontal: true },
+  };
+
+export const DownloadPngImageFlipV: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
+  {
+    ...DownloadRawImage,
+    args: { imageType: "png", flipVertical: true },
+  };
+
+export const DownloadPngImageFlipHV: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
+  {
+    ...DownloadRawImage,
+    args: { imageType: "png", flipHorizontal: true, flipVertical: true },
+  };
+
 export const DownloadPngImage90: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 90 },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -186,10 +186,14 @@ const ImageModeFoxgloveImage = ({
   zoomMode = "fit",
   rotation,
   onDownload,
+  flipHorizontal = false,
+  flipVertical = false,
 }: {
   imageType?: "raw" | "png";
   zoomMode?: "fit" | "fill";
   rotation?: 0 | 90 | 180 | 270;
+  flipHorizontal?: boolean;
+  flipVertical?: boolean;
   onDownload?: (blob: Blob, fileName: string) => void;
 }): JSX.Element => {
   const topics: Topic[] = [
@@ -317,6 +321,8 @@ const ImageModeFoxgloveImage = ({
             imageTopic: imageType === "raw" ? "/cam2/raw" : "/cam1/png",
             zoomMode,
             rotation,
+            flipHorizontal,
+            flipVertical,
           },
           cameraState: {
             distance: 1.5,
@@ -401,6 +407,27 @@ export const DownloadPngImage180: StoryObj<React.ComponentProps<typeof ImageMode
 export const DownloadPngImage270: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 270 },
+};
+
+export const DownloadPngImage90FlipH: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
+  ...DownloadRawImage,
+  args: { imageType: "png", rotation: 90, flipHorizontal: true },
+};
+
+export const DownloadPngImage90FlipV: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
+  ...DownloadRawImage,
+  args: { imageType: "png", rotation: 90, flipVertical: true },
+};
+
+export const DownloadPngImage90FlipHV: StoryObj<
+  React.ComponentProps<typeof ImageModeFoxgloveImage>
+> = {
+  ...DownloadRawImage,
+  args: { imageType: "png", rotation: 90, flipHorizontal: true, flipVertical: true },
 };
 
 export const ImageModeResizeHandled: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds flip horizontal/vertical settings.
Pan/zoom support was tested manually but is not fully tested in stories. Planning to do that as part of FG-3550 follow-up ticket.

https://github.com/foxglove/studio/assets/14237/8390ad38-6023-49d2-be1d-7bbdbee3738b

