### PR TITLE
Allow extension panels to seek precisely

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -18,6 +18,7 @@ import {
   RenderState,
   SettingsTree,
   Subscription,
+  Time,
   VariableValue,
 } from "@foxglove/studio";
 import {
@@ -316,11 +317,12 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       layout,
 
       seekPlayback: seekPlayback
-        ? (stamp: number) => {
+        ? (stamp: number | Time) => {
             if (!isMounted()) {
               return;
             }
-            seekPlayback(fromSec(stamp));
+            const seekTarget = typeof stamp === "object" ? stamp : fromSec(stamp);
+            seekPlayback(seekTarget);
           }
         : undefined,
 

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -460,7 +460,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   const onClick = useCallback(
     (messageEvent: MessageEvent) => {
-      context.seekPlayback?.(toSec(messageEvent.receiveTime));
+      context.seekPlayback?.(messageEvent.receiveTime);
     },
     [context],
   );

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -304,7 +304,7 @@ export type PanelExtensionContext = {
   /**
    * Seek playback to the given time. Behaves as if the user had clicked the playback bar to seek.
    */
-  seekPlayback?: (time: number) => void;
+  seekPlayback?: (time: number | Time) => void;
 
   /**
    * Subscribe to an array of topic names.

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -302,7 +302,10 @@ export type PanelExtensionContext = {
   setPreviewTime: (time: number | undefined) => void;
 
   /**
-   * Seek playback to the given time. Behaves as if the user had clicked the playback bar to seek.
+   * Seek playback to the given time. Behaves as if the user had clicked the playback bar
+   * to seek.
+   *
+   * Clients can pass a number or alternatively a Time object for greater precision.
    */
   seekPlayback?: (time: number | Time) => void;
 


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with time precision in seeking in extension panels.

**Description**
Fix an issue with time precision in seeking in extension panels.

The existing seek API takes a number as the seek target and then converts this back to a Time object, losing precision. Allow clients to also pass a Time object for greater seek precision to target specific messages.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
