### PR TITLE
[Image Beta] - add errors on topics when calibration is undefined

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -23,6 +23,7 @@ import {
   Topic,
   VariableValue,
 } from "@foxglove/studio";
+import { LayerErrors } from "@foxglove/studio-base/panels/ThreeDeeRender/LayerErrors";
 import { FoxgloveGrid } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/FoxgloveGrid";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";
 import { dark, light } from "@foxglove/studio-base/theme/palette";
@@ -667,13 +668,32 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.#addSubscriptionsFromSceneExtensions(
       (extension) => extension === this.#imageModeExtension,
     );
+    this.settings.addGlobalSettingsEntryValidator(this.#imageOnlyModeTopicSettingsValidator);
   };
 
   #disableImageOnlySubscriptionMode = (): void => {
+    // .clear() will clean up remaining errors on topics
+    this.settings.removeGlobalSettingsEntryValidator(this.#imageOnlyModeTopicSettingsValidator);
     this.clear({ clearTransforms: true, resetAllFramesCursor: true });
     this.#clearSubscriptions();
     this.#addSubscriptionsFromSceneExtensions();
     this.#addTransformSubscriptions();
+  };
+
+  /** Adds errors to visible topic nodes when calibration is undefined */
+  #imageOnlyModeTopicSettingsValidator = (entry: SettingsTreeEntry, errors: LayerErrors) => {
+    const { path, node } = entry;
+    if (path[0] === "topics") {
+      if (node.visible === true) {
+        errors.addToTopic(
+          path[1]!,
+          "IMAGE_ONLY_TOPIC",
+          "3D topics cannot be rendered while image calibration is not defined.",
+        );
+      } else {
+        errors.removeFromTopic(path[1]!, "IMAGE_ONLY_TOPIC");
+      }
+    }
   };
 
   public addCustomLayerAction(options: {
@@ -693,7 +713,17 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
       icon: options.icon,
     };
     this.#customLayerActions.set(options.layerId, { action, handler });
+    this.#updateTopicsAndCustomLayerSettingsNodes();
+  }
 
+  #updateTopicsAndCustomLayerSettingsNodes(): void {
+    this.settings.setNodesForKey(RENDERER_ID, [
+      this.#getTopicsSettingsEntry(),
+      this.#getCustomLayersSettingsEntry(),
+    ]);
+  }
+
+  #getTopicsSettingsEntry(): SettingsTreeEntry {
     // "Topics" settings tree node
     const topics: SettingsTreeEntry = {
       path: ["topics"],
@@ -709,8 +739,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
         handler: this.#handleTopicsAction,
       },
     };
+    return topics;
+  }
 
-    // "Custom Layers" settings tree node
+  #getCustomLayersSettingsEntry(): SettingsTreeEntry {
     const layerCount = Object.keys(this.config.layers).length;
     const customLayers: SettingsTreeEntry = {
       path: ["layers"],
@@ -721,9 +753,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
         handler: this.#handleCustomLayersAction,
       },
     };
-
-    this.settings.setNodesForKey(RENDERER_ID, [topics, customLayers]);
+    return customLayers;
   }
+
   /** Enable or disable object selection mode */
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   public setPickingEnabled(enabled: boolean): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/SettingsManager.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SettingsManager.ts
@@ -19,11 +19,16 @@ export type SettingsManagerEvents = {
   update: () => void;
 };
 
+type GlobalSettingsEntryValidator = (entry: SettingsTreeEntry, errorState: LayerErrors) => void;
+
 export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
   public errors = new LayerErrors();
 
   #nodesByKey = new Map<string, SettingsTreeEntry[]>();
   #root: SettingsTreeNodeWithActionHandler = { children: {} };
+
+  /** used to hold functions that check incoming nodes for errors and update error state based on them */
+  #globalSettingsEntryValidators: GlobalSettingsEntryValidator[] = [];
 
   public constructor(baseTree: SettingsTreeNodes) {
     super();
@@ -43,6 +48,10 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
           removeNodeAtPath(draft, path);
         }
       }
+
+      nodes.forEach((entry) =>
+        this.#globalSettingsEntryValidators.forEach((validator) => validator(entry, this.errors)),
+      );
 
       // Add the new nodes
       for (const { path, node } of nodes) {
@@ -94,6 +103,18 @@ export class SettingsManager extends EventEmitter<SettingsManagerEvents> {
       nextNode.handler?.(action);
       curNode = nextNode;
     }
+  };
+
+  public addGlobalSettingsEntryValidator = (nodeValidator: GlobalSettingsEntryValidator): void => {
+    this.#globalSettingsEntryValidators.push(nodeValidator);
+  };
+
+  public removeGlobalSettingsEntryValidator = (
+    nodeValidator: GlobalSettingsEntryValidator,
+  ): void => {
+    this.#globalSettingsEntryValidators = this.#globalSettingsEntryValidators.filter(
+      (v) => v !== nodeValidator,
+    );
   };
 
   public handleErrorUpdate = (path: Path): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -53,7 +53,6 @@ const CALIBRATION_TOPIC_PATH = ["imageMode", "calibrationTopic"];
 
 const IMAGE_TOPIC_UNAVAILABLE = "IMAGE_TOPIC_UNAVAILABLE";
 const CALIBRATION_TOPIC_UNAVAILABLE = "CALIBRATION_TOPIC_UNAVAILABLE";
-const FALLBACK_CALIBRATION_ACTIVE_ALERT_KEY = "FALLBACK_CALIBRATION_ACTIVE";
 
 const MISSING_CAMERA_INFO = "MISSING_CAMERA_INFO";
 const IMAGE_TOPIC_DIFFERENT_FRAME = "IMAGE_TOPIC_DIFFERENT_FRAME";
@@ -377,18 +376,6 @@ export class ImageMode
       this.renderer.settings.errors.remove(CALIBRATION_TOPIC_PATH, CALIBRATION_TOPIC_UNAVAILABLE);
     }
 
-    if (this.#fallbackCameraModelActive()) {
-      this.renderer.settings.errors.add(
-        CALIBRATION_TOPIC_PATH,
-        FALLBACK_CALIBRATION_ACTIVE_ALERT_KEY,
-        `This mode uses a fallback camera model based on the image. 3D Topics and transforms will not be available.`,
-      );
-    } else {
-      this.renderer.settings.errors.remove(
-        CALIBRATION_TOPIC_PATH,
-        FALLBACK_CALIBRATION_ACTIVE_ALERT_KEY,
-      );
-    }
     const imageTopicError = this.renderer.settings.errors.errors.errorAtPath(IMAGE_TOPIC_PATH);
     const calibrationTopicError =
       this.renderer.settings.errors.errors.errorAtPath(CALIBRATION_TOPIC_PATH);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
[Image Beta] - add errors on topics when calibration is undefined

**Description**
Added a function to the settings manager to "validate" incoming `SettingsTreeEntries` and potentially add relevant errors. Now when image only mode is enabled we can automatically apply errors to topics and keep them updated without having to make all scene extensions aware of image only mode.

<!-- link relevant GitHub issues -->
FG-3235
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
