### PR TITLE
Update sample layout to use new Image panel

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
@@ -1,43 +1,161 @@
 {
   "configById": {
-    "ImageViewPanel!1r5tdvh": {
-      "cameraTopic": "/CAM_FRONT_LEFT/image_rect_compressed",
-      "enabledMarkerTopics": ["/CAM_FRONT_LEFT/annotations", "/CAM_FRONT_LEFT/lidar"],
-      "transformMarkers": false,
-      "synchronize": false,
-      "mode": "fit",
-      "pan": {
-        "x": 0,
-        "y": 0
+    "Image!s2ii8x": {
+      "imageMode": {
+        "imageTopic": "/CAM_FRONT_LEFT/image_rect_compressed",
+        "calibrationTopic": "/CAM_FRONT_LEFT/camera_info",
+        "synchronize": false,
+        "rotation": 0,
+        "annotations": {
+          "/CAM_FRONT_LEFT/annotations": {
+            "visible": true
+          },
+          "/CAM_FRONT_LEFT/lidar": {
+            "visible": false
+          }
+        },
+        "foregroundOpacity": 0
       },
-      "rotation": 0,
-      "zoom": 1
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [0, 0, 0],
+        "targetOffset": [0, 0, 0],
+        "targetOrientation": [0, 0, 0, 1],
+        "thetaOffset": 45,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {
+        "/LIDAR_TOP": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo"
+        },
+        "/semantic_map": {
+          "visible": true
+        }
+      },
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      }
     },
-    "ImageViewPanel!15kmj7r": {
-      "cameraTopic": "/CAM_FRONT/image_rect_compressed",
-      "enabledMarkerTopics": ["/CAM_FRONT/lidar", "/CAM_FRONT/annotations"],
-      "transformMarkers": false,
-      "synchronize": false,
-      "mode": "fit",
-      "pan": {
-        "x": 0,
-        "y": 0
+    "Image!qd8g5l": {
+      "imageMode": {
+        "imageTopic": "/CAM_FRONT/image_rect_compressed",
+        "calibrationTopic": "/CAM_FRONT/camera_info",
+        "synchronize": false,
+        "rotation": 0,
+        "annotations": {
+          "/CAM_FRONT/lidar": {
+            "visible": false
+          },
+          "/CAM_FRONT/annotations": {
+            "visible": true
+          }
+        }
       },
-      "rotation": 0,
-      "zoom": 1
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [0, 0, 0],
+        "targetOffset": [0, 0, 0],
+        "targetOrientation": [0, 0, 0, 1],
+        "thetaOffset": 45,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {
+        "/LIDAR_TOP": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo"
+        },
+        "/semantic_map": {
+          "visible": true
+        }
+      },
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      }
     },
-    "ImageViewPanel!1jn49st": {
-      "cameraTopic": "/CAM_FRONT_RIGHT/image_rect_compressed",
-      "enabledMarkerTopics": ["/CAM_FRONT_RIGHT/annotations", "/CAM_FRONT_RIGHT/lidar"],
-      "transformMarkers": false,
-      "synchronize": false,
-      "mode": "fit",
-      "pan": {
-        "x": 0,
-        "y": 0
+    "Image!37zuv25": {
+      "imageMode": {
+        "imageTopic": "/CAM_FRONT_RIGHT/image_rect_compressed",
+        "calibrationTopic": "/CAM_FRONT_RIGHT/camera_info",
+        "synchronize": false,
+        "rotation": 0,
+        "annotations": {
+          "/CAM_FRONT_RIGHT/annotations": {
+            "visible": true
+          },
+          "/CAM_FRONT_RIGHT/lidar": {
+            "visible": false
+          }
+        }
       },
-      "rotation": 0,
-      "zoom": 1
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [0, 0, 0],
+        "targetOffset": [0, 0, 0],
+        "targetOrientation": [0, 0, 0, 1],
+        "thetaOffset": 45,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {
+        "/LIDAR_TOP": {
+          "visible": true,
+          "colorField": "intensity",
+          "colorMode": "colormap",
+          "colorMap": "turbo"
+        },
+        "/semantic_map": {
+          "visible": true
+        }
+      },
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      }
     },
     "3D!12ucir": {
       "cameraState": {
@@ -129,7 +247,8 @@
         "poseEstimateThetaDeviation": 0.26179939
       },
       "followMode": "follow-pose",
-      "followTf": "base_link"
+      "followTf": "base_link",
+      "imageMode": {}
     },
     "map!2vkib4e": {
       "disabledTopics": [],
@@ -141,7 +260,8 @@
         "lat": 1.2988182017789598,
         "lon": 103.78844261169435
       },
-      "topicColors": {}
+      "topicColors": {},
+      "maxNativeZoom": 18
     },
     "3D!3edtgyg": {
       "cameraState": {
@@ -197,7 +317,8 @@
         "poseEstimateThetaDeviation": 0.26179939
       },
       "followMode": "follow-pose",
-      "followTf": "base_link"
+      "followTf": "base_link",
+      "imageMode": {}
     },
     "Plot!2pb7zl7": {
       "paths": [
@@ -217,12 +338,12 @@
       "showLegend": true,
       "isSynced": true,
       "xAxisVal": "timestamp",
-      "title": "Plot",
       "showXAxisLabels": true,
       "showYAxisLabels": true,
       "legendDisplay": "floating",
       "showPlotValuesInLegend": false,
-      "sidebarDimension": 240
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "Plot"
     },
     "Plot!4792hqu": {
       "paths": [
@@ -252,12 +373,12 @@
       "showLegend": true,
       "isSynced": true,
       "xAxisVal": "timestamp",
-      "title": "Plot",
       "showXAxisLabels": true,
       "showYAxisLabels": true,
       "legendDisplay": "floating",
       "showPlotValuesInLegend": false,
-      "sidebarDimension": 240
+      "sidebarDimension": 240,
+      "foxglovePanelTitle": "Plot"
     },
     "StateTransitions!3i4dk1l": {
       "paths": [
@@ -297,10 +418,10 @@
           "title": "Perception",
           "layout": {
             "first": {
-              "first": "ImageViewPanel!1r5tdvh",
+              "first": "Image!s2ii8x",
               "second": {
-                "first": "ImageViewPanel!15kmj7r",
-                "second": "ImageViewPanel!1jn49st",
+                "first": "Image!qd8g5l",
+                "second": "Image!37zuv25",
                 "direction": "row",
                 "splitPercentage": 50
               },

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
@@ -30,7 +30,7 @@ export const defaultLayout: LayoutData = {
       },
     },
     "RawMessages!os6rgs": {},
-    "ImageViewPanel!3mnp456": {},
+    "Image!3mnp456": {},
   },
   globalVariables: {},
   userNodes: {},
@@ -38,7 +38,7 @@ export const defaultLayout: LayoutData = {
   layout: {
     first: "3D!18i6zy7",
     second: {
-      first: "ImageViewPanel!3mnp456",
+      first: "Image!3mnp456",
       second: "RawMessages!os6rgs",
       direction: "column",
       splitPercentage: 30,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Update to use the new Image panel, and display lidar points using `/LIDAR_TOP` rather than `/CAM_*/lidar`. Also added `/semantic_map`.
This way we'll avoid showing the deprecation banner on the sample layout when #6145 merges.

Old:
<img width="406" alt="image" src="https://github.com/foxglove/studio/assets/14237/0207e5a5-48d4-4601-a67d-2d869c03a681">

New:
<img width="391" alt="image" src="https://github.com/foxglove/studio/assets/14237/c0060349-6133-4fe9-a1e5-bbe094369a29">