### PR TITLE
[Image Beta] delete zoom mode setting, always use "fit" mode

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -74,8 +74,6 @@ export type ImageModeConfig = {
   calibrationTopic?: string;
   /** Annotation topic settings, analogous to {@link RendererConfig.topics} */
   annotations?: ImageAnnotationSubscription[];
-  /** Zoom mode */
-  zoomMode?: "fit" | "fill";
   /** Rotation */
   rotation?: 0 | 90 | 180 | 270;
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -27,7 +27,7 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/projections";
 import { makePose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 
-import { DEFAULT_ZOOM_MODE, ImageModeCamera } from "./ImageModeCamera";
+import { ImageModeCamera } from "./ImageModeCamera";
 import { ImageAnnotations } from "./annotations/ImageAnnotations";
 import type { IRenderer } from "../../IRenderer";
 import { PartialMessageEvent, SceneExtension } from "../../SceneExtension";
@@ -124,7 +124,6 @@ export class ImageMode
     this.#camera = new ImageModeCamera();
 
     this.#camera.setCanvasSize(canvasSize.width, canvasSize.height);
-    this.#camera.setZoomMode(renderer.config.imageMode.zoomMode ?? "fit");
     this.#camera.setRotation(renderer.config.imageMode.rotation ?? 0);
 
     renderer.settings.errors.on("update", this.#handleErrorChange);
@@ -374,15 +373,6 @@ export class ImageMode
       options: calibrationTopics,
       error: calibrationTopicError,
     };
-    fields.zoomMode = {
-      label: "Zoom mode",
-      input: "toggle",
-      value: config.imageMode.zoomMode ?? DEFAULT_ZOOM_MODE,
-      options: [
-        { label: "Fit", value: "fit" },
-        { label: "Fill", value: "fill" },
-      ],
-    };
     // fields.TODO_transformMarkers = {
     //   readonly: true,
     //   input: "boolean",
@@ -489,11 +479,6 @@ export class ImageMode
           });
           this.#setHasCalibrationTopic(true);
         }
-      }
-
-      if (config.zoomMode !== prevImageModeConfig.zoomMode) {
-        this.#camera.setZoomMode(config.zoomMode ?? DEFAULT_ZOOM_MODE);
-        this.resetViewModifications();
       }
 
       if (config.rotation !== prevImageModeConfig.rotation) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -19,7 +19,7 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
   readonly #cameraState = DEFAULT_CAMERA_STATE;
   #rotation: 0 | 90 | 180 | 270 = 0;
 
