### PR TITLE
Fix user script player recovery from missing input topic errors

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -87,6 +87,7 @@
     "@types/uuid": "9.0.1",
     "@types/wicg-file-system-access": "2020.9.6",
     "@uiw/react-textarea-code-editor": "2.1.1",
+    "async-mutex": "0.4.0",
     "babel-jest": "29.5.0",
     "babel-plugin-transform-import-meta": "2.2.0",
     "browserify-zlib": "0.2.0",

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -283,7 +283,7 @@ describe("UserNodePlayer", () => {
         setUserNodeDiagnostics: mockSetNodeDiagnostics,
       });
 
-      const [done1, done2] = setListenerHelper(userNodePlayer, 2);
+      const [done1, done2, done3] = setListenerHelper(userNodePlayer, 3);
 
       const activeData = {
         ...basicPlayerState,
@@ -294,9 +294,11 @@ describe("UserNodePlayer", () => {
       };
       await fakePlayer.emit({ activeData });
 
-      void userNodePlayer.setUserNodes({
+      await userNodePlayer.setUserNodes({
         nodeId: { name: `${DEFAULT_STUDIO_NODE_PREFIX}1`, sourceCode: nodeUserCode },
       });
+      await done1;
+
       await fakePlayer.emit({
         activeData: {
           ...activeData,
@@ -304,12 +306,12 @@ describe("UserNodePlayer", () => {
         },
       });
 
-      let { topicNames, messages } = await done1!;
+      let { topicNames, messages } = await done2!;
 
       expect(messages.length).toEqual(0);
-      expect(topicNames).toEqual([]);
+      expect(topicNames).toEqual([`${DEFAULT_STUDIO_NODE_PREFIX}1`]);
 
-      ({ topicNames, messages } = await done2!);
+      ({ topicNames, messages } = await done3!);
       expect(messages.length).toEqual(0);
       expect(topicNames).toEqual(["/np_input", `${DEFAULT_STUDIO_NODE_PREFIX}1`]);
 
@@ -337,11 +339,11 @@ describe("UserNodePlayer", () => {
         setUserNodeDiagnostics: mockSetNodeDiagnostics,
       });
 
-      void userNodePlayer.setUserNodes({
+      const [done1, done2, done3] = setListenerHelper(userNodePlayer, 3);
+
+      await userNodePlayer.setUserNodes({
         nodeId: { name: `${DEFAULT_STUDIO_NODE_PREFIX}1`, sourceCode: nodeUserCode },
       });
-
-      const [done1, done2, done3] = setListenerHelper(userNodePlayer, 3);
 
       const activeData: PlayerStateActiveData = {
         ...basicPlayerState,

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -1340,7 +1340,7 @@ describe("UserNodePlayer", () => {
         [nodeId]: { name: `${DEFAULT_STUDIO_NODE_PREFIX}1`, sourceCode: nodeUserCode },
       });
 
-      const [firstDone, secondDone] = setListenerHelper(userNodePlayer, 2);
+      const [firstDone, secondDone, thirdDone] = setListenerHelper(userNodePlayer, 3);
 
       await fakePlayer.emit({
         activeData: {
@@ -1357,7 +1357,10 @@ describe("UserNodePlayer", () => {
       const { topicNames: firstTopicNames }: any = await firstDone;
       expect(firstTopicNames).toEqual(["/np_input", `${DEFAULT_STUDIO_NODE_PREFIX}1`]);
 
-      void userNodePlayer.setUserNodes({});
+      await userNodePlayer.setUserNodes({});
+      const { topicNames: secondTopicNames }: any = await secondDone;
+      expect(secondTopicNames).toEqual(["/np_input", `${DEFAULT_STUDIO_NODE_PREFIX}1`]);
+
       await fakePlayer.emit({
         activeData: {
           ...basicPlayerState,
@@ -1369,9 +1372,10 @@ describe("UserNodePlayer", () => {
           ),
         },
       });
-      const { topicNames: secondTopicNames }: any = await secondDone;
-      expect(secondTopicNames).toEqual(["/np_input"]);
+      const { topicNames: thirdTopicNames }: any = await thirdDone;
+      expect(thirdTopicNames).toEqual(["/np_input"]);
     });
+
     it("properly sets diagnostics when there is an error", async () => {
       const code = `
         export const inputs = ["/np_input_does_not_exist"];

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -814,10 +814,13 @@ export default class UserNodePlayer implements Player {
         this.#playerState.activeData.datatypes,
         this.#memoizedNodeDatatypes,
       );
-      this.#playerState.activeData = {
-        ...this.#playerState.activeData,
-        topics: newTopics,
-        datatypes: newDatatypes,
+      this.#playerState = {
+        ...this.#playerState,
+        activeData: {
+          ...this.#playerState.activeData,
+          datatypes: newDatatypes,
+          topics: newTopics,
+        },
       };
       this.#emitState().catch(console.error);
     }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -810,9 +810,14 @@ export default class UserNodePlayer implements Player {
         this.#memoizedNodeTopics,
         (top) => top.name,
       );
+      const newDatatypes = this.#getDatatypes(
+        this.#playerState.activeData.datatypes,
+        this.#memoizedNodeDatatypes,
+      );
       this.#playerState.activeData = {
         ...this.#playerState.activeData,
         topics: newTopics,
+        datatypes: newDatatypes,
       };
       this.#emitState().catch(console.error);
     }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -822,7 +822,7 @@ export default class UserNodePlayer implements Player {
           topics: newTopics,
         },
       };
-      this.#emitState().catch(console.error);
+      void this.#emitState();
     }
   }
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Mutex } from "async-mutex";
 import { isEqual, unionBy, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import ReactDOM from "react-dom";
@@ -144,7 +145,7 @@ export default class UserNodePlayer implements Player {
     inputsByOutputTopic: new Map(),
   });
 
-  readonly #emitLock = new MutexLocked(undefined);
+  readonly #emitLock = new Mutex();
 
   // exposed as a static to allow testing to mock/replace
   public static CreateNodeTransformWorker = (): SharedWorker => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { isEqual, uniq } from "lodash";
+import { isEqual, unionBy, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import ReactDOM from "react-dom";
 import shallowequal from "shallowequal";
@@ -143,6 +143,8 @@ export default class UserNodePlayer implements Player {
     lastPlayerStateActiveData: undefined,
     inputsByOutputTopic: new Map(),
   });
+
+  readonly #emitLock = new MutexLocked(undefined);
 
   // exposed as a static to allow testing to mock/replace
   public static CreateNodeTransformWorker = (): SharedWorker => {
@@ -767,14 +769,17 @@ export default class UserNodePlayer implements Player {
       validNodeRegistrations.push(nodeRegistration);
     }
 
+    let changedTopicsRequireEmitState = false;
     state.nodeRegistrations = validNodeRegistrations;
     const nodeTopics = state.nodeRegistrations.map(({ output }) => output);
     if (!isEqual(nodeTopics, this.#memoizedNodeTopics)) {
       this.#memoizedNodeTopics = nodeTopics;
+      changedTopicsRequireEmitState = true;
     }
     const nodeDatatypes = state.nodeRegistrations.map(({ nodeData: { datatypes } }) => datatypes);
     if (!isEqual(nodeDatatypes, this.#memoizedNodeDatatypes)) {
       this.#memoizedNodeDatatypes = nodeDatatypes;
+      changedTopicsRequireEmitState = true;
     }
 
     // We need to set the user node diagnostics, which is a react set state
@@ -794,6 +799,23 @@ export default class UserNodePlayer implements Player {
         this.#setUserNodeDiagnostics(nodeRegistration.nodeId, []);
       }
     });
+
+    // If we have new topics after processing the node registrations we need to emit a new
+    // state to let downstream clients subscribe to newly available topics. This is
+    // necessary because we won't emit a new state otherwise if there are no other active
+    // subscriptions.
+    if (changedTopicsRequireEmitState && this.#playerState?.activeData) {
+      const newTopics = unionBy(
+        this.#playerState.activeData.topics,
+        this.#memoizedNodeTopics,
+        (top) => top.name,
+      );
+      this.#playerState.activeData = {
+        ...this.#playerState.activeData,
+        topics: newTopics,
+      };
+      this.#emitState().catch(console.error);
+    }
   }
 
   async #getRosLib(state: ProtectedState): Promise<string> {
@@ -977,25 +999,29 @@ export default class UserNodePlayer implements Player {
   }
 
   async #emitState() {
-    if (!this.#playerState) {
-      return;
-    }
+    // Wrap in mutex in case the emitState triggered by changed node registrations happens
+    // to run at the same time as an emitstate triggered by the underlying player.
+    await this.#emitLock.runExclusive(async () => {
+      if (!this.#playerState) {
+        return;
+      }
 
-    // only augment child problems if we have our own problems
-    // if neither child or parent have problems we do nothing
-    let problems = this.#playerState.problems;
-    if (this.#problemStore.size > 0) {
-      problems = (problems ?? []).concat(Array.from(this.#problemStore.values()));
-    }
+      // only augment child problems if we have our own problems
+      // if neither child or parent have problems we do nothing
+      let problems = this.#playerState.problems;
+      if (this.#problemStore.size > 0) {
+        problems = (problems ?? []).concat(Array.from(this.#problemStore.values()));
+      }
 
-    const playerState: PlayerState = {
-      ...this.#playerState,
-      problems,
-    };
+      const playerState: PlayerState = {
+        ...this.#playerState,
+        problems,
+      };
 
-    if (this.#listener) {
-      await this.#listener(playerState);
-    }
+      if (this.#listener) {
+        await this.#listener(playerState);
+      }
+    });
   }
 
   public setListener(listener: (_: PlayerState) => Promise<void>): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,6 +2986,7 @@ __metadata:
     "@types/uuid": 9.0.1
     "@types/wicg-file-system-access": 2020.9.6
     "@uiw/react-textarea-code-editor": 2.1.1
+    async-mutex: 0.4.0
     babel-jest: 29.5.0
     babel-plugin-transform-import-meta: 2.2.0
     browserify-zlib: 0.2.0


### PR DESCRIPTION
**User-Facing Changes**
Improve user scripts panel recovery from input topic errors.

**Description**
Update user node player to emit a new state when updated node registrations result in a changed topic list. This is necessary to correctly handle recovering from a initial error state that causes no subscriptions to be established and no messages to be emitted from the base player wrapped by UserNodePlayer.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
