### PR TITLE
Bump `@foxglove/rosmsg2-serialization`

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -28,7 +28,7 @@
     "@foxglove/message-definition": "0.2.0",
     "@foxglove/rosmsg": "4.2.2",
     "@foxglove/rosmsg-serialization": "2.0.1",
-    "@foxglove/rosmsg2-serialization": "2.0.0",
+    "@foxglove/rosmsg2-serialization": "2.0.1",
     "@foxglove/schemas": "1.3.0",
     "@foxglove/wasm-bz2": "0.1.1",
     "@foxglove/wasm-lz4": "1.0.2",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -35,7 +35,7 @@
     "@foxglove/rosmsg": "4.2.2",
     "@foxglove/rosmsg-msgs-common": "3.0.0",
     "@foxglove/rosmsg-serialization": "2.0.1",
-    "@foxglove/rosmsg2-serialization": "2.0.0",
+    "@foxglove/rosmsg2-serialization": "2.0.1",
     "@foxglove/rostime": "1.1.2",
     "@foxglove/schemas": "1.3.0",
     "@foxglove/studio": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,7 +2748,7 @@ __metadata:
     "@foxglove/message-definition": 0.2.0
     "@foxglove/rosmsg": 4.2.2
     "@foxglove/rosmsg-serialization": 2.0.1
-    "@foxglove/rosmsg2-serialization": 2.0.0
+    "@foxglove/rosmsg2-serialization": 2.0.1
     "@foxglove/schemas": 1.3.0
     "@foxglove/wasm-bz2": 0.1.1
     "@foxglove/wasm-lz4": 1.0.2
@@ -2862,18 +2862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg2-serialization@npm:2.0.0, @foxglove/rosmsg2-serialization@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@foxglove/rosmsg2-serialization@npm:2.0.0"
-  dependencies:
-    "@foxglove/cdr": ^2.0.0
-    "@foxglove/message-definition": ^0.2.0
-    "@foxglove/rostime": ^1.1.2
-  checksum: 03ca52f31b32ba9af52fc543c33166c9b1926eb05cf5f0b8dc45b21040ff3653356fd6ae5a5db215295617cf1a1d30db5200089b8443844ab2bbdd69de54491d
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg2-serialization@npm:2.0.1":
+"@foxglove/rosmsg2-serialization@npm:2.0.1, @foxglove/rosmsg2-serialization@npm:^2.0.0":
   version: 2.0.1
   resolution: "@foxglove/rosmsg2-serialization@npm:2.0.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,6 +2873,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/rosmsg2-serialization@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@foxglove/rosmsg2-serialization@npm:2.0.1"
+  dependencies:
+    "@foxglove/cdr": ^2.0.0
+    "@foxglove/message-definition": ^0.2.0
+    "@foxglove/rostime": ^1.1.2
+  checksum: 1e1a149d254ab498dabcae8009a74f5ae4b6c5d36846e4a05aa2da77c6bb0d70772b4e6771adc778c27bfb22ea56b5163d03de59ad0173561f3bb862a60ecb43
+  languageName: node
+  linkType: hard
+
 "@foxglove/rosmsg@npm:4.2.2, @foxglove/rosmsg@npm:^4.0.0":
   version: 4.2.2
   resolution: "@foxglove/rosmsg@npm:4.2.2"
@@ -2934,7 +2945,7 @@ __metadata:
     "@foxglove/rosmsg": 4.2.2
     "@foxglove/rosmsg-msgs-common": 3.0.0
     "@foxglove/rosmsg-serialization": 2.0.1
-    "@foxglove/rosmsg2-serialization": 2.0.0
+    "@foxglove/rosmsg2-serialization": 2.0.1
     "@foxglove/rostime": 1.1.2
     "@foxglove/schemas": 1.3.0
     "@foxglove/studio": "workspace:*"


### PR DESCRIPTION
**User-Facing Changes**
- Fix CDR serialization/deserialization of empty messages

**Description**
Includes https://github.com/foxglove/rosmsg2-serialization/commit/6541dd430 which fixes https://github.com/foxglove/ros-foxglove-bridge/issues/229