### PR TITLE
[Image Beta] Use toggle control for rotation setting

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -84,6 +84,7 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
     styledToggleButtonGroup: {
       backgroundColor: theme.palette.action.hover,
       gap: theme.spacing(0.25),
+      overflowX: "auto",
 
       "& .MuiToggleButtonGroup-grouped": {
         margin: theme.spacing(0.55),
@@ -197,10 +198,10 @@ function FieldInput({
         >
           {field.options.map((opt) => (
             <ToggleButton
-              key={(typeof opt === "string" ? opt : opt.value) ?? UNDEFINED_SENTINEL_VALUE}
-              value={(typeof opt === "string" ? opt : opt.value) ?? UNDEFINED_SENTINEL_VALUE}
+              key={(typeof opt === "object" ? opt.value : opt) ?? UNDEFINED_SENTINEL_VALUE}
+              value={(typeof opt === "object" ? opt.value : opt) ?? UNDEFINED_SENTINEL_VALUE}
             >
-              {typeof opt === "string" ? opt : opt.label}
+              {typeof opt === "object" ? opt.label : opt}
             </ToggleButton>
           ))}
         </ToggleButtonGroup>

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -417,7 +417,7 @@ export class ImageMode
     //   value: flipVertical,
     // };
     fields.rotation = {
-      input: "select",
+      input: "toggle",
       label: "Rotation",
       value: config.imageMode.rotation ?? 0,
       options: [

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -550,6 +550,11 @@ export type SettingsTreeFieldValue =
       options: string[] | Array<{ label: string; value: undefined | string }>;
     }
   | {
+      input: "toggle";
+      value?: number;
+      options: number[] | Array<{ label: string; value: undefined | number }>;
+    }
+  | {
       input: "vec3";
       value?: [undefined | number, undefined | number, undefined | number];
       placeholder?: [undefined | string, undefined | string, undefined | string];


### PR DESCRIPTION
**User-Facing Changes**
- Extension API now allows `"toggle"` settings fields to use `number`s for option values.

**Description**
<img width="337" alt="image" src="https://github.com/foxglove/studio/assets/14237/5c2f5fe9-b49a-4783-93bf-300b5d135c6e">

<img width="216" alt="image" src="https://github.com/foxglove/studio/assets/14237/4c1f7a06-c3cb-4d6b-b7fe-fa8b3654333b">
