### PR TITLE
Fix player warning on global variable change

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
@@ -82,6 +82,15 @@ describe("MessagePipeline/MessageOrderTracker", () => {
       ]);
     });
 
+    it("doesn't report out of order error when messages have been recomputed", () => {
+      const orderTracker = new MessageOrderTracker();
+      const playerState = playerStateWithMessages([message(7, 10), message(8, 9)]);
+      playerState.activeData!.messagesRecomputed = true;
+      const problems = orderTracker.update(playerState);
+
+      expect(problems).toEqual([]);
+    });
+
     it("does not report an error when messages are in order", () => {
       const orderTracker = new MessageOrderTracker();
       const playerState = playerStateWithMessages([message(8, 9), message(7, 10)]);

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -51,7 +51,7 @@ class MessageOrderTracker {
 
     const problems: PlayerProblem[] = [];
 
-    const { messages, currentTime, lastSeekTime } = playerState.activeData;
+    const { messages, currentTime, lastSeekTime, messagesRecomputed } = playerState.activeData;
     let didSeek = false;
 
     if (this.#lastLastSeekTime !== lastSeekTime) {
@@ -105,6 +105,8 @@ class MessageOrderTracker {
         }
 
         if (
+          // If we have recomputed the current frame there could be messages from before the lastMessageTime
+          messagesRecomputed !== true &&
           this.#lastMessageTime &&
           this.#lastMessageTopic != undefined &&
           isLessThan(messageTime, this.#lastMessageTime)

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -48,10 +48,6 @@ export type RendererEvents = {
     parameters: ReadonlyMap<string, ParameterValue> | undefined,
     renderer: IRenderer,
   ) => void;
-  variablesChange: (
-    variables: ReadonlyMap<string, VariableValue> | undefined,
-    renderer: IRenderer,
-  ) => void;
   /** Fired when the structure of the transform tree changes ie: new frame added/removed or frame assigned new parent */
   transformTreeUpdated: (renderer: IRenderer) => void;
   settingsTreeChange: (renderer: IRenderer) => void;
@@ -299,8 +295,6 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
   setTopics(topics: ReadonlyArray<Topic> | undefined): void;
 
   setParameters(parameters: Immutable<Map<string, ParameterValue>> | undefined): void;
-
-  setVariables(variables: Immutable<Map<string, VariableValue>>): void;
 
   updateCustomLayersCount(): void;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -789,14 +789,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     }
   }
 
-  public setVariables(variables: ReadonlyMap<string, VariableValue>): void {
-    const changed = this.variables !== variables;
-    this.variables = variables;
-    if (changed) {
-      this.emit("variablesChange", variables, this);
-    }
-  }
-
   public updateCustomLayersCount(): void {
     const layerCount = Object.keys(this.config.layers).length;
     const label = `Custom Layers${layerCount > 0 ? ` (${layerCount})` : ""}`;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -22,7 +22,6 @@ import {
   SettingsTreeNodes,
   Subscription,
   Topic,
-  VariableValue,
 } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
@@ -163,7 +162,6 @@ export function ThreeDeeRender(props: {
   const [parameters, setParameters] = useState<
     Immutable<Map<string, ParameterValue>> | undefined
   >();
-  const [variables, setVariables] = useState<Immutable<Map<string, VariableValue>> | undefined>();
   const [currentFrameMessages, setCurrentFrameMessages] = useState<
     ReadonlyArray<MessageEvent> | undefined
   >();
@@ -346,9 +344,6 @@ export function ThreeDeeRender(props: {
         // Watch for any changes in the map of observed parameters
         setParameters(renderState.parameters);
 
-        // Watch for any changes in the map of global variables
-        setVariables(renderState.variables);
-
         // currentFrame has messages on subscribed topics since the last render call
         deepParseMessageEvents(renderState.currentFrame);
         setCurrentFrameMessages(renderState.currentFrame);
@@ -366,7 +361,6 @@ export function ThreeDeeRender(props: {
     context.watch("didSeek");
     context.watch("parameters");
     context.watch("sharedPanelState");
-    context.watch("variables");
     context.watch("topics");
     context.watch("appSettings");
     context.subscribeAppSettings([AppSetting.TIMEZONE]);
@@ -457,13 +451,6 @@ export function ThreeDeeRender(props: {
       renderer.setParameters(parameters);
     }
   }, [parameters, renderer]);
-
-  // Keep the renderer variables up to date
-  useEffect(() => {
-    if (renderer && variables) {
-      renderer.setVariables(variables);
-    }
-  }, [variables, renderer]);
 
   // Keep the renderer currentTime up to date and handle seeking
   useEffect(() => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -919,6 +919,8 @@ export default class UserNodePlayer implements Player {
           this.#lastMessageByInputTopic.set(message.topic, message);
         }
 
+        const messagesRecomputed = messagesForRecompute.length > 0;
+
         const messagesToBeParsed =
           messagesForRecompute.length > 0 ? messages.concat(messagesForRecompute) : messages;
         const { parsedMessages } = await this.#getMessages(
@@ -952,6 +954,7 @@ export default class UserNodePlayer implements Player {
             messages: parsedMessages,
             topics: this.#getTopics(topics, this.#memoizedNodeTopics),
             datatypes: allDatatypes,
+            messagesRecomputed,
           },
         };
       });

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -194,6 +194,13 @@ export type PlayerStateActiveData = {
   // A map of parameter names to parameter values, used to describe remote parameters such as
   // rosparams.
   parameters?: Map<string, ParameterValue>;
+
+  /** Set to true when `messages` has been recomputed without seek, backfill or playback.
+   * For example: when global variables changes, user-scripts needs to be rerun to recompute
+   * messages. This variable would be set to true to indicate that `messages` may have changed
+   * without a seek or backfill occurring.
+   */
+  messagesRecomputed?: boolean;
 };
 
 // Represents a ROS topic, though the actual data does not need to come from a ROS system.


### PR DESCRIPTION


**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix player warning on global variable change

**Description**


- remove 3D panel listening to global variable changes
- add `messagesRecomputed` flag to ignore messages out of order error when recomputing current frame on global variable change


<!-- link relevant GitHub issues -->
FG-3170
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
