### PR TITLE
[Image Beta] - foreground image with opacity

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -91,7 +91,7 @@ export type ImageModeConfig = {
   minValue?: number;
   /** Maximum (white) value for single-channel images */
   maxValue?: number;
-  opacity?: number;
+  foregroundOpacity?: number;
 };
 
 export type RendererConfig = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -91,6 +91,7 @@ export type ImageModeConfig = {
   minValue?: number;
   /** Maximum (white) value for single-channel images */
   maxValue?: number;
+  opacity?: number;
 };
 
 export type RendererConfig = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -81,7 +81,7 @@ const DEFAULT_CONFIG = {
   flipHorizontal: false,
   flipVertical: false,
   rotation: 0 as 0 | 90 | 180 | 270,
-  opacity: 0.0,
+  foregroundOpacity: 0.0,
 };
 
 type ConfigWithDefaults = ImageModeConfig & typeof DEFAULT_CONFIG;
@@ -330,7 +330,7 @@ export class ImageMode
       rotation,
       minValue,
       maxValue,
-      opacity,
+      foregroundOpacity,
     } = this.#getImageModeSettings();
 
     const imageTopics = filterMap(this.renderer.topics ?? [], (topic) => {
@@ -451,7 +451,7 @@ export class ImageMode
       precision: 0,
       value: maxValue,
     };
-    fields.opacity = {
+    fields.foregroundOpacity = {
       input: "number",
       label: "Foreground opacity",
       placeholder: "0.50",
@@ -459,7 +459,7 @@ export class ImageMode
       precision: 3,
       min: 0,
       max: 1,
-      value: opacity,
+      value: foregroundOpacity,
     };
     return [
       {
@@ -520,10 +520,10 @@ export class ImageMode
       if (config.flipVertical !== prevImageModeConfig.flipVertical) {
         this.#camera.setFlipVertical(config.flipVertical);
       }
-      if (config.opacity !== prevImageModeConfig.opacity) {
+      if (config.foregroundOpacity !== prevImageModeConfig.foregroundOpacity) {
         this.#imageRenderable?.setSettings({
           ...this.#imageRenderable.userData.settings,
-          foregroundOpacity: config.opacity,
+          foregroundOpacity: config.foregroundOpacity,
         });
       }
       if (
@@ -676,7 +676,7 @@ export class ImageMode
       ...IMAGE_RENDERABLE_DEFAULT_SETTINGS,
       minValue: config.minValue,
       maxValue: config.maxValue,
-      foregroundOpacity: config.opacity,
+      foregroundOpacity: config.foregroundOpacity,
     };
     renderable = new ImageRenderable(topicName, this.renderer, {
       receiveTime,
@@ -697,7 +697,7 @@ export class ImageMode
 
     this.add(renderable);
     this.#imageRenderable = renderable;
-    renderable.setRenderBehindScene();
+    renderable.setRenderFrontAndBehind();
     renderable.visible = true;
     return renderable;
   }
@@ -742,7 +742,7 @@ export class ImageMode
       rotation: config.rotation ?? DEFAULT_CONFIG.rotation,
       flipHorizontal: config.flipHorizontal ?? DEFAULT_CONFIG.flipHorizontal,
       flipVertical: config.flipVertical ?? DEFAULT_CONFIG.flipVertical,
-      opacity: config.opacity ?? DEFAULT_CONFIG.opacity,
+      foregroundOpacity: config.foregroundOpacity ?? DEFAULT_CONFIG.foregroundOpacity,
     };
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -82,6 +82,7 @@ const DEFAULT_CONFIG = {
   flipHorizontal: false,
   flipVertical: false,
   rotation: 0 as 0 | 90 | 180 | 270,
+  opacity: 0.0,
 };
 
 type ConfigWithDefaults = ImageModeConfig & typeof DEFAULT_CONFIG;
@@ -523,7 +524,7 @@ export class ImageMode
       if (config.opacity !== prevImageModeConfig.opacity) {
         this.#imageRenderable?.setSettings({
           ...this.#imageRenderable.userData.settings,
-          opacity: config.opacity,
+          foregroundOpacity: config.opacity,
         });
       }
       if (
@@ -677,7 +678,7 @@ export class ImageMode
       ...IMAGE_RENDERABLE_DEFAULT_SETTINGS,
       minValue: config.minValue,
       maxValue: config.maxValue,
-      opacity: config.opacity,
+      foregroundOpacity: config.opacity,
     };
     renderable = new ImageRenderable(topicName, this.renderer, {
       receiveTime,
@@ -736,12 +737,15 @@ export class ImageMode
 
   #getImageModeSettings(): Immutable<ConfigWithDefaults> {
     const config = { ...this.renderer.config.imageMode };
-    config.synchronize ??= DEFAULT_CONFIG.synchronize;
-    config.rotation ??= DEFAULT_CONFIG.rotation;
-    config.flipHorizontal ??= DEFAULT_CONFIG.flipHorizontal;
-    config.flipVertical ??= DEFAULT_CONFIG.flipVertical;
 
-    return config as ConfigWithDefaults;
+    return {
+      ...config,
+      synchronize: config.synchronize ?? DEFAULT_CONFIG.synchronize,
+      rotation: config.rotation ?? DEFAULT_CONFIG.rotation,
+      flipHorizontal: config.flipHorizontal ?? DEFAULT_CONFIG.flipHorizontal,
+      flipVertical: config.flipVertical ?? DEFAULT_CONFIG.flipVertical,
+      opacity: config.opacity ?? DEFAULT_CONFIG.opacity,
+    };
   }
 
   /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -330,6 +330,7 @@ export class ImageMode
       rotation,
       minValue,
       maxValue,
+      opacity,
     } = this.#getImageModeSettings();
 
     const imageTopics = filterMap(this.renderer.topics ?? [], (topic) => {
@@ -450,6 +451,16 @@ export class ImageMode
       precision: 0,
       value: maxValue,
     };
+    fields.opacity = {
+      input: "number",
+      label: "Foreground opacity",
+      placeholder: "0.50",
+      step: 0.05,
+      precision: 3,
+      min: 0,
+      max: 1,
+      value: opacity,
+    };
     return [
       {
         path: ["imageMode"],
@@ -508,6 +519,12 @@ export class ImageMode
       }
       if (config.flipVertical !== prevImageModeConfig.flipVertical) {
         this.#camera.setFlipVertical(config.flipVertical);
+      }
+      if (config.opacity !== prevImageModeConfig.opacity) {
+        this.#imageRenderable?.setSettings({
+          ...this.#imageRenderable.userData.settings,
+          opacity: config.opacity,
+        });
       }
       if (
         config.minValue !== prevImageModeConfig.minValue ||
@@ -660,6 +677,7 @@ export class ImageMode
       ...IMAGE_RENDERABLE_DEFAULT_SETTINGS,
       minValue: config.minValue,
       maxValue: config.maxValue,
+      opacity: config.opacity,
     };
     renderable = new ImageRenderable(topicName, this.renderer, {
       receiveTime,
@@ -676,6 +694,8 @@ export class ImageMode
       material: undefined,
       geometry: undefined,
       mesh: undefined,
+      foregroundMaterial: undefined,
+      foregroundMesh: undefined,
     });
 
     this.add(renderable);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -694,8 +694,6 @@ export class ImageMode
       material: undefined,
       geometry: undefined,
       mesh: undefined,
-      foregroundMaterial: undefined,
-      foregroundMesh: undefined,
     });
 
     this.add(renderable);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderablePointsAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderablePointsAnnotation.ts
