### PR TITLE
Expose Immutable type from @foxglove/studio and mark message pipeline and renderState data as immutable

### DIFF
--- a/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
+++ b/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import { useShallowMemo } from "@foxglove/hooks";
+import { Immutable } from "@foxglove/studio";
 import {
   useMessagePipeline,
   MessagePipelineContext,
@@ -26,15 +27,15 @@ import {
   MessageBlock as PlayerMessageBlock,
 } from "@foxglove/studio-base/players/types";
 
-export type MessageBlock = {
-  readonly [topicName: string]: readonly MessageEvent[];
-};
+export type MessageBlock = Immutable<{
+  [topicName: string]: MessageEvent[];
+}>;
 
 // Memoization probably won't speed up the filtering appreciably, but preserves return identity.
 // That said, MessageBlock identity will change when the set of topics changes, so consumers should
 // prefer to use the identity of topic-block message arrays where possible.
 const filterBlockByTopics = memoizeWeak(
-  (block: PlayerMessageBlock | undefined, topics: readonly string[]): MessageBlock => {
+  (block: Immutable<PlayerMessageBlock> | undefined, topics: readonly string[]): MessageBlock => {
     if (!block) {
       // For our purposes, a missing MemoryCacheBlock just means "no topics have been cached for
       // this block". This is semantically different to an empty array per topic, but not different
@@ -93,7 +94,7 @@ export function useBlocksByTopic(topics: readonly string[]): readonly MessageBlo
 
   useSubscribeToTopicsForBlocks(requestedTopics);
 
-  const allBlocks = useMessagePipeline<readonly (PlayerMessageBlock | undefined)[] | undefined>(
+  const allBlocks = useMessagePipeline<Immutable<(PlayerMessageBlock | undefined)[] | undefined>>(
     useCallback((ctx) => ctx.playerState.progress.messageCache?.blocks, []),
   );
 

--- a/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
+++ b/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
@@ -13,11 +13,10 @@
 
 import { useMemo } from "react";
 
-import { Immutable } from "@foxglove/studio";
-import { Time } from "@foxglove/studio";
+import { Immutable, Time } from "@foxglove/studio";
 import {
-  useMessagePipeline,
   MessagePipelineContext,
+  useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";

--- a/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
+++ b/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
@@ -13,6 +13,7 @@
 
 import { useMemo } from "react";
 
+import { Immutable } from "@foxglove/studio";
 import { Time } from "@foxglove/studio";
 import {
   useMessagePipeline,
@@ -57,7 +58,7 @@ export type DataSourceInfo = {
  *
  * A data source might be a local file, a remote file, or a streaming source.
  */
-export function useDataSourceInfo(): DataSourceInfo {
+export function useDataSourceInfo(): Immutable<DataSourceInfo> {
   const datatypes = useMessagePipeline(selectDatatypes);
   const topics = useMessagePipeline(selectTopics);
   const startTime = useMessagePipeline(selectStartTime);
@@ -65,7 +66,7 @@ export function useDataSourceInfo(): DataSourceInfo {
   const playerId = useMessagePipeline(selectPlayerId);
 
   // we want the returned object to have a stable identity
-  return useMemo<DataSourceInfo>(() => {
+  return useMemo(() => {
     return {
       topics,
       datatypes,

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -7,9 +7,9 @@ import { IconButton, Button, Link, Tab, Tabs, Typography, Divider } from "@mui/m
 import { useSnackbar } from "notistack";
 import { useCallback, useState } from "react";
 import { useAsync, useMountedState } from "react-use";
-import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextContent from "@foxglove/studio-base/components/TextContent";
@@ -24,7 +24,7 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 type Props = {
   installed: boolean;
-  extension: DeepReadonly<ExtensionMarketplaceDetail>;
+  extension: Immutable<ExtensionMarketplaceDetail>;
   onClose: () => void;
 };
 

--- a/packages/studio-base/src/components/ExtensionsSettings/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.tsx
@@ -6,10 +6,10 @@ import { Button, List, ListItem, ListItemButton, ListItemText, Typography } from
 import { differenceWith, groupBy, isEmpty, keyBy } from "lodash";
 import { useEffect, useMemo, useState } from "react";
 import { useAsyncFn } from "react-use";
-import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
 import Log from "@foxglove/log";
+import { Immutable } from "@foxglove/studio";
 import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
@@ -36,7 +36,7 @@ function displayNameForNamespace(namespace: string): string {
 }
 
 function ExtensionListEntry(props: {
-  entry: DeepReadonly<ExtensionMarketplaceDetail>;
+  entry: Immutable<ExtensionMarketplaceDetail>;
   onClick: () => void;
 }): JSX.Element {
   const {
@@ -79,7 +79,7 @@ export default function ExtensionsSettings(): React.ReactElement {
   const [focusedExtension, setFocusedExtension] = useState<
     | {
         installed: boolean;
-        entry: DeepReadonly<ExtensionMarketplaceDetail>;
+        entry: Immutable<ExtensionMarketplaceDetail>;
       }
     | undefined
   >(undefined);

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -16,6 +16,7 @@ import { flatten, flatMap, partition } from "lodash";
 import { CSSProperties, useCallback, useMemo } from "react";
 
 import { MessageDefinitionField } from "@foxglove/message-definition";
+import { Immutable } from "@foxglove/studio";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
 import useGlobalVariables, {
@@ -54,8 +55,8 @@ import parseRosPath, { quoteFieldNameIfNeeded, quoteTopicNameIfNeeded } from "./
 
 // Get a list of Message Path strings for all of the fields (recursively) in a list of topics
 function getFieldPaths(
-  topics: readonly Topic[],
-  datatypes: RosDatatypes,
+  topics: Immutable<Topic[]>,
+  datatypes: Immutable<RosDatatypes>,
 ): Map<string, MessageDefinitionField> {
   const output = new Map<string, MessageDefinitionField>();
   for (const topic of topics) {
@@ -76,9 +77,9 @@ function getFieldPaths(
 function addFieldPathsForType(
   curPath: string,
   typeName: string,
-  datatypes: RosDatatypes,
+  datatypes: Immutable<RosDatatypes>,
   seenTypes: string[],
-  output: Map<string, MessageDefinitionField>,
+  output: Map<string, Immutable<MessageDefinitionField>>,
 ): void {
   const msgdef = datatypes.get(typeName);
   if (msgdef) {

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -14,6 +14,7 @@
 import { memoize } from "lodash";
 import memoizeWeak from "memoize-weak";
 
+import { Immutable } from "@foxglove/studio";
 import { MessagePathFilter } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
 import { isTypicalFilterName } from "@foxglove/studio-base/components/MessagePathSyntax/isTypicalFilterName";
 import { quoteFieldNameIfNeeded } from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
@@ -72,10 +73,10 @@ function structureItemIsIntegerPrimitive(item: MessagePathStructureItem) {
 //     }
 //   }
 // }
-let lastDatatypes: RosDatatypes | undefined;
+let lastDatatypes: Immutable<RosDatatypes> | undefined;
 let lastStructures: Record<string, MessagePathStructureItemMessage> | undefined;
 export function messagePathStructures(
-  datatypes: RosDatatypes,
+  datatypes: Immutable<RosDatatypes>,
 ): Record<string, MessagePathStructureItemMessage> {
   if (lastDatatypes === datatypes && lastStructures) {
     return lastStructures;
@@ -163,7 +164,7 @@ export function validTerminatingStructureItem(
 // list out all valid strings for the `messagePath` part of the path (sorted).
 export function messagePathsForDatatype(
   datatype: string,
-  datatypes: RosDatatypes,
+  datatypes: Immutable<RosDatatypes>,
   {
     validTypes,
     noMultiSlices,

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -15,6 +15,7 @@ import { isEqual } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 
 import { useShallowMemo } from "@foxglove/hooks";
+import { Immutable } from "@foxglove/studio";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import useChangeDetector from "@foxglove/studio-base/hooks/useChangeDetector";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
@@ -34,6 +35,8 @@ import { filterMatches } from "./filterMatches";
 import { TypicalFilterNames } from "./isTypicalFilterName";
 import { messagePathStructures } from "./messagePathsForDatatype";
 import parseRosPath, { quoteTopicNameIfNeeded } from "./parseRosPath";
+
+type ValueInMapRecord<T> = T extends Map<unknown, infer I> ? I : never;
 
 export type MessagePathDataItem = {
   value: unknown; // The actual value.
@@ -95,7 +98,7 @@ export function useCachedGetMessagePathDataItems(
   const relevantTopics = useDeepMemo(unmemoizedRelevantTopics);
 
   const unmemoizedRelevantDatatypes = useMemo(() => {
-    const relevantDatatypes: RosDatatypes = new Map();
+    const relevantDatatypes = new Map<string, Immutable<ValueInMapRecord<RosDatatypes>>>();
     function addRelevantDatatype(datatypeName: string, seen: string[]) {
       if (seen.includes(datatypeName)) {
         return;
@@ -220,7 +223,7 @@ export function getMessagePathDataItems(
   message: MessageEvent,
   filledInPath: RosPath,
   providerTopics: readonly Topic[],
-  datatypes: RosDatatypes,
+  datatypes: Immutable<RosDatatypes>,
 ): MessagePathDataItem[] | undefined {
   const structures = messagePathStructures(datatypes);
   const topic = getTopicsByTopicName(providerTopics)[filledInPath.topicName];

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 import { StoreApi, useStore } from "zustand";
 
+import { Immutable } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
@@ -98,7 +99,7 @@ export function MessagePipelineProvider({
   //
   // The delay of 0ms is intentional as we only want to give one timeout cycle to batch updates
   const debouncedPlayerSetSubscriptions = useMemo(() => {
-    return debounce((subs: SubscribePayload[]) => {
+    return debounce((subs: Immutable<SubscribePayload[]>) => {
       player?.setSubscriptions(subs);
     });
   }, [player]);

--- a/packages/studio-base/src/components/MessagePipeline/types.ts
+++ b/packages/studio-base/src/components/MessagePipeline/types.ts
@@ -3,8 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Time } from "@foxglove/rostime";
-import { Immutable } from "@foxglove/studio";
-import { MessageEvent, ParameterValue } from "@foxglove/studio";
+import { Immutable, MessageEvent, ParameterValue } from "@foxglove/studio";
 import {
   AdvertiseOptions,
   PlayerState,

--- a/packages/studio-base/src/components/MessagePipeline/types.ts
+++ b/packages/studio-base/src/components/MessagePipeline/types.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Time } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import { MessageEvent, ParameterValue } from "@foxglove/studio";
 import {
   AdvertiseOptions,
@@ -14,7 +15,7 @@ import {
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 type ResumeFrame = () => void;
-export type MessagePipelineContext = {
+export type MessagePipelineContext = Immutable<{
   playerState: PlayerState;
   sortedTopics: Topic[];
   datatypes: RosDatatypes;
@@ -32,4 +33,4 @@ export type MessagePipelineContext = {
   seekPlayback?: (time: Time) => void;
   // Don't render the next frame until the returned function has been called.
   pauseFrame: (name: string) => ResumeFrame;
-};
+}>;

--- a/packages/studio-base/src/components/PanelContextMenu.tsx
+++ b/packages/studio-base/src/components/PanelContextMenu.tsx
@@ -4,8 +4,8 @@
 
 import { Divider, ListItemText, Menu, MenuItem } from "@mui/material";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { DeepReadonly } from "ts-essentials";
 
+import { Immutable } from "@foxglove/studio";
 import { PANEL_ROOT_CLASS_NAME } from "@foxglove/studio-base/components/PanelRoot";
 
 /**
@@ -36,10 +36,7 @@ type PanelContextMenuProps = {
    * Function that returns a list of menu items, optionally dependent on the x,y
    * position of the click.
    */
-  itemsForClickPosition: (position: {
-    x: number;
-    y: number;
-  }) => DeepReadonly<PanelContextMenuItem[]>;
+  itemsForClickPosition: (position: { x: number; y: number }) => Immutable<PanelContextMenuItem[]>;
 };
 
 /**
@@ -55,7 +52,7 @@ export function PanelContextMenu(props: PanelContextMenuProps): JSX.Element {
 
   const handleClose = useCallback(() => setPosition(undefined), []);
 
-  const [items, setItems] = useState<undefined | DeepReadonly<PanelContextMenuItem[]>>();
+  const [items, setItems] = useState<undefined | Immutable<PanelContextMenuItem[]>>();
 
   const listener = useCallback(
     (event: MouseEvent) => {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.stories.tsx
@@ -7,7 +7,13 @@ import { ReactElement, useLayoutEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { toSec } from "@foxglove/rostime";
-import { PanelExtensionContext, ParameterValue, RenderState, Time } from "@foxglove/studio";
+import {
+  Immutable,
+  PanelExtensionContext,
+  ParameterValue,
+  RenderState,
+  Time,
+} from "@foxglove/studio";
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -60,12 +66,12 @@ export const CatchRenderError: StoryObj = {
 
 function SimplePanel({ context }: { context: PanelExtensionContext }) {
   const [currentTime, setCurrentTime] = useState<Time | undefined>(undefined);
-  const [parameters, setParameters] = useState<ReadonlyMap<string, ParameterValue>>(new Map());
+  const [parameters, setParameters] = useState<Immutable<Map<string, ParameterValue>>>(new Map());
 
   useLayoutEffect(() => {
     context.watch("currentTime");
     context.watch("parameters");
-    context.onRender = (renderState: RenderState, done) => {
+    context.onRender = (renderState: Immutable<RenderState>, done) => {
       setCurrentTime(renderState.currentTime);
       if (renderState.parameters != undefined) {
         setParameters(renderState.parameters);

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -11,7 +11,7 @@ import { act } from "react-dom/test-utils";
 
 import { Condvar, signal } from "@foxglove/den/async";
 import { Time } from "@foxglove/rostime";
-import { PanelExtensionContext, RenderState, MessageEvent } from "@foxglove/studio";
+import { PanelExtensionContext, RenderState, MessageEvent, Immutable } from "@foxglove/studio";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import { AdvertiseOptions, PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
@@ -61,7 +61,7 @@ describe("PanelExtensionAdapter", () => {
       .spyOn(window, "requestAnimationFrame")
       .mockImplementation((cb) => queueMicrotask(() => cb(performance.now())) as any);
 
-    const renderStates: RenderState[] = [];
+    const renderStates: Immutable<RenderState>[] = [];
 
     const initPanel = jest.fn((context: PanelExtensionContext) => {
       context.watch("currentFrame");
@@ -537,7 +537,7 @@ describe("PanelExtensionAdapter", () => {
       .mockImplementation((cb) => queueMicrotask(() => cb(performance.now())) as any);
 
     let sequence = 0;
-    const renderStates: RenderState[] = [];
+    const renderStates: Immutable<RenderState>[] = [];
 
     const initPanel = jest.fn((context: PanelExtensionContext) => {
       context.watch("variables");
@@ -598,7 +598,7 @@ describe("PanelExtensionAdapter", () => {
   });
 
   it("should call pause frame with new frame and resume after rendering", async () => {
-    const renderStates: RenderState[] = [];
+    const renderStates: Immutable<RenderState>[] = [];
 
     const initPanel = jest.fn((context: PanelExtensionContext) => {
       context.watch("currentTime");

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -4,8 +4,12 @@
 
 import { difference } from "lodash";
 
-import { Immutable } from "@foxglove/studio";
-import { MessageEvent, RegisterMessageConverterArgs, Subscription } from "@foxglove/studio";
+import {
+  Immutable,
+  MessageEvent,
+  RegisterMessageConverterArgs,
+  Subscription,
+} from "@foxglove/studio";
 import { Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
 
 // Branded string to ensure that users go through the `converterKey` function to compute a lookup key

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -3,8 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { difference } from "lodash";
-import { DeepReadonly } from "ts-essentials";
 
+import { Immutable } from "@foxglove/studio";
 import { MessageEvent, RegisterMessageConverterArgs, Subscription } from "@foxglove/studio";
 import { Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
 
@@ -29,8 +29,8 @@ function converterKey(topic: string, schema: string): ConverterKey {
  * convertedMessages in place for efficiency.
  */
 export function convertMessage(
-  messageEvent: DeepReadonly<MessageEvent<unknown>>,
-  converters: DeepReadonly<TopicSchemaConverterMap>,
+  messageEvent: Immutable<MessageEvent<unknown>>,
+  converters: Immutable<TopicSchemaConverterMap>,
   convertedMessages: MessageEvent<unknown>[],
 ): void {
   const key = converterKey(messageEvent.topic, messageEvent.schemaName);
@@ -159,9 +159,9 @@ export function collateTopicSchemaConversions(
  * @param forEach - callback to be executed on all items in the arrays to iterate over in sorted order across all arrays
  */
 export function forEachSortedArrays<Item>(
-  arrays: Item[][],
-  compareFn: (a: Item, b: Item) => number,
-  forEach: (item: Item) => void,
+  arrays: Immutable<Item[][]>,
+  compareFn: (a: Immutable<Item>, b: Immutable<Item>) => number,
+  forEach: (item: Immutable<Item>) => void,
 ): void {
   const cursors: number[] = Array(arrays.length).fill(0);
   if (arrays.length === 0) {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -150,8 +150,10 @@ describe("renderState", () => {
     });
 
     // need to change something to force a new, defined state
-    initialState.watchedFields = new Set(["currentTime", "endTime", "startTime", "topics"]);
-    const secondRenderState = buildRenderState(initialState);
+    const secondRenderState = buildRenderState({
+      ...initialState,
+      watchedFields: new Set(["currentTime", "endTime", "startTime", "topics"]),
+    });
     expect(secondRenderState).toEqual({
       currentTime: { sec: 33, nsec: 1 },
       endTime: { sec: 100, nsec: 1 },

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -3,12 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import memoizeWeak from "memoize-weak";
+import { Writable } from "ts-essentials";
 
 import { filterMap } from "@foxglove/den/collection";
 import { compare, toSec } from "@foxglove/rostime";
-import { Immutable } from "@foxglove/studio";
 import {
   AppSettingValue,
+  Immutable,
   MessageEvent,
   ParameterValue,
   RegisterMessageConverterArgs,
@@ -79,7 +80,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
   const memoMapDifference = memoizeWeak(mapDifference);
   const memoCollateTopicSchemaConversions = memoizeWeak(collateTopicSchemaConversions);
 
-  const prevRenderState: Immutable<RenderState> = {};
+  const prevRenderState: Writable<Immutable<RenderState>> = {};
 
   return function buildRenderState(input: BuilderRenderStateInput) {
     const {
@@ -103,7 +104,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     const activeData = playerState?.activeData;
 
     // The render state starts with the previous render state and changes are applied as detected
-    const renderState = { ...prevRenderState };
+    const renderState = prevRenderState;
 
     const collatedConversions = memoCollateTopicSchemaConversions(
       subscriptions,

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -6,6 +6,7 @@ import memoizeWeak from "memoize-weak";
 
 import { filterMap } from "@foxglove/den/collection";
 import { compare, toSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import {
   AppSettingValue,
   MessageEvent,
@@ -36,7 +37,7 @@ import {
 
 const EmptyParameters = new Map<string, ParameterValue>();
 
-export type BuilderRenderStateInput = {
+export type BuilderRenderStateInput = Immutable<{
   appSettings: Map<string, AppSettingValue> | undefined;
   colorScheme: RenderState["colorScheme"] | undefined;
   currentFrame: MessageEvent[] | undefined;
@@ -48,9 +49,9 @@ export type BuilderRenderStateInput = {
   sortedTopics: readonly PlayerTopic[];
   subscriptions: Subscription[];
   watchedFields: Set<string>;
-};
+}>;
 
-type BuildRenderStateFn = (input: BuilderRenderStateInput) => Readonly<RenderState> | undefined;
+type BuildRenderStateFn = (input: BuilderRenderStateInput) => Immutable<RenderState> | undefined;
 
 /**
  * initRenderStateBuilder creates a function that transforms render state input into a new
@@ -63,13 +64,13 @@ type BuildRenderStateFn = (input: BuilderRenderStateInput) => Readonly<RenderSta
  * undefined if there's no update for rendering
  */
 function initRenderStateBuilder(): BuildRenderStateFn {
-  let prevVariables: GlobalVariables = EMPTY_GLOBAL_VARIABLES;
-  let prevBlocks: undefined | readonly (undefined | MessageBlock)[];
+  let prevVariables: Immutable<GlobalVariables> = EMPTY_GLOBAL_VARIABLES;
+  let prevBlocks: undefined | Immutable<(undefined | MessageBlock)[]>;
   let prevSeekTime: number | undefined;
   let prevSortedTopics: BuilderRenderStateInput["sortedTopics"] | undefined;
   let prevMessageConverters: BuilderRenderStateInput["messageConverters"] | undefined;
   let prevSharedPanelState: BuilderRenderStateInput["sharedPanelState"];
-  let prevCurrentFrame: RenderState["currentFrame"];
+  let prevCurrentFrame: Immutable<RenderState["currentFrame"]>;
   let prevCollatedConversions: undefined | TopicSchemaConversions;
   const lastMessageByTopic: Map<string, MessageEvent> = new Map();
 
@@ -78,7 +79,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
   const memoMapDifference = memoizeWeak(mapDifference);
   const memoCollateTopicSchemaConversions = memoizeWeak(collateTopicSchemaConversions);
 
-  const prevRenderState: RenderState = {};
+  const prevRenderState: Immutable<RenderState> = {};
 
   return function buildRenderState(input: BuilderRenderStateInput) {
     const {
@@ -102,7 +103,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     const activeData = playerState?.activeData;
 
     // The render state starts with the previous render state and changes are applied as detected
-    const renderState: RenderState = prevRenderState;
+    const renderState = { ...prevRenderState };
 
     const collatedConversions = memoCollateTopicSchemaConversions(
       subscriptions,

--- a/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
@@ -10,13 +10,14 @@ import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
 import { filterMap } from "@foxglove/den/collection";
+import { Immutable } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Range } from "@foxglove/studio-base/util/ranges";
 
-type ProgressProps = {
+type ProgressProps = Immutable<{
   loading: boolean;
   availableRanges?: Range[];
-};
+}>;
 
 const STRIPE_WIDTH = 8;
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -16,10 +16,10 @@ import {
   TextField,
   ListProps,
 } from "@mui/material";
-import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuid } from "uuid";
 
+import { Immutable } from "@foxglove/studio";
 import { SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -119,7 +119,7 @@ function FieldInput({
   path,
 }: {
   actionHandler: (action: SettingsTreeAction) => void;
-  field: DeepReadonly<SettingsTreeField>;
+  field: Immutable<SettingsTreeField>;
   path: readonly string[];
 }): JSX.Element {
   const { classes, cx } = useStyles();
@@ -409,7 +409,7 @@ function FieldInput({
   }
 }
 
-function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.Element {
+function FieldLabel({ field }: { field: Immutable<SettingsTreeField> }): JSX.Element {
   const { classes } = useStyles();
 
   if (field.input === "vec2") {
@@ -493,7 +493,7 @@ function FieldEditorComponent({
   path,
 }: {
   actionHandler: (action: SettingsTreeAction) => void;
-  field: DeepReadonly<SettingsTreeField>;
+  field: Immutable<SettingsTreeField>;
   path: readonly string[];
 }): JSX.Element {
   const indent = Math.min(path.length, 4);

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -6,25 +6,24 @@ import ClearIcon from "@mui/icons-material/Clear";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
   Autocomplete,
-  ToggleButton,
-  ToggleButtonGroup,
-  Typography,
   List,
+  ListProps,
   MenuItem,
   Select,
-  Tooltip,
   TextField,
-  ListProps,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
 } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuid } from "uuid";
 
-import { Immutable } from "@foxglove/studio";
-import { SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
+import { Immutable, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import Stack from "@foxglove/studio-base/components/Stack";
 
-import { ColorPickerInput, ColorGradientInput, NumberInput, Vec3Input, Vec2Input } from "./inputs";
+import { ColorGradientInput, ColorPickerInput, NumberInput, Vec2Input, Vec3Input } from "./inputs";
 
 /** Used to allow both undefined and empty string in select inputs. */
 const UNDEFINED_SENTINEL_VALUE = uuid();

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -22,12 +22,12 @@ import memoizeWeak from "memoize-weak";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import tinycolor from "tinycolor2";
-import { DeepReadonly } from "ts-essentials";
 import { keyframes } from "tss-react";
 import { makeStyles } from "tss-react/mui";
 import { useImmer } from "use-immer";
 
 import { filterMap } from "@foxglove/den/collection";
+import { Immutable } from "@foxglove/studio";
 import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodeActionItem } from "@foxglove/studio";
 import { HighlightedText } from "@foxglove/studio-base/components/HighlightedText";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -44,7 +44,7 @@ export type NodeEditorProps = {
   filter?: string;
   focusedPath?: readonly string[];
   path: readonly string[];
-  settings?: DeepReadonly<SettingsTreeNode>;
+  settings?: Immutable<SettingsTreeNode>;
 };
 
 export const NODE_HEADER_MIN_HEIGHT = 35;
@@ -174,11 +174,11 @@ const SelectVisibilityFilterOptions: (t: TFunction<"settingsEditor">) => {
   { label: t("listVisible"), value: "visible" },
   { label: t("listInvisible"), value: "invisible" },
 ];
-function showVisibleFilter(child: DeepReadonly<SettingsTreeNode>): boolean {
+function showVisibleFilter(child: Immutable<SettingsTreeNode>): boolean {
   // want to show children with undefined visibility
   return child.visible !== false;
 }
-function showInvisibleFilter(child: DeepReadonly<SettingsTreeNode>): boolean {
+function showInvisibleFilter(child: Immutable<SettingsTreeNode>): boolean {
   // want to show children with undefined visibility
   return child.visible !== true;
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -27,8 +27,12 @@ import { makeStyles } from "tss-react/mui";
 import { useImmer } from "use-immer";
 
 import { filterMap } from "@foxglove/den/collection";
-import { Immutable } from "@foxglove/studio";
-import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodeActionItem } from "@foxglove/studio";
+import {
+  Immutable,
+  SettingsTreeAction,
+  SettingsTreeNode,
+  SettingsTreeNodeActionItem,
+} from "@foxglove/studio";
 import { HighlightedText } from "@foxglove/studio-base/components/HighlightedText";
 import Stack from "@foxglove/studio-base/components/Stack";
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -8,9 +8,9 @@ import { IconButton, TextField } from "@mui/material";
 import memoizeWeak from "memoize-weak";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import { SettingsTree, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor/FieldEditor";
@@ -52,7 +52,7 @@ const makeStablePath = memoizeWeak((key: string) => [key]);
 export default function SettingsTreeEditor({
   settings,
 }: {
-  settings: DeepReadonly<SettingsTree>;
+  settings: Immutable<SettingsTree>;
 }): JSX.Element {
   const { classes } = useStyles();
   const { actionHandler, focusedPath } = settings;

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -10,15 +10,14 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
-import { Immutable } from "@foxglove/studio";
-import { SettingsTree, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
+import { Immutable, SettingsTree, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor/FieldEditor";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { usePanelStateStore } from "@foxglove/studio-base/context/PanelStateContext";
-import { getPanelTypeFromId, PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
+import { PANEL_TITLE_CONFIG_KEY, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import { NodeEditor } from "./NodeEditor";
 import { filterTreeNodes, prepareSettingsNodes } from "./utils";

--- a/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
@@ -4,8 +4,7 @@
 
 import { sortBy } from "lodash";
 
-import { Immutable } from "@foxglove/studio";
-import { SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+import { Immutable, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
 
 /**
  * Filters and sorts roots to prepare them for rendering.

--- a/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
@@ -3,16 +3,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { sortBy } from "lodash";
-import { DeepReadonly } from "ts-essentials";
 
+import { Immutable } from "@foxglove/studio";
 import { SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
 
 /**
  * Filters and sorts roots to prepare them for rendering.
  */
 export function prepareSettingsNodes(
-  roots: DeepReadonly<SettingsTreeNodes>,
-): DeepReadonly<Array<[string, SettingsTreeNode]>> {
+  roots: Immutable<SettingsTreeNodes>,
+): Immutable<Array<[string, SettingsTreeNode]>> {
   // Use sortBy here for stable sorting.
   return sortBy(
     Object.entries(roots).filter(
@@ -26,10 +26,10 @@ export function prepareSettingsNodes(
  * Recursively filter out nodes that don't match the given filter.
  */
 export function filterTreeNodes(
-  nodes: DeepReadonly<SettingsTreeNodes>,
+  nodes: Immutable<SettingsTreeNodes>,
   filter: string,
-): DeepReadonly<SettingsTreeNodes> {
-  const result: Record<string, DeepReadonly<SettingsTreeNode>> = {};
+): Immutable<SettingsTreeNodes> {
+  const result: Record<string, Immutable<SettingsTreeNode>> = {};
   Object.entries(nodes).forEach(([key, node]) => {
     if (node == undefined) {
       return;

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -14,9 +14,9 @@
 import { Square24Filled } from "@fluentui/react-icons";
 import { sortBy } from "lodash";
 import { Fragment, PropsWithChildren, useMemo } from "react";
-import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -26,7 +26,7 @@ export type TimeBasedChartTooltipData = {
   constantName?: string;
 };
 
-type Props = DeepReadonly<{
+type Props = Immutable<{
   colorsByDatasetIndex?: Record<string, undefined | string>;
   content: TimeBasedChartTooltipData[];
   labelsByDatasetIndex?: Record<string, undefined | string>;

--- a/packages/studio-base/src/components/WssErrorModal.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.tsx
@@ -7,6 +7,7 @@ import { Dialog, IconButton, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import { PlayerProblem } from "@foxglove/studio-base/players/types";
 
 import WssErrorModalScreenshot from "./WssErrorModal.png";
@@ -17,7 +18,9 @@ const useStyles = makeStyles()({
   },
 });
 
-export default function WssErrorModal(props: { playerProblems?: PlayerProblem[] }): JSX.Element {
+export default function WssErrorModal(
+  props: Immutable<{ playerProblems?: PlayerProblem[] }>,
+): JSX.Element {
   const { playerProblems } = props;
   const { classes } = useStyles();
 

--- a/packages/studio-base/src/context/EventsContext.ts
+++ b/packages/studio-base/src/context/EventsContext.ts
@@ -4,10 +4,10 @@
 
 import { createContext } from "react";
 import { AsyncState } from "react-use/lib/useAsyncFn";
-import { DeepReadonly } from "ts-essentials";
 import { StoreApi, useStore } from "zustand";
 
 import { Time } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
 /**
@@ -44,7 +44,7 @@ export type TimelinePositionedEvent = {
   secondsSinceStart: number;
 };
 
-export type EventsStore = DeepReadonly<{
+export type EventsStore = Immutable<{
   /** Used to signal event refreshes. */
   eventFetchCount: number;
 

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -3,10 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { createContext } from "react";
-import { useStore, StoreApi } from "zustand";
+import { StoreApi, useStore } from "zustand";
 
-import { Immutable } from "@foxglove/studio";
-import { RenderState, SettingsTree } from "@foxglove/studio";
+import { Immutable, RenderState, SettingsTree } from "@foxglove/studio";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
 export type ImmutableSettingsTree = Immutable<SettingsTree>;

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { createContext } from "react";
-import { DeepReadonly } from "ts-essentials";
 import { useStore, StoreApi } from "zustand";
 
+import { Immutable } from "@foxglove/studio";
 import { RenderState, SettingsTree } from "@foxglove/studio";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
-export type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
+export type ImmutableSettingsTree = Immutable<SettingsTree>;
 
 export type SharedPanelState = RenderState["sharedPanelState"];
 

--- a/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
+++ b/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
@@ -12,9 +12,9 @@
 //   You may not use this file except in compliance with the License.
 
 import { createContext, useCallback } from "react";
-import { DeepReadonly } from "ts-essentials";
 import { StoreApi, useStore } from "zustand";
 
+import { Immutable } from "@foxglove/studio";
 import { TimelinePositionedEvent } from "@foxglove/studio-base/context/EventsContext";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 import type { HoverValue } from "@foxglove/studio-base/types/hoverValue";
@@ -34,7 +34,7 @@ export type SyncBounds = {
  * The TimelineInteractionStateStore manages state related to dynamic user interactions with data in the app.
  * Things like the hovered time value and global bounds for plots are managed here.
  */
-export type TimelineInteractionStateStore = DeepReadonly<{
+export type TimelineInteractionStateStore = Immutable<{
   /** The events overlapping the current hover time, if any. */
   eventsAtHoverValue: Record<string, TimelinePositionedEvent>;
 

--- a/packages/studio-base/src/hooks/usePublisher.tsx
+++ b/packages/studio-base/src/hooks/usePublisher.tsx
@@ -14,16 +14,17 @@
 import { useCallback, useEffect, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
+import { Immutable } from "@foxglove/studio";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
-type Props = {
+type Props = Immutable<{
   topic: string;
   schemaName: string;
   datatypes: RosDatatypes;
   name: string;
-};
+}>;
 
 // Registers a publisher with the player and returns a publish() function to publish data. This uses
 // no-op functions if the player does not have the `advertise` capability

--- a/packages/studio-base/src/hooks/useTopicPublishFrequences.ts
+++ b/packages/studio-base/src/hooks/useTopicPublishFrequences.ts
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useMemo, useRef } from "react";
-import { DeepReadonly } from "ts-essentials";
 
 import { areEqual, fromMillis, Time, toSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import {
   MessagePipelineContext,
   useMessagePipeline,
@@ -82,7 +82,7 @@ const EMPTY_FREQUENCIES: FrequenciesByTopic = {};
  *
  * @property interval - the interval, in frames, between updates.
  */
-export function useTopicPublishFrequencies(): DeepReadonly<FrequenciesByTopic> {
+export function useTopicPublishFrequencies(): Immutable<FrequenciesByTopic> {
   const playerCurrentTime = useMessagePipeline(selectCurrentTime);
   const startTime = useMessagePipeline(selectStartTime);
   const endTime = useMessagePipeline(selectEndTime);

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -5,8 +5,7 @@
 import { chain } from "lodash";
 import memoizeWeak from "memoize-weak";
 
-import { Immutable } from "@foxglove/studio";
-import { SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+import { Immutable, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 
 import { Config } from "./types";

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -2,10 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
 import { chain } from "lodash";
 import memoizeWeak from "memoize-weak";
 
+import { Immutable } from "@foxglove/studio";
 import { SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 

--- a/packages/studio-base/src/panels/Image/types.ts
+++ b/packages/studio-base/src/panels/Image/types.ts
@@ -5,6 +5,7 @@
 import type { AVLTree } from "@foxglove/avl";
 import type { PinholeCameraModel } from "@foxglove/den/image";
 import type { Time } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import type { RenderState } from "@foxglove/studio";
 import type { CameraInfo, Color, ImageMarker, Point2D } from "@foxglove/studio-base/types/Messages";
 
@@ -47,7 +48,7 @@ export type ImagePanelState = UseImagePanelMessagesParams & {
   tree: AVLTree<Time, SynchronizationItem>;
 
   actions: {
-    setCurrentFrame(currentFrame: NonNullable<RenderState["currentFrame"]>): void;
+    setCurrentFrame(currentFrame: NonNullable<Immutable<RenderState["currentFrame"]>>): void;
     clear(): void;
     setParams(newParams: UseImagePanelMessagesParams): void;
   };

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -188,7 +188,7 @@ function Parameters(): ReactElement {
 
   // Don't run the animation when the Table first renders
   const skipAnimation = useRef<boolean>(true);
-  const previousParametersRef = useRef<Map<string, unknown> | undefined>(parameters);
+  const previousParametersRef = useRef<ReadonlyMap<string, unknown> | undefined>(parameters);
 
   useEffect(() => {
     const timeoutId = setTimeout(() => (skipAnimation.current = false), ANIMATION_RESET_DELAY_MS);

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.tsx
@@ -16,6 +16,7 @@ import { last, sumBy } from "lodash";
 import { ReactElement } from "react";
 
 import { subtract as subtractTimes, toSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -55,19 +56,18 @@ function PlaybackPerformanceItem(props: PlaybackPerformanceItemProps): ReactElem
   );
 }
 
-export type UnconnectedPlaybackPerformanceProps = {
-  readonly timestamp: number;
-  readonly activeData?: PlayerStateActiveData;
-};
+export type UnconnectedPlaybackPerformanceProps = Immutable<{
+  timestamp: number;
+  activeData?: PlayerStateActiveData;
+}>;
 
 // Exported for stories
 export function UnconnectedPlaybackPerformance({
   timestamp,
   activeData,
 }: UnconnectedPlaybackPerformanceProps): JSX.Element {
-  const playbackInfo = React.useRef<
-    { timestamp: number; activeData: PlayerStateActiveData } | undefined
-  >();
+  const playbackInfo =
+    React.useRef<Immutable<{ timestamp: number; activeData: PlayerStateActiveData } | undefined>>();
   const lastPlaybackInfo = playbackInfo.current;
   if (activeData && (!playbackInfo.current || playbackInfo.current.activeData !== activeData)) {
     playbackInfo.current = { timestamp, activeData };

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
-
 import { filterMap } from "@foxglove/den/collection";
 import { isTime, subtract, Time, toSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import { format } from "@foxglove/studio-base/util/formatTime";
 import { darkColor, getLineColor, lightColor } from "@foxglove/studio-base/util/plotColors";
 import { formatTimeRaw, TimestampMethod } from "@foxglove/studio-base/util/time";

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -2,12 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable as Im } from "immer";
 import { assignWith, last, isEmpty } from "lodash";
 import memoizeWeak from "memoize-weak";
 
 import { filterMap } from "@foxglove/den/collection";
 import { Time, isLessThan, isGreaterThan, compare as compareTimes } from "@foxglove/rostime";
+import { Immutable as Im } from "@foxglove/studio";
 import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksByTopic";
 import { MessageDataItemsByPath } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { PlotDataByPath, PlotDataItem } from "@foxglove/studio-base/panels/Plot/internalTypes";

--- a/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
@@ -2,11 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
 import { groupBy, isEmpty, pick } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { isLessThan, isTimeInRangeInclusive, subtract } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import { useBlocksByTopic, useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import parseRosPath, {
   getTopicsFromPaths,

--- a/packages/studio-base/src/panels/Publish/buildSampleMessage.ts
+++ b/packages/studio-base/src/panels/Publish/buildSampleMessage.ts
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Immutable } from "@foxglove/studio";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 export const builtinSampleValues: Record<string, unknown> = {
@@ -31,7 +32,7 @@ export const builtinSampleValues: Record<string, unknown> = {
 };
 
 export default function buildSampleMessage(
-  datatypes: RosDatatypes,
+  datatypes: Immutable<RosDatatypes>,
   datatype: string,
 ): unknown | undefined {
   const builtin = builtinSampleValues[datatype];

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -30,9 +30,9 @@ import { first, isEqual, get, last, padStart } from "lodash";
 import { useState, useCallback, useMemo, useEffect } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
-import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import useGetItemStringWithTimezone from "@foxglove/studio-base/components/JsonTree/useGetItemStringWithTimezone";
@@ -80,7 +80,7 @@ export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";
 
 type Props = {
-  config: DeepReadonly<RawMessagesPanelConfig>;
+  config: Immutable<RawMessagesPanelConfig>;
   saveConfig: SaveConfig<RawMessagesPanelConfig>;
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -3,15 +3,21 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import EventEmitter from "eventemitter3";
-import { Immutable } from "immer";
 import * as THREE from "three";
 
-import { MessageEvent, ParameterValue, SettingsIcon, Topic, VariableValue } from "@foxglove/studio";
+import {
+  Immutable,
+  MessageEvent,
+  ParameterValue,
+  SettingsIcon,
+  Topic,
+  VariableValue,
+} from "@foxglove/studio";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";
 import { LabelPool } from "@foxglove/three-text";
 
 import { Input } from "./Input";
-import { ModelCache, MeshUpAxis } from "./ModelCache";
+import { MeshUpAxis, ModelCache } from "./ModelCache";
 import { PickedRenderable } from "./Picker";
 import { SceneExtension } from "./SceneExtension";
 import { SettingsManager } from "./SettingsManager";
@@ -290,9 +296,9 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
    * of the topics list changes */
   setTopics(topics: ReadonlyArray<Topic> | undefined): void;
 
-  setParameters(parameters: ReadonlyMap<string, ParameterValue> | undefined): void;
+  setParameters(parameters: Immutable<Map<string, ParameterValue>> | undefined): void;
 
-  setVariables(variables: ReadonlyMap<string, VariableValue>): void;
+  setVariables(variables: Immutable<Map<string, VariableValue>>): void;
 
   updateCustomLayersCount(): void;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -4,7 +4,7 @@
 
 import EventEmitter from "eventemitter3";
 import i18next from "i18next";
-import { Immutable, produce } from "immer";
+import { produce } from "immer";
 import * as THREE from "three";
 import { DeepPartial, assert } from "ts-essentials";
 import { v4 as uuidv4 } from "uuid";
@@ -13,6 +13,7 @@ import Logger from "@foxglove/log";
 import { Time, fromNanoSec, isLessThan, toNanoSec } from "@foxglove/rostime";
 import type { FrameTransform, FrameTransforms, SceneUpdate } from "@foxglove/schemas";
 import {
+  Immutable,
   MessageEvent,
   ParameterValue,
   SettingsIcon,
@@ -24,7 +25,7 @@ import {
 } from "@foxglove/studio";
 import { FoxgloveGrid } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/FoxgloveGrid";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";
-import { light, dark } from "@foxglove/studio-base/theme/palette";
+import { dark, light } from "@foxglove/studio-base/theme/palette";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { LabelMaterial, LabelPool } from "@foxglove/three-text";
 
@@ -38,7 +39,7 @@ import {
 } from "./IRenderer";
 import { Input } from "./Input";
 import { LineMaterial } from "./LineMaterial";
-import { ModelCache, DEFAULT_MESH_UP_AXIS } from "./ModelCache";
+import { DEFAULT_MESH_UP_AXIS, ModelCache } from "./ModelCache";
 import { PickedRenderable, Picker } from "./Picker";
 import type { Renderable } from "./Renderable";
 import { SceneExtension } from "./SceneExtension";
@@ -82,8 +83,8 @@ import {
   Quaternion,
   TFMessage,
   TF_DATATYPES,
-  TransformStamped,
   TRANSFORM_STAMPED_DATATYPES,
+  TransformStamped,
   Vector3,
 } from "./ros";
 import { SelectEntry } from "./settings";

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -6,13 +6,13 @@ import { cloneDeep, isEqual, merge } from "lodash";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { useLatest } from "react-use";
-import { DeepPartial, DeepReadonly } from "ts-essentials";
+import { DeepPartial } from "ts-essentials";
 import { useDebouncedCallback } from "use-debounce";
 
 import Logger from "@foxglove/log";
 import { Time, toNanoSec } from "@foxglove/rostime";
-import { Immutable } from "@foxglove/studio";
 import {
+  Immutable,
   LayoutActions,
   MessageEvent,
   PanelExtensionContext,
@@ -28,12 +28,12 @@ import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import type {
-  RendererConfig,
-  RendererSubscription,
   FollowMode,
-  RendererEvents,
   IRenderer,
   ImageModeConfig,
+  RendererConfig,
+  RendererEvents,
+  RendererSubscription,
 } from "./IRenderer";
 import type { PickedRenderable } from "./Picker";
 import { SELECTED_ID_VARIABLE } from "./Renderable";
@@ -42,11 +42,11 @@ import { RendererContext, useRendererEvent } from "./RendererContext";
 import { RendererOverlay } from "./RendererOverlay";
 import { CameraState, DEFAULT_CAMERA_STATE } from "./camera";
 import {
+  PublishRos1Datatypes,
+  PublishRos2Datatypes,
   makePointMessage,
   makePoseEstimateMessage,
   makePoseMessage,
-  PublishRos1Datatypes,
-  PublishRos2Datatypes,
 } from "./publish";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent } from "./renderables/PublishClickTool";

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -2,16 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Immutable } from "immer";
 import { cloneDeep, isEqual, merge } from "lodash";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { useLatest } from "react-use";
-import { DeepPartial } from "ts-essentials";
+import { DeepPartial, DeepReadonly } from "ts-essentials";
 import { useDebouncedCallback } from "use-debounce";
 
 import Logger from "@foxglove/log";
 import { Time, toNanoSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import {
   LayoutActions,
   MessageEvent,
@@ -160,8 +160,10 @@ export function ThreeDeeRender(props: {
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
   const [timezone, setTimezone] = useState<string | undefined>();
   const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();
-  const [parameters, setParameters] = useState<ReadonlyMap<string, ParameterValue> | undefined>();
-  const [variables, setVariables] = useState<ReadonlyMap<string, VariableValue> | undefined>();
+  const [parameters, setParameters] = useState<
+    Immutable<Map<string, ParameterValue>> | undefined
+  >();
+  const [variables, setVariables] = useState<Immutable<Map<string, VariableValue>> | undefined>();
   const [currentFrameMessages, setCurrentFrameMessages] = useState<
     ReadonlyArray<MessageEvent> | undefined
   >();
@@ -313,7 +315,7 @@ export function ThreeDeeRender(props: {
 
   // Establish a connection to the message pipeline with context.watch and context.onRender
   useLayoutEffect(() => {
-    context.onRender = (renderState: RenderState, done) => {
+    context.onRender = (renderState: Immutable<RenderState>, done) => {
       ReactDOM.unstable_batchedUpdates(() => {
         if (renderState.currentTime) {
           setCurrentTime(renderState.currentTime);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -8,8 +8,12 @@ import { Line2 } from "three/examples/jsm/lines/Line2";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 
-import { Immutable } from "@foxglove/studio";
-import { SettingsTreeAction, SettingsTreeChildren, SettingsTreeFields } from "@foxglove/studio";
+import {
+  Immutable,
+  SettingsTreeAction,
+  SettingsTreeChildren,
+  SettingsTreeFields,
+} from "@foxglove/studio";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 import { Label } from "@foxglove/three-text";
 
@@ -22,7 +26,7 @@ import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { getLuminance, stringToRgb } from "../color";
 import { BaseSettings, fieldSize, PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
-import { Duration, Transform, makePose, CoordinateFrame, MAX_DURATION } from "../transforms";
+import { CoordinateFrame, Duration, makePose, MAX_DURATION, Transform } from "../transforms";
 
 export type LayerSettingsTransform = BaseSettings & {
   xyzOffset: Readonly<[number | undefined, number | undefined, number | undefined]>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { t } from "i18next";
-import { Immutable } from "immer";
 import * as THREE from "three";
 import { Line2 } from "three/examples/jsm/lines/Line2";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 
+import { Immutable } from "@foxglove/studio";
 import { SettingsTreeAction, SettingsTreeChildren, SettingsTreeFields } from "@foxglove/studio";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 import { Label } from "@foxglove/three-text";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -8,8 +8,7 @@ import * as THREE from "three";
 import { TwoKeyMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas";
-import { Immutable } from "@foxglove/studio";
-import { MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
+import { Immutable, MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
 import { normalizeAnnotations } from "@foxglove/studio-base/panels/Image/lib/normalizeAnnotations";
 import {
   ImageMarker as RosImageMarker,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { t } from "i18next";
-import { Immutable } from "immer";
 import * as THREE from "three";
 
 import { TwoKeyMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas";
+import { Immutable } from "@foxglove/studio";
 import { MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
 import { normalizeAnnotations } from "@foxglove/studio-base/panels/Image/lib/normalizeAnnotations";
 import {

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -162,7 +162,7 @@ const topicVisibilityToLabelMap: Record<TopicVisibility, string> = {
   "disconnected-sub": "Disconnected subscribed topics",
 };
 
-function unionInto<T>(dest: Set<T>, ...iterables: Set<T>[]): void {
+function unionInto<T>(dest: Set<T>, ...iterables: ReadonlySet<T>[]): void {
   for (const iterable of iterables) {
     for (const item of iterable) {
       dest.add(item);

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -11,10 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Immutable } from "@foxglove/studio";
 import { MessageDefinition } from "@foxglove/message-definition";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
+import { Immutable } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { Range } from "@foxglove/studio-base/util/ranges";

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -11,8 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { DeepReadonly } from "ts-essentials";
-
+import { Immutable } from "@foxglove/studio";
 import { MessageDefinition } from "@foxglove/message-definition";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
@@ -46,7 +45,7 @@ export interface Player {
   close(): void;
   // Set a new set of subscriptions/advertisers. This might trigger fetching
   // new data, which might in turn trigger a backfill of messages.
-  setSubscriptions(subscriptions: SubscribePayload[]): void;
+  setSubscriptions(subscriptions: Immutable<SubscribePayload[]>): void;
   setPublishers(publishers: AdvertiseOptions[]): void;
   // Modify a remote parameter such as a rosparam.
   setParameter(key: string, value: ParameterValue): void;
@@ -86,7 +85,7 @@ export type PlayerProblem = {
   tip?: string;
 };
 
-export type PlayerURLState = DeepReadonly<{
+export type PlayerURLState = Immutable<{
   sourceId: string;
   parameters?: Record<string, string>;
 }>;

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -5,9 +5,9 @@
 import { pick, uniq } from "lodash";
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
 import { createSelector, createSelectorCreator, defaultMemoize } from "reselect";
-import { Immutable } from "@foxglove/studio";
 import { StoreApi, createStore } from "zustand";
 
+import { Immutable } from "@foxglove/studio";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import {
   LayoutState,

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -5,7 +5,7 @@
 import { pick, uniq } from "lodash";
 import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
 import { createSelector, createSelectorCreator, defaultMemoize } from "reselect";
-import { DeepReadonly } from "ts-essentials";
+import { Immutable } from "@foxglove/studio";
 import { StoreApi, createStore } from "zustand";
 
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
@@ -102,8 +102,8 @@ const updateDefaultTitleSelector = (store: PanelStateStore) => store.updateDefau
  * panel state.
  */
 export function useSharedPanelState(): [
-  DeepReadonly<SharedPanelState>,
-  (data: DeepReadonly<SharedPanelState>) => void,
+  Immutable<SharedPanelState>,
+  (data: Immutable<SharedPanelState>) => void,
 ] {
   const panelId = usePanelContext().id;
   const panelType = useMemo(() => getPanelTypeFromId(panelId), [panelId]);
@@ -118,7 +118,7 @@ export function useSharedPanelState(): [
   const updateSharedData = usePanelStateStore(updateSharedDataSelector);
   const sharedData = usePanelStateStore(selector);
   const update = useCallback(
-    (data: DeepReadonly<SharedPanelState>) => {
+    (data: Immutable<SharedPanelState>) => {
       updateSharedData(panelType, data);
     },
     [panelType, updateSharedData],

--- a/packages/studio-base/src/util/selectors.ts
+++ b/packages/studio-base/src/util/selectors.ts
@@ -14,6 +14,7 @@
 import { keyBy } from "lodash";
 import { createSelector } from "reselect";
 
+import { Immutable } from "@foxglove/studio";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -30,9 +31,9 @@ export const getTopicsByTopicName = createSelector(
 
 // Only exported for tests
 export const constantsByDatatype = createSelector(
-  (datatypes: RosDatatypes) => datatypes,
+  (datatypes: Immutable<RosDatatypes>) => datatypes,
   (
-    datatypes: RosDatatypes,
+    datatypes,
   ): {
     [key: string]: {
       [key: string]: string;
@@ -72,9 +73,9 @@ export function extractTypeFromStudioEnumAnnotation(name: string): string | unde
 
 // returns a map of the form {datatype -> {field -> {value -> name}}}
 export const enumValuesByDatatypeAndField = createSelector(
-  (datatypes: RosDatatypes) => datatypes,
+  (datatypes: Immutable<RosDatatypes>) => datatypes,
   (
-    datatypes: RosDatatypes,
+    datatypes: Immutable<RosDatatypes>,
   ): { [datatype: string]: { [field: string]: { [value: string]: string } } } => {
     const results: { [datatype: string]: { [field: string]: { [value: string]: string } } } = {};
     for (const [datatype, value] of datatypes) {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -19,6 +19,7 @@
     "prepack": "tsc -b tsconfig.json"
   },
   "devDependencies": {
+    "ts-essentials": "9.3.2",
     "typescript": "5.0.4"
   }
 }

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -88,7 +88,7 @@ export type Subscription = {
 /**
  * A message event frames message data with the topic and receive time
  */
-export type MessageEvent<T = unknown> = Readonly<{
+export type MessageEvent<T = unknown> = {
   /** The topic name this message was received on, i.e. "/some/topic" */
   topic: string;
   /**
@@ -103,14 +103,14 @@ export type MessageEvent<T = unknown> = Readonly<{
    * relative to another event such as system boot time or simulation start
    * time depending on the context.
    */
-  receiveTime: Readonly<Time>;
+  receiveTime: Time;
   /**
    * The time in nanoseconds this message was originally published. This is
    * only available for some data sources. The timestamp is often nanoseconds
    * since the UNIX epoch, but may be relative to another event such as system
    * boot time or simulation start time depending on the context.
    */
-  publishTime?: Readonly<Time>;
+  publishTime?: Time;
   /** The deserialized message as a JavaScript object. */
   message: T;
   /**
@@ -125,7 +125,7 @@ export type MessageEvent<T = unknown> = Readonly<{
    * un-converted message event.
    */
   originalMessageEvent?: MessageEvent;
-}>;
+};
 
 export interface LayoutActions {
   /** Open a new panel or update an existing panel in the layout.  */

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -2,6 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import type { DeepReadonly as Immutable } from "ts-essentials";
+
+export type { DeepReadonly as Immutable } from "ts-essentials";
+
 // Valid types for parameter data (such as rosparams)
 export type ParameterValue =
   | undefined
@@ -99,14 +103,14 @@ export type MessageEvent<T = unknown> = Readonly<{
    * relative to another event such as system boot time or simulation start
    * time depending on the context.
    */
-  receiveTime: Time;
+  receiveTime: Readonly<Time>;
   /**
    * The time in nanoseconds this message was originally published. This is
    * only available for some data sources. The timestamp is often nanoseconds
    * since the UNIX epoch, but may be relative to another event such as system
    * boot time or simulation start time depending on the context.
    */
-  publishTime?: Time;
+  publishTime?: Readonly<Time>;
   /** The deserialized message as a JavaScript object. */
   message: T;
   /**
@@ -155,11 +159,11 @@ export interface LayoutActions {
   }): void;
 }
 
-export interface RenderState {
+export type RenderState = {
   /**
    * The latest messages for the current render frame. These are new messages since the last render frame.
    */
-  currentFrame?: readonly MessageEvent[];
+  currentFrame?: MessageEvent[];
 
   /**
    * True if the data source performed a seek. This indicates that some data may have been skipped
@@ -171,32 +175,32 @@ export interface RenderState {
   /**
    * All available messages. Best-effort list of all available messages.
    */
-  allFrames?: readonly MessageEvent[];
+  allFrames?: MessageEvent[];
 
   /**
    * Map of current parameter values. Parameters are key/value pairs associated with the data
    * source, and may not be available for all data sources. For example, ROS 1 live connections
    * support parameters through the Parameter Server <http://wiki.ros.org/Parameter%20Server>.
    */
-  parameters?: ReadonlyMap<string, ParameterValue>;
+  parameters?: Map<string, ParameterValue>;
 
   /**
    * Transient panel state shared between panels of the same type. This can be any data a
    * panel author wishes to share between panels.
    */
-  sharedPanelState?: Readonly<Record<string, unknown>>;
+  sharedPanelState?: Record<string, unknown>;
 
   /**
    * Map of current Studio variables. Variables are key/value pairs that are globally accessible
    * to panels and scripts in the current layout. See
    * <https://foxglove.dev/docs/studio/app-concepts/variables> for more information.
    */
-  variables?: ReadonlyMap<string, VariableValue>;
+  variables?: Map<string, VariableValue>;
 
   /**
    * List of available topics. This list includes subscribed and unsubscribed topics.
    */
-  topics?: readonly Topic[];
+  topics?: Topic[];
 
   /**
    * A timestamp value indicating the current playback time.
@@ -231,8 +235,8 @@ export interface RenderState {
   colorScheme?: "dark" | "light";
 
   /** Application settings. This will only contain subscribed application setting key/values */
-  appSettings?: ReadonlyMap<string, AppSettingValue>;
-}
+  appSettings?: Map<string, AppSettingValue>;
+};
 
 export type PanelExtensionContext = {
   /**
@@ -374,13 +378,13 @@ export type PanelExtensionContext = {
    *
    * The done callback should be called once the panel has rendered the render state.
    */
-  onRender?: (renderState: Readonly<RenderState>, done: () => void) => void;
+  onRender?: (renderState: Immutable<RenderState>, done: () => void) => void;
 
   /**
    * Updates the panel's settings editor. Call this every time you want to update
    * the representation of the panel settings in the editor.
    */
-  updatePanelSettingsEditor(settings: Readonly<SettingsTree>): void;
+  updatePanelSettingsEditor(settings: Immutable<SettingsTree>): void;
 
   /**
    * Updates the panel's default title. Users can always override the default title by editing it

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,6 +2741,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/studio@workspace:packages/studio"
   dependencies:
+    ts-essentials: 9.3.2
     typescript: 5.0.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Expose an Immutable type in @foxglove/studio and mark the message pipeline context and RenderState data as immutable. The implementation here uses the DeepReadonly type from the `ts-essentials` package and re-exposes it as `Immutable` but we could also just copy over the typedefs if we prefer not to have the dependency.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
