### PR TITLE
[3D Panel] update allframes cursor logic to clear if messages were added or removed before the index

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -60,6 +60,7 @@ export type RendererEvents = {
   topicHandlersChanged: (renderer: IRenderer) => void;
   topicsChanged: (renderer: IRenderer) => void;
   resetViewChanged: (renderer: IRenderer) => void;
+  resetAllFramesCursor: (renderer: IRenderer) => void;
 };
 
 export type FollowMode = "follow-pose" | "follow-position" | "follow-none";

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -702,4 +702,36 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     // will read from the beginning of the array again  because cursor was reset
     expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime - 1);
   });
+  it.failing(
+    "(does not) reset the cursor if number of messages added **and** removed before cursor are equal in a single update",
+    () => {
+      const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
+
+      const msgs = [];
+      let i = 2;
+      for (i; i < 10; i++) {
+        msgs.push(createTFMessageEvent("a", "b", BigInt(i), [BigInt(i)]));
+      }
+      const addMessageEventMock = jest.spyOn(renderer, "addMessageEvent");
+      renderer.setCurrentTime(5n);
+      renderer.handleAllFramesMessages(msgs);
+      const numMessagesBeforeTime = msgs.filter(
+        (msg) => toNanoSec(msg.message.transforms[0]!.header.stamp) <= 5n,
+      ).length;
+      expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime);
+
+      addMessageEventMock.mockClear();
+
+      // remove message at beginning of array, before cursor
+      msgs.shift();
+
+      // add message to beginning of array, before cursor
+      msgs.unshift(createTFMessageEvent("a", "b", 1n, [1n]));
+
+      const newMessagesHandled = renderer.handleAllFramesMessages(msgs);
+      expect(newMessagesHandled).toBeTruthy();
+      // will read from the beginning of the array again  because cursor was reset
+      expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime - 1);
+    },
+  );
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -5,7 +5,7 @@
 
 import { setupJestCanvasMock } from "jest-canvas-mock";
 
-import { fromNanoSec } from "@foxglove/rostime";
+import { fromNanoSec, toNanoSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 import { Renderer } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderer";
 import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
@@ -649,5 +649,57 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(newMessagesHandled).toBeTruthy();
     // will read all messages in twice
     expect(addMessageEventMock).toHaveBeenCalledTimes(20);
+  });
+  it("resets cursor if messages were added before the cursor index", () => {
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
+
+    const msgs = [];
+    let i = 2;
+    for (i; i < 10; i++) {
+      msgs.push(createTFMessageEvent("a", "b", BigInt(i), [BigInt(i)]));
+    }
+    const addMessageEventMock = jest.spyOn(renderer, "addMessageEvent");
+    renderer.setCurrentTime(5n);
+    renderer.handleAllFramesMessages(msgs);
+    const numMessagesBeforeTime = msgs.filter(
+      (msg) => toNanoSec(msg.message.transforms[0]!.header.stamp) <= 5n,
+    ).length;
+    expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime);
+
+    addMessageEventMock.mockClear();
+
+    // add message to beginning of array, before cursor
+    msgs.unshift(createTFMessageEvent("a", "b", 1n, [1n]));
+
+    const newMessagesHandled = renderer.handleAllFramesMessages(msgs);
+    expect(newMessagesHandled).toBeTruthy();
+    // will read from the beginning of the array again  because cursor was reset
+    expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime + 1);
+  });
+  it("resets cursor if messages were removed before the cursor index", () => {
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
+
+    const msgs = [];
+    let i = 2;
+    for (i; i < 10; i++) {
+      msgs.push(createTFMessageEvent("a", "b", BigInt(i), [BigInt(i)]));
+    }
+    const addMessageEventMock = jest.spyOn(renderer, "addMessageEvent");
+    renderer.setCurrentTime(5n);
+    renderer.handleAllFramesMessages(msgs);
+    const numMessagesBeforeTime = msgs.filter(
+      (msg) => toNanoSec(msg.message.transforms[0]!.header.stamp) <= 5n,
+    ).length;
+    expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime);
+
+    addMessageEventMock.mockClear();
+
+    // remove message at beginning of array, before cursor
+    msgs.shift();
+
+    const newMessagesHandled = renderer.handleAllFramesMessages(msgs);
+    expect(newMessagesHandled).toBeTruthy();
+    // will read from the beginning of the array again  because cursor was reset
+    expect(addMessageEventMock).toHaveBeenCalledTimes(numMessagesBeforeTime - 1);
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -466,7 +466,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     },
   ): void {
     if (clearTransforms === true) {
-      this.transformTree.clear();
+      this.#clearTransformTree();
     }
     if (resetAllFramesCursor === true) {
       this.#resetAllFramesCursor();
@@ -608,13 +608,15 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       shouldSubscribe: () => true,
       preload: preloadTransforms,
     });
