### PR TITLE
Rename PinholeCameraModel methods to be less confusing

### DIFF
--- a/packages/den/image/PinholeCameraModel.test.ts
+++ b/packages/den/image/PinholeCameraModel.test.ts
@@ -127,52 +127,52 @@ describe("PinholeCameraModel", () => {
     });
   });
 
-  it("rectifyPixel - no distortion", () => {
+  it("undistortPixel - no distortion", () => {
     const model = new PinholeCameraModel(makeCameraInfo(640, 480, 45));
     const rectified = { x: 0, y: 0 };
 
-    model.rectifyPixel(rectified, { x: 320, y: 240 });
+    model.undistortPixel(rectified, { x: 320, y: 240 });
     expect(rectified).toEqual({ x: 320, y: 240 });
 
-    model.rectifyPixel(rectified, { x: 100, y: 100 });
+    model.undistortPixel(rectified, { x: 100, y: 100 });
     expect(rectified).toMatchObject({ x: closeTo(100), y: closeTo(100) });
   });
 
-  it("rectifyPixel - plumb_bob", () => {
+  it("undistortPixel - plumb_bob", () => {
     const model = new PinholeCameraModel(makeCameraInfo(640, 480, 60, "plumb_bob", D1));
     const rectified = { x: 0, y: 0 };
 
-    model.rectifyPixel(rectified, { x: 320, y: 240 });
+    model.undistortPixel(rectified, { x: 320, y: 240 });
     expect(rectified).toEqual({ x: 320, y: 240 });
 
-    model.rectifyPixel(rectified, { x: 0, y: 0 });
+    model.undistortPixel(rectified, { x: 0, y: 0 });
     expect(rectified).toMatchObject({
       x: closeTo(-72.45696739),
       y: closeTo(-54.4783923),
     });
   });
 
-  it("unrectifyPixel - no distortion", () => {
+  it("distortPixel - no distortion", () => {
     const model = new PinholeCameraModel(makeCameraInfo(640, 480, 45));
     const unrectified = { x: 0, y: 0 };
 
-    model.unrectifyPixel(unrectified, { x: 320, y: 240 });
+    model.distortPixel(unrectified, { x: 320, y: 240 });
     expect(unrectified).toEqual({ x: 320, y: 240 });
 
-    model.unrectifyPixel(unrectified, { x: 0, y: 0 });
+    model.distortPixel(unrectified, { x: 0, y: 0 });
     expect(unrectified).toMatchObject({
       x: closeTo(0),
       y: closeTo(0),
     });
   });
 
-  it("unrectifyPixel - plumb_bob", () => {
+  it("distortPixel - plumb_bob", () => {
     const model = new PinholeCameraModel(makeCameraInfo(640, 480, 60, "plumb_bob", D1));
     const rectified = { x: 0, y: 0 };
     const unrectified = { x: 0, y: 0 };
 
-    model.rectifyPixel(rectified, { x: 0, y: 0 });
-    model.unrectifyPixel(unrectified, rectified);
+    model.undistortPixel(rectified, { x: 0, y: 0 });
+    model.distortPixel(unrectified, rectified);
     expect(unrectified).toMatchObject({
       // low precision comparison since we're approximating a nonlinear function
       x: closeTo(0, 1),

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -180,14 +180,15 @@ export class PinholeCameraModel {
   }
 
   /**
-   * Rectifies the given pixel 2D coordinate.
+   * Undoes camera distortion to map a given pixel coordinate from a raw image to a rectified image.
+   * Similar to OpenCV `undistortPoints()`.
    *
    * @param out - The output rectified 2D pixel coordinate.
-   * @param point - The input unrectified 2D pixel to rectify.
+   * @param point - The input distorted/unrectified 2D pixel to rectify.
    * @param iterations - The number of iterations to use in the iterative optimization.
    * @returns The rectified pixel, a reference to `out`.
    */
-  public rectifyPixel(out: Vector2, point: Readonly<Vector2>, iterations = 5): Vector2 {
+  public undistortPixel(out: Vector2, point: Readonly<Vector2>, iterations = 5): Vector2 {
     const { P, D } = this;
     const [k1, k2, p1, p2, k3] = D;
 
@@ -242,13 +243,14 @@ export class PinholeCameraModel {
   }
 
   /**
-   * Unrectifies the given 2D pixel coordinate.
+   * Applies camera distortion parameters to a given 2D pixel coordinate on a rectified image,
+   * returning the corresponding pixel coordinate on the raw (distorted) image.
    *
-   * @param out - The output unrectified 2D pixel coordinate
-   * @param point - The input rectified 2D pixel coordinate
-   * @returns The unrectified pixel, a reference to `out`
+   * @param out - The output 2D pixel coordinate on the original (distorted/unrectified) image
+   * @param point - The input 2D pixel coordinate on a rectified image
+   * @returns The distorted pixel, a reference to `out`
    */
-  public unrectifyPixel(out: Vector2, point: Readonly<Vector2>): Vector2 {
+  public distortPixel(out: Vector2, point: Readonly<Vector2>): Vector2 {
     out.x = point.x;
     out.y = point.y;
 
@@ -260,7 +262,7 @@ export class PinholeCameraModel {
     const tx = P[3];
     const ty = P[7];
 
-    // Formulae from docs for cv::initUndistortRectifyMap,
+    // Formulae from:
     // <https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html>
 
     // x <- (u - c'x) / f'x

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -112,8 +112,8 @@ function toRGBA(color: Color) {
   return `rgba(${color.r * 255}, ${color.g * 255}, ${color.b * 255}, ${color.a})`;
 }
 
-function maybeUnrectifyPixel(cameraModel: PinholeCameraModel | undefined, point: Point2D): Point2D {
-  return cameraModel?.unrectifyPixel({ x: 0, y: 0 }, point) ?? point;
+function maybeDistortPixel(cameraModel: PinholeCameraModel | undefined, point: Point2D): Point2D {
+  return cameraModel?.distortPixel({ x: 0, y: 0 }, point) ?? point;
 }
 
 // Potentially performance-sensitive; await can be expensive
@@ -320,8 +320,8 @@ function paintLine(
     return;
   }
 
-  const { x: x1, y: y1 } = maybeUnrectifyPixel(cameraModel, pointA);
-  const { x: x2, y: y2 } = maybeUnrectifyPixel(cameraModel, pointB);
+  const { x: x1, y: y1 } = maybeDistortPixel(cameraModel, pointA);
+  const { x: x2, y: y2 } = maybeDistortPixel(cameraModel, pointB);
 
   ctx.beginPath();
   ctx.moveTo(x1, y1);
@@ -337,7 +337,7 @@ function paintTextAnnotation(
   annotation: TextAnnotation,
   cameraModel: PinholeCameraModel | undefined,
 ) {
-  const { x, y } = maybeUnrectifyPixel(cameraModel, annotation.position);
+  const { x, y } = maybeDistortPixel(cameraModel, annotation.position);
   const text = annotation.text;
   if (!text) {
     return;
@@ -375,7 +375,7 @@ function paintCircleAnnotation(
     return;
   }
 
-  const { x, y } = maybeUnrectifyPixel(cameraModel, position);
+  const { x, y } = maybeDistortPixel(cameraModel, position);
   ctx.beginPath();
   ctx.arc(x, y, radius, 0, 2 * Math.PI);
 
@@ -445,10 +445,10 @@ function paintPointsAnnotation(
         break;
       }
       ctx.beginPath();
-      const { x, y } = maybeUnrectifyPixel(cameraModel, annotation.points[0]!);
+      const { x, y } = maybeDistortPixel(cameraModel, annotation.points[0]!);
       ctx.moveTo(x, y);
       for (let i = 1; i < annotation.points.length; i++) {
-        const maybeUnrectifiedPoint = maybeUnrectifyPixel(cameraModel, annotation.points[i]!);
+        const maybeUnrectifiedPoint = maybeDistortPixel(cameraModel, annotation.points[i]!);
         ctx.lineTo(maybeUnrectifiedPoint.x, maybeUnrectifiedPoint.y);
       }
       if (annotation.style === "polygon") {
@@ -510,7 +510,7 @@ function paintCircle(
     return;
   }
 
-  const { x, y } = maybeUnrectifyPixel(cameraModel, point);
+  const { x, y } = maybeDistortPixel(cameraModel, point);
   ctx.beginPath();
   ctx.arc(x, y, radius, 0, 2 * Math.PI);
 
@@ -546,7 +546,7 @@ function paintFastPoint(
     return;
   }
 
-  const { x, y } = maybeUnrectifyPixel(cameraModel, point);
+  const { x, y } = maybeDistortPixel(cameraModel, point);
   const size = Math.round(radius * 2);
   const rx = Math.round(x - size / 2);
   const ry = Math.round(y - size / 2);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/projections.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/projections.ts
@@ -27,7 +27,7 @@ export function projectPixel(
   cameraModel: PinholeCameraModel,
   settings: { distance: number; planarProjectionFactor: number },
 ): Vector3 {
-  cameraModel.rectifyPixel(tempVec2, uv);
+  cameraModel.undistortPixel(tempVec2, uv);
 
   if (settings.planarProjectionFactor === 0) {
     cameraModel.projectPixelTo3dRay(out, tempVec2);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
`rectifyPixel` -> `undistortPixel`
`unrectifyPixel` -> `distortPixel`