@@ -7,6 +7,10 @@ import * as THREE from "three";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { getAnnotationAtPath } from "@foxglove/studio-base/panels/Image/lib/normalizeAnnotations";
 import { PointsAnnotation as NormalizedPointsAnnotation } from "@foxglove/studio-base/panels/Image/types";
+import {
+  ANNOTATION_RENDER_ORDER,
+  annotationRenderOrderMaterialProps,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ImageMode/annotations/annotationRenderOrder";
 import { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 
 import { DynamicBufferGeometry } from "../../../DynamicBufferGeometry";
@@ -73,9 +77,11 @@ export class RenderablePointsAnnotation extends Renderable<BaseUserData, /*TRend
       size: 0,
       sizeAttenuation: false,
       vertexColors: true,
+      ...annotationRenderOrderMaterialProps,
     });
     this.#pickingMaterial = new PickingMaterial();
     this.#points = new THREE.Points(this.#geometry, this.#pointsMaterial);
+    this.#points.renderOrder = ANNOTATION_RENDER_ORDER.POINTS;
     this.#points.userData.pickingMaterial = this.#pickingMaterial;
     this.add(this.#points);
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/annotationRenderOrder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/annotationRenderOrder.ts
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/** Want to render after all other objects in the scene so that they are not occluded by other objects */
+const ANNOTATION_FRONT_POSITION = 100000;
+
+/** Render order for given annotations. Higher numbers rendered after lower numbers */
+export const ANNOTATION_RENDER_ORDER = {
+  FILL: 1 + ANNOTATION_FRONT_POSITION,
+  LINE_PREPASS: 2 + ANNOTATION_FRONT_POSITION,
+  LINE: 3 + ANNOTATION_FRONT_POSITION,
+  POINTS: 4 + ANNOTATION_FRONT_POSITION,
+  TEXT: 5 + ANNOTATION_FRONT_POSITION,
+};
+
+/** we want annotations to show on top of the entire scene. These are material props to achieve that */
+export const annotationRenderOrderMaterialProps = {
+  /** We need to set transparent to true so that transparent objects aren't rendered on top of it.
+   * Transparent objects are rendered after non-transparent objects. If this were set to false or
+   * set based on color of annotations, then the foreground image with opacity would be rendered on top
+   * until it is fully opaque.
+   */
+  transparent: true,
+  depthWrite: false,
+  depthTest: false,
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -26,7 +26,8 @@ export interface ImageRenderableSettings {
   color: string;
   minValue?: number;
   maxValue?: number;
-  opacity?: number;
+  /** Opacity of foreground image, not used when `renderBehindScene` set to true */
+  foregroundOpacity: number;
 }
 
 export const CREATE_BITMAP_ERR_KEY = "CreateBitmap";
@@ -40,6 +41,7 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
   distance: DEFAULT_DISTANCE,
   planarProjectionFactor: DEFAULT_PLANAR_PROJECTION_FACTOR,
   color: "#ffffff",
+  foregroundOpacity: 0.0,
 };
 export type ImageUserData = BaseUserData & {
   topic: string;
@@ -144,7 +146,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     ) {
       this.#textureNeedsUpdate = true;
     }
-    if (prevSettings.opacity !== newSettings.opacity) {
+    if (prevSettings.foregroundOpacity !== newSettings.foregroundOpacity) {
       this.#materialNeedsUpdate = true;
     }
 
@@ -280,8 +282,8 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       if (texture) {
         foregroundMaterial.map = texture;
       }
-      const foregroundTransparent = this.userData.settings.opacity !== 1;
-      foregroundMaterial.opacity = this.userData.settings.opacity ?? 0.5;
+      const foregroundTransparent = this.userData.settings.foregroundOpacity !== 1;
+      foregroundMaterial.opacity = this.userData.settings.foregroundOpacity;
       foregroundMaterial.transparent = foregroundTransparent;
       foregroundMaterial.depthWrite = !foregroundTransparent;
       material.depthWrite = false;
@@ -312,7 +314,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       name: `${this.userData.topic}:ForegroundMaterial`,
       color,
       side: THREE.DoubleSide,
-      opacity: this.userData.settings.opacity ?? 0.5,
+      opacity: this.userData.settings.foregroundOpacity,
       transparent,
       depthWrite: !transparent,
     });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -49,10 +49,8 @@ export type ImageUserData = BaseUserData & {
   image: AnyImage | undefined;
   texture: THREE.Texture | undefined;
   material: THREE.MeshBasicMaterial | undefined;
-  foregroundMaterial: THREE.MeshBasicMaterial | undefined;
   geometry: THREE.PlaneGeometry | undefined;
   mesh: THREE.Mesh | undefined;
-  foregroundMesh: THREE.Mesh | undefined;
 };
 
 export class ImageRenderable extends Renderable<ImageUserData> {
@@ -72,6 +70,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
   #isUpdating = false;
 
+  #foregroundMaterial: THREE.MeshBasicMaterial | undefined;
+  #foregroundMesh: THREE.Mesh | undefined;
+
   public constructor(topicName: string, renderer: IRenderer, userData: ImageUserData) {
     super(topicName, renderer, userData);
   }
@@ -80,7 +81,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.userData.texture?.dispose();
     this.userData.material?.dispose();
     this.userData.geometry?.dispose();
-    this.userData.foregroundMaterial?.dispose();
+    this.#foregroundMaterial?.dispose();
     super.dispose();
   }
 
@@ -272,10 +273,10 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
     if (this.#renderBehindScene) {
       assert(
-        this.userData.foregroundMaterial,
+        this.#foregroundMaterial,
         "ForegroundMaterial must be set before mesh can be updated or created",
       );
-      const { foregroundMaterial } = this.userData;
+      const foregroundMaterial = this.#foregroundMaterial;
       if (texture) {
         foregroundMaterial.map = texture;
       }
@@ -307,7 +308,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     if (!this.#renderBehindScene) {
       return;
     }
-    this.userData.foregroundMaterial = new THREE.MeshBasicMaterial({
+    this.#foregroundMaterial = new THREE.MeshBasicMaterial({
       name: `${this.userData.topic}:ForegroundMaterial`,
       color,
       side: THREE.DoubleSide,
@@ -330,19 +331,17 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
     if (this.#renderBehindScene) {
       assert(
-        this.userData.foregroundMaterial,
+        this.#foregroundMaterial,
         "ForegroundMaterial must be set before mesh can be updated or created",
       );
 
-      if (!this.userData.foregroundMesh) {
-        this.userData.foregroundMesh = new THREE.Mesh(
-          this.userData.geometry,
-          this.userData.foregroundMaterial,
-        );
-        this.add(this.userData.foregroundMesh);
+      if (!this.#foregroundMesh) {
+        this.#foregroundMesh = new THREE.Mesh(this.userData.geometry, this.#foregroundMaterial);
+        this.#foregroundMesh.userData.pickable = false;
+        this.add(this.#foregroundMesh);
       } else {
-        this.userData.foregroundMesh.geometry = this.userData.geometry;
-        this.userData.foregroundMesh.material = this.userData.foregroundMaterial;
+        this.#foregroundMesh.geometry = this.userData.geometry;
+        this.#foregroundMesh.material = this.#foregroundMaterial;
       }
       // this.userData.foregroundMesh.renderOrder = -1;
       this.userData.mesh.renderOrder = -1 * Number.MAX_SAFE_INTEGER;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -67,7 +67,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   // set when material or texture changes
   #materialNeedsUpdate = true;
 
-  #renderBehindScene: boolean = false;
+  #renderFrontAndBehind: boolean = false;
 
   #bitmap?: ImageBitmap;
 
@@ -108,8 +108,8 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     return { image: this.userData.image, camera_info: this.userData.cameraInfo };
   }
 
-  public setRenderBehindScene(): void {
-    this.#renderBehindScene = true;
+  public setRenderFrontAndBehind(): void {
+    this.#renderFrontAndBehind = true;
     this.#materialNeedsUpdate = true;
     this.#meshNeedsUpdate = true;
   }
@@ -289,7 +289,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     material.transparent = transparent;
     material.depthWrite = !transparent;
 
-    if (this.#renderBehindScene) {
+    if (this.#renderFrontAndBehind) {
       assert(
         this.#foregroundMaterial,
         "ForegroundMaterial must be set before mesh can be updated or created",
@@ -323,7 +323,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       transparent,
       depthWrite: !transparent,
     });
-    if (!this.#renderBehindScene) {
+    if (!this.#renderFrontAndBehind) {
       return;
     }
     this.#foregroundMaterial = new THREE.MeshBasicMaterial({
@@ -347,25 +347,25 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       this.userData.mesh.material = this.userData.material;
     }
 
-    if (this.#renderBehindScene) {
-      assert(
-        this.#foregroundMaterial,
-        "ForegroundMaterial must be set before mesh can be updated or created",
-      );
-
-      if (!this.#foregroundMesh) {
-        this.#foregroundMesh = new THREE.Mesh(this.userData.geometry, this.#foregroundMaterial);
-        this.#foregroundMesh.userData.pickable = false;
-        this.add(this.#foregroundMesh);
-      } else {
-        this.#foregroundMesh.geometry = this.userData.geometry;
-        this.#foregroundMesh.material = this.#foregroundMaterial;
-      }
-      // this.userData.foregroundMesh.renderOrder = -1;
-      this.userData.mesh.renderOrder = -1 * Number.MAX_SAFE_INTEGER;
-    } else {
+    if (!this.#renderFrontAndBehind) {
       this.userData.mesh.renderOrder = 0;
+      return;
     }
+
+    assert(
+      this.#foregroundMaterial,
+      "ForegroundMaterial must be set before mesh can be updated or created",
+    );
+
+    if (!this.#foregroundMesh) {
+      this.#foregroundMesh = new THREE.Mesh(this.userData.geometry, this.#foregroundMaterial);
+      this.#foregroundMesh.userData.pickable = false;
+      this.add(this.#foregroundMesh);
+    } else {
+      this.#foregroundMesh.geometry = this.userData.geometry;
+      this.#foregroundMesh.material = this.#foregroundMaterial;
+    }
+    this.userData.mesh.renderOrder = -1 * Number.MAX_SAFE_INTEGER;
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -26,6 +26,7 @@ export interface ImageRenderableSettings {
   color: string;
   minValue?: number;
   maxValue?: number;
+  opacity?: number;
 }
 
 export const CREATE_BITMAP_ERR_KEY = "CreateBitmap";
@@ -48,8 +49,10 @@ export type ImageUserData = BaseUserData & {
   image: AnyImage | undefined;
   texture: THREE.Texture | undefined;
   material: THREE.MeshBasicMaterial | undefined;
+  foregroundMaterial: THREE.MeshBasicMaterial | undefined;
   geometry: THREE.PlaneGeometry | undefined;
   mesh: THREE.Mesh | undefined;
+  foregroundMesh: THREE.Mesh | undefined;
 };
 
 export class ImageRenderable extends Renderable<ImageUserData> {
@@ -77,6 +80,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.userData.texture?.dispose();
     this.userData.material?.dispose();
     this.userData.geometry?.dispose();
+    this.userData.foregroundMaterial?.dispose();
     super.dispose();
   }
 
@@ -138,6 +142,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       prevSettings.maxValue !== newSettings.maxValue
     ) {
       this.#textureNeedsUpdate = true;
+    }
+    if (prevSettings.opacity !== newSettings.opacity) {
+      this.#materialNeedsUpdate = true;
     }
 
     this.userData.settings = newSettings;
@@ -264,6 +271,18 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     material.depthWrite = !transparent;
 
     if (this.#renderBehindScene) {
+      assert(
+        this.userData.foregroundMaterial,
+        "ForegroundMaterial must be set before mesh can be updated or created",
+      );
+      const { foregroundMaterial } = this.userData;
+      if (texture) {
+        foregroundMaterial.map = texture;
+      }
+      const foregroundTransparent = this.userData.settings.opacity !== 1;
+      foregroundMaterial.opacity = this.userData.settings.opacity ?? 0.5;
+      foregroundMaterial.transparent = foregroundTransparent;
+      foregroundMaterial.depthWrite = !foregroundTransparent;
       material.depthWrite = false;
       material.depthTest = false;
     } else {
@@ -285,6 +304,17 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       transparent,
       depthWrite: !transparent,
     });
+    if (!this.#renderBehindScene) {
+      return;
+    }
+    this.userData.foregroundMaterial = new THREE.MeshBasicMaterial({
+      name: `${this.userData.topic}:ForegroundMaterial`,
+      color,
+      side: THREE.DoubleSide,
+      opacity: this.userData.settings.opacity ?? 0.5,
+      transparent,
+      depthWrite: !transparent,
+    });
   }
 
   #updateMesh(): void {
@@ -299,6 +329,22 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     }
 
     if (this.#renderBehindScene) {
+      assert(
+        this.userData.foregroundMaterial,
+        "ForegroundMaterial must be set before mesh can be updated or created",
+      );
+
+      if (!this.userData.foregroundMesh) {
+        this.userData.foregroundMesh = new THREE.Mesh(
+          this.userData.geometry,
+          this.userData.foregroundMaterial,
+        );
+        this.add(this.userData.foregroundMesh);
+      } else {
+        this.userData.foregroundMesh.geometry = this.userData.geometry;
+        this.userData.foregroundMesh.material = this.userData.foregroundMaterial;
+      }
+      // this.userData.foregroundMesh.renderOrder = -1;
       this.userData.mesh.renderOrder = -1 * Number.MAX_SAFE_INTEGER;
     } else {
       this.userData.mesh.renderOrder = 0;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
@@ -11,6 +11,7 @@ import tinycolor from "tinycolor2";
 
 import { ImageAnnotations, LineType, PointsAnnotationType, SceneUpdate } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
+import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import { xyzrpyToPose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -26,13 +27,7 @@ export default {
   parameters: { colorScheme: "light" },
 };
 
-const ImageWith3D = ({
-  initialCalibrationTopic,
-  initialImageTopic,
-}: {
-  initialImageTopic: string | undefined;
-  initialCalibrationTopic: string | undefined;
-}): JSX.Element => {
+const ImageWith3D = (initialConfig: ImageModeConfig): JSX.Element => {
   const topics: Topic[] = [
     { name: "annotations", schemaName: "foxglove.ImageAnnotations" },
     { name: "camera/calibration", schemaName: "foxglove.CameraCalibration" },
@@ -269,8 +264,7 @@ const ImageWith3D = ({
             },
           },
           imageMode: {
-            calibrationTopic: initialCalibrationTopic,
-            imageTopic: initialImageTopic,
+            ...initialConfig,
             annotations: [
               {
                 topic: "annotations",
@@ -292,29 +286,51 @@ const ImageWith3D = ({
 
 export const ImageOnlyModeOff: StoryObj<React.ComponentProps<typeof ImageWith3D>> = {
   render: ImageWith3D,
-  args: { initialImageTopic: "camera/img", initialCalibrationTopic: "camera/calibration" },
+  args: { imageTopic: "camera/img", calibrationTopic: "camera/calibration" },
 };
 
 export const ImageOnlyModeOn: StoryObj<React.ComponentProps<typeof ImageWith3D>> = {
   render: ImageWith3D,
-  args: { initialImageTopic: "camera/img", initialCalibrationTopic: undefined },
+  args: { imageTopic: "camera/img", calibrationTopic: undefined },
 };
 
 export const ImageOnlyModeOffWithAutoSelectedTopics: StoryObj<
   React.ComponentProps<typeof ImageWith3D>
 > = {
   render: ImageWith3D,
-  args: { initialImageTopic: undefined, initialCalibrationTopic: undefined },
+  args: { imageTopic: undefined, calibrationTopic: undefined },
 };
 
 export const ImageOnlyModeOffWithAutoSelectedCalibration: StoryObj<
   React.ComponentProps<typeof ImageWith3D>
 > = {
   render: ImageWith3D,
-  args: { initialImageTopic: "abc", initialCalibrationTopic: undefined },
+  args: { imageTopic: "abc", calibrationTopic: undefined },
   play: async () => {
     userEvent.click(await screen.findByText("abc", { selector: ".MuiSelect-select" }));
     userEvent.click(await screen.findByText("camera/img"));
+  },
+};
+
+export const ImageModeForegroundOpacity50Percent: StoryObj<
+  React.ComponentProps<typeof ImageWith3D>
+> = {
+  render: ImageWith3D,
+  args: {
+    imageTopic: "camera/img",
+    calibrationTopic: "camera/calibration",
+    foregroundOpacity: 0.5,
+  },
+};
+
+export const ImageModeForegroundOpacity100Percent: StoryObj<
+  React.ComponentProps<typeof ImageWith3D>
+> = {
+  render: ImageWith3D,
+  args: {
+    imageTopic: "camera/img",
+    calibrationTopic: "camera/calibration",
+    foregroundOpacity: 1.0,
   },
 };
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - [Image Beta] - add image overlay with opacity setting

**Description**
Add foreground image with opacity control in image mode settings. This is to mirror RVIZ behavior where it renders a foreground and background image with alpha, it is not currently present in the old image panel. 

Also updated ImageAnnotations to always render on top of everything in the scene

- [x] add stories (waiting for @jtbandes to merge story changes from [this PR](https://github.com/foxglove/studio/pull/6172) so there aren't conflicts)

opacity @ 0.0 (default):
<img width="815" alt="image" src="https://github.com/foxglove/studio/assets/10187776/07d1838d-13cb-4a9e-8f95-f26a13510e29">

opacity @ 0.5:
<img width="814" alt="image" src="https://github.com/foxglove/studio/assets/10187776/1d188ff5-fb2a-4a18-8905-b8e457b3508a">

opacity @ 1.0:
<img width="814" alt="image" src="https://github.com/foxglove/studio/assets/10187776/166c9b6a-8cb7-4ef0-b680-b414e50c5a2d">



<!-- link relevant GitHub issues -->
FG-2689
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
