### PR TITLE
Add items to Open welcome dialog and Explore sample data to AppMenu

### DIFF
--- a/packages/studio-base/src/components/AppBar/AppMenu.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.stories.tsx
@@ -2,8 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryFn, StoryObj } from "@storybook/react";
-import { screen, userEvent } from "@storybook/testing-library";
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/testing-library";
 
 import PlayerSelectionContext, {
   PlayerSelection,
@@ -14,7 +14,17 @@ import { AppMenu } from "./AppMenu";
 
 export default {
   title: "components/AppBar/AppMenu",
-  component: AppMenu,
+  component: (): JSX.Element => (
+    <AppMenu
+      open
+      anchorPosition={{ top: 0, left: 0 }}
+      anchorReference="anchorPosition"
+      disablePortal
+      handleClose={() => {
+        // no-op
+      }}
+    />
+  ),
   decorators: [
     (Story: StoryFn): JSX.Element => (
       <WorkspaceContextProvider>
@@ -24,7 +34,11 @@ export default {
       </WorkspaceContextProvider>
     ),
   ],
-};
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    userEvent.hover(canvas.getByTestId(args.id));
+  },
+} as Meta<{ id: string }>;
 
 // Connection
 const playerSelection: PlayerSelection = {
@@ -42,131 +56,96 @@ const playerSelection: PlayerSelection = {
   availableSources: [],
 };
 
-export const Default: StoryObj = {
-  render: () => (
-    <AppMenu
-      open
-      anchorPosition={{ top: 0, left: 0 }}
-      anchorReference="anchorPosition"
-      disablePortal
-      handleClose={() => {
-        // no-op
-      }}
-    />
-  ),
-};
+type AppMenuStory = StoryObj<{ id: string }>;
 
-const Selected: StoryObj<{ id: string }> = {
-  ...Default,
-  play: async ({ args: { id } }) => {
-    userEvent.hover(screen.getByTestId(id));
-  },
-};
+export const Default: AppMenuStory = {};
 
-export const FileMenuDark = {
-  ...Selected,
+export const FileMenuDark: AppMenuStory = {
   args: { id: "app-menu-file" },
   parameters: { colorScheme: "dark" },
 };
 
-export const FileMenuDarkChinese = {
-  ...Selected,
+export const FileMenuDarkChinese: AppMenuStory = {
   args: { id: "app-menu-file" },
   parameters: { colorScheme: "dark", forceLanguage: "zh" },
 };
 
-export const FileMenuDarkJapanese = {
-  ...Selected,
+export const FileMenuDarkJapanese: AppMenuStory = {
   args: { id: "app-menu-file" },
   parameters: { colorScheme: "dark", forceLanguage: "ja" },
 };
 
-export const FileMenuLight = {
-  ...Selected,
+export const FileMenuLight: AppMenuStory = {
   args: { id: "app-menu-file" },
   parameters: { colorScheme: "light" },
 };
 
-export const FileMenuLightChinese = {
-  ...Selected,
+export const FileMenuLightChinese: AppMenuStory = {
   args: { id: "app-menu-file" },
   parameters: { colorScheme: "light", forceLanguage: "zh" },
 };
 
-export const FileMenuLightJapanese = {
-  ...Selected,
+export const FileMenuLightJapanese: AppMenuStory = {
   args: { id: "app-menu-file" },
   parameters: { colorScheme: "light", forceLanguage: "ja" },
 };
 
-export const ViewMenuDark = {
-  ...Selected,
+export const ViewMenuDark: AppMenuStory = {
   args: { id: "app-menu-view" },
   parameters: { colorScheme: "dark" },
 };
 
-export const ViewMenuDarkChinese = {
-  ...Selected,
+export const ViewMenuDarkChinese: AppMenuStory = {
   args: { id: "app-menu-view" },
   parameters: { colorScheme: "dark", forceLanguage: "zh" },
 };
 
-export const ViewMenuDarkJapanese = {
-  ...Selected,
+export const ViewMenuDarkJapanese: AppMenuStory = {
   args: { id: "app-menu-view" },
   parameters: { colorScheme: "dark", forceLanguage: "ja" },
 };
 
-export const ViewMenuLight = {
-  ...Selected,
+export const ViewMenuLight: AppMenuStory = {
   args: { id: "app-menu-view" },
   parameters: { colorScheme: "light" },
 };
 
-export const ViewMenuLightChinese = {
-  ...Selected,
+export const ViewMenuLightChinese: AppMenuStory = {
   args: { id: "app-menu-view" },
   parameters: { colorScheme: "light", forceLanguage: "zh" },
 };
 
-export const ViewMenuLightJapanese = {
-  ...Selected,
-  args: { id: "app-menu-view" },
+export const ViewMenuLightJapanese: AppMenuStory = {
+  ...ViewMenuLight,
   parameters: { colorScheme: "light", forceLanguage: "ja" },
 };
 
-export const HelpMenuDark = {
-  ...Selected,
+export const HelpMenuDark: AppMenuStory = {
   args: { id: "app-menu-help" },
   parameters: { colorScheme: "dark" },
 };
 
-export const HelpMenuDarkChinese = {
-  ...Selected,
+export const HelpMenuDarkChinese: AppMenuStory = {
   args: { id: "app-menu-help" },
   parameters: { colorScheme: "dark", forceLanguage: "zh" },
 };
 
-export const HelpMenuDarkJapanese = {
-  ...Selected,
+export const HelpMenuDarkJapanese: AppMenuStory = {
   args: { id: "app-menu-help" },
   parameters: { colorScheme: "dark", forceLanguage: "ja" },
 };
 
-export const HelpMenuLight = {
-  ...Selected,
+export const HelpMenuLight: AppMenuStory = {
   args: { id: "app-menu-help" },
   parameters: { colorScheme: "light" },
 };
 
-export const HelpMenuLightChinese = {
-  ...Selected,
+export const HelpMenuLightChinese: AppMenuStory = {
   args: { id: "app-menu-help" },
   parameters: { colorScheme: "light", forceLanguage: "zh" },
 };
 
-export const HelpMenuLightJapanese = {
-  ...Selected,
+export const HelpMenuLightJapanese: AppMenuStory = {
   args: { id: "app-menu-help" },
   parameters: { colorScheme: "light", forceLanguage: "ja" },
 };

--- a/packages/studio-base/src/components/AppBar/AppMenu.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.stories.tsx
@@ -35,10 +35,13 @@ export default {
     ),
   ],
   play: async ({ canvasElement, args }) => {
+    if (args.id == undefined) {
+      return;
+    }
     const canvas = within(canvasElement);
-    userEvent.hover(canvas.getByTestId(args.id));
+    userEvent.hover(await canvas.findByTestId(args.id));
   },
-} as Meta<{ id: string }>;
+} as Meta<{ id?: string }>;
 
 // Connection
 const playerSelection: PlayerSelection = {
@@ -56,7 +59,7 @@ const playerSelection: PlayerSelection = {
   availableSources: [],
 };
 
-type AppMenuStory = StoryObj<{ id: string }>;
+type AppMenuStory = StoryObj<{ id?: string }>;
 
 export const Default: AppMenuStory = {};
 

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -2,7 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Menu, PaperProps, PopoverPosition, PopoverReference } from "@mui/material";
+import {
+  Menu,
+  MenuItem as MuiMenuItem,
+  PaperProps,
+  PopoverPosition,
+  PopoverReference,
+} from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
@@ -84,6 +90,16 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
 
   const fileItems = useMemo(() => {
     const items: MenuItem[] = [
+      {
+        type: "item",
+        label: t("open"),
+        key: "open",
+        onClick: () => {
+          dialogActions.dataSource.open("start");
+          handleAnalytics("open-data-source-dialog");
+          handleNestedMenuClose();
+        },
+      },
       {
         type: "item",
         label: t("openLocalFile"),
@@ -249,6 +265,17 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
         >
           {t("help")}
         </NestedMenuItem>
+        <MuiMenuItem
+          id="app-menu-demo"
+          onPointerEnter={() => handleItemPointerEnter("app-menu-demo")}
+          onClick={() => {
+            dialogActions.dataSource.open("demo");
+            handleAnalytics("demo");
+            handleNestedMenuClose();
+          }}
+        >
+          {t("exploreSampleData")}
+        </MuiMenuItem>
       </Menu>
     </>
   );

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import {
+  Chip,
   Menu,
   MenuItem as MuiMenuItem,
   PaperProps,
@@ -36,7 +37,7 @@ type AppMenuProps = {
   open: boolean;
 };
 
-const useStyles = makeStyles()({
+const useStyles = makeStyles<void, "chip">()((theme, _params, classes) => ({
   menuList: {
     minWidth: 180,
     maxWidth: 220,
@@ -44,7 +45,21 @@ const useStyles = makeStyles()({
   truncate: {
     alignSelf: "center !important",
   },
-});
+  exploreSampleData: {
+    justifyContent: "space-between",
+    gap: theme.spacing(3),
+    paddingRight: theme.spacing(1),
+
+    [`:not(:hover, :focus) .${classes.chip}`]: {
+      backgroundColor: "transparent",
+      color: theme.palette.mode === "light" ? theme.palette.primary.main : undefined,
+    },
+  },
+  chip: {
+    height: 23,
+    border: `1px solid ${theme.palette.primary.main}`,
+  },
+}));
 
 const selectWorkspace = (store: WorkspaceContextStore) => store;
 
@@ -266,6 +281,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
           {t("help")}
         </NestedMenuItem>
         <MuiMenuItem
+          className={classes.exploreSampleData}
           id="app-menu-demo"
           onPointerEnter={() => handleItemPointerEnter("app-menu-demo")}
           onClick={() => {
@@ -275,6 +291,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
           }}
         >
           {t("exploreSampleData")}
+          <Chip className={classes.chip} label="Try it" color="primary" size="small" />
         </MuiMenuItem>
       </Menu>
     </>

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -87,7 +87,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   );
 
   // FILE
-
   const fileItems = useMemo(() => {
     const items: MenuItem[] = [
       {
@@ -149,7 +148,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   ]);
 
   // VIEW
-
   const viewItems = useMemo<MenuItem[]>(
     () => [
       {
@@ -184,7 +182,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   );
 
   // HELP
-
   const onAboutClick = useCallback(() => {
     dialogActions.preferences.open("about");
     handleAnalytics("about");

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import {
-  Chip,
   Menu,
   MenuItem as MuiMenuItem,
   PaperProps,
@@ -37,7 +36,7 @@ type AppMenuProps = {
   open: boolean;
 };
 
-const useStyles = makeStyles<void, "chip">()((theme, _params, classes) => ({
+const useStyles = makeStyles()({
   menuList: {
     minWidth: 180,
     maxWidth: 220,
@@ -45,21 +44,7 @@ const useStyles = makeStyles<void, "chip">()((theme, _params, classes) => ({
   truncate: {
     alignSelf: "center !important",
   },
-  exploreSampleData: {
-    justifyContent: "space-between",
-    gap: theme.spacing(3),
-    paddingRight: theme.spacing(1),
-
-    [`:not(:hover, :focus) .${classes.chip}`]: {
-      backgroundColor: "transparent",
-      color: theme.palette.mode === "light" ? theme.palette.primary.main : undefined,
-    },
-  },
-  chip: {
-    height: 23,
-    border: `1px solid ${theme.palette.primary.main}`,
-  },
-}));
+});
 
 const selectWorkspace = (store: WorkspaceContextStore) => store;
 
@@ -281,7 +266,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
           {t("help")}
         </NestedMenuItem>
         <MuiMenuItem
-          className={classes.exploreSampleData}
           id="app-menu-demo"
           onPointerEnter={() => handleItemPointerEnter("app-menu-demo")}
           onClick={() => {
@@ -291,7 +275,6 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
           }}
         >
           {t("exploreSampleData")}
-          <Chip className={classes.chip} label="Try it" color="primary" size="small" />
         </MuiMenuItem>
       </Menu>
     </>

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -87,6 +87,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   );
 
   // FILE
+
   const fileItems = useMemo(() => {
     const items: MenuItem[] = [
       {
@@ -148,6 +149,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   ]);
 
   // VIEW
+
   const viewItems = useMemo<MenuItem[]>(
     () => [
       {
@@ -182,6 +184,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
   );
 
   // HELP
+
   const onAboutClick = useCallback(() => {
     dialogActions.preferences.open("about");
     handleAnalytics("about");

--- a/packages/studio-base/src/i18n/en/appBar.ts
+++ b/packages/studio-base/src/i18n/en/appBar.ts
@@ -4,6 +4,8 @@
 
 export const appBar = {
   about: "About",
+  exploreSampleData: "Explore sample data",
+  open: "Open…",
   openLocalFile: "Open local file…",
   openConnection: "Open connection…",
   noDataSource: "No data source",

--- a/packages/studio-base/src/i18n/ja/appBar.ts
+++ b/packages/studio-base/src/i18n/ja/appBar.ts
@@ -6,6 +6,8 @@ import { TypeOptions } from "i18next";
 
 export const appBar: Partial<TypeOptions["resources"]["appBar"]> = {
   about: "情報",
+  exploreSampleData: "サンプルデータを探索する",
+  open: "を開く",
   openLocalFile: "ローカルファイルを開く",
   openConnection: "接続を開く",
   noDataSource: undefined,

--- a/packages/studio-base/src/i18n/zh/appBar.ts
+++ b/packages/studio-base/src/i18n/zh/appBar.ts
@@ -6,6 +6,8 @@ import { TypeOptions } from "i18next";
 
 export const appBar: Partial<TypeOptions["resources"]["appBar"]> = {
   about: "关于",
+  exploreSampleData: "探索样本数据",
+  open: "打开……",
   openConnection: "打开连接……",
   noDataSource: undefined,
   openLocalFile: "打开本地文件……",


### PR DESCRIPTION
**User-Facing Changes**
Users can now get to Example Data and Open Dialog

<img width="413" alt="Screen Shot 2023-05-31 at 1 37 54 pm" src="https://github.com/foxglove/studio/assets/924528/3112674b-408f-4265-bde4-e85c0bce79de">


Closes FG-3599