-  /** x/y zoom factors derived from image and window aspect ratios and zoom mode */
+  /** x/y zoom factors derived from image and window aspect ratios */
   readonly #aspectZoom = new THREE.Vector2();
   readonly #canvasSize = new THREE.Vector2();
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageModeCamera.ts
@@ -13,12 +13,10 @@ const DEFAULT_CAMERA_STATE = {
 
 const MIN_USER_ZOOM = 0.5;
 const MAX_USER_ZOOM = 50;
-export const DEFAULT_ZOOM_MODE = "fit";
 
 export class ImageModeCamera extends THREE.PerspectiveCamera {
   #model?: PinholeCameraModel;
   readonly #cameraState = DEFAULT_CAMERA_STATE;
-  #zoomMode: "fit" | "fill" | "custom" = DEFAULT_ZOOM_MODE;
   #rotation: 0 | 90 | 180 | 270 = 0;
 
   /** x/y zoom factors derived from image and window aspect ratios and zoom mode */
@@ -47,11 +45,6 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
   public resetModifications(): void {
     this.#panOffset.set(0, 0);
     this.#userZoom = 1;
-    this.#updateProjection();
-  }
-
-  public setZoomMode(mode: "fit" | "fill" | "custom"): void {
-    this.#zoomMode = mode;
     this.#updateProjection();
   }
 
@@ -230,11 +223,7 @@ export class ImageModeCamera extends THREE.PerspectiveCamera {
       rendererAspect = 1 / rendererAspect;
     }
 
-    let adjustY = imageAspect > rendererAspect;
-    if (this.#zoomMode === "fill") {
-      adjustY = !adjustY;
-    }
-    if (adjustY) {
+    if (imageAspect > rendererAspect) {
       this.#aspectZoom.y = (this.#aspectZoom.y / imageAspect) * rendererAspect;
     } else {
       this.#aspectZoom.x = (this.#aspectZoom.x / rendererAspect) * imageAspect;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -183,12 +183,10 @@ export const ImageModeRosPngImage: StoryObj<React.ComponentProps<typeof ImageMod
 
 const ImageModeFoxgloveImage = ({
   imageType = "raw",
-  zoomMode = "fit",
   rotation,
   onDownload,
 }: {
   imageType?: "raw" | "png";
-  zoomMode?: "fit" | "fill";
   rotation?: 0 | 90 | 180 | 270;
   onDownload?: (blob: Blob, fileName: string) => void;
 }): JSX.Element => {
@@ -315,7 +313,6 @@ const ImageModeFoxgloveImage = ({
           imageMode: {
             calibrationTopic: imageType === "raw" ? "/cam2/info" : "/cam1/info",
             imageTopic: imageType === "raw" ? "/cam2/raw" : "/cam1/png",
-            zoomMode,
             rotation,
           },
           cameraState: {
@@ -419,16 +416,6 @@ export const ImageModeResizeHandled: StoryObj<React.ComponentProps<typeof ImageM
     },
   };
 
-export const ImageModeResizeHandledFill: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
-  ...ImageModeResizeHandled,
-  args: {
-    ...ImageModeResizeHandled.args,
-    zoomMode: "fill",
-  },
-};
-
 export const ImageModePan: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   render: ImageModeFoxgloveImage,
   play: async () => {
@@ -452,14 +439,6 @@ export const ImageModePan180: StoryObj<React.ComponentProps<typeof ImageModeFoxg
 export const ImageModePan270: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   ...ImageModePan,
   args: { rotation: 270 },
-};
-
-export const ImageModePanFill: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
-  ...ImageModePan,
-  args: {
-    ...ImageModePan.args,
-    zoomMode: "fill",
-  },
 };
 
 export const ImageModeZoomThenPan: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
@@ -494,16 +473,6 @@ export const ImageModeZoomThenPan270: StoryObj<
   args: { rotation: 270 },
 };
 
-export const ImageModeZoomThenPanFill: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
-  ...ImageModeZoomThenPan,
-  args: {
-    ...ImageModeZoomThenPan.args,
-    zoomMode: "fill",
-  },
-};
-
 export const ImageModePanThenZoom: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
@@ -517,16 +486,6 @@ export const ImageModePanThenZoom: StoryObj<React.ComponentProps<typeof ImageMod
   },
 };
 
-export const ImageModePanThenZoomFill: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
-  ...ImageModePanThenZoom,
-  args: {
-    ...ImageModePanThenZoom.args,
-    zoomMode: "fill",
-  },
-};
-
 export const ImageModePanThenZoomReset: StoryObj<
   React.ComponentProps<typeof ImageModeFoxgloveImage>
 > = {
@@ -535,16 +494,6 @@ export const ImageModePanThenZoomReset: StoryObj<
   play: async (ctx) => {
     await ImageModePanThenZoom.play?.(ctx);
     userEvent.click(await screen.findByTestId("reset-view"));
-  },
-};
-
-export const ImageModePanThenZoomResetFill: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
-  ...ImageModePanThenZoomReset,
-  args: {
-    ...ImageModePanThenZoomReset.args,
-    zoomMode: "fill",
   },
 };
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Basically a revert of #6007. After realizing that the old panel didn't correctly persist this setting for years, and some internal discussion, we decided we don't need this setting.