### PR TITLE
Improve User Scripts error when symbol is undefined

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -523,7 +523,15 @@ export const constructDatatypes = (
       default: {
         const locationType = checker.getTypeAtLocation(tsNode);
 
-        const symbol = locationType.symbol;
+        const symbol = locationType.symbol as ts.Symbol | undefined;
+        if (symbol == undefined) {
+          throw new DatatypeExtractionError({
+            severity: DiagnosticSeverity.Error,
+            message: `Unsupported type for member '${name}'.`,
+            source: Sources.DatatypeExtraction,
+            code: ErrorCodes.DatatypeExtraction.BAD_TYPE_RETURN,
+          });
+        }
         const declaration = symbol.declarations?.[0];
         if (symbol.declarations?.length !== 1 || !declaration) {
           throw new DatatypeExtractionError(badTypeReturnError);


### PR DESCRIPTION
**User-Facing Changes**
Improved error messages in the User Scripts panel in certain cases.

**Description**
The root cause of FG-3589 was `locationType.symbol` being `undefined` (although the type signature would indicate that it should not be undefined). The `undefined` arises while trying to extract datatypes from a reference to `Message<"Foo">`, where `Message` is imported from the `types` lib. I've added an extra check to provide a less generic error message in this case.

After reading a bit more about how datatype extraction is being done, I believe that using `switch (tsNode.kind) {` may be fundamentally the wrong approach. Its requires our extraction code to handle all sorts of weird TypeScript syntax features and we bump into limitations around generics (as was this case with `Message<"Foo">`). Ideally, the type checker could just tell us what the actual, _final_ "resolved" type is. Based on [this discussion thread](https://github.com/microsoft/TypeScript/issues/5871#issuecomment-161163260) I believe that using `checker.getPropertiesOfType()` may do what we need and provide a more universally applicable way of extracting members from a type (even if it includes generic references like `Message<"Foo">`). That said, I didn't get a chance to try it out because it seems like a much more involved change that requires reworking the whole `constructDatatypes` function.