### PR TITLE
Fix point hover logic on map panel

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -637,9 +637,10 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       return;
     }
 
-    // get the point occuring most recently before preview time but not after preview time
+    // Find the point occuring most recently before or at preview time but not after
+    // preview time.
     const prevNavMessages = allNavMessages.filter(
-      (message) => toSec(message.receiveTime) < previewTime,
+      (message) => toSec(message.receiveTime) <= previewTime,
     );
     const event = minBy(prevNavMessages, (message) => previewTime - toSec(message.receiveTime));
     if (!event) {


### PR DESCRIPTION
**User-Facing Changes**
Fix logic to detect hovered points on map panel.

**Description**
Fix logic to detect hovered points on map panel. When we have a preview time the existing logic looks for the most recent point _before_ the hover time, which causes it to pick the point before the actual hovered point. The fix is to look for the most precent point _before or at_ the current hover time which includes the currently hovered point.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
