### PR TITLE
Support multiple message converters on the same topic

### DIFF
--- a/packages/den/records/index.ts
+++ b/packages/den/records/index.ts
@@ -3,3 +3,4 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export * from "./pickFields";
+export * from "./recordEntries";

--- a/packages/den/records/recordEntries.ts
+++ b/packages/den/records/recordEntries.ts
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+/**
+ * Version of Object.entries that retains typings of keys & values.
+ */
+export function recordEntries<K extends number | string | symbol, V, T extends Record<K, V>>(
+  obj: T,
+): Entries<T> {
+  return Object.entries(obj) as Entries<T>;
+}

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -159,7 +159,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       if (sortedTopics !== prevSortedTopics || prevMessageConverters !== messageConverters) {
         shouldRender = true;
 
-        const topics = sortedTopics.map<Topic>((topic) => {
+        const topics = sortedTopics.map((topic) => {
           const newTopic: Topic = {
             name: topic.name,
             datatype: topic.schemaName ?? "",

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -16,25 +16,26 @@ import {
   VariableValue,
 } from "@foxglove/studio";
 import { BuiltinPanelExtensionContext } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";
 import { LabelPool } from "@foxglove/three-text";
 
 import { Input } from "./Input";
-import { MeshUpAxis, ModelCache } from "./ModelCache";
+import { ModelCache } from "./ModelCache";
 import { PickedRenderable } from "./Picker";
 import { SceneExtension } from "./SceneExtension";
 import { SettingsManager } from "./SettingsManager";
 import { SharedGeometry } from "./SharedGeometry";
 import { CameraState } from "./camera";
+import { RendererConfig } from "./config";
 import { DetailLevel } from "./lod";
-import { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { DownloadImageInfo } from "./renderables/Images/ImageTypes";
 import { MeasurementTool } from "./renderables/MeasurementTool";
-import { PublishClickTool, PublishClickType } from "./renderables/PublishClickTool";
+import { PublishClickTool } from "./renderables/PublishClickTool";
 import { ColorModeSettings } from "./renderables/colorMode";
 import { MarkerPool } from "./renderables/markers/MarkerPool";
 import { Quaternion, Vector3 } from "./ros";
-import { BaseSettings, CustomLayerSettings, SelectEntry } from "./settings";
+import { SelectEntry } from "./settings";
 import { TransformTree } from "./transforms";
 import { InterfaceMode } from "./types";
 
@@ -75,8 +76,8 @@ export type ImageModeConfig = Partial<ColorModeSettings> & {
   imageTopic?: string;
   /** Topic containing CameraCalibration or CameraInfo */
   calibrationTopic?: string;
-  /** Annotation topicName -> settings, analogous to {@link RendererConfig.topics} */
-  annotations?: Record<string, Partial<ImageAnnotationSettings> | undefined>;
+  /** Annotation topic settings, analogous to {@link RendererConfig.namespacedTopics} */
+  annotations?: Record<NamespacedTopic, undefined | Partial<ImageAnnotationSettings>>;
   synchronize?: boolean;
   /** Rotation */
   rotation?: 0 | 90 | 180 | 270;
@@ -86,71 +87,6 @@ export type ImageModeConfig = Partial<ColorModeSettings> & {
   minValue?: number;
   /** Maximum (white) value for single-channel images */
   maxValue?: number;
-};
-
-export type RendererConfig = {
-  /** Camera settings for the currently rendering scene */
-  cameraState: CameraState;
-  /** Coordinate frameId of the rendering frame */
-  followTf: string | undefined;
-  /** Camera follow mode */
-  followMode: FollowMode;
-  scene: {
-    /** Show rendering metrics in a DOM overlay */
-    enableStats?: boolean;
-    /** Background color override for the scene, sent to `glClearColor()` */
-    backgroundColor?: string;
-    /* Scale factor to apply to all labels */
-    labelScaleFactor?: number;
-    /** Ignore the <up_axis> tag in COLLADA files (matching rviz behavior) */
-    ignoreColladaUpAxis?: boolean;
-    meshUpAxis?: MeshUpAxis;
-    transforms?: {
-      /** Toggles translation and rotation offset controls for frames */
-      editable?: boolean;
-      /** Toggles visibility of frame axis labels */
-      showLabel?: boolean;
-      /** Size of frame axis labels */
-      labelSize?: number;
-      /** Size of coordinate frame axes */
-      axisScale?: number;
-      /** Width of the connecting line between child and parent frames */
-      lineWidth?: number;
-      /** Color of the connecting line between child and parent frames */
-      lineColor?: string;
-      /** Enable transform preloading */
-      enablePreloading?: boolean;
-    };
-    /** Sync camera with other 3d panels */
-    syncCamera?: boolean;
-    /** Toggles visibility of all topics */
-    topicsVisible?: boolean;
-  };
-  publish: {
-    /** The type of message to publish when clicking in the scene */
-    type: PublishClickType;
-    /** The topic on which to publish poses */
-    poseTopic: string;
-    /** The topic on which to publish points */
-    pointTopic: string;
-    /** The topic on which to publish pose estimates */
-    poseEstimateTopic: string;
-    /** The X standard deviation to publish with poses */
-    poseEstimateXDeviation: number;
-    /** The Y standard deviation to publish with poses */
-    poseEstimateYDeviation: number;
-    /** The theta standard deviation to publish with poses */
-    poseEstimateThetaDeviation: number;
-  };
-  /** frameId -> settings */
-  transforms: Record<string, Partial<LayerSettingsTransform> | undefined>;
-  /** topicName -> settings */
-  topics: Record<string, Partial<BaseSettings> | undefined>;
-  /** instanceId -> settings */
-  layers: Record<string, Partial<CustomLayerSettings> | undefined>;
-
-  /** Settings pertaining to Image mode */
-  imageMode: ImageModeConfig;
 };
 
 export type RendererSubscription<T = unknown> = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/LayerErrors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/LayerErrors.ts
@@ -8,7 +8,7 @@ import Logger from "@foxglove/log";
 
 export type Path = ReadonlyArray<string>;
 
-const TOPIC_PATH: [string, string] = ["topics", ""];
+const TOPIC_PATH: [string, string] = ["namespacedTopics", ""];
 
 export class NodeError {
   public path: Path;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
@@ -4,9 +4,11 @@
 
 import * as THREE from "three";
 
+import { SettingsPath } from "@foxglove/studio-base/panels/ThreeDeeRender/SettingsManager";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import type { IRenderer } from "./IRenderer";
+import { NamespacedTopic } from "./namespaceTopic";
 import type { BaseSettings } from "./settings";
 import type { Pose } from "./transforms";
 
@@ -22,11 +24,11 @@ export type BaseUserData = {
   /** Local position and orientation of the Renderable */
   pose: Pose;
   /** Settings tree path where errors will be displayed */
-  settingsPath: ReadonlyArray<string>;
+  settingsPath: [] | SettingsPath;
   /** User-customizable settings for this Renderable */
   settings: BaseSettings;
   /** Topic that the Renderable belongs to, if applicable*/
-  topic?: string;
+  topic?: NamespacedTopic;
 };
 
 /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -15,7 +15,7 @@ import { CameraStateSettings } from "@foxglove/studio-base/panels/ThreeDeeRender
 import { DEFAULT_PUBLISH_SETTINGS } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/PublishSettings";
 import { TFMessage } from "@foxglove/studio-base/panels/ThreeDeeRender/ros";
 
-import { RendererConfig } from "./IRenderer";
+import { RendererConfig } from "./config";
 
 // Jest doesn't support ES module imports fully yet, so we need to mock the wasm file
 jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
@@ -72,12 +72,14 @@ const defaultRendererConfig: RendererConfig = {
   cameraState: DEFAULT_CAMERA_STATE,
   followMode: "follow-pose",
   followTf: undefined,
-  scene: {},
-  transforms: {},
-  topics: {},
-  layers: {},
-  publish: DEFAULT_PUBLISH_SETTINGS,
   imageMode: {},
+  layers: {},
+  namespacedTopics: {},
+  publish: DEFAULT_PUBLISH_SETTINGS,
+  scene: {},
+  topics: {},
+  transforms: {},
+  version: "2",
 };
 
 const makeTf = () => ({

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -39,7 +39,6 @@ import { LabelMaterial, LabelPool } from "@foxglove/three-text";
 import {
   IRenderer,
   InstancedLineMaterial,
-  RendererConfig,
   RendererEvents,
   RendererSubscription,
 } from "./IRenderer";
@@ -53,6 +52,7 @@ import { SettingsManager, SettingsTreeEntry } from "./SettingsManager";
 import { SharedGeometry } from "./SharedGeometry";
 import { CameraState } from "./camera";
 import { DARK_OUTLINE, LIGHT_OUTLINE, stringToRgb } from "./color";
+import { RendererConfig } from "./config";
 import { FRAME_TRANSFORMS_DATATYPES, FRAME_TRANSFORM_DATATYPES } from "./foxglove";
 import { DetailLevel, msaaSamples } from "./lod";
 import {
@@ -679,7 +679,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   /** Adds errors to visible topic nodes when calibration is undefined */
   #imageOnlyModeTopicSettingsValidator = (entry: SettingsTreeEntry, errors: LayerErrors) => {
     const { path, node } = entry;
-    if (path[0] === "topics") {
+    if (path[0] === "namespacedTopics") {
       if (node.visible === true) {
         errors.addToTopic(
           path[1]!,
@@ -722,7 +722,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   #getTopicsSettingsEntry(): SettingsTreeEntry {
     // "Topics" settings tree node
     const topics: SettingsTreeEntry = {
-      path: ["topics"],
+      path: ["namespacedTopics"],
       node: {
         enableVisibilityFilter: true,
         label: i18next.t("threeDee:topics"),
@@ -731,7 +731,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
           { id: "show-all", type: "action", label: i18next.t("threeDee:showAll") },
           { id: "hide-all", type: "action", label: i18next.t("threeDee:hideAll") },
         ],
-        children: this.settings.tree()["topics"]?.children,
+        children: this.settings.tree()["namespacedTopics"]?.children,
         handler: this.#handleTopicsAction,
       },
     };
@@ -1176,7 +1176,11 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   #handleTopicsAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
-    if (action.action !== "perform-node-action" || path.length !== 1 || path[0] !== "topics") {
+    if (
+      action.action !== "perform-node-action" ||
+      path.length !== 1 ||
+      path[0] !== "namespacedTopics"
+    ) {
       return;
     }
     log.debug(`handleTopicsAction(${action.payload.id})`);
@@ -1185,7 +1189,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     const toggleTopicVisibility = (value: boolean) => {
       for (const extension of this.sceneExtensions.values()) {
         for (const node of extension.settingsNodes()) {
-          if (node.path[0] === "topics") {
+          if (node.path[0] === "namespacedTopics") {
             extension.handleSettingsAction({
               action: "update",
               payload: { path: [...node.path, "visible"], input: "boolean", value },
@@ -1413,7 +1417,7 @@ function baseSettingsTree(interfaceMode: InterfaceMode): SettingsTreeNodes {
   if (interfaceMode === "3d") {
     keys.push("cameraState");
   }
-  keys.push("transforms", "topics", "layers");
+  keys.push("transforms", "namespacedTopics", "layers");
   if (interfaceMode === "3d") {
     keys.push("publish");
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/RendererOverlay.tsx
@@ -30,6 +30,7 @@ import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon"
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMousePresence";
+import { unnamespacetopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { downloadFiles } from "@foxglove/studio-base/util/download";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -179,7 +180,9 @@ export function RendererOverlay(props: {
             object: {
               pose: selectedRenderable.renderable.pose,
               interactionData: {
-                topic: selectedRenderable.renderable.topic,
+                topic: selectedRenderable.renderable.topic
+                  ? unnamespacetopic(selectedRenderable.renderable.topic)
+                  : undefined,
                 highlighted: true,
                 originalMessage: selectedRenderable.renderable.details(),
                 instanceDetails:

--- a/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
@@ -7,12 +7,13 @@ import * as THREE from "three";
 import { DeepPartial, Writable } from "ts-essentials";
 
 import { DraggedMessagePath, MessageEvent, SettingsTreeAction } from "@foxglove/studio";
+import { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/config";
 
-import type { AnyRendererSubscription, IRenderer, RendererConfig } from "./IRenderer";
+import type { AnyRendererSubscription, IRenderer } from "./IRenderer";
 import { Path } from "./LayerErrors";
 import { Renderable } from "./Renderable";
 import type { SettingsTreeEntry } from "./SettingsManager";
-import { missingTransformMessage, MISSING_TRANSFORM } from "./renderables/transforms";
+import { MISSING_TRANSFORM, missingTransformMessage } from "./renderables/transforms";
 import { AnyFrameId } from "./transforms";
 import { updatePose } from "./updatePose";
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/SettingsManager.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SettingsManager.ts
@@ -6,6 +6,7 @@ import EventEmitter from "eventemitter3";
 import { produce } from "immer";
 
 import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { LayerErrors, Path } from "./LayerErrors";
 
@@ -13,7 +14,23 @@ export type ActionHandler = (action: SettingsTreeAction) => void;
 
 export type SettingsTreeNodeWithActionHandler = SettingsTreeNode & { handler?: ActionHandler };
 
-export type SettingsTreeEntry = { path: Path; node: SettingsTreeNodeWithActionHandler };
+export type SettingsPath =
+  | ["cameraState"]
+  | ["general"]
+  | ["imageAnnotations"]
+  | ["imageAnnotations", NamespacedTopic]
+  | ["imageMode"]
+  | ["imageMode", "imageTopic"]
+  | ["layers"]
+  | ["layers", string]
+  | ["namespacedTopics"]
+  | ["namespacedTopics", NamespacedTopic]
+  | ["publish"]
+  | ["scene"]
+  | ["transforms"]
+  | ["transforms", string];
+
+export type SettingsTreeEntry = { path: SettingsPath; node: SettingsTreeNodeWithActionHandler };
 
 export type SettingsManagerEvents = {
   update: () => void;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -28,22 +28,18 @@ import {
   DEFAULT_SCENE_EXTENSION_CONFIG,
   SceneExtensionConfig,
 } from "@foxglove/studio-base/panels/ThreeDeeRender/SceneExtensionConfig";
+import { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/config";
+import { useMigratedThreeDeeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/useMigratedThreeDeeConfig";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
-import type {
-  FollowMode,
-  IRenderer,
-  ImageModeConfig,
-  RendererConfig,
-  RendererEvents,
-  RendererSubscription,
-} from "./IRenderer";
+import type { FollowMode, IRenderer, RendererEvents, RendererSubscription } from "./IRenderer";
 import type { PickedRenderable } from "./Picker";
 import { SELECTED_ID_VARIABLE } from "./Renderable";
 import { Renderer } from "./Renderer";
 import { RendererContext, useRendererEvent } from "./RendererContext";
 import { RendererOverlay } from "./RendererOverlay";
-import { CameraState, DEFAULT_CAMERA_STATE } from "./camera";
+import { CameraState } from "./camera";
+import { namespaceTopic } from "./namespaceTopic";
 import {
   PublishRos1Datatypes,
   PublishRos2Datatypes,
@@ -51,9 +47,7 @@ import {
   makePoseEstimateMessage,
   makePoseMessage,
 } from "./publish";
-import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent } from "./renderables/PublishClickTool";
-import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/PublishSettings";
 import { InterfaceMode } from "./types";
 
 const log = Logger.getLogger(__filename);
@@ -96,7 +90,7 @@ function useRendererProperty<K extends keyof IRenderer>(
 }
 
 /**
- * A panel that renders a 3D scene. This is a thin wrapper around a `Renderer` instance.
+ * A panel that renders a 3D scene. This is a wrapper around a `Renderer` instance.
  */
 export function ThreeDeeRender(props: {
   context: BuiltinPanelExtensionContext;
@@ -111,36 +105,13 @@ export function ThreeDeeRender(props: {
   const { context, interfaceMode, onDownloadImage, debugPicking, customSceneExtensions } = props;
   const { initialState, saveState, unstable_fetchAsset: fetchAsset } = context;
 
-  // Load and save the persisted panel configuration
-  const [config, setConfig] = useState<Immutable<RendererConfig>>(() => {
-    const partialConfig = initialState as DeepPartial<RendererConfig> | undefined;
+  const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();
 
-    // Initialize the camera from default settings overlaid with persisted settings
-    const cameraState: CameraState = _.merge(
-      _.cloneDeep(DEFAULT_CAMERA_STATE),
-      partialConfig?.cameraState,
-    );
-    const publish = _.merge(_.cloneDeep(DEFAULT_PUBLISH_SETTINGS), partialConfig?.publish);
+  const [config, setConfig] = useMigratedThreeDeeConfig(
+    initialState as undefined | Record<string, unknown>,
+    topics,
+  );
 
-    const transforms = (partialConfig?.transforms ?? {}) as Record<
-      string,
-      Partial<LayerSettingsTransform>
-    >;
-
-    return {
-      cameraState,
-      followMode: partialConfig?.followMode ?? "follow-pose",
-      followTf: partialConfig?.followTf,
-      scene: partialConfig?.scene ?? {},
-      transforms,
-      topics: partialConfig?.topics ?? {},
-      layers: partialConfig?.layers ?? {},
-      publish,
-      // deep partial on config, makes gradient tuple type [string | undefined, string | undefined]
-      // which is incompatible with `Partial<ColorModeSettings>`
-      imageMode: (partialConfig?.imageMode ?? {}) as Partial<ImageModeConfig>,
-    };
-  });
   const configRef = useLatest(config);
   const { cameraState } = config;
   const backgroundColor = config.scene.backgroundColor;
@@ -192,7 +163,6 @@ export function ThreeDeeRender(props: {
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
   const [timezone, setTimezone] = useState<string | undefined>();
-  const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();
   const [parameters, setParameters] = useState<
     Immutable<Map<string, ParameterValue>> | undefined
   >();
@@ -244,7 +214,14 @@ export function ThreeDeeRender(props: {
     };
     renderer?.addListener("cameraMove", listener);
     return () => void renderer?.removeListener("cameraMove", listener);
-  }, [config.scene.syncCamera, config.followMode, context, renderer?.followFrameId, renderer]);
+  }, [
+    config.scene.syncCamera,
+    config.followMode,
+    context,
+    renderer?.followFrameId,
+    renderer,
+    setConfig,
+  ]);
 
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
@@ -280,9 +257,13 @@ export function ThreeDeeRender(props: {
   useRendererEvent("settingsTreeChange", updateSettingsTree, renderer);
 
   // Save the panel configuration when it changes
-  const updateConfig = useCallback((curRenderer: IRenderer) => {
-    setConfig(curRenderer.config);
-  }, []);
+  const updateConfig = useCallback(
+    (curRenderer: IRenderer) => {
+      setConfig(curRenderer.config);
+    },
+    [setConfig],
+  );
+
   useRendererEvent("configChange", updateConfig, renderer);
 
   // Write to a global variable when the current selection changes
@@ -419,16 +400,12 @@ export function ThreeDeeRender(props: {
       rendererSubscription: RendererSubscription,
       convertTo?: string,
     ) => {
-      let shouldSubscribe = rendererSubscription.shouldSubscribe?.(topic.name);
-      if (shouldSubscribe == undefined) {
-        if (config.topics[topic.name]?.visible === true) {
-          shouldSubscribe = true;
-        } else if (config.imageMode.annotations?.[topic.name]?.visible === true) {
-          shouldSubscribe = true;
-        } else {
-          shouldSubscribe = false;
-        }
-      }
+      const namespacedTopic = namespaceTopic(topic.name, convertTo ?? topic.schemaName);
+      const imageAnnotations = config.imageMode.annotations ?? {};
+      const shouldSubscribe =
+        rendererSubscription.shouldSubscribe?.(topic.name) === true ||
+        config.namespacedTopics[namespacedTopic]?.visible === true ||
+        imageAnnotations[namespacedTopic]?.visible === true;
       if (shouldSubscribe) {
         newSubscriptions.push({
           topic: topic.name,
@@ -457,11 +434,11 @@ export function ThreeDeeRender(props: {
     setTopicsToSubscribe((prev) => (_.isEqual(prev, newSubscriptions) ? prev : newSubscriptions));
   }, [
     topics,
-    config.topics,
     // Need to update subscriptions when imagemode topics change
     // shouldSubscribe values will be re-evaluated
     config.imageMode.calibrationTopic,
     config.imageMode.imageTopic,
+    config.namespacedTopics,
     schemaHandlers,
     topicHandlers,
     config.imageMode.annotations,
@@ -579,9 +556,10 @@ export function ThreeDeeRender(props: {
   }, [
     config.scene.syncCamera,
     config.followMode,
-    renderer,
     renderer?.followFrameId,
     sharedPanelState,
+    setConfig,
+    renderer,
   ]);
 
   // Render a new frame if requested

--- a/packages/studio-base/src/panels/ThreeDeeRender/config.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/config.test.ts
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Topic } from "@foxglove/studio";
+import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+import { DEFAULT_PUBLISH_SETTINGS } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/PublishSettings";
+
+import { RendererConfig, migrateConfigTopicsNodes } from "./config";
+
+// Jest doesn't support ES module imports fully yet, so we need to mock the wasm file
+jest.mock("three/examples/jsm/libs/draco/draco_decoder.wasm", () => "");
+
+describe("migrateConfigTopicNodes", () => {
+  it("migrates topics", () => {
+    const oldConfig: RendererConfig = {
+      cameraState: DEFAULT_CAMERA_STATE,
+      followMode: "follow-pose",
+      followTf: undefined,
+      imageMode: {},
+      layers: {},
+      namespacedTopics: {},
+      publish: DEFAULT_PUBLISH_SETTINGS,
+      scene: {},
+      topics: {
+        topic_a: {},
+        topic_b: {},
+        topic_c: {},
+        "/robot_description": {},
+      },
+      transforms: {},
+      version: "2",
+    };
+
+    const topics: Topic[] = [
+      { name: "topic_a", schemaName: "foxglove.Grid", datatype: "datatype_a" },
+      {
+        name: "topic_c",
+        schemaName: "unsupported.Schema",
+        datatype: "datatype_a",
+        convertibleTo: ["foxglove.RawImage"],
+      },
+      { name: "/robot_description", schemaName: "std_msgs/String", datatype: "datatype_a" },
+    ];
+
+    const migrated = migrateConfigTopicsNodes(oldConfig, topics);
+    expect(migrated).toMatchObject({
+      namespacedTopics: {
+        "topic_a:foxglove.Grid": {},
+        "topic_c:foxglove.RawImage": {},
+        [namespaceTopic("/robot_description", "std_msgs/String")]: {},
+      },
+      topics: {
+        topic_b: {},
+      },
+    });
+  });
+});

--- a/packages/studio-base/src/panels/ThreeDeeRender/config.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/config.ts
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable as Im } from "immer";
+import * as _ from "lodash-es";
+
+import { Topic } from "@foxglove/studio";
+import { FollowMode, ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import { MeshUpAxis } from "@foxglove/studio-base/panels/ThreeDeeRender/ModelCache";
+import { CameraState } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
+import { ALL_FOXGLOVE_DATATYPES } from "@foxglove/studio-base/panels/ThreeDeeRender/foxglove";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+import { LayerSettingsTransform } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/FrameAxes";
+import { PublishClickType } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/PublishClickTool";
+import { ALL_ROS_DATATYPES } from "@foxglove/studio-base/panels/ThreeDeeRender/ros";
+import {
+  BaseSettings,
+  CustomLayerSettings,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/settings";
+
+export type RendererConfigV1 = {
+  /** Camera settings for the currently rendering scene */
+  cameraState: CameraState;
+  /** Coordinate frameId of the rendering frame */
+  followTf: string | undefined;
+  /** Camera follow mode */
+  followMode: FollowMode;
+  scene: {
+    /** Show rendering metrics in a DOM overlay */
+    enableStats?: boolean;
+    /** Background color override for the scene, sent to `glClearColor()` */
+    backgroundColor?: string;
+    /* Scale factor to apply to all labels */
+    labelScaleFactor?: number;
+    /** Ignore the <up_axis> tag in COLLADA files (matching rviz behavior) */
+    ignoreColladaUpAxis?: boolean;
+    meshUpAxis?: MeshUpAxis;
+    transforms?: {
+      /** Toggles translation and rotation offset controls for frames */
+      editable?: boolean;
+      /** Toggles visibility of frame axis labels */
+      showLabel?: boolean;
+      /** Size of frame axis labels */
+      labelSize?: number;
+      /** Size of coordinate frame axes */
+      axisScale?: number;
+      /** Width of the connecting line between child and parent frames */
+      lineWidth?: number;
+      /** Color of the connecting line between child and parent frames */
+      lineColor?: string;
+      /** Enable transform preloading */
+      enablePreloading?: boolean;
+    };
+    /** Sync camera with other 3d panels */
+    syncCamera?: boolean;
+    /** Toggles visibility of all topics */
+    topicsVisible?: boolean;
+  };
+  publish: {
+    /** The type of message to publish when clicking in the scene */
+    type: PublishClickType;
+    /** The topic on which to publish poses */
+    poseTopic: string;
+    /** The topic on which to publish points */
+    pointTopic: string;
+    /** The topic on which to publish pose estimates */
+    poseEstimateTopic: string;
+    /** The X standard deviation to publish with poses */
+    poseEstimateXDeviation: number;
+    /** The Y standard deviation to publish with poses */
+    poseEstimateYDeviation: number;
+    /** The theta standard deviation to publish with poses */
+    poseEstimateThetaDeviation: number;
+  };
+  /** frameId -> settings */
+  transforms: Record<string, Partial<LayerSettingsTransform> | undefined>;
+  /** topicName -> settings */
+  topics: Record<string, Partial<BaseSettings> | undefined>;
+  /** instanceId -> settings */
+  layers: Record<string, Partial<CustomLayerSettings> | undefined>;
+
+  /** Settings pertaining to Image mode */
+  imageMode: ImageModeConfig;
+};
+
+// Migrated configuration with version stamp and namespaced topic nodes.
+type RendererConfigV2 = RendererConfigV1 & {
+  version: "2";
+  /**
+   * Namespaced topics, scoped by a combination of topic + schema.
+   */
+  namespacedTopics: Record<NamespacedTopic, undefined | Partial<BaseSettings>>;
+};
+
+export type AnyRendererConfig = RendererConfigV1 | RendererConfigV2;
+export type RendererConfig = RendererConfigV2;
+
+const ALL_SUPPORTED_SCHEMAS = new Set([
+  ...ALL_ROS_DATATYPES,
+  ...ALL_FOXGLOVE_DATATYPES,
+  "std_msgs/String",
+]);
+
+/**
+ * Migrates the old, unnamespaced `topics` nodes in a config into the new `namespacedTopics`
+ * nodes. Because this depends on the topics available at the time of migration we leave
+ * any nodes we couldn't migrate in `topics` in case we may be able to migrate them later.
+ *
+ * @param oldConfig the old configuration to migrate
+ * @param topics the topics used to guide the migration
+ * @returns a new config with as many nodes migrated as possible
+ */
+export function migrateConfigTopicsNodes(
+  oldConfig: Im<RendererConfig>,
+  topics: Im<Topic[]>,
+): Im<RendererConfig> {
+  if (topics.length === 0) {
+    return oldConfig;
+  }
+
+  const unmigratedTopics: Record<string, undefined | Partial<BaseSettings>> = {};
+  const newNamespacedTopics: Record<string, undefined | Partial<BaseSettings>> = {};
+
+  for (const [key, config] of Object.entries(oldConfig.topics)) {
+    const topic = topics.find((top) => top.name === key);
+    if (topic) {
+      if (topic.schemaName && ALL_SUPPORTED_SCHEMAS.has(topic.schemaName)) {
+        const mappedKey = namespaceTopic(topic.name, topic.schemaName);
+        newNamespacedTopics[mappedKey] = config;
+      } else {
+        const convertibleSchema = topic.convertibleTo?.find((schema) =>
+          ALL_SUPPORTED_SCHEMAS.has(schema),
+        );
+        if (convertibleSchema) {
+          const mappedKey = namespaceTopic(topic.name, convertibleSchema);
+          newNamespacedTopics[mappedKey] = config;
+        } else {
+          unmigratedTopics[key] = config;
+        }
+      }
+    } else {
+      unmigratedTopics[key] = config;
+    }
+  }
+
+  if (_.isEmpty(newNamespacedTopics)) {
+    return oldConfig;
+  }
+
+  return {
+    ...oldConfig,
+    namespacedTopics: {
+      ...oldConfig.namespacedTopics,
+      ...newNamespacedTopics,
+    },
+    topics: unmigratedTopics,
+  };
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/foxglove.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/foxglove.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+export const ALL_FOXGLOVE_DATATYPES = new Set<string>();
+
 export const FRAME_TRANSFORM_DATATYPES = new Set<string>();
 addFoxgloveSchema(FRAME_TRANSFORM_DATATYPES, "foxglove.FrameTransform");
 
@@ -58,6 +60,10 @@ function addFoxgloveSchema(output: Set<string>, dataType: string): Set<string> {
 
   // Add the IDL variation: foxglove::PointCloud
   output.add(`foxglove::${leaf}`);
+
+  for (const schema of output) {
+    ALL_FOXGLOVE_DATATYPES.add(schema);
+  }
 
   return output;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/namespaceTopic.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/namespaceTopic.ts
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type NamespacedTopic = string & { __type: "namespaced_topic" };
+
+/**
+ * Creates a namespaced topic out of a topic out of a combination of a topic + schema.
+ */
+export function namespaceTopic(topic: string, schema: string): NamespacedTopic {
+  return `${encodeURIComponent(topic)}:${encodeURIComponent(schema)}` as NamespacedTopic;
+}
+
+/**
+ * Extract the plain topic name from a namespaced topic. Ideally we wouldn't have to do
+ * this but this would require more extensive changes to renderables that currently assume
+ * their "topic" is something that can be directly displayed to the user.
+ */
+export function unnamespacetopic(topic: NamespacedTopic): string {
+  const encodedTopic = topic.split(":")[0] ?? "";
+  return decodeURIComponent(encodedTopic);
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
@@ -9,6 +9,10 @@ import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
 import { CameraCalibration } from "@foxglove/schemas";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import { RenderableLineList } from "./markers/RenderableLineList";
@@ -21,16 +25,16 @@ import { makeRgba, rgbaToCssString, stringToRgba } from "../color";
 import { CAMERA_CALIBRATION_DATATYPES } from "../foxglove";
 import {
   CameraInfo,
-  CAMERA_INFO_DATATYPES as ROS_CAMERA_INFO_DATATYPES,
   IncomingCameraInfo,
   Marker,
   MarkerAction,
   MarkerType,
+  CAMERA_INFO_DATATYPES as ROS_CAMERA_INFO_DATATYPES,
   TIME_ZERO,
   Vector3,
 } from "../ros";
-import { BaseSettings, fieldLineWidth, PRECISION_DISTANCE } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { BaseSettings, PRECISION_DISTANCE, fieldLineWidth } from "../settings";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 const log = Logger.getLogger(__filename);
@@ -104,19 +108,19 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (
-        !(
-          topicIsConvertibleToSchema(topic, ROS_CAMERA_INFO_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, CAMERA_CALIBRATION_DATATYPES)
-        )
-      ) {
+      const schema =
+        convertibleSchemaForTopic(topic, ROS_CAMERA_INFO_DATATYPES) ??
+        convertibleSchemaForTopic(topic, CAMERA_CALIBRATION_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsCameraInfo>;
+
+      const namespacedTopic = namespaceTopic(topic.name, topic.schemaName);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsCameraInfo>;
 
       const fields: SettingsTreeFields = {
         distance: {
@@ -146,9 +150,10 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
       };
 
       entries.push({
-        path: ["topics", topic.name],
+        path: ["namespacedTopics", namespacedTopic],
         node: {
           icon: "Camera",
+          label: topic.name,
           fields,
           visible: config.visible ?? DEFAULT_SETTINGS.visible,
           handler,
@@ -156,6 +161,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
         },
       });
     }
+    console.log({ entries });
     return entries;
   }
 
@@ -168,12 +174,12 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const renderable = this.renderables.get(topicName);
     if (renderable) {
       const { cameraInfo, receiveTime, originalMessage } = renderable.userData;
       if (cameraInfo) {
-        const settings = this.renderer.config.topics[topicName] as
+        const settings = this.renderer.config.namespacedTopics[topicName] as
           | Partial<LayerSettingsCameraInfo>
           | undefined;
         this.#updateCameraInfoRenderable(
@@ -190,7 +196,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
   #handleCameraInfo = (
     messageEvent: PartialMessageEvent<IncomingCameraInfo | CameraCalibration>,
   ): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const cameraInfo = normalizeCameraInfo(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
@@ -200,7 +206,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
       const frameId = this.renderer.normalizeFrameId(cameraInfo.header.frame_id);
 
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsCameraInfo>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -210,7 +216,7 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
         messageTime,
         frameId,
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         cameraInfo: undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -8,15 +8,19 @@ import { toNanoSec } from "@foxglove/rostime";
 import { Grid, NumericType, PackedElementField } from "@foxglove/schemas";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { GRID_DATATYPES } from "@foxglove/studio-base/panels/ThreeDeeRender/foxglove";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import {
-  colorModeSettingsFields,
   ColorModeSettings,
-  getColorConverter,
-  NEEDS_MIN_MAX,
   FS_SRGB_TO_LINEAR,
+  NEEDS_MIN_MAX,
   RGBA_PACKED_FIELDS,
+  colorModeSettingsFields,
+  getColorConverter,
   hasSeparateRgbaFields,
 } from "./colorMode";
 import { FieldReader, getReader } from "./pointClouds/fieldReaders";
@@ -25,9 +29,9 @@ import { BaseUserData, Renderable } from "../Renderable";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
 import { rgbaToCssString, rgbaToLinear, stringToRgba } from "../color";
-import { normalizePose, normalizeTime, normalizeByteArray } from "../normalizeMessages";
+import { normalizeByteArray, normalizePose, normalizeTime } from "../normalizeMessages";
 import { BaseSettings } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 
 type GridColorModeSettings = ColorModeSettings & {
   // rgba packed modes are only supported for sensor_msgs/PointCloud2
@@ -403,14 +407,16 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (!topicIsConvertibleToSchema(topic, GRID_DATATYPES)) {
+      const schema = convertibleSchemaForTopic(topic, GRID_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsFoxgloveGrid>;
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsFoxgloveGrid>;
 
       const colorModeFields = colorModeSettingsFields({
         msgFields: this.#fieldsByTopic.get(topic.name),
@@ -435,7 +441,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       };
 
       entries.push({
-        path: ["topics", topic.name],
+        path: ["namespacedTopics", namespacedTopic],
         node,
       });
     }
@@ -451,10 +457,10 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
-    const renderable = this.renderables.get(topicName);
+    const topic = path[1]! as NamespacedTopic;
+    const renderable = this.renderables.get(topic);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsFoxgloveGrid>
         | undefined;
       renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
@@ -475,7 +481,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
   };
 
   #handleFoxgloveGrid = (messageEvent: PartialMessageEvent<Grid>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const foxgloveGrid = normalizeFoxgloveGrid(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
@@ -492,7 +498,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       renderable.visible = true;
     } else {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsFoxgloveGrid>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -505,7 +511,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          draft.topics[topic] = updatedUserSettings;
+          draft.namespacedTopics[topic] = updatedUserSettings;
         });
       }
 
@@ -525,7 +531,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         messageTime: toNanoSec(foxgloveGrid.timestamp),
         frameId: this.renderer.normalizeFrameId(foxgloveGrid.frame_id),
         pose: foxgloveGrid.pose,
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         foxgloveGrid,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -20,11 +20,12 @@ import { Label } from "@foxglove/three-text";
 import { Axis, AXIS_LENGTH } from "./Axis";
 import { DEFAULT_LABEL_SCALE_FACTOR } from "./SceneSettings";
 import { makeLinePickingMaterial } from "./markers/materials";
-import type { IRenderer, RendererConfig } from "../IRenderer";
+import type { IRenderer } from "../IRenderer";
 import { BaseUserData, Renderable } from "../Renderable";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { getLuminance, stringToRgb } from "../color";
+import { RendererConfig } from "../config";
 import { BaseSettings, fieldSize, PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
 import { CoordinateFrame, Duration, makePose, MAX_DURATION, Transform } from "../transforms";
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
@@ -7,6 +7,7 @@ import * as _ from "lodash-es";
 
 import Logger from "@foxglove/log";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderableLineList } from "./markers/RenderableLineList";
 import type { IRenderer } from "../IRenderer";
@@ -263,7 +264,7 @@ export class Grids extends SceneExtension<GridRenderable> {
     const marker = createMarker(settings);
     const lineListId = `${instanceId}:LINE_LIST`;
     const lineList = new RenderableLineList(
-      lineListId,
+      lineListId as NamespacedTopic,
       marker,
       undefined,
       this.renderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -17,6 +17,11 @@ import {
   Topic,
 } from "@foxglove/studio";
 import { Path } from "@foxglove/studio-base/panels/ThreeDeeRender/LayerErrors";
+import { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/config";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import {
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,
   ImageRenderable,
@@ -37,14 +42,9 @@ import { makePose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms
 import { ImageModeCamera } from "./ImageModeCamera";
 import { MessageHandler, MessageRenderState } from "./MessageHandler";
 import { ImageAnnotations } from "./annotations/ImageAnnotations";
-import type {
-  AnyRendererSubscription,
-  IRenderer,
-  ImageModeConfig,
-  RendererConfig,
-} from "../../IRenderer";
+import type { AnyRendererSubscription, IRenderer, ImageModeConfig } from "../../IRenderer";
 import { PartialMessageEvent, SceneExtension } from "../../SceneExtension";
-import { SettingsTreeEntry } from "../../SettingsManager";
+import { SettingsPath, SettingsTreeEntry } from "../../SettingsManager";
 import {
   CAMERA_CALIBRATION_DATATYPES,
   COMPRESSED_IMAGE_DATATYPES,
@@ -61,7 +61,7 @@ import { ICameraHandler } from "../ICameraHandler";
 import { getTopicMatchPrefix, sortPrefixMatchesToFront } from "../Images/topicPrefixMatching";
 import { ColorModeSettings, colorModeSettingsFields } from "../colorMode";
 
-const IMAGE_TOPIC_PATH = ["imageMode", "imageTopic"];
+const IMAGE_TOPIC_PATH: SettingsPath = ["imageMode", "imageTopic"];
 const CALIBRATION_TOPIC_PATH = ["imageMode", "calibrationTopic"];
 
 const IMAGE_TOPIC_UNAVAILABLE = "IMAGE_TOPIC_UNAVAILABLE";
@@ -558,14 +558,15 @@ export class ImageMode
     draft: Writable<RendererConfig>,
     path: DraggedMessagePath,
   ): void => {
-    if (path.rootSchemaName == undefined) {
-      return;
+    if (!path.isTopic || path.rootSchemaName == undefined) {
+      return undefined;
     }
     if (ALL_SUPPORTED_IMAGE_SCHEMAS.has(path.rootSchemaName)) {
       draft.imageMode.imageTopic = path.path;
     } else if (this.#annotations.supportedAnnotationSchemas.has(path.rootSchemaName)) {
       draft.imageMode.annotations ??= {};
-      draft.imageMode.annotations[path.path] = { visible: true };
+      const namespacedTopic = namespaceTopic(path.path, path.rootSchemaName);
+      draft.imageMode.annotations[namespacedTopic] = { visible: true };
     }
   };
 
@@ -598,7 +599,7 @@ export class ImageMode
   };
 
   #handleImageChange = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const frameId = "header" in image ? image.header.frame_id : image.frame_id;
 
@@ -648,7 +649,7 @@ export class ImageMode
   };
 
   #getImageRenderable(
-    topicName: string,
+    topicName: NamespacedTopic,
     receiveTime: bigint,
     image: AnyImage | undefined,
     frameId: string,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.test.ts
@@ -14,8 +14,9 @@ import {
   TextAnnotation,
 } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
-import { MessageHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
+import { MessageHandler, MessageHandlerConfig } from "./MessageHandler";
 import { PartialMessageEvent } from "../../SceneExtension";
 
 function wrapInMessageEvent<T>(
@@ -33,6 +34,16 @@ function wrapInMessageEvent<T>(
   };
 }
 
+function fixtures(messageHandlerConfig?: Partial<MessageHandlerConfig>) {
+  const topic = namespaceTopic("annotations", "foxglove.ImageAnnotations");
+  const messageHandler = new MessageHandler({
+    synchronize: true,
+    annotations: { [topic]: { visible: true } },
+    ...messageHandlerConfig,
+  });
+  return { topic, messageHandler };
+}
+
 describe("MessageHandler: synchronized = false", () => {
   it("should return an empty state if no messages are handled", () => {
     const messageHandler = new MessageHandler({ synchronize: false });
@@ -40,7 +51,7 @@ describe("MessageHandler: synchronized = false", () => {
     const state = messageHandler.getRenderState();
 
     expect(state).toEqual({
-      annotationsByTopic: new Map(),
+      annotationsByNamespacedTopic: new Map(),
     });
   });
   it("should have camera info if handled camera info", () => {
@@ -66,9 +77,8 @@ describe("MessageHandler: synchronized = false", () => {
     expect(state.image).not.toBeUndefined();
   });
   it("should have annotations if handled annotations", () => {
-    const messageHandler = new MessageHandler({
+    const { topic, messageHandler } = fixtures({
       synchronize: false,
-      annotations: { annotations: { visible: true } },
     });
 
     const annotation = createCircleAnnotations([0n]);
@@ -81,7 +91,7 @@ describe("MessageHandler: synchronized = false", () => {
     messageHandler.handleAnnotations(annotationMessage as MessageEvent<ImageAnnotations>);
     const state = messageHandler.getRenderState();
 
-    expect(state.annotationsByTopic?.get("annotations")).not.toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(topic)).not.toBeUndefined();
   });
   it("clears image if image topic changed", () => {
     const messageHandler = new MessageHandler({ synchronize: false, imageTopic: "image1" });
@@ -112,11 +122,13 @@ describe("MessageHandler: synchronized = false", () => {
     expect(state.cameraInfo).toBeUndefined();
   });
   it("clears specific annotations if annotations subscriptions change", () => {
+    const topic1 = namespaceTopic("annotations1", "foxglove.ImageAnnotations");
+    const topic2 = namespaceTopic("annotations2", "foxglove.ImageAnnotations");
     const messageHandler = new MessageHandler({
       synchronize: false,
       annotations: {
-        annotations1: { visible: true },
-        annotations2: { visible: true },
+        [topic1]: { visible: true },
+        [topic2]: { visible: true },
       },
     });
 
@@ -138,20 +150,18 @@ describe("MessageHandler: synchronized = false", () => {
 
     // annotations2 removed
     messageHandler.setConfig({
-      annotations: { annotations1: { visible: true }, annotations2: { visible: false } },
+      annotations: {
+        [topic1]: { visible: true },
+        [topic2]: { visible: false },
+      },
     });
     const state = messageHandler.getRenderState();
 
-    expect(state.annotationsByTopic?.get("annotations1")).not.toBeUndefined();
-    expect(state.annotationsByTopic?.get("annotations2")).toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(topic1)).not.toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(topic2)).toBeUndefined();
   });
   it("listener function called whenever a message is handled or when config changes", () => {
-    const messageHandler = new MessageHandler({
-      synchronize: false,
-      imageTopic: "image",
-      calibrationTopic: "calibration",
-      annotations: { annotations: { visible: true } },
-    });
+    const { topic, messageHandler } = fixtures();
     const listener = jest.fn();
 
     messageHandler.addListener(listener);
@@ -177,7 +187,9 @@ describe("MessageHandler: synchronized = false", () => {
 
     // annotations2 removed
     messageHandler.setConfig({
-      annotations: { annotations: { visible: false } },
+      annotations: {
+        [topic]: { visible: false },
+      },
     });
     expect(listener).toHaveBeenCalledTimes(4);
   });
@@ -209,10 +221,7 @@ describe("MessageHandler: synchronized = true", () => {
   });
 
   it("does not show state with annotations if only handled annotations", () => {
-    const messageHandler = new MessageHandler({
-      synchronize: true,
-      annotations: { annotations: { visible: true } },
-    });
+    const { messageHandler } = fixtures();
 
     const annotation = createCircleAnnotations([0n]);
     const annotationMessage = wrapInMessageEvent(
@@ -221,19 +230,18 @@ describe("MessageHandler: synchronized = true", () => {
       0n,
       annotation,
     );
+    const namespacedTopic = namespaceTopic(annotationMessage.topic, annotationMessage.schemaName);
+
     messageHandler.handleAnnotations(annotationMessage as MessageEvent<ImageAnnotations>);
     const state = messageHandler.getRenderState();
 
-    expect(state.annotationsByTopic?.get("annotations")).toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(namespacedTopic)).toBeUndefined();
     expect(state.presentAnnotationTopics).toBeUndefined();
     expect(state.missingAnnotationTopics).toBeUndefined();
   });
 
   it("shows state with image and annotations if they have the same timestamp", () => {
-    const messageHandler = new MessageHandler({
-      synchronize: true,
-      annotations: { annotations: { visible: true } },
-    });
+    const { messageHandler } = fixtures();
     const time = 2n;
 
     const image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
@@ -248,12 +256,14 @@ describe("MessageHandler: synchronized = true", () => {
       annotation,
     );
 
+    const namespacedTopic = namespaceTopic(annotationMessage.topic, annotationMessage.schemaName);
+
     messageHandler.handleRawImage(image);
     messageHandler.handleAnnotations(annotationMessage as MessageEvent<ImageAnnotations>);
     const state = messageHandler.getRenderState();
 
     expect(state.image).not.toBeUndefined();
-    expect(state.annotationsByTopic?.get("annotations")).not.toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(namespacedTopic)).not.toBeUndefined();
     expect(state.presentAnnotationTopics).toBeUndefined();
     expect(state.missingAnnotationTopics).toBeUndefined();
   });
@@ -262,8 +272,8 @@ describe("MessageHandler: synchronized = true", () => {
     const messageHandler = new MessageHandler({
       synchronize: true,
       annotations: {
-        annotations1: { visible: true },
-        annotations2: { visible: true },
+        [namespaceTopic("annotations1", "foxglove.ImageAnnotations")]: { visible: true },
+        [namespaceTopic("annotations2", "foxglove.ImageAnnotations")]: { visible: true },
       },
     });
     const time = 2n;
@@ -286,6 +296,10 @@ describe("MessageHandler: synchronized = true", () => {
       0n,
       annotation2,
     );
+    const namespacedTopic2 = namespaceTopic(
+      annotationMessage2.topic,
+      annotationMessage2.schemaName,
+    );
 
     messageHandler.handleRawImage(image);
     messageHandler.handleAnnotations(annotationMessage1 as MessageEvent<ImageAnnotations>);
@@ -293,17 +307,17 @@ describe("MessageHandler: synchronized = true", () => {
     const state = messageHandler.getRenderState();
 
     expect(state.image).toBeUndefined();
-    expect(state.annotationsByTopic?.get("annotations1")).toBeUndefined();
-    expect(state.annotationsByTopic?.get("annotations2")).toBeUndefined();
-    expect(state.presentAnnotationTopics).toEqual(["annotations1"]);
-    expect(state.missingAnnotationTopics).toEqual(["annotations2"]);
+    expect(state.annotationsByNamespacedTopic?.get(namespacedTopic2)).toBeUndefined();
+    expect(state.presentAnnotationTopics).toEqual([
+      namespaceTopic("annotations1", "foxglove.ImageAnnotations"),
+    ]);
+    expect(state.missingAnnotationTopics).toEqual([
+      namespaceTopic("annotations2", "foxglove.ImageAnnotations"),
+    ]);
   });
 
   it("shows most recent image and annotations with same timestamps", () => {
-    const messageHandler = new MessageHandler({
-      synchronize: true,
-      annotations: { annotations: { visible: true } },
-    });
+    const { topic, messageHandler } = fixtures();
     let time = 2n;
 
     let image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
@@ -340,17 +354,13 @@ describe("MessageHandler: synchronized = true", () => {
     const state = messageHandler.getRenderState();
 
     expect((state.image?.message as RawImage).timestamp).toEqual(fromNanoSec(time));
-    expect(state.annotationsByTopic?.get("annotations")?.annotations[0]?.stamp).toEqual(
+    expect(state.annotationsByNamespacedTopic?.get(topic)?.annotations[0]?.stamp).toEqual(
       fromNanoSec(time),
     );
   });
 
   it("shows most older image and annotations with same timestamps if newer messages have different timestamps", () => {
-    const messageHandler = new MessageHandler({
-      synchronize: true,
-      annotations: { annotations: { visible: true } },
-    });
-
+    const { topic, messageHandler } = fixtures();
     const time = 2n;
 
     let image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
@@ -387,15 +397,21 @@ describe("MessageHandler: synchronized = true", () => {
     const state = messageHandler.getRenderState();
 
     expect((state.image?.message as RawImage).timestamp).toEqual(fromNanoSec(time));
-    expect(state.annotationsByTopic?.get("annotations")?.annotations[0]?.stamp).toEqual(
+    expect(state.annotationsByNamespacedTopic?.get(topic)?.annotations[0]?.stamp).toEqual(
       fromNanoSec(time),
     );
   });
 
   it("does not show image in state if it hasn't received requisite annotations at same timestamp", () => {
+    const topic1 = namespaceTopic("annotations1", "foxglove.ImageAnnotations");
+    const topic2 = namespaceTopic("annotations2", "foxglove.ImageAnnotations");
+
     const messageHandler = new MessageHandler({
       synchronize: true,
-      annotations: { annotations1: { visible: true }, annotations2: { visible: true } },
+      annotations: {
+        [topic1]: { visible: true },
+        [topic2]: { visible: true },
+      },
     });
     const time = 2n;
 
@@ -417,14 +433,12 @@ describe("MessageHandler: synchronized = true", () => {
     const state = messageHandler.getRenderState();
 
     expect(state.image).toBeUndefined();
-    expect(state.annotationsByTopic).toBeUndefined();
+    expect(state.annotationsByNamespacedTopic).toBeUndefined();
   });
 
   it("clears image when image topic changed", () => {
-    const messageHandler = new MessageHandler({
+    const { messageHandler } = fixtures({
       imageTopic: "image1",
-      synchronize: true,
-      annotations: { annotations: { visible: true } },
     });
     const time = 2n;
 
@@ -447,13 +461,16 @@ describe("MessageHandler: synchronized = true", () => {
     expect(state.image).toBeUndefined();
   });
   it("clears specific annotations if annotations subscriptions change", () => {
+    const topic1 = namespaceTopic("annotations1", "foxglove.ImageAnnotations");
+    const topic2 = namespaceTopic("annotations2", "foxglove.ImageAnnotations");
+
     const messageHandler = new MessageHandler({
       synchronize: true,
       imageTopic: "image",
       calibrationTopic: "calibration",
       annotations: {
-        annotations1: { visible: true },
-        annotations2: { visible: true },
+        [topic1]: { visible: true },
+        [topic2]: { visible: true },
       },
     });
     const time = 2n;
@@ -482,19 +499,20 @@ describe("MessageHandler: synchronized = true", () => {
 
     // annotations2 removed
     messageHandler.setConfig({
-      annotations: { annotations1: { visible: true }, annotations2: { visible: false } },
+      annotations: {
+        [topic1]: { visible: true },
+        [topic2]: { visible: false },
+      },
     });
     const state = messageHandler.getRenderState();
 
-    expect(state.annotationsByTopic?.get("annotations1")).not.toBeUndefined();
-    expect(state.annotationsByTopic?.get("annotations2")).toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(topic1)).not.toBeUndefined();
+    expect(state.annotationsByNamespacedTopic?.get(topic2)).toBeUndefined();
   });
   it("listener function called whenever a message is handled or when config changes", () => {
-    const messageHandler = new MessageHandler({
-      synchronize: true,
+    const { topic, messageHandler } = fixtures({
       imageTopic: "image",
       calibrationTopic: "calibration",
-      annotations: { annotations: { visible: true } },
     });
     const listener = jest.fn();
 
@@ -521,7 +539,7 @@ describe("MessageHandler: synchronized = true", () => {
 
     // annotations2 removed
     messageHandler.setConfig({
-      annotations: { annotations: { visible: false } },
+      annotations: { [topic]: { visible: false } },
     });
     expect(listener).toHaveBeenCalledTimes(4);
   });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
@@ -5,20 +5,25 @@
 import * as _ from "lodash-es";
 
 import { AVLTree } from "@foxglove/avl";
+import { recordEntries } from "@foxglove/den/records";
 import {
   Time,
-  fromNanoSec,
-  toNanoSec,
   compare as compareTime,
+  fromNanoSec,
   isLessThan,
+  toNanoSec,
 } from "@foxglove/rostime";
 import {
   CompressedImage,
-  RawImage,
   ImageAnnotations as FoxgloveImageAnnotations,
+  RawImage,
 } from "@foxglove/schemas";
 import { Immutable, MessageEvent } from "@foxglove/studio";
 import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import {
   AnyImage,
   getTimestampFromImage,
@@ -38,7 +43,7 @@ import {
 import { normalizeAnnotations } from "./annotations/normalizeAnnotations";
 import { Annotation } from "./annotations/types";
 import { PartialMessageEvent } from "../../SceneExtension";
-import { CompressedImage as RosCompressedImage, Image as RosImage, CameraInfo } from "../../ros";
+import { CameraInfo, CompressedImage as RosCompressedImage, Image as RosImage } from "../../ros";
 
 type NormalizedAnnotations = {
   // required for setting the original message on the renderable
@@ -48,10 +53,10 @@ type NormalizedAnnotations = {
 
 type SynchronizationItem = {
   image?: Readonly<MessageEvent<AnyImage>>;
-  annotationsByTopic: Map<string, NormalizedAnnotations>;
+  annotationsByNamespacedTopic: Map<NamespacedTopic, NormalizedAnnotations>;
 };
 
-type Config = Pick<
+export type MessageHandlerConfig = Pick<
   ImageModeConfig,
   "synchronize" | "annotations" | "calibrationTopic" | "imageTopic"
 >;
@@ -59,12 +64,13 @@ type Config = Pick<
 type MessageHandlerState = {
   image?: MessageEvent<AnyImage>;
   cameraInfo?: CameraInfo;
-  annotationsByTopic: Map<string, NormalizedAnnotations>;
 
   /** Topics that were present in a potential synchronized set */
   presentAnnotationTopics?: string[];
   /** Topics that were missing so that a synchronized set could not be found */
   missingAnnotationTopics?: string[];
+
+  annotationsByNamespacedTopic: Map<NamespacedTopic, NormalizedAnnotations>;
 };
 
 export type MessageRenderState = Readonly<Partial<MessageHandlerState>>;
@@ -82,7 +88,7 @@ type RenderStateListener = (
  */
 export class MessageHandler {
   /** settings that should reflect image mode config */
-  #config: Immutable<Config>;
+  #config: Immutable<MessageHandlerConfig>;
 
   /** last state passed to listeners */
   #oldRenderState: MessageRenderState | undefined;
@@ -100,10 +106,10 @@ export class MessageHandler {
    *
    * @param config - subset of ImageMode settings required for message handling
    */
-  public constructor(config: Immutable<Config>) {
+  public constructor(config: Immutable<MessageHandlerConfig>) {
     this.#config = config;
     this.#lastReceivedMessages = {
-      annotationsByTopic: new Map(),
+      annotationsByNamespacedTopic: new Map(),
     };
     this.#tree = new AVLTree<Time, SynchronizationItem>(compareTime);
   }
@@ -156,7 +162,7 @@ export class MessageHandler {
     } else {
       this.#tree.set(getTimestampFromImage(image), {
         image: normalizedImageMessage,
-        annotationsByTopic: new Map(),
+        annotationsByNamespacedTopic: new Map(),
       });
     }
     this.#emitState();
@@ -173,9 +179,9 @@ export class MessageHandler {
   ): void => {
     const annotations = normalizeAnnotations(messageEvent.message, messageEvent.schemaName);
 
-    const { topic } = messageEvent;
+    const namespacedTopic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     if (this.#config.synchronize !== true) {
-      this.#lastReceivedMessages.annotationsByTopic.set(topic, {
+      this.#lastReceivedMessages.annotationsByNamespacedTopic.set(namespacedTopic, {
         originalMessage: messageEvent,
         annotations,
       });
@@ -200,11 +206,11 @@ export class MessageHandler {
       if (!item) {
         item = {
           image: undefined,
-          annotationsByTopic: new Map(),
+          annotationsByNamespacedTopic: new Map(),
         };
         this.#tree.set(stamp, item);
       }
-      item.annotationsByTopic.set(topic, {
+      item.annotationsByNamespacedTopic.set(namespacedTopic, {
         originalMessage: messageEvent,
         annotations: group,
       });
@@ -242,24 +248,24 @@ export class MessageHandler {
       this.#config.annotations &&
       this.#config.annotations !== newConfig.annotations
     ) {
-      const newVisibleTopics = new Set<string>();
+      const newVisibleAnnotationsMap = new Map<NamespacedTopic, boolean>();
 
-      for (const [topic, settings] of Object.entries(newConfig.annotations)) {
+      for (const [topic, settings] of recordEntries(newConfig.annotations)) {
         if (settings?.visible === true) {
-          newVisibleTopics.add(topic);
+          newVisibleAnnotationsMap.set(topic, settings.visible);
         }
       }
 
-      for (const topic of this.#lastReceivedMessages.annotationsByTopic.keys()) {
-        if (!newVisibleTopics.has(topic)) {
-          this.#lastReceivedMessages.annotationsByTopic.delete(topic);
+      for (const topic of this.#lastReceivedMessages.annotationsByNamespacedTopic.keys()) {
+        if (newVisibleAnnotationsMap.get(topic) == undefined) {
+          this.#lastReceivedMessages.annotationsByNamespacedTopic.delete(topic);
           changed = true;
         }
       }
       for (const syncEntry of this.#tree.values()) {
-        for (const topic of syncEntry.annotationsByTopic.keys()) {
-          if (!newVisibleTopics.has(topic)) {
-            syncEntry.annotationsByTopic.delete(topic);
+        for (const topic of syncEntry.annotationsByNamespacedTopic.keys()) {
+          if (newVisibleAnnotationsMap.get(topic) == undefined) {
+            syncEntry.annotationsByNamespacedTopic.delete(topic);
             changed = true;
           }
         }
@@ -278,7 +284,7 @@ export class MessageHandler {
 
   public clear(): void {
     this.#lastReceivedMessages = {
-      annotationsByTopic: new Map(),
+      annotationsByNamespacedTopic: new Map(),
     };
     this.#tree.clear();
     this.#oldRenderState = undefined;
@@ -301,7 +307,7 @@ export class MessageHandler {
         return {
           cameraInfo: this.#lastReceivedMessages.cameraInfo,
           image: result.messages.image,
-          annotationsByTopic: result.messages.annotationsByTopic,
+          annotationsByNamespacedTopic: result.messages.annotationsByNamespacedTopic,
         };
       }
       return {
@@ -314,9 +320,9 @@ export class MessageHandler {
     return { ...this.#lastReceivedMessages };
   }
 
-  #visibleAnnotations(): Set<string> {
-    const visibleAnnotations = new Set<string>();
-    for (const [topic, settings] of Object.entries(this.#config.annotations ?? {})) {
+  #visibleAnnotations(): Set<NamespacedTopic> {
+    const visibleAnnotations = new Set<NamespacedTopic>();
+    for (const [topic, settings] of recordEntries(this.#config.annotations ?? {})) {
       if (settings?.visible === true) {
         visibleAnnotations.add(topic);
       }
@@ -352,7 +358,7 @@ type SynchronizationResult =
  */
 function findSynchronizedSetAndRemoveOlderItems(
   tree: AVLTree<Time, SynchronizationItem>,
-  visibleAnnotations: Set<string>,
+  visibleAnnotations: Set<NamespacedTopic>,
 ): SynchronizationResult {
   let validEntry: [Time, SynchronizationItem] | undefined = undefined;
   let presentAnnotationTopics: string[] | undefined;
@@ -364,7 +370,7 @@ function findSynchronizedSetAndRemoveOlderItems(
     }
     [presentAnnotationTopics, missingAnnotationTopics] = _.partition(
       Array.from(visibleAnnotations),
-      (topic) => messageState.annotationsByTopic.has(topic),
+      (topic) => messageState.annotationsByNamespacedTopic.has(topic),
     );
 
     // If we have an image and all the messages for annotation topics then we have a synchronized set.

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -10,6 +10,10 @@ import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas"
 import { Immutable, MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
 import { Path } from "@foxglove/studio-base/panels/ThreeDeeRender/LayerErrors";
 import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+import {
   ImageMarker as RosImageMarker,
   ImageMarkerArray as RosImageMarkerArray,
 } from "@foxglove/studio-base/types/Messages";
@@ -21,13 +25,14 @@ import { AnyRendererSubscription, ImageModeConfig } from "../../../IRenderer";
 import { SettingsTreeEntry } from "../../../SettingsManager";
 import { IMAGE_ANNOTATIONS_DATATYPES } from "../../../foxglove";
 import { IMAGE_MARKER_ARRAY_DATATYPES, IMAGE_MARKER_DATATYPES } from "../../../ros";
-import { topicIsConvertibleToSchema } from "../../../topicIsConvertibleToSchema";
+import {
+  convertibleSchemaForTopic,
+  topicIsConvertibleToSchema,
+} from "../../../topicIsConvertibleToSchema";
 import { sortPrefixMatchesToFront } from "../../Images/topicPrefixMatching";
 import { MessageHandler, MessageRenderState } from "../MessageHandler";
 
 const MISSING_SYNCHRONIZED_ANNOTATION = "MISSING_SYNCHRONIZED_ANNOTATION";
-
-type TopicName = string & { __brand: "TopicName" };
 
 interface ImageAnnotationsContext {
   initialScale: number;
@@ -66,7 +71,7 @@ const ALL_SUPPORTED_ANNOTATION_SCHEMAS = new Set([
 export class ImageAnnotations extends THREE.Object3D {
   #context: ImageAnnotationsContext;
 
-  #renderablesByTopic = new Map<TopicName, RenderableTopicAnnotations>();
+  #renderablesByTopic = new Map<NamespacedTopic, RenderableTopicAnnotations>();
   #cameraModel?: PinholeCameraModel;
 
   #scale: number;
@@ -138,8 +143,11 @@ export class ImageAnnotations extends THREE.Object3D {
   }
 
   #updateFromMessageState = (newState: MessageRenderState) => {
-    if (newState.annotationsByTopic != undefined) {
-      for (const { originalMessage, annotations } of newState.annotationsByTopic.values()) {
+    if (newState.annotationsByNamespacedTopic != undefined) {
+      for (const {
+        originalMessage,
+        annotations,
+      } of newState.annotationsByNamespacedTopic.values()) {
         this.#handleMessage(originalMessage, annotations);
 
         // Hide any remaining errors for annotations we are able to render
@@ -169,12 +177,13 @@ export class ImageAnnotations extends THREE.Object3D {
     messageEvent: MessageEvent<FoxgloveImageAnnotations | RosImageMarker | RosImageMarkerArray>,
     annotations: Annotation[],
   ) {
-    let renderable = this.#renderablesByTopic.get(messageEvent.topic as TopicName);
+    const namespacedTopic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
+    let renderable = this.#renderablesByTopic.get(namespacedTopic);
     if (!renderable) {
-      renderable = new RenderableTopicAnnotations(messageEvent.topic, this.#context.labelPool);
+      renderable = new RenderableTopicAnnotations(namespacedTopic, this.#context.labelPool);
       renderable.setScale(this.#scale, this.#canvasWidth, this.#canvasHeight, this.#pixelRatio);
       renderable.setCameraModel(this.#cameraModel);
-      this.#renderablesByTopic.set(messageEvent.topic as TopicName, renderable);
+      this.#renderablesByTopic.set(namespacedTopic, renderable);
       this.add(renderable);
     }
 
@@ -188,7 +197,7 @@ export class ImageAnnotations extends THREE.Object3D {
       return;
     }
     const { value, path } = action.payload;
-    const topic = path[1]! as TopicName;
+    const topic = path[1]! as NamespacedTopic;
     if (path[0] === "imageAnnotations" && path[2] === "visible" && typeof value === "boolean") {
       this.#handleTopicVisibilityChange(topic, value);
     }
@@ -196,12 +205,12 @@ export class ImageAnnotations extends THREE.Object3D {
   }
 
   #handleTopicVisibilityChange(
-    topic: TopicName,
+    topic: NamespacedTopic,
     visible: boolean, // eslint-disable-line @foxglove/no-boolean-parameters
   ): void {
     this.#context.updateConfig((draft) => {
       draft.annotations ??= {};
-      const settings = (draft.annotations[topic] ??= {});
+      const settings = (draft.annotations[topic] ??= { visible: false });
       settings.visible = visible;
     });
     this.#context.messageHandler.setConfig({
@@ -236,15 +245,19 @@ export class ImageAnnotations extends THREE.Object3D {
     }
 
     for (const topic of annotationTopics) {
-      const settings = config.annotations?.[topic.name];
-      entries.push({
-        path: ["imageAnnotations", topic.name],
-        node: {
-          label: topic.name,
-          visible: settings?.visible ?? false,
-          handler: this.#handleSettingsAction.bind(this),
-        },
-      });
+      const schema = convertibleSchemaForTopic(topic, ALL_SUPPORTED_ANNOTATION_SCHEMAS);
+      if (schema) {
+        const namespacedTopic = namespaceTopic(topic.name, schema);
+        const settings = config.annotations?.[namespacedTopic];
+        entries.push({
+          path: ["imageAnnotations", namespacedTopic],
+          node: {
+            label: topic.name,
+            visible: settings?.visible ?? false,
+            handler: this.#handleSettingsAction.bind(this),
+          },
+        });
+      }
     }
     return entries;
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -9,6 +9,7 @@ import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeome
 
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { Color } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 
 import {
@@ -87,7 +88,7 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
   #cameraModel?: PinholeCameraModel;
   #cameraModelNeedsUpdate = false;
 
-  public constructor(topicName: string) {
+  public constructor(topicName: NamespacedTopic) {
     super(topicName, undefined, {
       receiveTime: 0n,
       messageTime: 0n,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderablePointsAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderablePointsAnnotation.ts
@@ -5,6 +5,7 @@
 import * as THREE from "three";
 
 import { PinholeCameraModel } from "@foxglove/den/image";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 
 import {
@@ -59,7 +60,7 @@ export class RenderablePointsAnnotation extends Renderable<BaseUserData, /*TRend
   #cameraModel?: PinholeCameraModel;
   #cameraModelNeedsUpdate = false;
 
-  public constructor(topicName: string) {
+  public constructor(topicName: NamespacedTopic) {
     super(topicName, undefined, {
       receiveTime: 0n,
       messageTime: 0n,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTextAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTextAnnotation.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { PinholeCameraModel } from "@foxglove/den/image";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 import { Label, LabelPool } from "@foxglove/three-text";
 
@@ -30,7 +31,7 @@ export class RenderableTextAnnotation extends Renderable<BaseUserData, /*TRender
   #cameraModel?: PinholeCameraModel;
   #cameraModelNeedsUpdate = false;
 
-  public constructor(topicName: string, labelPool: LabelPool) {
+  public constructor(topicName: NamespacedTopic, labelPool: LabelPool) {
     super(topicName, undefined, {
       receiveTime: 0n,
       messageTime: 0n,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
@@ -5,6 +5,7 @@
 import * as THREE from "three";
 
 import { PinholeCameraModel } from "@foxglove/den/image";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { RosObject } from "@foxglove/studio-base/players/types";
 import { LabelPool } from "@foxglove/three-text";
 
@@ -35,9 +36,9 @@ export class RenderableTopicAnnotations extends THREE.Object3D {
   #cameraModelNeedsUpdate = false;
 
   #originalMessage?: RosObject;
-  #topicName: string;
+  #topicName: NamespacedTopic;
 
-  public constructor(topicName: string, labelPool: LabelPool) {
+  public constructor(topicName: NamespacedTopic, labelPool: LabelPool) {
     super();
     this.#labelPool = labelPool;
     this.#topicName = topicName;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -11,6 +11,10 @@ import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
 import { CameraCalibration, CompressedImage, RawImage } from "@foxglove/schemas";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { IMAGE_RENDERABLE_DEFAULT_SETTINGS, ImageRenderable } from "./Images/ImageRenderable";
 import { ALL_CAMERA_INFO_SCHEMAS, AnyImage } from "./Images/ImageTypes";
@@ -39,7 +43,10 @@ import {
   CAMERA_INFO_DATATYPES,
 } from "../ros";
 import { BaseSettings, PRECISION_DISTANCE } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import {
+  convertibleSchemaForTopic,
+  topicIsConvertibleToSchema,
+} from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 const log = Logger.getLogger(__filename);
@@ -135,21 +142,20 @@ export class Images extends SceneExtension<ImageRenderable> {
   };
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (
-        !(
-          topicIsConvertibleToSchema(topic, ROS_IMAGE_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, ROS_COMPRESSED_IMAGE_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, RAW_IMAGE_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, COMPRESSED_IMAGE_DATATYPES)
-        )
-      ) {
+      const schema =
+        convertibleSchemaForTopic(topic, ROS_IMAGE_DATATYPES) ??
+        convertibleSchemaForTopic(topic, ROS_COMPRESSED_IMAGE_DATATYPES) ??
+        convertibleSchemaForTopic(topic, RAW_IMAGE_DATATYPES) ??
+        convertibleSchemaForTopic(topic, COMPRESSED_IMAGE_DATATYPES);
+      if (schema == undefined) {
         continue;
       }
-      const imageTopic = topic.name;
+
+      const imageTopic = namespaceTopic(topic.name, schema);
       const config = (configTopics[imageTopic] ?? {}) as Partial<LayerSettingsImage>;
 
       // Build a list of all matching CameraInfo topics
@@ -189,12 +195,13 @@ export class Images extends SceneExtension<ImageRenderable> {
       };
 
       entries.push({
-        path: ["topics", imageTopic],
+        path: ["namespacedTopics", imageTopic],
         node: {
           icon: "ImageProjection",
+          label: topic.name,
           fields,
           visible: config.visible ?? IMAGE_RENDERABLE_DEFAULT_SETTINGS.visible,
-          order: imageTopic.toLocaleLowerCase(),
+          order: topic.name.toLocaleLowerCase(),
           handler,
         },
       });
@@ -208,15 +215,15 @@ export class Images extends SceneExtension<ImageRenderable> {
       return;
     }
 
-    const imageTopic = path[1]!;
-    const prevSettings = this.renderer.config.topics[imageTopic] as
+    const imageTopic = path[1]! as NamespacedTopic;
+    const prevSettings = this.renderer.config.namespacedTopics[imageTopic] as
       | Partial<LayerSettingsImage>
       | undefined;
     const prevCameraInfoTopic = prevSettings?.cameraInfoTopic;
 
     this.saveSetting(path, action.payload.value);
 
-    const settings = this.renderer.config.topics[imageTopic] as
+    const settings = this.renderer.config.namespacedTopics[imageTopic] as
       | Partial<LayerSettingsImage>
       | undefined;
     const cameraInfoTopic = settings?.cameraInfoTopic;
@@ -262,7 +269,7 @@ export class Images extends SceneExtension<ImageRenderable> {
     // Iterate over each topic config and check if it has a cameraInfoTopic setting that matches
     // the cameraInfoTopic we might want to turn on. If it does and the topic is visible, return
     // true so we know to subscribe.
-    for (const topicConfig of Object.values(this.renderer.config.topics)) {
+    for (const topicConfig of Object.values(this.renderer.config.namespacedTopics)) {
       const maybeImageConfig = topicConfig as Partial<LayerSettingsImage>;
       if (
         maybeImageConfig.cameraInfoTopic === cameraInfoTopic &&
@@ -292,18 +299,18 @@ export class Images extends SceneExtension<ImageRenderable> {
   };
 
   #handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
-    const imageTopic = messageEvent.topic;
+    const namespacedTopic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const frameId = "header" in image ? image.header.frame_id : image.frame_id;
 
-    const renderable = this.#getImageRenderable(imageTopic, receiveTime, image, frameId);
+    const renderable = this.#getImageRenderable(namespacedTopic, receiveTime, image, frameId);
     renderable.setImage(image, DEFAULT_BITMAP_WIDTH);
 
     renderable.userData.receiveTime = receiveTime;
     // Auto-select settings.cameraInfoTopic if it's not already set
     const settings = renderable.userData.settings;
     if (settings.cameraInfoTopic == undefined) {
-      const prefix = getTopicMatchPrefix(imageTopic);
+      const prefix = getTopicMatchPrefix(messageEvent.topic);
       const newCameraInfoTopic =
         prefix != undefined
           ? filterMap(this.#cameraInfoTopics, (topic) =>
@@ -317,7 +324,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       // There's no way to render without camera info
       if (newCameraInfoTopic == undefined) {
         this.renderer.settings.errors.addToTopic(
-          imageTopic,
+          namespacedTopic,
           NO_CAMERA_INFO_ERR,
           "No CameraInfo topic found",
         );
@@ -332,19 +339,19 @@ export class Images extends SceneExtension<ImageRenderable> {
       this.renderer.updateConfig((draft) => {
         const updatedUserSettings = { ...settings };
         updatedUserSettings.cameraInfoTopic = newCameraInfoTopic;
-        draft.topics[imageTopic] = updatedUserSettings;
+        draft.namespacedTopics[namespacedTopic] = updatedUserSettings;
       });
       this.updateSettingsTree();
     }
 
     assert(settings.cameraInfoTopic != undefined);
-    this.#cameraInfoToImageTopics.set(settings.cameraInfoTopic, imageTopic);
+    this.#cameraInfoToImageTopics.set(settings.cameraInfoTopic, namespacedTopic);
 
     // Look up the camera info for our renderable
     const cameraInfo = this.#cameraInfoByTopic.get(settings.cameraInfoTopic);
     if (!cameraInfo) {
       this.renderer.settings.errors.addToTopic(
-        imageTopic,
+        namespacedTopic,
         NO_CAMERA_INFO_ERR,
         `No CameraInfo received on ${settings.cameraInfoTopic}`,
       );
@@ -411,7 +418,7 @@ export class Images extends SceneExtension<ImageRenderable> {
 
   // Get or create an image renderable for the imageTopic
   #getImageRenderable(
-    imageTopic: string,
+    imageTopic: NamespacedTopic,
     receiveTime: bigint,
     image: AnyImage | undefined,
     frameId: string,
@@ -422,7 +429,7 @@ export class Images extends SceneExtension<ImageRenderable> {
     }
 
     // Look up any existing settings for the image topic to save as user data with the renderable
-    const userSettings = this.renderer.config.topics[imageTopic] as
+    const userSettings = this.renderer.config.namespacedTopics[imageTopic] as
       | Partial<LayerSettingsImage>
       | undefined;
 
@@ -431,7 +438,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       messageTime: image ? toNanoSec("header" in image ? image.header.stamp : image.timestamp) : 0n,
       frameId: this.renderer.normalizeFrameId(frameId),
       pose: makePose(),
-      settingsPath: ["topics", imageTopic],
+      settingsPath: ["namespacedTopics", imageTopic],
       topic: imageTopic,
       settings: { ...IMAGE_RENDERABLE_DEFAULT_SETTINGS, ...userSettings },
       cameraInfo: undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/LaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/LaserScans.ts
@@ -10,9 +10,9 @@ import { SettingsTreeAction } from "@foxglove/studio";
 import {
   DEFAULT_POINT_SETTINGS,
   LayerSettingsPointExtension,
-  pointSettingsNode,
   PointsRenderable,
   RenderObjectHistory,
+  pointSettingsNode,
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/pointExtensionUtils";
 import type { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
@@ -24,9 +24,10 @@ import { BaseUserData, Renderable } from "../Renderable";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
 import { LASERSCAN_DATATYPES as FOXGLOVE_LASERSCAN_DATATYPES } from "../foxglove";
-import { normalizeFloat32Array, normalizeTime, normalizePose } from "../normalizeMessages";
+import { NamespacedTopic, namespaceTopic } from "../namespaceTopic";
+import { normalizeFloat32Array, normalizePose, normalizeTime } from "../normalizeMessages";
 import { LASERSCAN_DATATYPES as ROS_LASERSCAN_DATATYPES, LaserScan as RosLaserScan } from "../ros";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { Pose } from "../transforms";
 
 type LayerSettingsLaserScan = LayerSettingsPointExtension;
@@ -136,7 +137,11 @@ class LaserScanHistoryRenderable extends Renderable<LaserScanHistoryUserData> {
   public override pickable = false; // Picking happens on child renderables
   #pointsHistory: RenderObjectHistory<LaserScanRenderable>;
 
-  public constructor(topic: string, renderer: IRenderer, userData: LaserScanHistoryUserData) {
+  public constructor(
+    topic: NamespacedTopic,
+    renderer: IRenderer,
+    userData: LaserScanHistoryUserData,
+  ) {
     super(topic, renderer, userData);
 
     const isDecay = userData.settings.decayTime > 0;
@@ -336,15 +341,16 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      const isLaserScan = topicIsConvertibleToSchema(topic, ALL_LASERSCAN_DATATYPES);
-      if (!isLaserScan) {
+      const schema = convertibleSchemaForTopic(topic, ALL_LASERSCAN_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsLaserScan>;
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsLaserScan>;
       const messageFields = LASERSCAN_FIELDS;
       const node: SettingsTreeNodeWithActionHandler = pointSettingsNode(
         topic,
@@ -353,7 +359,8 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
       );
       node.handler = handler;
       node.icon = "Radar";
-      entries.push({ path: ["topics", topic.name], node });
+      node.label = topic.name;
+      entries.push({ path: ["namespacedTopics", namespacedTopic], node });
     }
     return entries;
   }
@@ -388,10 +395,10 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const prevSettings = this.renderer.config.topics[topicName] as
+      const prevSettings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsLaserScan>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...prevSettings };
@@ -408,7 +415,7 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
   #handleLaserScan = (
     messageEvent: PartialMessageEvent<RosLaserScan | FoxgloveLaserScan>,
   ): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const laserScan =
       "header" in messageEvent.message
         ? normalizeRosLaserScan(messageEvent.message)
@@ -418,7 +425,7 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsLaserScan>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -433,7 +440,7 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          draft.topics[topic] = updatedUserSettings;
+          draft.namespacedTopics[topic] = updatedUserSettings;
         });
       }
 
@@ -443,7 +450,7 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
         messageTime,
         frameId: this.renderer.normalizeFrameId(laserScan.frame_id),
         pose: laserScan.pose,
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         latestLaserScan: laserScan,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -7,6 +7,10 @@ import * as _ from "lodash-es";
 
 import { toNanoSec } from "@foxglove/rostime";
 import { SettingsTreeAction } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { LayerSettingsMarker, LayerSettingsMarkerNamespace, TopicMarkers } from "./TopicMarkers";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
@@ -22,8 +26,8 @@ import {
   normalizeVector3,
   normalizeVector3s,
 } from "../normalizeMessages";
-import { Marker, MarkerArray, MARKER_ARRAY_DATATYPES, MARKER_DATATYPES } from "../ros";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { MARKER_ARRAY_DATATYPES, MARKER_DATATYPES, Marker, MarkerArray } from "../ros";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 const DEFAULT_SETTINGS: LayerSettingsMarker = {
@@ -55,18 +59,19 @@ export class Markers extends SceneExtension<TopicMarkers> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (
-        !(
-          topicIsConvertibleToSchema(topic, MARKER_ARRAY_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, MARKER_DATATYPES)
-        )
-      ) {
+      const schema =
+        convertibleSchemaForTopic(topic, MARKER_ARRAY_DATATYPES) ??
+        convertibleSchemaForTopic(topic, MARKER_DATATYPES);
+
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsMarker>;
+
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsMarker>;
 
       const node: SettingsTreeNodeWithActionHandler = {
         label: topic.name,
@@ -110,7 +115,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
         }
       }
 
-      entries.push({ path: ["topics", topic.name], node });
+      entries.push({ path: ["namespacedTopics", namespacedTopic], node });
     }
     return entries;
   }
@@ -136,10 +141,10 @@ export class Markers extends SceneExtension<TopicMarkers> {
     this.saveSetting(path, action.payload.value);
 
     // Update the TopicMarkers settings
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const topicMarkers = this.renderables.get(topicName);
     if (topicMarkers) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsMarker>
         | undefined;
       topicMarkers.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
@@ -153,24 +158,24 @@ export class Markers extends SceneExtension<TopicMarkers> {
       return;
     }
 
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const namespaceKey = path[2]!;
     const fieldName = path[3]!;
     const namespace = namespaceKey.slice(3); // remove `ns:` prefix
 
     this.renderer.updateConfig((draft) => {
       // We build the settings tree with paths of the form
-      //   ["topics", <topic>, "ns:"<namespace>, "visible"]
+      //   ["namespacedTopics", <topic>, "ns:"<namespace>, "visible"]
       // but the config is stored with paths of the form
-      //   ["topics", <topic>, "namespaces", <namespace>, "visible"]
-      const actualPath = ["topics", topicName, "namespaces", namespace, fieldName];
+      //   ["namespacedTopics", <topic>, "namespaces", <namespace>, "visible"]
+      const actualPath = ["namespacedTopics", topicName, "namespaces", namespace, fieldName];
       _.set(draft, actualPath, action.payload.value);
     });
 
     // Update the MarkersNamespace settings
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsMarker>
         | undefined;
       const ns = renderable.namespaces.get(namespace);
@@ -187,7 +192,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
   };
 
   #handleMarkerArray = (messageEvent: PartialMessageEvent<MarkerArray>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const markerArray = messageEvent.message;
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
@@ -200,14 +205,14 @@ export class Markers extends SceneExtension<TopicMarkers> {
   };
 
   #handleMarker = (messageEvent: PartialMessageEvent<Marker>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const marker = normalizeMarker(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
     this.#addMarker(topic, marker, receiveTime);
   };
 
-  #addMarker(topic: string, marker: Marker, receiveTime: bigint): void {
+  #addMarker(topic: NamespacedTopic, marker: Marker, receiveTime: bigint): void {
     const topicMarkers = this.#getTopicMarkers(topic, marker, receiveTime);
     const prevNsCount = topicMarkers.namespaces.size;
     topicMarkers.addMarkerMessage(marker, receiveTime);
@@ -218,7 +223,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
     }
   }
 
-  public addMarkerArray(topic: string, markerArray: Marker[], receiveTime: bigint): void {
+  public addMarkerArray(topic: NamespacedTopic, markerArray: Marker[], receiveTime: bigint): void {
     const firstMarker = markerArray[0];
     if (!firstMarker) {
       return;
@@ -236,10 +241,10 @@ export class Markers extends SceneExtension<TopicMarkers> {
     }
   }
 
-  #getTopicMarkers(topic: string, marker: Marker, receiveTime: bigint): TopicMarkers {
+  #getTopicMarkers(topic: NamespacedTopic, marker: Marker, receiveTime: bigint): TopicMarkers {
     let topicMarkers = this.renderables.get(topic);
     if (!topicMarkers) {
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsMarker>
         | undefined;
 
@@ -248,7 +253,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
         messageTime: toNanoSec(marker.header.stamp),
         frameId: this.renderer.normalizeFrameId(marker.header.frame_id),
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         topic,
         settings: { ...DEFAULT_SETTINGS, ...userSettings },
       });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -7,22 +7,26 @@ import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
 import { BaseUserData, Renderable } from "../Renderable";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
-import { rgbaToCssString, SRGBToLinear, stringToRgba } from "../color";
+import { SRGBToLinear, rgbaToCssString, stringToRgba } from "../color";
 import {
   normalizeHeader,
-  normalizePose,
   normalizeInt8Array,
+  normalizePose,
   normalizeTime,
 } from "../normalizeMessages";
-import { ColorRGBA, OccupancyGrid, OCCUPANCY_GRID_DATATYPES } from "../ros";
+import { ColorRGBA, OCCUPANCY_GRID_DATATYPES, OccupancyGrid } from "../ros";
 import { BaseSettings } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 
 type ColorModes = "custom" | "costmap" | "map" | "raw";
 
@@ -99,15 +103,18 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (!topicIsConvertibleToSchema(topic, OCCUPANCY_GRID_DATATYPES)) {
+      const schema = convertibleSchemaForTopic(topic, OCCUPANCY_GRID_DATATYPES);
+      if (schema == undefined) {
         continue;
       }
 
-      const configWithDefaults = { ...DEFAULT_SETTINGS, ...configTopics[topic.name] };
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+
+      const configWithDefaults = { ...DEFAULT_SETTINGS, ...configTopics[namespacedTopic] };
 
       let fields: SettingsTreeFields = {
         colorMode: {
@@ -175,7 +182,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
       };
 
       entries.push({
-        path: ["topics", topic.name],
+        path: ["namespacedTopics", namespacedTopic],
         node: {
           label: topic.name,
           icon: "Cells",
@@ -198,11 +205,11 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
-    const renderable = this.renderables.get(topicName);
+    const settingsKey = path[1]! as NamespacedTopic;
+    const renderable = this.renderables.get(settingsKey);
     if (renderable) {
       const prevTransparent = occupancyGridHasTransparency(renderable.userData.settings);
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[settingsKey] as
         | Partial<LayerSettingsOccupancyGrid>
         | undefined;
       renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
@@ -224,14 +231,14 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
   };
 
   #handleOccupancyGrid = (messageEvent: PartialMessageEvent<OccupancyGrid>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const occupancyGrid = normalizeOccupancyGrid(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsOccupancyGrid>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -251,7 +258,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
         messageTime: toNanoSec(occupancyGrid.header.stamp),
         frameId: this.renderer.normalizeFrameId(occupancyGrid.header.frame_id),
         pose: occupancyGrid.info.origin,
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         occupancyGrid,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -10,6 +10,10 @@ import { NumericType, PackedElementField, PointCloud } from "@foxglove/schemas";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRender/DynamicBufferGeometry";
 import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+import {
   autoSelectColorField,
   createGeometry,
   createInstancePickingMaterial,
@@ -45,7 +49,7 @@ import {
   PointField,
   PointFieldType,
 } from "../ros";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose, Pose } from "../transforms";
 
 type PointCloudFieldReaders = {
@@ -133,7 +137,11 @@ export class PointCloudHistoryRenderable extends Renderable<PointCloudHistoryUse
   #pointsHistory: RenderObjectHistory<PointCloudRenderable>;
   #stixelsHistory: RenderObjectHistory<StixelsRenderable>;
 
-  public constructor(topic: string, renderer: IRenderer, userData: PointCloudHistoryUserData) {
+  public constructor(
+    topic: NamespacedTopic,
+    renderer: IRenderer,
+    userData: PointCloudHistoryUserData,
+  ) {
     super(topic, renderer, userData);
 
     const isDecay = userData.settings.decayTime > 0;
@@ -718,16 +726,17 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      const isPointCloud = topicIsConvertibleToSchema(topic, ALL_POINTCLOUD_DATATYPES);
-      if (!isPointCloud) {
+      const schema = convertibleSchemaForTopic(topic, ALL_POINTCLOUD_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsPointClouds>;
-      const messageFields = this.#fieldsByTopic.get(topic.name) ?? POINT_CLOUD_REQUIRED_FIELDS;
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsPointClouds>;
+      const messageFields = this.#fieldsByTopic.get(namespacedTopic) ?? POINT_CLOUD_REQUIRED_FIELDS;
       const node: SettingsTreeNodeWithActionHandler = pointSettingsNode(
         topic,
         messageFields,
@@ -740,7 +749,8 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
       };
       node.handler = handler;
       node.icon = "Points";
-      entries.push({ path: ["topics", topic.name], node });
+      node.label = topic.name;
+      entries.push({ path: ["namespacedTopics", namespacedTopic], node });
     }
     return entries;
   }
@@ -775,10 +785,10 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const prevSettings = this.renderer.config.topics[topicName] as
+      const prevSettings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsPointClouds>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...prevSettings };
@@ -792,7 +802,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
   };
 
   #handleFoxglovePointCloud = (messageEvent: PartialMessageEvent<PointCloud>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const pointCloud = normalizePointCloud(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const messageTime = toNanoSec(pointCloud.timestamp);
@@ -816,7 +826,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
   };
 
   #handleRosPointCloud = (messageEvent: PartialMessageEvent<PointCloud2>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const pointCloud = normalizePointCloud2(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const messageTime = toNanoSec(pointCloud.header.stamp);
@@ -848,7 +858,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
   };
 
   #handlePointCloud(
-    topic: string,
+    topic: NamespacedTopic,
     pointCloud: PointCloud | PointCloud2,
     receiveTime: bigint,
     messageTime: bigint,
@@ -858,7 +868,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsPointClouds>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -871,7 +881,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          draft.topics[topic] = updatedUserSettings;
+          draft.namespacedTopics[topic] = updatedUserSettings;
         });
       }
 
@@ -885,7 +895,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
         messageTime,
         frameId: this.renderer.normalizeFrameId(frameId),
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         latestPointCloud: pointCloud,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Polygons.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Polygons.ts
@@ -4,6 +4,10 @@
 
 import { toNanoSec } from "@foxglove/rostime";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import { RenderableLineStrip } from "./markers/RenderableLineStrip";
@@ -17,13 +21,13 @@ import {
   Marker,
   MarkerAction,
   MarkerType,
+  POLYGON_STAMPED_DATATYPES,
   Polygon,
   PolygonStamped,
-  POLYGON_STAMPED_DATATYPES,
   TIME_ZERO,
 } from "../ros";
 import { BaseSettings } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 export type LayerSettingsPolygon = BaseSettings & {
@@ -77,14 +81,16 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (!topicIsConvertibleToSchema(topic, POLYGON_STAMPED_DATATYPES)) {
+      const schema = convertibleSchemaForTopic(topic, POLYGON_STAMPED_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsPolygon>;
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsPolygon>;
 
       // prettier-ignore
       const fields: SettingsTreeFields = {
@@ -93,7 +99,7 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
       };
 
       entries.push({
-        path: ["topics", topic.name],
+        path: ["namespacedTopics", namespacedTopic],
         node: {
           label: topic.name,
           icon: "Star",
@@ -115,10 +121,10 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsPolygon>
         | undefined;
       renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
@@ -131,14 +137,14 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
   };
 
   #handlePolygon = (messageEvent: PartialMessageEvent<PolygonStamped>): void => {
-    const topic = messageEvent.topic;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const polygonStamped = normalizePolygonStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsPolygon>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -148,7 +154,7 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
         messageTime: toNanoSec(polygonStamped.header.stamp),
         frameId: this.renderer.normalizeFrameId(polygonStamped.header.frame_id),
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         polygonStamped,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -8,6 +8,10 @@ import * as THREE from "three";
 import { toNanoSec } from "@foxglove/rostime";
 import { PosesInFrame } from "@foxglove/schemas";
 import { SettingsTreeAction, SettingsTreeFields, Topic } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import { Axis, AXIS_LENGTH } from "./Axis";
@@ -39,7 +43,10 @@ import {
   fieldScaleVec3,
   fieldSize,
 } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import {
+  convertibleSchemaForTopic,
+  topicIsConvertibleToSchema,
+} from "../topicIsConvertibleToSchema";
 import { makePose, Pose } from "../transforms";
 
 type GradientRgba = [ColorRGBA, ColorRGBA];
@@ -164,20 +171,20 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (
-        !(
-          topicIsConvertibleToSchema(topic, POSE_ARRAY_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, NAV_PATH_DATATYPES) ||
-          topicIsConvertibleToSchema(topic, POSES_IN_FRAME_DATATYPES)
-        )
-      ) {
+      const schema =
+        convertibleSchemaForTopic(topic, POSE_ARRAY_DATATYPES) ??
+        convertibleSchemaForTopic(topic, NAV_PATH_DATATYPES) ??
+        convertibleSchemaForTopic(topic, POSES_IN_FRAME_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsPoseArray>;
+
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsPoseArray>;
       const displayType = config.type ?? getDefaultType(topic);
       const { axisScale, lineWidth } = config;
       const arrowScale = config.arrowScale ?? DEFAULT_ARROW_SCALE;
@@ -217,7 +224,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
       }
 
       entries.push({
-        path: ["topics", topic.name],
+        path: ["namespacedTopics", namespacedTopic],
         node: {
           label: topic.name,
           icon: topicIsConvertibleToSchema(topic, NAV_PATH_DATATYPES) ? "Timeline" : "Flag",
@@ -239,10 +246,10 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsPoseArray>
         | undefined;
       const defaultType = { type: getDefaultType(this.renderer.topicsByName?.get(topicName)) };
@@ -259,7 +266,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
   #handlePoseArray = (messageEvent: PartialMessageEvent<PoseArray>): void => {
     const poseArrayMessage = normalizePoseArray(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.#addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
+    this.#addPoseArray(messageEvent, poseArrayMessage, messageEvent.message, receiveTime);
   };
 
   #handleNavPath = (messageEvent: PartialMessageEvent<NavPath>): void => {
@@ -269,28 +276,31 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
 
     const poseArrayMessage = normalizeNavPathToPoseArray(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.#addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
+    this.#addPoseArray(messageEvent, poseArrayMessage, messageEvent.message, receiveTime);
   };
 
   #handlePosesInFrame = (messageEvent: PartialMessageEvent<PosesInFrame>): void => {
     const poseArrayMessage = normalizePosesInFrameToPoseArray(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.#addPoseArray(messageEvent.topic, poseArrayMessage, messageEvent.message, receiveTime);
+    this.#addPoseArray(messageEvent, poseArrayMessage, messageEvent.message, receiveTime);
   };
 
   #addPoseArray(
-    topic: string,
+    messageEvent: PartialMessageEvent<unknown>,
     poseArrayMessage: PoseArray,
     originalMessage: Record<string, RosValue>,
     receiveTime: bigint,
   ): void {
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsPoseArray>
         | undefined;
-      const defaultType = { type: getDefaultType(this.renderer.topicsByName?.get(topic)) };
+      const defaultType = {
+        type: getDefaultType(this.renderer.topicsByName?.get(messageEvent.topic)),
+      };
       const settings = { ...DEFAULT_SETTINGS, ...defaultType, ...userSettings };
 
       renderable = new PoseArrayRenderable(topic, this.renderer, {
@@ -298,7 +308,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
         messageTime: toNanoSec(poseArrayMessage.header.stamp),
         frameId: this.renderer.normalizeFrameId(poseArrayMessage.header.frame_id),
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         poseArrayMessage,
@@ -355,7 +365,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
   #createArrowsToMatchPoses(
     renderable: PoseArrayRenderable,
     poseArray: PoseArray,
-    topic: string,
+    topic: NamespacedTopic,
     colorStart: ColorRGBA,
     colorEnd: ColorRGBA,
   ): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
@@ -7,7 +7,11 @@ import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
 import { PoseInFrame } from "@foxglove/schemas";
-import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import { MessageEvent, SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import { Axis, AXIS_LENGTH } from "./Axis";
@@ -27,19 +31,19 @@ import {
   normalizeTime,
 } from "../normalizeMessages";
 import {
+  ColorRGBA,
   Marker,
-  PoseWithCovarianceStamped,
-  PoseStamped,
-  POSE_WITH_COVARIANCE_STAMPED_DATATYPES,
   MarkerAction,
   MarkerType,
-  TIME_ZERO,
   POSE_STAMPED_DATATYPES,
+  POSE_WITH_COVARIANCE_STAMPED_DATATYPES,
+  PoseStamped,
   PoseWithCovariance,
-  ColorRGBA,
+  PoseWithCovarianceStamped,
+  TIME_ZERO,
 } from "../ros";
 import { BaseSettings, PRECISION_DISTANCE } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 type DisplayType = "axis" | "arrow";
@@ -123,19 +127,23 @@ export class Poses extends SceneExtension<PoseRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      const isPoseStamped = topicIsConvertibleToSchema(topic, POSE_STAMPED_DATATYPES);
-      const isPoseInFrame = topicIsConvertibleToSchema(topic, POSE_IN_FRAME_DATATYPES);
-      const isPoseWithCovarianceStamped = isPoseStamped
-        ? false
-        : topicIsConvertibleToSchema(topic, POSE_WITH_COVARIANCE_STAMPED_DATATYPES);
-      if (!(isPoseStamped || isPoseWithCovarianceStamped || isPoseInFrame)) {
+      const poseStampedSchema = convertibleSchemaForTopic(topic, POSE_STAMPED_DATATYPES);
+      const poseInFrameSchema = convertibleSchemaForTopic(topic, POSE_IN_FRAME_DATATYPES);
+      const poseWithCovarianceStampedSchema = poseStampedSchema
+        ? undefined
+        : convertibleSchemaForTopic(topic, POSE_WITH_COVARIANCE_STAMPED_DATATYPES);
+
+      const schema = poseStampedSchema ?? poseInFrameSchema ?? poseWithCovarianceStampedSchema;
+      if (schema == undefined) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsPose>;
+
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsPose>;
       const type = config.type ?? DEFAULT_TYPE;
 
       const fields: SettingsTreeFields = {
@@ -174,7 +182,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
         };
       }
 
-      if (isPoseWithCovarianceStamped) {
+      if (schema === poseWithCovarianceStampedSchema) {
         const showCovariance = config.showCovariance ?? DEFAULT_SHOW_COVARIANCE;
         const covarianceColor = config.covarianceColor ?? DEFAULT_COVARIANCE_COLOR_STR;
 
@@ -193,7 +201,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
       }
 
       entries.push({
-        path: ["topics", topic.name],
+        path: ["namespacedTopics", namespacedTopic],
         node: {
           label: topic.name,
           icon: "Flag",
@@ -204,6 +212,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
         },
       });
     }
+
     return entries;
   }
 
@@ -216,10 +225,10 @@ export class Poses extends SceneExtension<PoseRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
-    const renderable = this.renderables.get(topicName);
+    const topic = path[1]! as NamespacedTopic;
+    const renderable = this.renderables.get(topic);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsPose>
         | undefined;
       this.#updatePoseRenderable(
@@ -235,13 +244,13 @@ export class Poses extends SceneExtension<PoseRenderable> {
   #handlePoseStamped = (messageEvent: PartialMessageEvent<PoseStamped>): void => {
     const poseMessage = normalizePoseStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.#addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
+    this.#addPose(messageEvent, poseMessage, receiveTime);
   };
 
   #handlePoseInFrame = (messageEvent: PartialMessageEvent<PoseInFrame>): void => {
     const poseMessage = normalizePoseInFrameToPoseStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.#addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
+    this.#addPose(messageEvent, poseMessage, receiveTime);
   };
 
   #handlePoseWithCovariance = (
@@ -249,46 +258,46 @@ export class Poses extends SceneExtension<PoseRenderable> {
   ): void => {
     const poseMessage = normalizePoseWithCovarianceStamped(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
-    this.#addPose(messageEvent.topic, poseMessage, messageEvent.message, receiveTime);
+    this.#addPose(messageEvent, poseMessage, receiveTime);
   };
 
   #addPose(
-    topic: string,
+    originalMessage: MessageEvent<Record<string, RosValue>>,
     poseMessage: PoseStamped | PoseWithCovarianceStamped,
-    originalMessage: Record<string, RosValue>,
     receiveTime: bigint,
   ): void {
-    let renderable = this.renderables.get(topic);
+    const namespacedTopic = namespaceTopic(originalMessage.topic, originalMessage.schemaName);
+    let renderable = this.renderables.get(namespacedTopic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[namespacedTopic] as
         | Partial<LayerSettingsPose>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
 
-      renderable = new PoseRenderable(topic, this.renderer, {
+      renderable = new PoseRenderable(namespacedTopic, this.renderer, {
         receiveTime,
         messageTime: toNanoSec(poseMessage.header.stamp),
         frameId: this.renderer.normalizeFrameId(poseMessage.header.frame_id),
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", namespacedTopic],
         settings,
-        topic,
+        topic: namespacedTopic,
         poseMessage,
-        originalMessage,
+        originalMessage: originalMessage.message,
         axis: undefined,
         arrow: undefined,
         sphere: undefined,
       });
 
       this.add(renderable);
-      this.renderables.set(topic, renderable);
+      this.renderables.set(namespacedTopic, renderable);
     }
 
     this.#updatePoseRenderable(
       renderable,
       poseMessage,
-      originalMessage,
+      originalMessage.message,
       receiveTime,
       renderable.userData.settings,
     );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishClickTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishClickTool.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableArrow } from "./markers/RenderableArrow";
 import { RenderableSphere } from "./markers/RenderableSphere";
 import type { IRenderer } from "../IRenderer";
@@ -78,9 +80,14 @@ export class PublishClickTool extends SceneExtension<Renderable, PublishClickEve
   public constructor(renderer: IRenderer) {
     super("foxglove.PublishClickTool", renderer);
 
-    this.#sphere = new RenderableSphere("", makeSphereMarker(), undefined, this.renderer);
+    this.#sphere = new RenderableSphere(
+      "" as NamespacedTopic,
+      makeSphereMarker(),
+      undefined,
+      this.renderer,
+    );
     this.#arrow = new RenderableArrow(
-      "",
+      "" as NamespacedTopic,
       makeArrowMarker(this.publishClickType),
       undefined,
       this.renderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishSettings.ts
@@ -6,9 +6,10 @@ import { t } from "i18next";
 import * as _ from "lodash-es";
 
 import { SettingsTreeAction } from "@foxglove/studio";
+import { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/config";
 
 import { PublishClickType } from "./PublishClickTool";
-import type { IRenderer, RendererConfig } from "../IRenderer";
+import type { IRenderer } from "../IRenderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
@@ -19,6 +19,10 @@ import {
   TriangleListPrimitive,
 } from "@foxglove/schemas";
 import { SettingsTreeAction } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { TopicEntities } from "./TopicEntities";
 import { PrimitivePool } from "./primitives/PrimitivePool";
@@ -28,15 +32,15 @@ import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExt
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
 import { SCENE_UPDATE_DATATYPES } from "../foxglove";
 import {
+  normalizeByteArray,
   normalizeColorRGBA,
   normalizeColorRGBAs,
   normalizePose,
   normalizeTime,
   normalizeVector3,
-  normalizeByteArray,
 } from "../normalizeMessages";
 import { LayerSettingsEntity } from "../settings";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 const SCENE_ENTITIES_DEFAULT_SETTINGS: LayerSettingsEntity = {
@@ -64,13 +68,15 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (!topicIsConvertibleToSchema(topic, SCENE_UPDATE_DATATYPES)) {
+      const schema = convertibleSchemaForTopic(topic, SCENE_UPDATE_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsEntity>;
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsEntity>;
 
       const node: SettingsTreeNodeWithActionHandler = {
         label: topic.name,
@@ -95,7 +101,7 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
         handler: this.handleSettingsAction,
       };
 
-      entries.push({ path: ["topics", topic.name], node });
+      entries.push({ path: ["namespacedTopics", namespacedTopic], node });
     }
     return entries;
   }
@@ -130,10 +136,10 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
     this.saveSetting(path, action.payload.value);
 
     // Update the TopicEntities settings
-    const topicName = path[1]!;
-    const renderable = this.renderables.get(topicName);
+    const namespacedTopic = path[1]! as NamespacedTopic;
+    const renderable = this.renderables.get(namespacedTopic);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName] as
+      const settings = this.renderer.config.namespacedTopics[namespacedTopic] as
         | Partial<LayerSettingsEntity>
         | undefined;
       renderable.userData.settings = { ...SCENE_ENTITIES_DEFAULT_SETTINGS, ...settings };
@@ -142,20 +148,20 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
   };
 
   #handleSceneUpdate = (messageEvent: PartialMessageEvent<SceneUpdate>): void => {
-    const topic = messageEvent.topic;
+    const namespacedTopic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const sceneUpdates = messageEvent.message;
 
     for (const deletionMsg of sceneUpdates.deletions ?? []) {
       if (deletionMsg) {
         const deletion = normalizeSceneEntityDeletion(deletionMsg);
-        this.#getTopicEntities(topic).deleteEntities(deletion);
+        this.#getTopicEntities(namespacedTopic).deleteEntities(deletion);
       }
     }
 
     for (const entityMsg of sceneUpdates.entities ?? []) {
       if (entityMsg) {
         const entity = normalizeSceneEntity(entityMsg);
-        this.#getTopicEntities(topic).addOrUpdateEntity(
+        this.#getTopicEntities(namespacedTopic).addOrUpdateEntity(
           entity,
           toNanoSec(messageEvent.receiveTime),
         );
@@ -163,10 +169,10 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
     }
   };
 
-  #getTopicEntities(topic: string): TopicEntities {
+  #getTopicEntities(topic: NamespacedTopic): TopicEntities {
     let topicEntities = this.renderables.get(topic);
     if (!topicEntities) {
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsEntity>
         | undefined;
 
@@ -175,7 +181,7 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
         messageTime: -1n,
         frameId: "",
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         topic,
         settings: { ...SCENE_ENTITIES_DEFAULT_SETTINGS, ...userSettings },
       });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker, getMarkerId } from "./markers/RenderableMarker";
 import { RenderableMeshResource } from "./markers/RenderableMeshResource";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
@@ -44,11 +46,11 @@ export class MarkersNamespace {
   public markersById = new Map<number, RenderableMarker>();
   public settings: LayerSettingsMarkerNamespace;
 
-  public constructor(topic: string, namespace: string, renderer: IRenderer) {
+  public constructor(topic: NamespacedTopic, namespace: string, renderer: IRenderer) {
     this.namespace = namespace;
 
     // Set the initial settings from default values merged with any user settings
-    const topicSettings = renderer.config.topics[topic] as PartialMarkerSettings;
+    const topicSettings = renderer.config.namespacedTopics[topic] as PartialMarkerSettings;
     const userSettings = topicSettings?.namespaces?.[namespace];
     this.settings = { ...DEFAULT_NAMESPACE_SETTINGS, ...userSettings };
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -19,6 +19,7 @@ import {
   SettingsTreeFields,
 } from "@foxglove/studio";
 import { makeRgba, stringToRgba } from "@foxglove/studio-base/panels/ThreeDeeRender/color";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { eulerToQuaternion } from "@foxglove/studio-base/util/geometry";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
@@ -30,7 +31,7 @@ import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
 import { BaseUserData, Renderable } from "../Renderable";
 import { PartialMessageEvent, SceneExtension } from "../SceneExtension";
-import { SettingsTreeEntry } from "../SettingsManager";
+import { SettingsPath, SettingsTreeEntry } from "../SettingsManager";
 import {
   ColorRGBA,
   JointState,
@@ -53,10 +54,10 @@ import { updatePose } from "../updatePose";
 const log = Logger.getLogger(__filename);
 
 const LAYER_ID = "foxglove.Urdf";
-const TOPIC_NAME = "/robot_description";
+const TOPIC_NAME = "/robot_description" as NamespacedTopic;
 
 /** ID of fake "topic" used to represent the /robot_description parameter */
-const PARAM_KEY = "param:/robot_description";
+const PARAM_KEY = "param:/robot_description" as NamespacedTopic;
 /** Standard parameter name used for URDF data in ROS */
 const PARAM_NAME = "/robot_description";
 const PARAM_DISPLAY_NAME = "/robot_description (parameter)";
@@ -271,7 +272,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         },
       };
       entries.push({
-        path: ["topics", TOPIC_NAME],
+        path: ["namespacedTopics", TOPIC_NAME],
         node: {
           label: TOPIC_NAME,
           icon: "PrecisionManufacturing",
@@ -304,7 +305,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       };
 
       entries.push({
-        path: ["topics", PARAM_KEY],
+        path: ["namespacedTopics", PARAM_KEY],
         node: {
           label: PARAM_DISPLAY_NAME,
           icon: "PrecisionManufacturing",
@@ -809,12 +810,14 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
 
     const isTopicOrParam = instanceId === TOPIC_NAME || instanceId === PARAM_KEY;
     const frameId = this.renderer.fixedFrameId ?? ""; // Unused
-    const settingsPath = isTopicOrParam ? ["topics", instanceId] : ["layers", instanceId];
+    const settingsPath: SettingsPath = isTopicOrParam
+      ? ["namespacedTopics", instanceId as NamespacedTopic]
+      : ["layers", instanceId];
     const sourceType = (settings as Partial<LayerSettingsCustomUrdf>).sourceType;
     const url = (settings as Partial<LayerSettingsCustomUrdf>).url;
     const filePath = (settings as Partial<LayerSettingsCustomUrdf>).filePath;
     const parameter = (settings as Partial<LayerSettingsCustomUrdf>).parameter;
-    const topic = (settings as Partial<LayerSettingsCustomUrdf>).topic;
+    const topic = (settings as Partial<LayerSettingsCustomUrdf>).topic as NamespacedTopic;
     const framePrefix = (settings as Partial<LayerSettingsCustomUrdf>).framePrefix;
     const label =
       (settings as Partial<LayerSettingsCustomUrdf>).label ?? DEFAULT_CUSTOM_SETTINGS.label;
@@ -1062,7 +1065,7 @@ function createRenderable(args: {
   fallbackColor?: ColorRGBA;
 }): Renderable {
   const { visual, robot, id, frameId, renderer, baseUrl, fallbackColor } = args;
-  const name = `${frameId}-${id}-${visual.geometry.geometryType}`;
+  const name = `${frameId}-${id}-${visual.geometry.geometryType}` as NamespacedTopic;
   const orientation = eulerToQuaternion(visual.origin.rpy);
   const pose = { position: visual.origin.xyz, orientation };
   const color = getColor(visual, robot) ?? fallbackColor ?? DEFAULT_COLOR;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
@@ -3,8 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { toNanoSec, toSec } from "@foxglove/rostime";
-import { NumericType, PointCloud as FoxglovePointCloud } from "@foxglove/schemas";
+import { PointCloud as FoxglovePointCloud, NumericType } from "@foxglove/schemas";
 import { MessageEvent, SettingsTreeAction } from "@foxglove/studio";
+import {
+  NamespacedTopic,
+  namespaceTopic,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import {
   createStixelMaterial,
   PointCloudHistoryRenderable,
@@ -21,20 +25,20 @@ import {
 } from "@foxglove/velodyne-cloud";
 
 import {
+  DEFAULT_POINT_SETTINGS,
+  LayerSettingsPointExtension,
+  POINT_CLOUD_REQUIRED_FIELDS,
   autoSelectColorField,
   createInstancePickingMaterial,
   createPickingMaterial,
-  DEFAULT_POINT_SETTINGS,
-  LayerSettingsPointExtension,
-  pointSettingsNode,
   pointCloudMaterial,
-  POINT_CLOUD_REQUIRED_FIELDS,
+  pointSettingsNode,
 } from "./pointExtensionUtils";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
 import { VELODYNE_SCAN_DATATYPES } from "../ros";
-import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
+import { convertibleSchemaForTopic } from "../topicIsConvertibleToSchema";
 import { makePose } from "../transforms";
 
 type LayerSettingsVelodyneScans = LayerSettingsPointExtension & {
@@ -143,14 +147,16 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
-    const configTopics = this.renderer.config.topics;
+    const configTopics = this.renderer.config.namespacedTopics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (!topicIsConvertibleToSchema(topic, VELODYNE_SCAN_DATATYPES)) {
+      const schema = convertibleSchemaForTopic(topic, VELODYNE_SCAN_DATATYPES);
+      if (!schema) {
         continue;
       }
-      const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsVelodyneScans>;
+      const namespacedTopic = namespaceTopic(topic.name, schema);
+      const config = (configTopics[namespacedTopic] ?? {}) as Partial<LayerSettingsVelodyneScans>;
       const messageFields =
         this.#pointCloudFieldsByTopic.get(topic.name) ?? POINT_CLOUD_REQUIRED_FIELDS;
       const node: SettingsTreeNodeWithActionHandler = pointSettingsNode(
@@ -165,7 +171,7 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
       };
       node.handler = handler;
       node.icon = "Points";
-      entries.push({ path: ["topics", topic.name], node });
+      entries.push({ path: ["namespacedTopics", namespacedTopic], node });
     }
     return entries;
   }
@@ -179,10 +185,10 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
     this.saveSetting(path, action.payload.value);
 
     // Update the renderable
-    const topicName = path[1]!;
+    const topicName = path[1]! as NamespacedTopic;
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const prevSettings = this.renderer.config.topics[topicName] as
+      const prevSettings = this.renderer.config.namespacedTopics[topicName] as
         | Partial<LayerSettingsVelodyneScans>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...prevSettings };
@@ -211,7 +217,7 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
   }
 
   #handleVelodyneScan = (messageEvent: MessageEvent<VelodyneScan>): void => {
-    const { topic } = messageEvent;
+    const topic = namespaceTopic(messageEvent.topic, messageEvent.schemaName);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const pointCloud = this.#velodyneCloudConverter.decode(messageEvent.message);
     if (!pointCloud) {
@@ -221,7 +227,7 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic] as
+      const userSettings = this.renderer.config.namespacedTopics[topic] as
         | Partial<LayerSettingsVelodyneScans>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
@@ -234,7 +240,7 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          draft.topics[topic] = updatedUserSettings;
+          draft.namespacedTopics[topic] = updatedUserSettings;
         });
       }
 
@@ -249,7 +255,7 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
         messageTime,
         frameId: this.renderer.normalizeFrameId(pointCloud.frame_id),
         pose: makePose(),
-        settingsPath: ["topics", topic],
+        settingsPath: ["namespacedTopics", topic],
         settings,
         topic,
         latestPointCloud: pointCloud,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableArrow } from "./RenderableArrow";
 import { RenderableCube } from "./RenderableCube";
 import { RenderableCubeList } from "./RenderableCubeList";
@@ -43,7 +45,7 @@ export class MarkerPool {
 
   public acquire<T extends MarkerType>(
     type: T,
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
   ): RenderableMarker {
@@ -51,7 +53,7 @@ export class MarkerPool {
     if (renderables) {
       const renderable = renderables.pop();
       if (renderable) {
-        renderable.userData.settingsPath = ["topics", topic];
+        renderable.userData.settingsPath = ["namespacedTopics", topic];
         renderable.userData.settings = { visible: true, frameLocked: marker.frame_locked };
         renderable.userData.topic = topic;
         renderable.name = getMarkerId(topic, marker.ns, marker.id);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
@@ -5,6 +5,8 @@
 import * as THREE from "three";
 import { clamp } from "three/src/math/MathUtils";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { IRenderer } from "../../IRenderer";
@@ -33,7 +35,7 @@ export class RenderableArrow extends RenderableMarker {
   #headOutline: THREE.LineSegments;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { IRenderer } from "../../IRenderer";
@@ -15,7 +17,7 @@ export class RenderableCube extends RenderableMarker {
   #outline: THREE.LineSegments;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { createGeometry as createCubeGeometry } from "./RenderableCube";
 import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makeStandardInstancedMaterial } from "./materials";
@@ -16,7 +18,7 @@ export class RenderableCubeList extends RenderableMarker {
   // outline: THREE.LineSegments | undefined;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: Renderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { IRenderer } from "../../IRenderer";
@@ -16,7 +18,7 @@ export class RenderableCylinder extends RenderableMarker {
   #outline: THREE.LineSegments;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
@@ -6,6 +6,8 @@ import * as THREE from "three";
 import { LineSegments2 } from "three/examples/jsm/lines/LineSegments2";
 import { LineSegmentsGeometry } from "three/examples/jsm/lines/LineSegmentsGeometry";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import {
   makeLineMaterial,
@@ -25,7 +27,7 @@ export class RenderableLineList extends RenderableMarker {
   #colorBuffer = new Uint8Array();
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -6,6 +6,8 @@ import * as THREE from "three";
 import { Line2 } from "three/examples/jsm/lines/Line2";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import {
   makeLineMaterial,
@@ -27,7 +29,7 @@ export class RenderableLineStrip extends RenderableMarker {
   #colorBuffer = new Uint8Array();
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
@@ -5,6 +5,7 @@
 import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { RosValue } from "@foxglove/studio-base/players/types";
 
 import type { IRenderer } from "../../IRenderer";
@@ -30,7 +31,7 @@ export function getMarkerId(topic: string, ns: string, id: number): string {
 
 export class RenderableMarker extends Renderable<MarkerUserData> {
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,
@@ -43,7 +44,7 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
       messageTime: toNanoSec(marker.header.stamp),
       frameId: renderer.normalizeFrameId(marker.header.frame_id),
       pose: marker.pose,
-      settingsPath: ["topics", topic],
+      settingsPath: ["namespacedTopics", topic],
       settings: { visible: true, frameLocked: marker.frame_locked },
       topic,
       marker,
@@ -62,7 +63,9 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
   }
 
   public getSettings(): LayerSettingsMarker | undefined {
-    return this.renderer.config.topics[this.userData.topic] as LayerSettingsMarker | undefined;
+    return this.renderer.config.namespacedTopics[this.userData.topic] as
+      | LayerSettingsMarker
+      | undefined;
   }
 
   public override details(): Record<string, RosValue> {
@@ -114,7 +117,7 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
 
   #renderMarker(marker: Marker): Marker {
     const topicName = this.userData.topic;
-    const settings = this.renderer.config.topics[topicName] as
+    const settings = this.renderer.config.namespacedTopics[topicName] as
       | Partial<LayerSettingsMarker>
       | undefined;
     const colorStr = settings?.color;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -5,6 +5,7 @@
 import * as THREE from "three";
 
 import { EDGE_LINE_SEGMENTS_NAME } from "@foxglove/studio-base/panels/ThreeDeeRender/ModelCache";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
@@ -24,7 +25,7 @@ export class RenderableMeshResource extends RenderableMarker {
   #updateId = 0;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makePointsMaterial } from "./materials";
 import { DynamicBufferGeometry } from "../../DynamicBufferGeometry";
@@ -15,7 +17,7 @@ export class RenderablePoints extends RenderableMarker {
   #points: THREE.Points<DynamicBufferGeometry, THREE.PointsMaterial>;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { IRenderer } from "../../IRenderer";
@@ -15,7 +17,7 @@ export class RenderableSphere extends RenderableMarker {
   public mesh: THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { createGeometry as createSphereGeometry } from "./RenderableSphere";
 import { markerHasTransparency, makeStandardInstancedMaterial } from "./materials";
@@ -15,7 +17,7 @@ export class RenderableSphereList extends RenderableMarker {
   #mesh: DynamicInstancedMesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: Renderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Label } from "@foxglove/three-text";
 
 import { RenderableMarker } from "./RenderableMarker";
@@ -13,7 +14,7 @@ export class RenderableTextViewFacing extends RenderableMarker {
   #label: Label;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: Renderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
+
 import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makeStandardVertexColorMaterial } from "./materials";
 import { DynamicBufferGeometry } from "../../DynamicBufferGeometry";
@@ -22,7 +24,7 @@ export class RenderableTriangleList extends RenderableMarker {
   #mesh: THREE.Mesh<DynamicBufferGeometry, THREE.MeshStandardMaterial>;
 
   public constructor(
-    topic: string,
+    topic: NamespacedTopic,
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: Renderer,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -6,6 +6,7 @@ import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
 import { ArrowPrimitive, SceneEntity } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -248,7 +249,7 @@ export class RenderableArrows extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
@@ -6,6 +6,7 @@ import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
 import { CubePrimitive, SceneEntity } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -164,7 +165,7 @@ export class RenderableCubes extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -6,6 +6,7 @@ import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
 import { CylinderPrimitive, SceneEntity } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -200,7 +201,7 @@ export class RenderableCylinders extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -12,6 +12,7 @@ import { assert } from "ts-essentials";
 import { toNanoSec } from "@foxglove/rostime";
 import { LinePrimitive, LineType, SceneEntity } from "@foxglove/schemas";
 import { LineMaterialWithAlphaVertex } from "@foxglove/studio-base/panels/ThreeDeeRender/LineMaterialWithAlphaVertex";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -70,7 +71,7 @@ export class RenderableLines extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
@@ -7,6 +7,7 @@ import * as THREE from "three";
 import { crc32 } from "@foxglove/crc";
 import { toNanoSec } from "@foxglove/rostime";
 import { ModelPrimitive, SceneEntity } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -218,7 +219,7 @@ export class RenderableModels extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
@@ -5,6 +5,7 @@
 import { SceneEntity } from "@foxglove/schemas";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { BaseUserData, Renderable } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderable";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { RosValue } from "@foxglove/studio-base/players/types";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
@@ -40,7 +41,7 @@ export class RenderablePrimitive extends Renderable<EntityRenderableUserData> {
     super(name, renderer, userData);
   }
   public update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -5,7 +5,8 @@
 import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
-import { SpherePrimitive, SceneEntity } from "@foxglove/schemas";
+import { SceneEntity, SpherePrimitive } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -131,7 +132,7 @@ export class RenderableSpheres extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
@@ -4,6 +4,7 @@
 
 import { toNanoSec } from "@foxglove/rostime";
 import { SceneEntity, TextPrimitive } from "@foxglove/schemas";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Label, LabelPool } from "@foxglove/three-text";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
@@ -90,7 +91,7 @@ export class RenderableTexts extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -7,6 +7,7 @@ import * as THREE from "three";
 import { toNanoSec } from "@foxglove/rostime";
 import { Point3, SceneEntity, TriangleListPrimitive } from "@foxglove/schemas";
 import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRender/DynamicBufferGeometry";
+import { NamespacedTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
@@ -214,7 +215,7 @@ export class RenderableTriangles extends RenderablePrimitive {
   }
 
   public override update(
-    topic: string | undefined,
+    topic: NamespacedTopic | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,

--- a/packages/studio-base/src/panels/ThreeDeeRender/ros.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ros.ts
@@ -288,6 +288,8 @@ export type JointState = {
 
 export const TIME_ZERO = { sec: 0, nsec: 0 };
 
+export const ALL_ROS_DATATYPES = new Set<string>();
+
 export const TRANSFORM_STAMPED_DATATYPES = new Set<string>();
 addRosDataType(TRANSFORM_STAMPED_DATATYPES, "geometry_msgs/TransformStamped");
 
@@ -365,6 +367,10 @@ function addRosDataType(output: Set<string>, dataType: string): Set<string> {
 
   // Add the protobuf variation: ros.tf2_msgs.TFMessage
   output.add("ros." + dataType.split("/").join("."));
+
+  for (const schema of output) {
+    ALL_ROS_DATATYPES.add(schema);
+  }
 
   return output;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { ImageAnnotations, PointsAnnotationType } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
@@ -261,7 +262,9 @@ const AnnotationsStory = (
             imageMode: {
               calibrationTopic: "calibration",
               imageTopic: "camera",
-              annotations: { annotations: { visible: true } },
+              annotations: {
+                [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: true },
+              },
               ...imageModeConfigOverride,
             },
           }}
@@ -459,8 +462,16 @@ export const MessageConverterSupport: StoryObj = {
               calibrationTopic: "calibration",
               imageTopic: "camera",
               annotations: {
-                annotations: { visible: true },
-                custom_annotations: { visible: true },
+                [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: false },
+                [namespaceTopic("annotations", "foxglove_msgs/ImageAnnotations")]: {
+                  visible: true,
+                },
+                [namespaceTopic("custom_annotations", "foxglove_msgs/ImageAnnotations")]: {
+                  visible: false,
+                },
+                [namespaceTopic("custom_annotations", "foxglove_msgs/msg/ImageAnnotations")]: {
+                  visible: true,
+                },
               },
             },
           }}
@@ -775,7 +786,12 @@ const AnnotationsUpdateStory = (
           imageMode: {
             calibrationTopic: "calibration",
             imageTopic: "camera",
-            annotations: { annotations: { visible: true }, annotationsToClear: { visible: true } },
+            annotations: {
+              [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: true },
+              [namespaceTopic("annotationsToClear", "foxglove.ImageAnnotations")]: {
+                visible: true,
+              },
+            },
             ...imageModeConfigOverride,
           },
         }}
@@ -889,7 +905,9 @@ function UpdateLineStory({ messages }: UpdateLineArgs): JSX.Element {
           imageMode: {
             calibrationTopic: "calibration",
             imageTopic: "camera",
-            annotations: { annotations: { visible: true } },
+            annotations: {
+              [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: true },
+            },
           },
         }}
       />

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -18,6 +18,7 @@ import {
 } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import {
   makeCompressedImageAndCalibration,
   makeRawImageAndCalibration,
@@ -28,7 +29,7 @@ import delay from "@foxglove/studio-base/util/delay";
 
 import { ImagePanel } from "../../index";
 import { CameraInfo, CompressedImage as RosCompressedImage, Image as RosRawImage } from "../../ros";
-import { PNG_TEST_IMAGE, rad2deg, SENSOR_FRAME_ID } from "../common";
+import { PNG_TEST_IMAGE, SENSOR_FRAME_ID, rad2deg } from "../common";
 
 export default {
   title: "panels/ThreeDeeRender/Images",
@@ -640,7 +641,9 @@ const InvalidPinholeCamera = (): JSX.Element => {
           imageMode: {
             calibrationTopic: "calibration",
             imageTopic: "camera",
-            annotations: { annotations: { visible: true } },
+            annotations: {
+              [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: true },
+            },
           },
         }}
       />
@@ -1077,7 +1080,9 @@ export const RationalPolynomialDistortion: StoryObj = {
             imageMode: {
               imageTopic,
               calibrationTopic,
-              annotations: { [annotationsTopic]: { visible: true } },
+              annotations: {
+                [namespaceTopic(annotationsTopic, "foxglove.ImageAnnotations")]: { visible: true },
+              },
             },
           }}
         />

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
@@ -9,6 +9,7 @@ import tinycolor from "tinycolor2";
 import { ImageAnnotations, LineType, PointsAnnotationType, SceneUpdate } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import { xyzrpyToPose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -267,15 +268,13 @@ const ImageWith3D = (initialConfig: ImageModeConfig): JSX.Element => {
           },
           imageMode: {
             ...initialConfig,
-            annotations: { annotations: { visible: true } },
+            annotations: {
+              [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: true },
+            },
           },
-          topics: {
-            sceneUpdate1: {
-              visible: false,
-            },
-            sceneUpdate2: {
-              visible: true,
-            },
+          namespacedTopics: {
+            [namespaceTopic("sceneUpdate1", "foxglove.SceneUpdate")]: { visible: false },
+            [namespaceTopic("sceneUpdate2", "foxglove.SceneUpdate")]: { visible: true },
           },
         }}
       />

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImagePanZoomRotate.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImagePanZoomRotate.stories.tsx
@@ -8,6 +8,7 @@ import * as THREE from "three";
 
 import { ImageAnnotations, SceneUpdate } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -125,7 +126,9 @@ const BaseStory = ({ rotation, flipHorizontal, flipVertical }: BaseStoryProps): 
             imageMode: {
               calibrationTopic: "calibration",
               imageTopic: "camera",
-              annotations: { annotations: { visible: true } },
+              annotations: {
+                [namespaceTopic("annotations", "foxglove.ImageAnnotations")]: { visible: true },
+              },
               rotation,
               flipHorizontal,
               flipVertical,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -9,6 +9,7 @@ import { create } from "zustand";
 
 import { CompressedImage, RawImage } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -189,7 +190,12 @@ export const ImageRenderSettings: typeof ImageRender = {
   args: { includeSettings: true },
   play: async () => {
     await userEvent.click(
-      await screen.findByTestId("settings__nodeHeaderToggle__topics-/cam1/info"),
+      await screen.findByTestId(
+        `settings__nodeHeaderToggle__namespacedTopics-${namespaceTopic(
+          "/cam1/info",
+          "sensor_msgs/CameraInfo",
+        )}`,
+      ),
     );
   },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -7,6 +7,7 @@ import { userEvent, screen } from "@storybook/testing-library";
 import { useEffect, useState } from "react";
 
 import { MessageEvent } from "@foxglove/studio";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
@@ -567,7 +568,14 @@ export const MarkersSettings: StoryObj = {
     return <AllMarkers showOutlines={true} includeSettings />;
   },
   play: async () => {
-    await userEvent.click(await screen.findByTestId("settings__nodeHeaderToggle__topics-/markers"));
+    await userEvent.click(
+      await screen.findByTestId(
+        `settings__nodeHeaderToggle__namespacedTopics-${namespaceTopic(
+          "/markers",
+          "visualization_msgs/Marker",
+        )}`,
+      ),
+    );
   },
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -8,6 +8,7 @@ import { vec3 } from "gl-matrix";
 
 import type { PointCloud } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -29,7 +30,12 @@ export const Foxglove_PointCloud_RGBA_Settings: StoryObj = {
   play: async () => {
     await userEvent.click(await screen.findByTestId("settings__nodeHeaderToggle__general"));
     await userEvent.click(
-      await screen.findByTestId("settings__nodeHeaderToggle__topics-/pointcloud"),
+      await screen.findByTestId(
+        `settings__nodeHeaderToggle__namespacedTopics-${namespaceTopic(
+          "/pointcloud",
+          "foxglove.PointCloud",
+        )}`,
+      ),
     );
   },
 };
@@ -47,7 +53,12 @@ export const Foxglove_PointCloud_Gradient_Settings: StoryObj = {
   play: async () => {
     await userEvent.click(await screen.findByTestId("settings__nodeHeaderToggle__general"));
     await userEvent.click(
-      await screen.findByTestId("settings__nodeHeaderToggle__topics-/pointcloud"),
+      await screen.findByTestId(
+        `settings__nodeHeaderToggle__namespacedTopics-${namespaceTopic(
+          "/pointcloud",
+          "foxglove.PointCloud",
+        )}`,
+      ),
     );
   },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
@@ -8,6 +8,7 @@ import { quat } from "gl-matrix";
 
 import { FrameTransform, PoseInFrame } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -167,7 +168,14 @@ export const Foxglove_PoseInFrame: StoryObj = {
   },
 
   play: async () => {
-    await userEvent.click(await screen.findByTestId("settings__nodeHeaderToggle__topics-/pose1"));
+    await userEvent.click(
+      await screen.findByTestId(
+        `settings__nodeHeaderToggle__namespacedTopics-${namespaceTopic(
+          "/pose1",
+          "foxglove.PoseInFrame",
+        )}`,
+      ),
+    );
   },
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
@@ -8,6 +8,7 @@ import { quat } from "gl-matrix";
 
 import { FrameTransform, PosesInFrame } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
+import { namespaceTopic } from "@foxglove/studio-base/panels/ThreeDeeRender/namespaceTopic";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -181,7 +182,12 @@ export const Foxglove_PosesInFrame: StoryObj = {
 
   play: async () => {
     await userEvent.click(
-      await screen.findByTestId("settings__nodeHeaderToggle__topics-/baselink_path"),
+      await screen.findByTestId(
+        `settings__nodeHeaderToggle__namespacedTopics-${namespaceTopic(
+          "/baselink_path",
+          "foxglove.PosesInFrame",
+        )}`,
+      ),
     );
   },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/topicIsConvertibleToSchema.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/topicIsConvertibleToSchema.ts
@@ -17,3 +17,22 @@ export function topicIsConvertibleToSchema(
     (topic.convertibleTo?.some((name) => supportedSchemaNames.has(name)) ?? false)
   );
 }
+
+/**
+ * Finds the most appropriate schema for a topic given a set of supported schemas. Prefers
+ * a schema we support directly and falls back to a schema we can convert the topic to.
+ *
+ * @param topic the topic in question
+ * @param supportedSchemaNames schemas that the client supports
+ * @returns the best schema for the client to subscribe under
+ */
+export function convertibleSchemaForTopic(
+  topic: Topic,
+  supportedSchemaNames: ReadonlySet<string>,
+): undefined | string {
+  if (supportedSchemaNames.has(topic.schemaName)) {
+    return topic.schemaName;
+  }
+
+  return topic.convertibleTo?.find((name) => supportedSchemaNames.has(name));
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/useMigratedThreeDeeConfig.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/useMigratedThreeDeeConfig.ts
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as _ from "lodash-es";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { DeepPartial } from "ts-essentials";
+
+import { Immutable, Topic } from "@foxglove/studio";
+import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
+import { LayerSettingsTransform } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/FrameAxes";
+import { DEFAULT_PUBLISH_SETTINGS } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/PublishSettings";
+
+import { AnyRendererConfig, RendererConfig, migrateConfigTopicsNodes } from "./config";
+
+/**
+ * Fills out missing pieces of a 3d panel config and performs any migrations necessary to
+ * the current version.
+ *
+ * @param initialState initial state obtained from the stored config
+ * @param topics topics used to guide migration of unnamespaced topics
+ * @returns a migrated config
+ */
+export function useMigratedThreeDeeConfig(
+  initialState: undefined | DeepPartial<AnyRendererConfig>,
+  topics: undefined | Immutable<Topic[]>,
+): [Immutable<RendererConfig>, Dispatch<SetStateAction<Immutable<RendererConfig>>>] {
+  const [initialTopics] = useState(topics);
+
+  const [config, setConfig] = useState<Immutable<RendererConfig>>(() => {
+    const partialConfig: DeepPartial<RendererConfig> = initialState ?? {};
+
+    // Initialize the camera from default settings overlaid with persisted settings
+    const cameraState = _.merge(_.cloneDeep(DEFAULT_CAMERA_STATE), partialConfig.cameraState ?? {});
+    const publish = _.merge(_.cloneDeep(DEFAULT_PUBLISH_SETTINGS), partialConfig.publish ?? {});
+
+    const transforms = (partialConfig.transforms ?? {}) as Record<
+      string,
+      Partial<LayerSettingsTransform>
+    >;
+
+    const completeConfig: RendererConfig = {
+      version: "2",
+      cameraState,
+      followMode: partialConfig.followMode ?? "follow-pose",
+      followTf: partialConfig.followTf,
+      imageMode: {
+        ...(partialConfig.imageMode as RendererConfig["imageMode"]),
+        annotations: partialConfig.imageMode?.annotations as
+          | ImageModeConfig["annotations"]
+          | undefined,
+      },
+      layers: partialConfig.layers ?? {},
+      publish,
+      scene: partialConfig.scene ?? {},
+      namespacedTopics: partialConfig.namespacedTopics ?? {},
+      topics: partialConfig.topics ?? {},
+      transforms,
+    };
+
+    return migrateConfigTopicsNodes(completeConfig, topics ?? []);
+  });
+
+  useEffect(() => {
+    if (topics !== initialTopics) {
+      setConfig((old) => migrateConfigTopicsNodes(old, topics ?? []));
+    }
+  }, [initialTopics, topics]);
+
+  return [config, setConfig];
+}

--- a/packages/studio-base/src/services/migrateLayout/migrateLegacyToNew3DPanels.ts
+++ b/packages/studio-base/src/services/migrateLayout/migrateLegacyToNew3DPanels.ts
@@ -6,8 +6,8 @@ import * as _ from "lodash-es";
 
 import { filterMap } from "@foxglove/den/collection";
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-import type { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
+import { RendererConfigV1 } from "@foxglove/studio-base/panels/ThreeDeeRender/config";
 import {
   getAllPanelIds,
   getPanelIdForType,
@@ -16,7 +16,7 @@ import {
 
 import { replacePanel } from "./replacePanel";
 
-const DEFAULT_PUBLISH_SETTINGS: RendererConfig["publish"] = {
+const DEFAULT_PUBLISH_SETTINGS: RendererConfigV1["publish"] = {
   type: "point",
   poseTopic: "/move_base_simple/goal",
   pointTopic: "/clicked_point",
@@ -50,7 +50,7 @@ type Legacy3DConfig = {
   followTf?: string;
 };
 
-function migrateLegacyToNew3DConfig(legacyConfig: Partial<Legacy3DConfig>): RendererConfig {
+function migrateLegacyToNew3DConfig(legacyConfig: Partial<Legacy3DConfig>): RendererConfigV1 {
   return {
     followTf: legacyConfig.followTf,
     followMode:

--- a/packages/studio-base/src/services/migrateLayout/migrateLegacyToNewImagePanels.ts
+++ b/packages/studio-base/src/services/migrateLayout/migrateLegacyToNewImagePanels.ts
@@ -3,8 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-import type { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
+import { RendererConfigV1 } from "@foxglove/studio-base/panels/ThreeDeeRender/config";
 import { DEFAULT_PUBLISH_SETTINGS } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/PublishSettings";
 import {
   getAllPanelIds,
@@ -31,7 +31,7 @@ type LegacyImageConfig = {
   zoomPercentage?: number;
 };
 
-function migrateLegacyToNewImageConfig(legacyConfig: Partial<LegacyImageConfig>): RendererConfig {
+function migrateLegacyToNewImageConfig(legacyConfig: Partial<LegacyImageConfig>): RendererConfigV1 {
   return {
     cameraState: DEFAULT_CAMERA_STATE,
     followMode: "follow-pose",


### PR DESCRIPTION
**User-Facing Changes**
Support multiple message converters on the same topic

**Description**
Support multiple message converters on the same topic. This requires two changes:
1. A migration of the 3d panel config to a new version.
2. Replacement of namespacing various objects in 3d panel code by plain topics with "namespaced" topics, which combine topic + schema into a single key.

The migration here is complicated by the fact that it depends on the topics available from the datasource at the time of the migration. The solution proposed here is to migrate only the data in the existing 3d panel config we have topic data for at the time of the migration to a new `namespacedTopics` config key and leave the unmigrated data as-is in `topics`. 

The downside of this is that the migration is not a one-shot migration and needs to be run every time we get a new config in the 3d panel. The upside is data we can't migrate because topics are not available at any point in time can be rescued later if we do get the topics from new data.

I think we may also need to special case a few topics like tfs and maybe URDF related topics.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
