### PR TITLE
Display VersionBanner instead of crashing on Safari <16.4

### DIFF
--- a/packages/studio-web/src/canRenderApp.ts
+++ b/packages/studio-web/src/canRenderApp.ts
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Safari < 16.4 doesn't support `static{}` blocks in classes. TypeScript sometimes uses these when
+ * emitting code for decorators.
+ */
+function supportsClassStaticInitialization() {
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function("class X { static { } }");
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+/** Returns true if JS syntax and APIs required for rendering the rest of the app are supported. */
+export function canRenderApp(): boolean {
+  return (
+    typeof BigInt64Array === "function" &&
+    typeof BigUint64Array === "function" &&
+    supportsClassStaticInitialization()
+  );
+}

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -10,6 +10,7 @@ import type { IDataSourceFactory } from "@foxglove/studio-base";
 import CssBaseline from "@foxglove/studio-base/components/CssBaseline";
 
 import VersionBanner from "./VersionBanner";
+import { canRenderApp } from "./canRenderApp";
 
 const log = Logger.getLogger(__filename);
 
@@ -29,20 +30,6 @@ export type MainParams = {
   extraProviders?: JSX.Element[];
 };
 
-/**
- * Safari < 16.4 doesn't support `static{}` blocks in classes. TypeScript sometimes uses these when
- * emitting code for decorators.
- */
-function supportsClassStaticInitialization() {
-  try {
-    // eslint-disable-next-line no-new-func
-    new Function("class X { static { } }");
-    return true;
-  } catch (err) {
-    return false;
-  }
-}
-
 export async function main(getParams: () => Promise<MainParams> = async () => ({})): Promise<void> {
   log.debug("initializing");
 
@@ -59,19 +46,12 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
   const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
   const isChrome = chromeVersion !== 0;
 
-  const canRenderApp =
-    typeof BigInt64Array === "function" &&
-    typeof BigUint64Array === "function" &&
-    supportsClassStaticInitialization();
+  const canRender = canRenderApp();
   const banner = (
-    <VersionBanner
-      isChrome={isChrome}
-      currentVersion={chromeVersion}
-      isDismissable={canRenderApp}
-    />
+    <VersionBanner isChrome={isChrome} currentVersion={chromeVersion} isDismissable={canRender} />
   );
 
-  if (!canRenderApp) {
+  if (!canRender) {
     ReactDOM.render(
       <StrictMode>
         <LogAfterRender>

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -35,8 +35,8 @@ export type MainParams = {
  */
 function supportsClassStaticInitialization() {
   try {
-    // eslint-disable-next-line no-eval
-    eval("class X { static { } }");
+    // eslint-disable-next-line no-new-func
+    new Function("class X { static { } }");
     return true;
   } catch (err) {
     return false;

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -6,7 +6,8 @@ import { StrictMode, useEffect } from "react";
 import ReactDOM from "react-dom";
 
 import Logger from "@foxglove/log";
-import { IDataSourceFactory } from "@foxglove/studio-base";
+import type { IDataSourceFactory } from "@foxglove/studio-base";
+import CssBaseline from "@foxglove/studio-base/components/CssBaseline";
 
 import VersionBanner from "./VersionBanner";
 
@@ -23,12 +24,26 @@ function LogAfterRender(props: React.PropsWithChildren<unknown>): JSX.Element {
   return <>{props.children}</>;
 }
 
-type MainParams = {
+export type MainParams = {
   dataSources?: IDataSourceFactory[];
   extraProviders?: JSX.Element[];
 };
 
-export async function main(params: MainParams = {}): Promise<void> {
+/**
+ * Safari < 16.4 doesn't support `static{}` blocks in classes. TypeScript sometimes uses these when
+ * emitting code for decorators.
+ */
+function supportsClassStaticInitialization() {
+  try {
+    // eslint-disable-next-line no-eval
+    eval("class X { static { } }");
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function main(getParams: () => Promise<MainParams> = async () => ({})): Promise<void> {
   log.debug("initializing");
 
   window.onerror = (...args) => {
@@ -44,7 +59,10 @@ export async function main(params: MainParams = {}): Promise<void> {
   const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
   const isChrome = chromeVersion !== 0;
 
-  const canRenderApp = typeof BigInt64Array === "function" && typeof BigUint64Array === "function";
+  const canRenderApp =
+    typeof BigInt64Array === "function" &&
+    typeof BigUint64Array === "function" &&
+    supportsClassStaticInitialization();
   const banner = (
     <VersionBanner
       isChrome={isChrome}
@@ -56,7 +74,9 @@ export async function main(params: MainParams = {}): Promise<void> {
   if (!canRenderApp) {
     ReactDOM.render(
       <StrictMode>
-        <LogAfterRender>{banner}</LogAfterRender>
+        <LogAfterRender>
+          <CssBaseline>{banner}</CssBaseline>
+        </LogAfterRender>
       </StrictMode>,
       rootEl,
     );
@@ -73,6 +93,7 @@ export async function main(params: MainParams = {}): Promise<void> {
   await initI18n();
 
   const { Root } = await import("./Root");
+  const params = await getParams();
 
   ReactDOM.render(
     <StrictMode>


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
For older browsers such as Safari < 16.4 that don't support [static initialization blocks](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks), we need to avoid importing the majority of Studio code or we'll hit a SyntaxError. By adding this check, we reduce the amount of code imported before we're sure the required features are supported by the browser. If the features are not supported, we display only the VersionBanner.

Additionally, the `params` object is changed to a `getParams` async function that's called after the compatibility checks, so the embedding code can similarly avoid importing most of its code until the checks have passed.