### PR TITLE
Fix calculation of number of points for plot data memory limit

### DIFF
--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -118,7 +118,11 @@ export function getBlockItemsByPath(
     }
 
     for (const [path, messagePathItems] of Object.entries(messagePathItemsForBlock)) {
-      count += messagePathItems[0]?.[0]?.queriedData.length ?? 0;
+      for (const items of messagePathItems) {
+        for (const item of items) {
+          count += item.queriedData.length;
+        }
+      }
 
       const existingItems = ret[path] ?? [];
       // getMessagePathItemsForBlock returns an array of exactly one range of items.


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix calculation of number of points for plot data memory limit. The existing calculation undercounts the number of points.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