+    this.off("resetAllFramesCursor", this.#clearTransformTree);
     if (preloadTransforms) {
-      this.off("resetAllFramesCursor");
-      this.on("resetAllFramesCursor", () => {
-        this.transformTree.clear();
-      });
+      this.on("resetAllFramesCursor", this.#clearTransformTree);
     }
   }
+
+  #clearTransformTree = () => {
+    this.transformTree.clear();
+  };
 
   // Call on scene extensions to add subscriptions to the renderer
   #addSubscriptionsFromSceneExtensions(filterFn?: (extension: SceneExtension) => boolean): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -482,49 +482,61 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   #allFramesCursor: {
     // index represents where the last read message is in allFrames
     index: number;
+    lastReadMessage: MessageEvent<unknown> | undefined;
     cursorTimeReached?: Time;
   } = {
     index: -1,
+    lastReadMessage: undefined,
     cursorTimeReached: undefined,
   };
 
   #resetAllFramesCursor() {
     this.#allFramesCursor = {
       index: -1,
+      lastReadMessage: undefined,
       cursorTimeReached: undefined,
     };
+    this.emit("resetAllFramesCursor", this);
   }
 
   /**
    * Iterates through allFrames and handles messages with a receiveTime <= currentTime
-   * @param allFrames - array of all preloaded messages
+   * @param allFrames - sorted array of all preloaded messages
    * @returns {boolean} - whether the allFramesCursor has been updated and new messages were read in
    */
   public handleAllFramesMessages(allFrames?: readonly MessageEvent[]): boolean {
-    const currentTime = fromNanoSec(this.currentTime);
-    const allFramesCursor = this.#allFramesCursor;
-    // index always indicates last read-in message
-    let cursor = allFramesCursor.index;
-    let cursorTimeReached = allFramesCursor.cursorTimeReached;
-
     if (!allFrames || allFrames.length === 0) {
-      // when tf preloading is disabled
-      if (cursor > -1) {
-        this.#resetAllFramesCursor();
-      }
       return false;
     }
+
+    const currentTime = fromNanoSec(this.currentTime);
 
     /**
      * Assumptions about allFrames needed by allFramesCursor:
      *  - always sorted by receiveTime
-     *  - preloaded topics/schemas are only ever all removed or all added at once, otherwise it is not stable and would need to be reset
      *  - allFrame chunks are only ever loaded from beginning to end and does not have any eviction
      */
+
+    const messageAtCursor = allFrames[this.#allFramesCursor.index];
+
+    // reset cursor if lastReadMessage no longer is the same as the message at the cursor
+    // This means that messages were added or removed from the array and need to be re-read
+    if (
+      this.#allFramesCursor.lastReadMessage != undefined &&
+      messageAtCursor != undefined &&
+      this.#allFramesCursor.lastReadMessage !== messageAtCursor
+    ) {
+      this.#resetAllFramesCursor();
+    }
+
+    let cursor = this.#allFramesCursor.index;
+    let cursorTimeReached = this.#allFramesCursor.cursorTimeReached;
+    let lastReadMessage = this.#allFramesCursor.lastReadMessage;
 
     // cursor should never be over allFramesLength, if it some how is, it means the cursor was at the end of `allFrames` prior to eviction and eviction shortened allframes
     // in this case we should set the cursor to the end of allFrames
     cursor = Math.min(cursor, allFrames.length - 1);
+
     let message;
 
     let hasAddedMessageEvents = false;
@@ -544,6 +556,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       }
 
       this.addMessageEvent(message);
+      lastReadMessage = message;
       if (cursor === allFrames.length - 1) {
         cursorTimeReached = message.receiveTime;
       }
@@ -554,7 +567,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       return false;
     }
 
-    this.#allFramesCursor = { index: cursor, cursorTimeReached };
+    this.#allFramesCursor = { index: cursor, cursorTimeReached, lastReadMessage };
     return true;
   }
 
@@ -573,27 +586,34 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   #addTransformSubscriptions(): void {
     const config = this.config;
+    const preloadTransforms = config.scene.transforms?.enablePreloading ?? true;
     // Internal handlers for TF messages to update the transform tree
     this.addSchemaSubscriptions(FRAME_TRANSFORM_DATATYPES, {
       handler: this.#handleFrameTransform,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: preloadTransforms,
     });
     this.addSchemaSubscriptions(FRAME_TRANSFORMS_DATATYPES, {
       handler: this.#handleFrameTransforms,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: preloadTransforms,
     });
     this.addSchemaSubscriptions(TF_DATATYPES, {
       handler: this.#handleTFMessage,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: preloadTransforms,
     });
     this.addSchemaSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
       handler: this.#handleTransformStamped,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: preloadTransforms,
     });
+    if (preloadTransforms) {
+      this.off("resetAllFramesCursor");
+      this.on("resetAllFramesCursor", () => {
+        this.transformTree.clear();
+      });
+    }
   }
 
   // Call on scene extensions to add subscriptions to the renderer


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
not relevant

**Description**

Update allFrames cursor logic to account for messages being added or removed before the cursor index. It doesn't account for the case when messages were added and removed however; this case will require additional info from the extension api. 

<!-- link relevant GitHub issues -->
FG-3408
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
