### PR TITLE
[Image Beta] prevent flickering when toggling 3D/annotation topics

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -45,7 +45,7 @@ import {
 } from "../../ros";
 import { topicIsConvertibleToSchema } from "../../topicIsConvertibleToSchema";
 import { ICameraHandler } from "../ICameraHandler";
-import { decodeCompressedImageToBitmap } from "../Images/decodeImage";
+import { BitmapCache } from "../Images/BitmapCache";
 import { getTopicMatchPrefix, sortPrefixMatchesToFront } from "../Images/topicPrefixMatching";
 
 const IMAGE_TOPIC_PATH = ["imageMode", "imageTopic"];
@@ -112,6 +112,9 @@ export class ImageMode
 
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   #setHasCalibrationTopic: (hasCalibrationTopic: boolean) => void;
+
+  /** Cache of decoded bitmaps to avoid flickering when toggling topics */
+  #bitmapCache = new BitmapCache();
 
   /**
    * @param canvasSize Canvas size in CSS pixels
@@ -589,8 +592,9 @@ export class ImageMode
     }
 
     const resizeBitmapWidth = !this.#fallbackCameraModelActive() ? DEFAULT_IMAGE_WIDTH : undefined;
-    decodeCompressedImageToBitmap(image, resizeBitmapWidth)
-      .then((maybeBitmap) => {
+    this.#bitmapCache
+      .getBitmap(messageEvent, image, resizeBitmapWidth)
+      .then((bitmap) => {
         const prevRenderable = renderable;
         const currentRenderable = this.#imageRenderable;
         // prevent setting and updating disposed renderables
@@ -598,9 +602,9 @@ export class ImageMode
           return;
         }
         this.renderer.settings.errors.removeFromTopic(topic, CREATE_BITMAP_ERR_KEY);
-        renderable.setBitmap(maybeBitmap);
+        renderable.setBitmap(bitmap);
         if (this.#fallbackCameraModelActive()) {
-          this.#updateFallbackCameraModel(maybeBitmap, getFrameIdFromImage(image));
+          this.#updateFallbackCameraModel(bitmap, getFrameIdFromImage(image));
         }
 
         renderable.update();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -590,9 +590,11 @@ export class ImageMode
       return;
     }
 
-    this.#bitmapCache
-      .getBitmap(messageEvent, image)
-      .then((bitmap) => {
+    this.#bitmapCache.getBitmap(
+      messageEvent,
+      image,
+      undefined,
+      (bitmap) => {
         const prevRenderable = renderable;
         const currentRenderable = this.#imageRenderable;
         // prevent setting and updating disposed renderables
@@ -607,8 +609,8 @@ export class ImageMode
 
         renderable.update();
         this.renderer.queueAnimationFrame();
-      })
-      .catch((err) => {
+      },
+      (err) => {
         const prevRenderable = renderable;
         const currentRenderable = this.#imageRenderable;
         if (currentRenderable !== prevRenderable) {
@@ -619,7 +621,8 @@ export class ImageMode
           CREATE_BITMAP_ERR_KEY,
           `Error creating bitmap: ${err.message}`,
         );
-      });
+      },
+    );
   };
 
   #updateFallbackCameraModel = (

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -288,9 +288,11 @@ export class Images extends SceneExtension<ImageRenderable> {
     const isCompressedImage = "format" in image;
 
     if (isCompressedImage) {
-      this.#bitmapCache
-        .getBitmap(messageEvent, image, DEFAULT_BITMAP_WIDTH)
-        .then((bitmap) => {
+      this.#bitmapCache.getBitmap(
+        messageEvent,
+        image,
+        DEFAULT_BITMAP_WIDTH,
+        (bitmap) => {
           const prevRenderable = renderable;
           const currentRenderable = this.renderables.get(imageTopic);
           if (currentRenderable !== prevRenderable) {
@@ -300,8 +302,8 @@ export class Images extends SceneExtension<ImageRenderable> {
           renderable.setBitmap(bitmap);
           renderable.update();
           this.renderer.queueAnimationFrame();
-        })
-        .catch((err) => {
+        },
+        (err) => {
           const prevRenderable = renderable;
           const currentRenderable = this.renderables.get(imageTopic);
           if (currentRenderable !== prevRenderable) {
@@ -312,7 +314,8 @@ export class Images extends SceneExtension<ImageRenderable> {
             CREATE_BITMAP_ERR_KEY,
             `Error creating bitmap: ${err.message}`,
           );
-        });
+        },
+      );
     }
 
     renderable.userData.receiveTime = receiveTime;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -11,13 +11,13 @@ import { toNanoSec } from "@foxglove/rostime";
 import { CameraCalibration, CompressedImage, RawImage } from "@foxglove/schemas";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
 
+import { BitmapCache } from "./Images/BitmapCache";
 import {
   CREATE_BITMAP_ERR_KEY,
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,
   ImageRenderable,
 } from "./Images/ImageRenderable";
 import { ALL_CAMERA_INFO_SCHEMAS, AnyImage } from "./Images/ImageTypes";
-import { decodeCompressedImageToBitmap } from "./Images/decodeImage";
 import {
   normalizeCompressedImage,
   normalizeRawImage,
@@ -77,6 +77,9 @@ export class Images extends SceneExtension<ImageRenderable> {
    * This stores the last camera info message on each topic so it can be applied when rendering the image
    */
   #cameraInfoByTopic = new Map<string, CameraInfo>();
