### PR TITLE
[Image Beta] remove migration of legacy config within new panel code

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -94,24 +94,6 @@ import { InterfaceMode } from "./types";
 
 const log = Logger.getLogger(__filename);
 
-/** Legacy Image panel settings that occur at the root level */
-export type LegacyImageConfig = {
-  cameraTopic: string;
-  enabledMarkerTopics: string[];
-  synchronize: boolean;
-  flipHorizontal: boolean;
-  flipVertical: boolean;
-  maxValue: number;
-  minValue: number;
-  mode: "fit" | "fill" | "other";
-  pan: { x: number; y: number };
-  rotation: number;
-  smooth: boolean;
-  transformMarkers: boolean;
-  zoom: number;
-  zoomPercentage: number;
-};
-
 /** Menu item entry and callback for the "Custom Layers" menu */
 export type CustomLayerAction = {
   action: SettingsTreeNodeActionItem;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -37,7 +37,7 @@ import type {
 } from "./IRenderer";
 import type { PickedRenderable } from "./Picker";
 import { SELECTED_ID_VARIABLE } from "./Renderable";
-import { LegacyImageConfig, Renderer } from "./Renderer";
+import { Renderer } from "./Renderer";
 import { RendererContext, useRendererEvent } from "./RendererContext";
 import { RendererOverlay } from "./RendererOverlay";
 import { CameraState, DEFAULT_CAMERA_STATE } from "./camera";
@@ -118,16 +118,6 @@ export function ThreeDeeRender(props: {
       Partial<LayerSettingsTransform>
     >;
 
-    // Merge in config from the legacy Image panel
-    const legacyImageConfig = partialConfig as DeepPartial<LegacyImageConfig> | undefined;
-    const imageMode: ImageModeConfig = {
-      imageTopic: legacyImageConfig?.cameraTopic,
-      ...partialConfig?.imageMode,
-      annotations: partialConfig?.imageMode?.annotations as
-        | ImageModeConfig["annotations"]
-        | undefined,
-    };
-
     return {
       cameraState,
       followMode: partialConfig?.followMode ?? "follow-pose",
@@ -137,7 +127,12 @@ export function ThreeDeeRender(props: {
       topics: partialConfig?.topics ?? {},
       layers: partialConfig?.layers ?? {},
       publish,
-      imageMode,
+      imageMode: {
+        ...partialConfig?.imageMode,
+        annotations: partialConfig?.imageMode?.annotations as
+          | ImageModeConfig["annotations"]
+          | undefined,
+      },
     };
   });
   const configRef = useLatest(config);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Since we are not swapping the old and new panels in-place, the new panel doesn't need to read config written by the old panel. We will move this into a separate migration step, like https://github.com/foxglove/studio/blob/main/packages/studio-base/src/services/migrateLegacyToNew3DPanels.ts (see also: #6145)