### PR TITLE
[Image Beta] Remove resizeWidth to display images at full resolution

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -61,7 +61,6 @@ const IMAGE_TOPIC_DIFFERENT_FRAME = "IMAGE_TOPIC_DIFFERENT_FRAME";
 const CAMERA_MODEL = "CameraModel";
 
 const DEFAULT_FOCAL_LENGTH = 500;
-const DEFAULT_IMAGE_WIDTH = 512;
 
 type ImageModeEvent = { type: "hasModifiedViewChanged" };
 
@@ -588,8 +587,7 @@ export class ImageMode
       return;
     }
 
-    const resizeBitmapWidth = !this.#fallbackCameraModelActive() ? DEFAULT_IMAGE_WIDTH : undefined;
-    decodeCompressedImageToBitmap(image, resizeBitmapWidth)
+    decodeCompressedImageToBitmap(image)
       .then((maybeBitmap) => {
         const prevRenderable = renderable;
         const currentRenderable = this.#imageRenderable;
@@ -597,7 +595,7 @@ export class ImageMode
         if (currentRenderable !== prevRenderable) {
           return;
         }
-        this.renderer.settings.errors.removeFromTopic(topic, CREATE_BITMAP_ERR_KEY);
+        this.renderer.settings.errors.remove(IMAGE_TOPIC_PATH, CREATE_BITMAP_ERR_KEY);
         renderable.setBitmap(maybeBitmap);
         if (this.#fallbackCameraModelActive()) {
           this.#updateFallbackCameraModel(maybeBitmap, getFrameIdFromImage(image));
@@ -612,8 +610,8 @@ export class ImageMode
         if (currentRenderable !== prevRenderable) {
           return;
         }
-        this.renderer.settings.errors.addToTopic(
-          topic,
+        this.renderer.settings.errors.add(
+          IMAGE_TOPIC_PATH,
           CREATE_BITMAP_ERR_KEY,
           `Error creating bitmap: ${err.message}`,
         );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -235,9 +235,15 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         decodeRawImage(image, this.#getRawImageOptions(), texture.image.data);
         texture.needsUpdate = true;
         this.renderer.settings.errors.remove(IMAGE_TOPIC_PATH, CREATE_BITMAP_ERR_KEY);
+        this.renderer.settings.errors.removeFromTopic(this.userData.topic, CREATE_BITMAP_ERR_KEY);
       } catch (error) {
         this.renderer.settings.errors.add(
           IMAGE_TOPIC_PATH,
+          CREATE_BITMAP_ERR_KEY,
+          `Error decoding raw image: ${error.message}`,
+        );
+        this.renderer.settings.errors.addToTopic(
+          this.userData.topic,
           CREATE_BITMAP_ERR_KEY,
           `Error decoding raw image: ${error.message}`,
         );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -29,6 +29,7 @@ export interface ImageRenderableSettings {
 }
 
 export const CREATE_BITMAP_ERR_KEY = "CreateBitmap";
+const IMAGE_TOPIC_PATH = ["imageMode", "imageTopic"];
 
 const DEFAULT_DISTANCE = 1;
 const DEFAULT_PLANAR_PROJECTION_FACTOR = 0;
@@ -230,8 +231,17 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       }
 
       const texture = this.userData.texture as THREE.DataTexture;
-      decodeRawImage(image, this.#getRawImageOptions(), texture.image.data);
-      texture.needsUpdate = true;
+      try {
+        decodeRawImage(image, this.#getRawImageOptions(), texture.image.data);
+        texture.needsUpdate = true;
+        this.renderer.settings.errors.remove(IMAGE_TOPIC_PATH, CREATE_BITMAP_ERR_KEY);
+      } catch (error) {
+        this.renderer.settings.errors.add(
+          IMAGE_TOPIC_PATH,
+          CREATE_BITMAP_ERR_KEY,
+          `Error decoding raw image: ${error.message}`,
+        );
+      }
     }
     this.#materialNeedsUpdate = true;
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 import { ImageAnnotations, PointsAnnotationType } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
-import { makeImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
+import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 
@@ -23,7 +23,7 @@ export default {
 const AnnotationsStory = (imageModeConfigOverride: Partial<ImageModeConfig> = {}): JSX.Element => {
   const width = 60;
   const height = 45;
-  const { calibrationMessage, cameraMessage } = makeImageAndCalibration({
+  const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
     width,
     height,
     frameId: "camera",
@@ -283,7 +283,7 @@ export const MessageConverterSupport: StoryObj = {
     const width = 60;
     const height = 45;
 
-    const { calibrationMessage, cameraMessage } = makeImageAndCalibration({
+    const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
       width,
       height,
       frameId: "camera",
@@ -473,7 +473,7 @@ const AnnotationsUpdateStory = (
   const readySignal = useReadySignal();
   const width = 60;
   const height = 45;
-  const { calibrationMessage, cameraMessage } = makeImageAndCalibration({
+  const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
     width,
     height,
     frameId: "camera",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
@@ -11,7 +11,7 @@ import tinycolor from "tinycolor2";
 
 import { ImageAnnotations, LineType, PointsAnnotationType, SceneUpdate } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
-import { makeImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
+import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import { xyzrpyToPose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
@@ -224,7 +224,7 @@ const ImageWith3D = ({
   const width = 60;
   const height = 45;
 
-  const { calibrationMessage, cameraMessage } = makeImageAndCalibration({
+  const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
     width,
     height,
     frameId: "cam",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImagePanZoomRotate.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImagePanZoomRotate.stories.tsx
@@ -8,7 +8,7 @@ import * as THREE from "three";
 
 import { ImageAnnotations, SceneUpdate } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
-import { makeImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
+import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
 import { ImagePanel, ThreeDeePanel } from "../../index";
@@ -27,7 +27,7 @@ type BaseStoryProps = {
 const BaseStory = ({ rotation, flipHorizontal, flipVertical }: BaseStoryProps): JSX.Element => {
   const width = 60;
   const height = 45;
-  const { calibrationMessage, cameraMessage } = makeImageAndCalibration({
+  const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
     width,
     height,
     frameId: "camera",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/imageCommon.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/imageCommon.ts
@@ -83,6 +83,7 @@ export function makeRawImageAndCalibration(args: MakeImageArgs): {
   return { calibrationMessage, cameraMessage };
 }
 
+// ts-prune-ignore-next
 export async function makeCompressedImageAndCalibration(args: MakeImageArgs): Promise<{
   calibrationMessage: MessageEvent<Partial<CameraCalibration>>;
   cameraMessage: MessageEvent<Partial<CompressedImage>>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/imageCommon.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/imageCommon.ts
@@ -2,11 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { CameraCalibration, RawImage } from "@foxglove/schemas";
+import { CameraCalibration, CompressedImage, RawImage } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 
-// ts-prune-ignore-next
-export function makeImageAndCalibration(args: {
+type MakeImageArgs = {
   width: number;
   height: number;
   frameId: string;
@@ -14,7 +13,10 @@ export function makeImageAndCalibration(args: {
   calibrationTopic: string;
   fx?: number;
   fy?: number;
-}): {
+};
+
+// ts-prune-ignore-next
+export function makeRawImageAndCalibration(args: MakeImageArgs): {
   calibrationMessage: MessageEvent<Partial<CameraCalibration>>;
   cameraMessage: MessageEvent<Partial<RawImage>>;
 } {
@@ -39,6 +41,15 @@ export function makeImageAndCalibration(args: {
     sizeInBytes: 0,
   };
 
+  function getGridLineColor(idx: number) {
+    if (idx % 10 === 0) {
+      return 0;
+    }
+    if (idx % 2 === 0) {
+      return 100;
+    }
+    return 127;
+  }
   const imageData = new Uint8Array(width * height * 3);
   for (let i = 0, r = 0; r < height; r++) {
     for (let c = 0; c < width; c++) {
@@ -47,9 +58,9 @@ export function makeImageAndCalibration(args: {
         imageData[i++] = 150;
         imageData[i++] = 255;
       } else {
-        imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
-        imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
-        imageData[i++] = (r % 2 === 0 ? 127 : 0) + (c % 2 === 0 ? 127 : 0);
+        imageData[i++] = getGridLineColor(r) + getGridLineColor(c);
+        imageData[i++] = getGridLineColor(r) + getGridLineColor(c);
+        imageData[i++] = getGridLineColor(r) + getGridLineColor(c);
       }
     }
   }
@@ -69,5 +80,53 @@ export function makeImageAndCalibration(args: {
     sizeInBytes: 0,
   };
 
+  return { calibrationMessage, cameraMessage };
+}
+
+export async function makeCompressedImageAndCalibration(args: MakeImageArgs): Promise<{
+  calibrationMessage: MessageEvent<Partial<CameraCalibration>>;
+  cameraMessage: MessageEvent<Partial<CompressedImage>>;
+}> {
+  const { calibrationMessage, cameraMessage: rawCameraMessage } = makeRawImageAndCalibration(args);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = args.width;
+  canvas.height = args.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Failed to get canvas context");
+  }
+  const imageData = ctx.createImageData(args.width, args.height);
+  for (let i = 0, j = 0; i < rawCameraMessage.message.data!.length; i += 3, j += 4) {
+    imageData.data[j] = rawCameraMessage.message.data![i]!;
+    imageData.data[j + 1] = rawCameraMessage.message.data![i + 1]!;
+    imageData.data[j + 2] = rawCameraMessage.message.data![i + 2]!;
+    imageData.data[j + 3] = 255;
+  }
+  ctx.putImageData(imageData, 0, 0);
+
+  const imageBlob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject();
+      } else {
+        resolve(blob);
+      }
+    }, "image/png");
+  });
+
+  const buffer = await imageBlob.arrayBuffer();
+  const cameraMessage: MessageEvent<Partial<CompressedImage>> = {
+    topic: rawCameraMessage.topic,
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      timestamp: rawCameraMessage.message.timestamp,
+      frame_id: rawCameraMessage.message.frame_id,
+      data: new Uint8Array(buffer),
+      format: "png",
+    },
+    schemaName: "foxglove.CompressedImage",
+    sizeInBytes: 0,
+  };
   return { calibrationMessage, cameraMessage };
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Remove `resizeWidth` setting for Image panel (but keep it for images in 3D panel for now). This likely poses a performance issue for larger images, but we plan to try moving the image decoding into a worker to help alleviate that.

Also fixes some error handling so errors are displayed in the settings instead of crashing the panel.

Large image with resizeWidth 512:
<img width="909" alt="image" src="https://github.com/foxglove/studio/assets/14237/dd24059d-cbe0-497d-b5fc-6b581c88938d">

Large image without resizeWidth:
<img width="915" alt="image" src="https://github.com/foxglove/studio/assets/14237/0e3d5d1a-5cb3-4a47-80ed-8adbf2dd26cc">
