### PR TITLE
Keep value when clicking on "toggle" settings field

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -184,7 +184,7 @@ function FieldInput({
           disabled={field.disabled}
           size="small"
           onChange={(_event, value) => {
-            if (field.readonly !== true) {
+            if (value != undefined && field.readonly !== true) {
               actionHandler({
                 action: "update",
                 payload: {


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out

**Description**
We already had the `value != undefined` in the `"boolean"` case. I just ported it to the `"toggle"` case as well.
Fixes FG-3519