### PR TITLE
[Image Beta] Fix line annotation colors when switching vertexColors on/off

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -361,6 +361,8 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         this.#linePrepassMaterial.vertexColors = true;
         this.#lineMaterial.vertexColors = true;
         this.#lineMaterial.color.setRGB(1, 1, 1); // any non-white color will tint the vertex colors
+        this.#geometry.getAttribute("instanceColorStart").needsUpdate = true;
+        this.#geometry.getAttribute("instanceColorEnd").needsUpdate = true;
       } else {
         const color = outlineColor ?? FALLBACK_COLOR;
         this.#linePrepassMaterial.vertexColors = false;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -248,11 +248,27 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
             // color buffer is unused (we don't use vertex colors)
             this.#geometry = new LineGeometry();
             break;
-          case "line_list":
+          case "line_list": {
             this.#positionBuffer = new Float32Array(pointsLength * 3);
             this.#colorBuffer = new Uint8Array(pointsLength * 8);
             this.#geometry = new LineSegmentsGeometry();
+
+            // [rgba, rgba]
+            const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(
+              this.#colorBuffer,
+              8,
+              1,
+            );
+            this.#geometry.setAttribute(
+              "instanceColorStart",
+              new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0, true),
+            );
+            this.#geometry.setAttribute(
+              "instanceColorEnd",
+              new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 4, true),
+            );
             break;
+          }
         }
         this.#linePrepass.geometry = this.#geometry;
         this.#line.geometry = this.#geometry;
@@ -344,6 +360,7 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
       if (useVertexColors) {
         this.#linePrepassMaterial.vertexColors = true;
         this.#lineMaterial.vertexColors = true;
+        this.#lineMaterial.color.setRGB(1, 1, 1); // any non-white color will tint the vertex colors
       } else {
         const color = outlineColor ?? FALLBACK_COLOR;
         this.#linePrepassMaterial.vertexColors = false;
@@ -367,17 +384,6 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
           this.#geometry.instanceCount = pointsLength >>> 1;
           break;
       }
-
-      // [rgba, rgba]
-      const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(colors, 8, 1);
-      this.#geometry.setAttribute(
-        "instanceColorStart",
-        new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0, true),
-      );
-      this.#geometry.setAttribute(
-        "instanceColorEnd",
-        new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 4, true),
-      );
     }
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableTopicAnnotations.ts
@@ -125,11 +125,13 @@ export class RenderableTopicAnnotations extends THREE.Object3D {
 
     this.#annotationsNeedsUpdate = false;
 
-    const unusedPoints = this.#points;
+    // Reverse arrays so renderables are more likely to be reused for similarly-structured
+    // annotations when using pop() below.
+    const unusedPoints = this.#points.reverse();
     this.#points = [];
-    const unusedLines = this.#lines;
+    const unusedLines = this.#lines.reverse();
     this.#lines = [];
-    const unusedTexts = this.#texts;
+    const unusedTexts = this.#texts.reverse();
     this.#texts = [];
 
     for (const annotation of this.#annotations) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -245,6 +245,7 @@ class LinePrimitiveRenderable extends THREE.Object3D {
           this.#colorBuffer = new Float32Array(necessaryColorBufferSize);
         }
         this.#material.vertexColors = true;
+        (this.#material.color as THREE.Color).setRGB(1, 1, 1); // any non-white color will tint the vertex colors
         this.#material.opacity = 1;
         this.#material.uniforms.opacity!.value = 1;
         if (useIndices) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -128,7 +128,7 @@ export class RenderableTriangles extends RenderablePrimitive {
       if (colorChanged) {
         material.vertexColors = true;
         // need to set overall material color back or else it will blend them with the vertex colors
-        material.color.set("#ffffff");
+        material.color.setRGB(1, 1, 1);
         material.opacity = 1.0;
         // can assume that color exists since colorchanged is true
         geometry.attributes.color!.needsUpdate = true;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Set `color` back to white so it doesn't blend with the vertex colors.

This only occurred when switching between vertexColors=true and vertexColors=false, which was made more likely by the use of `pop()` in reusing renderables. I've added a `reverse()` so that renderables are more likely to be reused for similarly-structured annotations.