### PR TITLE
Fix built-in datatypes overwriting player datatypes

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -212,7 +212,7 @@ export default class UserNodePlayer implements Player {
     (datatypes: RosDatatypes, nodeDatatypes: readonly RosDatatypes[]): RosDatatypes => {
       return nodeDatatypes.reduce(
         (allDatatypes, userNodeDatatypes) => new Map([...allDatatypes, ...userNodeDatatypes]),
-        new Map([...datatypes, ...basicDatatypes]),
+        new Map([...basicDatatypes, ...datatypes]),
       );
     },
   );


### PR DESCRIPTION
**User-Facing Changes**

- Fix built-in datatypes overwriting player datatypes

**Description**

From https://github.com/foxglove/studio/issues/6190#issuecomment-1576719837

> The reason for the shift is, because Studio uses the ROS1 std_msgs/Header definition instead of the ROS2 definition which should actually be used. The ROS1 definition contains an extra uint32 seq field which causes the shift.
>
> The ROS1 definitions are added [here](https://github.com/foxglove/studio/blob/54a1534574d97a5bcb60083d7065b507af0daa1d/packages/studio-base/src/util/basicDatatypes.ts#L18-L26) and communicated to the publish panel via the UserNodePlayer.

This patch fixes that player datatypes are being overwritten by builtin datatypes with the same name (e.g. `std_msgs/Header` in this specific case).

Fixes #6190