### PR TITLE
Fix image annotations not clearing when receiving empty annotation

### DIFF
--- a/packages/studio-base/src/panels/Image/hooks/synchronizedAddMessages.ts
+++ b/packages/studio-base/src/panels/Image/hooks/synchronizedAddMessages.ts
@@ -28,7 +28,7 @@ export function synchronizedAddMessages(
         ? normalizeImageMessage(event.message, event.schemaName)
         : undefined;
     const annotations = normalizeAnnotations(event.message, event.schemaName);
-    if (!cameraInfo && !image && !annotations) {
+    if (!cameraInfo && !image && annotations.length === 0) {
       continue;
     }
 
@@ -50,7 +50,7 @@ export function synchronizedAddMessages(
       }
     }
 
-    if (annotations) {
+    if (annotations.length > 0) {
       // Group annotations by timestamp, then update the annotations by topic at each stamp
       const groups = new Map<bigint, Annotation[]>();
       for (const annotation of annotations) {

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -234,7 +234,7 @@ function normalizeAnnotations(maybeLazyMessage: unknown, datatype: string): Anno
       return normalizeRosImageMarkerArray(message as ImageMarkerArray);
     // backwards compat with webviz
     case "webviz_msgs/ImageMarkerArray":
-      return [];
+      break;
     // foxglove
     case "foxglove_msgs/ImageAnnotations":
     case "foxglove_msgs/msg/ImageAnnotations":

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -58,9 +58,7 @@ function foxglovePointTypeToStyle(
   return undefined;
 }
 
-function normalizeFoxgloveImageAnnotations(
-  message: Partial<ImageAnnotations>,
-): Annotation[] | undefined {
+function normalizeFoxgloveImageAnnotations(message: Partial<ImageAnnotations>): Annotation[] {
   const annotations: Annotation[] = [];
 
   const circles = message.circles ?? [];
@@ -115,7 +113,7 @@ function normalizeFoxgloveImageAnnotations(
     });
   }
 
-  return annotations.length === 0 ? undefined : annotations;
+  return annotations;
 }
 
 function normalizeTimestamp(stamp: Time | bigint): Time {

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -120,7 +120,7 @@ function normalizeTimestamp(stamp: Time | bigint): Time {
   return typeof stamp === "bigint" ? fromNanoSec(stamp) : stamp;
 }
 
-function normalizeRosImageMarkerArray(message: ImageMarkerArray): Annotation[] | undefined {
+function normalizeRosImageMarkerArray(message: ImageMarkerArray): Annotation[] {
   return filterMap(message.markers, (marker, i) => normalizeRosImageMarker(marker, ["markers", i]));
 }
 
@@ -210,10 +210,7 @@ function toPOD(message: unknown): unknown {
     : message;
 }
 
-function normalizeAnnotations(
-  maybeLazyMessage: unknown,
-  datatype: string,
-): Annotation[] | undefined {
+function normalizeAnnotations(maybeLazyMessage: unknown, datatype: string): Annotation[] {
   // The panel may send the annotations to a web worker, for this we need
   const message = toPOD(maybeLazyMessage);
 
@@ -224,10 +221,7 @@ function normalizeAnnotations(
     case "visualization_msgs/msg/ImageMarker":
     case "ros.visualization_msgs.ImageMarker": {
       const normalized = normalizeRosImageMarker(message as ImageMarker, []);
-      if (normalized) {
-        return [normalized];
-      }
-      break;
+      return normalized ? [normalized] : [];
     }
     // marker arrays
     case "foxglove_msgs/ImageMarkerArray":
@@ -240,7 +234,7 @@ function normalizeAnnotations(
       return normalizeRosImageMarkerArray(message as ImageMarkerArray);
     // backwards compat with webviz
     case "webviz_msgs/ImageMarkerArray":
-      break;
+      return [];
     // foxglove
     case "foxglove_msgs/ImageAnnotations":
     case "foxglove_msgs/msg/ImageAnnotations":
@@ -248,8 +242,7 @@ function normalizeAnnotations(
       return normalizeFoxgloveImageAnnotations(message as ImageAnnotations);
     }
   }
-
-  return undefined;
+  return [];
 }
 
 /** Only used for getting details to display from original message */

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -159,7 +159,7 @@ export const FoxgloveAnnotations: StoryObj = {
         },
         imageMessage,
         rawMarkerData: {
-          markers: normalizeAnnotations(foxgloveAnnotations, "foxglove.ImageAnnotations")!,
+          markers: normalizeAnnotations(foxgloveAnnotations, "foxglove.ImageAnnotations"),
           cameraInfo,
           transformMarkers: false,
         },

--- a/packages/studio-base/src/panels/Image/storySupport/annotations.ts
+++ b/packages/studio-base/src/panels/Image/storySupport/annotations.ts
@@ -180,8 +180,7 @@ const markers: ImageMarker[] = [
   }),
 ];
 
-export const annotations =
-  normalizeAnnotations({ markers }, "foxglove_msgs/ImageMarkerArray") ?? [];
+export const annotations = normalizeAnnotations({ markers }, "foxglove_msgs/ImageMarkerArray");
 
 const points = [
   { x: 40, y: 40 },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
@@ -169,10 +169,6 @@ export class MessageHandler {
   ): void => {
     const annotations = normalizeAnnotations(messageEvent.message, messageEvent.schemaName);
 
-    if (!annotations) {
-      return;
-    }
-
     const { topic, schemaName } = messageEvent;
     if (this.#config.synchronize !== true) {
       this.#lastReceivedMessages.annotationsByTopicSchema.set(topic, schemaName, {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -677,16 +677,39 @@ const AnnotationsUpdateStory = (
     sizeInBytes: 0,
   };
 
+  const annotationShouldDisappear: MessageEvent<Partial<ImageAnnotations>> = {
+    topic: "annotationsToClear",
+    receiveTime: { sec: 0, nsec: 0 },
+    message: {
+      circles: [],
+      points: [],
+      texts: [
+        {
+          timestamp: { sec: 0, nsec: 0 },
+          position: { x: 30, y: 40 },
+          text: "erase me",
+          font_size: 5,
+          text_color: { r: 1, g: 0, b: 0, a: 1 },
+          background_color: { r: 1, g: 1, b: 0, a: 1 },
+        },
+      ],
+    },
+    schemaName: "foxglove.ImageAnnotations",
+    sizeInBytes: 0,
+  };
+
   const [fixture, setFixture] = useState({
     topics: [
       { name: "calibration", schemaName: "foxglove.CameraCalibration" },
       { name: "camera", schemaName: "foxglove.RawImage" },
       { name: "annotations", schemaName: "foxglove.ImageAnnotations" },
+      { name: "annotationsToClear", schemaName: "foxglove.ImageAnnotations" },
     ],
     frame: {
       calibration: [calibrationMessage],
       camera: [cameraMessage],
       annotations: [annotationsMessage],
+      annotationsToClear: [annotationShouldDisappear],
     },
     capabilities: [],
     activeData: {
@@ -704,6 +727,14 @@ const AnnotationsUpdateStory = (
       sizeInBytes: 0,
     };
 
+    const emptyAnnotations: MessageEvent<Partial<ImageAnnotations>> = {
+      topic: "annotationsToClear",
+      schemaName: "foxglove.ImageAnnotations",
+      receiveTime: { sec: 1, nsec: 0 },
+      message: {},
+      sizeInBytes: 0,
+    };
+
     let timeOutID2: NodeJS.Timeout;
 
     const timeOutID = setTimeout(() => {
@@ -711,6 +742,7 @@ const AnnotationsUpdateStory = (
         const newFixture = { ...oldFixture };
         newFixture.frame = {
           annotations: [newAnnotations],
+          annotationsToClear: [emptyAnnotations],
           calibration: [],
           camera: [],
         };
@@ -741,6 +773,11 @@ const AnnotationsUpdateStory = (
             annotations: [
               {
                 topic: "annotations",
+                schemaName: "foxglove.ImageAnnotations",
+                settings: { visible: true },
+              },
+              {
+                topic: "annotationsToClear",
                 schemaName: "foxglove.ImageAnnotations",
                 settings: { visible: true },
               },


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix image annotations not clearing when receiving empty annotation

**Description**

Normalization of Foxglove ImageAnnotations now returns empty array instead of undefined when message does not have any annotations. This allows the `MessageHandler` to update and emit state.


<!-- link relevant GitHub issues -->
FG-3415
https://github.com/foxglove/studio/issues/6033
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
