### PR TITLE
[Image Beta] Fix imprecise projection due to linear interpolation

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -671,6 +671,8 @@ export class ImageMode
       minValue: config.minValue,
       maxValue: config.maxValue,
       foregroundOpacity: config.foregroundOpacity,
+      // planarProjectionFactor must be 1 to avoid imprecise projection due to small number of grid subdivisions
+      planarProjectionFactor: 1,
     };
     renderable = new ImageRenderable(topicName, this.renderer, {
       receiveTime,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Images were wiggly due to grid segments being non-coplanar.

It appears there are still some rounding artifacts visible around straight lines in some stories. I'm not sure it's possible to completely avoid these except by making the mesh vertices a perfect rectangle in clip space without any other math (which is not a viable approach for images with distortion). I think this effect will be basically invisible in most real-world images that come from a real camera.

This is the golden story: https://www.chromatic.com/test?appId=603ec8bf7908b500231841e2&id=647fb028151c51e4d183bcaf

<img width="1421" alt="image" src="https://github.com/foxglove/studio/assets/14237/754cd5ee-8245-4626-9c77-bac39a0a9e27">
