### PR TITLE
Prevent plot legend toggles from opening the settings sidebar

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -165,6 +165,7 @@ export function PlotLegendRow({
           style={{ color: getLineColor(path.color, index) }}
           icon={<Square24Regular />}
           checkedIcon={<Square24Filled />}
+          onClick={(event) => event.stopPropagation()}
           onChange={(event) => {
             event.stopPropagation();
 

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -165,10 +165,8 @@ export function PlotLegendRow({
           style={{ color: getLineColor(path.color, index) }}
           icon={<Square24Regular />}
           checkedIcon={<Square24Filled />}
-          onClick={(event) => event.stopPropagation()}
-          onChange={(event) => {
-            event.stopPropagation();
-
+          onClick={(event) => event.stopPropagation()} // prevent toggling from opening settings
+          onChange={() => {
             const newPaths = paths.slice();
             const newPath = newPaths[index];
 


### PR DESCRIPTION
**User-Facing Changes**
Prevent plot legend toggles from opening the settings sidebar.

**Description**
Prevent plot legend toggles from opening the settings sidebar by calling `stopPropagation` on the `onClick` handler on the toggle.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