+
+  /** Cache of decoded bitmaps to avoid flickering when toggling topics */
+  #bitmapCache = new BitmapCache();
 
   public constructor(renderer: IRenderer) {
     super("foxglove.Images", renderer);
@@ -285,17 +288,16 @@ export class Images extends SceneExtension<ImageRenderable> {
     const isCompressedImage = "format" in image;
 
     if (isCompressedImage) {
-      decodeCompressedImageToBitmap(image, DEFAULT_BITMAP_WIDTH)
-        .then((maybeBitmap) => {
+      this.#bitmapCache
+        .getBitmap(messageEvent, image, DEFAULT_BITMAP_WIDTH)
+        .then((bitmap) => {
           const prevRenderable = renderable;
           const currentRenderable = this.renderables.get(imageTopic);
           if (currentRenderable !== prevRenderable) {
             return;
           }
           this.renderer.settings.errors.removeFromTopic(imageTopic, CREATE_BITMAP_ERR_KEY);
-          if (maybeBitmap instanceof ImageBitmap) {
-            renderable.setBitmap(maybeBitmap);
-          }
+          renderable.setBitmap(bitmap);
           renderable.update();
           this.renderer.queueAnimationFrame();
         })

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -371,10 +371,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       this.#recomputeCameraModel(renderable, cameraInfo);
     }
 
-    // Compressed images handle their own update after loading the bitmap
-    if (!isCompressedImage) {
-      renderable.update();
-    }
+    renderable.update();
   };
 
   #handleCameraInfo = (

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/BitmapCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/BitmapCache.ts
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { areEqual } from "@foxglove/rostime";
+import { PartialMessageEvent } from "@foxglove/studio-base/panels/ThreeDeeRender/SceneExtension";
+
+import { AnyImage, CompressedImageTypes } from "./ImageTypes";
+import { decodeCompressedImageToBitmap } from "./decodeImage";
+
+export class BitmapCache {
+  #latestBitmapsByTopic = new Map<
+    string,
+    { messageEvent: PartialMessageEvent<AnyImage>; bitmap: Promise<ImageBitmap> }
+  >();
+
+  public async getBitmap(
+    messageEvent: PartialMessageEvent<AnyImage>,
+    image: CompressedImageTypes,
+    resizeWidth?: number,
+  ): Promise<ImageBitmap> {
+    const cachedBitmap = this.#latestBitmapsByTopic.get(messageEvent.topic);
+    if (cachedBitmap && areEqual(cachedBitmap.messageEvent.receiveTime, messageEvent.receiveTime)) {
+      return await cachedBitmap.bitmap;
+    }
+    const newBitmap = {
+      messageEvent,
+      bitmap: decodeCompressedImageToBitmap(image, resizeWidth),
+    };
+    this.#latestBitmapsByTopic.set(messageEvent.topic, newBitmap);
+    return await newBitmap.bitmap;
+  }
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/BitmapCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/BitmapCache.ts
@@ -11,23 +11,44 @@ import { decodeCompressedImageToBitmap } from "./decodeImage";
 export class BitmapCache {
   #latestBitmapsByTopic = new Map<
     string,
-    { messageEvent: PartialMessageEvent<AnyImage>; bitmap: Promise<ImageBitmap> }
+    { messageEvent: PartialMessageEvent<AnyImage>; bitmap: ImageBitmap | Promise<ImageBitmap> }
   >();
 
-  public async getBitmap(
+  /**
+   * Get the cached bitmap for the given MessageEvent if it exists, or if not, decode it asynchronously.
+   *
+   * @param thenFn Called when the bitmap is available. If the bitmap was already cached, this will be called synchronously.
+   * @param catchFn Called with any errors encountered during decoding
+   */
+  public getBitmap(
     messageEvent: PartialMessageEvent<AnyImage>,
     image: CompressedImageTypes,
-    resizeWidth?: number,
-  ): Promise<ImageBitmap> {
+    resizeWidth: number | undefined,
+    thenFn: (bitmap: ImageBitmap) => void,
+    catchFn: (error: Error) => void,
+  ): void {
     const cachedBitmap = this.#latestBitmapsByTopic.get(messageEvent.topic);
     if (cachedBitmap && areEqual(cachedBitmap.messageEvent.receiveTime, messageEvent.receiveTime)) {
-      return await cachedBitmap.bitmap;
+      if (cachedBitmap.bitmap instanceof Promise) {
+        cachedBitmap.bitmap.then(thenFn).catch(catchFn);
+      } else {
+        thenFn(cachedBitmap.bitmap);
+      }
+      return;
     }
     const newBitmap = {
       messageEvent,
       bitmap: decodeCompressedImageToBitmap(image, resizeWidth),
     };
     this.#latestBitmapsByTopic.set(messageEvent.topic, newBitmap);
-    return await newBitmap.bitmap;
+    newBitmap.bitmap
+      .then((bitmap) => {
+        thenFn(bitmap);
+        // Update the cache with the resolved bitmap so we can call thenFn synchronously in the future
+        if (this.#latestBitmapsByTopic.get(messageEvent.topic)?.messageEvent === messageEvent) {
+          this.#latestBitmapsByTopic.set(messageEvent.topic, { messageEvent, bitmap });
+        }
+      })
+      .catch(catchFn);
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/BitmapCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/BitmapCache.ts
@@ -15,9 +15,11 @@ export class BitmapCache {
   >();
 
   /**
-   * Get the cached bitmap for the given MessageEvent if it exists, or if not, decode it asynchronously.
+   * Get the cached bitmap for the given MessageEvent if it exists, or if not, decode it
+   * asynchronously. Cache is keyed on topic and receiveTime.
    *
-   * @param thenFn Called when the bitmap is available. If the bitmap was already cached, this will be called synchronously.
+   * @param thenFn Called when the bitmap is available. If the bitmap was already cached, this will
+   * be called synchronously.
    * @param catchFn Called with any errors encountered during decoding
    */
   public getBitmap(


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**

Fixes images in 3D/Image panel flickering when toggling topics. Some re-processing of messages is inevitable due to the seek-backfill behavior of the player when subscriptions change. This fixes the flickering issue by caching decoded bitmaps, and reusing them (synchronously if possible).

Before:

https://github.com/foxglove/studio/assets/14237/781c06fd-0bf8-4ff3-8dce-9b24bbcc25d9

After:

https://github.com/foxglove/studio/assets/14237/08e52ed3-5e98-40b2-9954-1d3f06f37917

