### PR TITLE
Bump flatbuffers_reflection to 0.0.6

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -36,7 +36,7 @@
     "@mcap/core": "1.2.1",
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "23.5.9",
-    "flatbuffers_reflection": "0.0.5",
+    "flatbuffers_reflection": "0.0.6",
     "protobufjs": "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
   }
 }

--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -200,6 +200,7 @@ export function parseFlatbufferSchema(
       byteBuffer,
       typeIndex,
       byteBuffer.readInt32(byteBuffer.position()) + byteBuffer.position(),
+      false,
     );
     return toObject(table);
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,7 +2345,7 @@ __metadata:
     "@protobufjs/base64": 1.1.2
     "@types/protobufjs": "workspace:*"
     flatbuffers: 23.5.9
-    flatbuffers_reflection: 0.0.5
+    flatbuffers_reflection: 0.0.6
     protobufjs: "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
     typescript: 5.0.4
   languageName: unknown
@@ -11505,10 +11505,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatbuffers_reflection@npm:0.0.5":
-  version: 0.0.5
-  resolution: "flatbuffers_reflection@npm:0.0.5"
-  checksum: 34c15174aba37caf37e0f433442e04df2a224ed460d39a0c7098f8c1dcf0436d3779ab5489edbcbdd231866183554e9e69308b847061f8bad9fecdc736b8694d
+"flatbuffers_reflection@npm:0.0.6":
+  version: 0.0.6
+  resolution: "flatbuffers_reflection@npm:0.0.6"
+  checksum: 65cc9aa9344705b50c106fed739b154b722f212e8af00663d035581914d5e7c229757410a54beb0d267bc6af0983032fe723d81af758d51c5c76cc8ed6c9f5de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

**User-Facing Changes**

Flatbuffers-based formats (MCAP or websocket) will no longer fail to parse tables with structs in them.

**Description**

Pulls in latest `flatbuffers_reflection` which correctly handles verification of flatbuffer tables that contain structs (the initial implementation erroneously failed verification for flatbuffer structs).

Resolves FG-3669
