### PR TITLE
Move publish panel inputs into panel settings

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -56,7 +56,7 @@ all_versions_in_group(Group, Result) :-
 % Define version groups for dependencies. All dependencies in the same group will be required to have the same version.
 version_group(Dep, storybook) :-
   Dep = 'storybook';
-  has_prefix('@storybook/', Dep), Dep \= '@storybook/testing-library'.
+  has_prefix('@storybook/', Dep), Dep \= '@storybook/testing-library', Dep \= '@storybook/jest'.
 version_group(Dep, typescript_eslint) :-
   has_prefix('@typescript-eslint/', Dep).
 version_group(Dep, emotion) :-

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@storybook/addon-actions": "7.0.20",
     "@storybook/addon-essentials": "7.0.20",
     "@storybook/addon-interactions": "7.0.20",
+    "@storybook/csf-tools": "7.0.20",
     "@storybook/react": "7.0.20",
     "@storybook/react-webpack5": "7.0.20",
     "@types/babel__core": "^7.20.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@storybook/addon-actions": "7.0.20",
     "@storybook/addon-essentials": "7.0.20",
     "@storybook/addon-interactions": "7.0.20",
+    "@storybook/jest": "0.1.0",
     "@storybook/react": "7.0.20",
     "@storybook/react-webpack5": "7.0.20",
     "@types/babel__core": "^7.20.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@storybook/addon-actions": "7.0.20",
     "@storybook/addon-essentials": "7.0.20",
     "@storybook/addon-interactions": "7.0.20",
-    "@storybook/csf-tools": "7.0.20",
     "@storybook/react": "7.0.20",
     "@storybook/react-webpack5": "7.0.20",
     "@types/babel__core": "^7.20.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@storybook/addon-actions": "7.0.20",
     "@storybook/addon-essentials": "7.0.20",
     "@storybook/addon-interactions": "7.0.20",
-    "@storybook/jest": "0.1.0",
     "@storybook/react": "7.0.20",
     "@storybook/react-webpack5": "7.0.20",
     "@types/babel__core": "^7.20.1",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -53,6 +53,7 @@
     "@popperjs/core": "2.11.8",
     "@protobufjs/base64": "1.1.2",
     "@storybook/addon-actions": "7.0.20",
+    "@storybook/jest": "0.1.0",
     "@storybook/react": "7.0.20",
     "@storybook/testing-library": "0.1.0",
     "@svgr/webpack": "8.0.1",

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -6,9 +6,9 @@ import ClearIcon from "@mui/icons-material/Clear";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
   Autocomplete,
-  List,
-  ListProps,
   MenuItem,
+  MenuList,
+  MenuListProps,
   Select,
   TextField,
   ToggleButton,
@@ -37,6 +37,11 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
     : "rgba(0, 0, 0, 0.06)";
 
   return {
+    autocomplete: {
+      ".MuiInputBase-root.MuiInputBase-sizeSmall": {
+        paddingInline: 0,
+      },
+    },
     error: {},
     fieldLabel: {
       color: theme.palette.text.secondary,
@@ -127,13 +132,14 @@ function FieldInput({
     case "autocomplete":
       return (
         <Autocomplete
+          className={classes.autocomplete}
           size="small"
           freeSolo={true}
           value={field.value}
           disabled={field.disabled}
           readOnly={field.readonly}
-          ListboxComponent={List}
-          ListboxProps={{ dense: true } as Partial<ListProps>}
+          ListboxComponent={MenuList}
+          ListboxProps={{ dense: true } as Partial<MenuListProps>}
           renderOption={(props, option, { selected }) => (
             <MenuItem selected={selected} {...props}>
               {option}
@@ -141,7 +147,9 @@ function FieldInput({
           )}
           componentsProps={{ clearIndicator: { size: "small" } }}
           clearIcon={<ClearIcon fontSize="small" />}
-          renderInput={(params) => <TextField {...params} variant="filled" size="small" />}
+          renderInput={(params) => (
+            <TextField {...params} variant="filled" size="small" placeholder={field.placeholder} />
+          )}
           onInputChange={(_event, value) =>
             actionHandler({ action: "update", payload: { path, input: "autocomplete", value } })
           }

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import ClearIcon from "@mui/icons-material/Clear";
+import CancelIcon from "@mui/icons-material/Cancel";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
   Autocomplete,
@@ -40,6 +40,7 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
     autocomplete: {
       ".MuiInputBase-root.MuiInputBase-sizeSmall": {
         paddingInline: 0,
+        paddingBlock: theme.spacing(0.3125),
       },
     },
     error: {},
@@ -146,7 +147,7 @@ function FieldInput({
             </MenuItem>
           )}
           componentsProps={{ clearIndicator: { size: "small" } }}
-          clearIcon={<ClearIcon fontSize="small" />}
+          clearIcon={<CancelIcon fontSize="small" />}
           renderInput={(params) => (
             <TextField {...params} variant="filled" size="small" placeholder={field.placeholder} />
           )}

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -43,6 +43,15 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
         paddingBlock: theme.spacing(0.3125),
       },
     },
+    clearIndicator: {
+      marginRight: theme.spacing(-0.25),
+      opacity: theme.palette.action.disabledOpacity,
+
+      ":hover": {
+        background: "transparent",
+        opacity: 1,
+      },
+    },
     error: {},
     fieldLabel: {
       color: theme.palette.text.secondary,
@@ -146,7 +155,12 @@ function FieldInput({
               {option}
             </MenuItem>
           )}
-          componentsProps={{ clearIndicator: { size: "small" } }}
+          componentsProps={{
+            clearIndicator: {
+              size: "small",
+              className: classes.clearIndicator,
+            },
+          }}
           clearIcon={<CancelIcon fontSize="small" />}
           renderInput={(params) => (
             <TextField {...params} variant="filled" size="small" placeholder={field.placeholder} />

--- a/packages/studio-base/src/hooks/usePublisher.tsx
+++ b/packages/studio-base/src/hooks/usePublisher.tsx
@@ -21,7 +21,7 @@ import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 type Props = Immutable<{
   topic: string;
-  schemaName: string;
+  schemaName?: string;
   datatypes: RosDatatypes;
   name: string;
 }>;

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -10,14 +10,15 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
+
 import { action } from "@storybook/addon-actions";
-import { StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 
-import Publish from "@foxglove/studio-base/panels/Publish";
+import Publish, { Config } from "@foxglove/studio-base/panels/Publish";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
-import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
-const getFixture = ({ allowPublish }: { allowPublish: boolean }) => {
+const getFixture = ({ allowPublish }: { allowPublish: boolean }): Fixture => {
   return {
     topics: [],
     datatypes: new Map(
@@ -32,142 +33,104 @@ const getFixture = ({ allowPublish }: { allowPublish: boolean }) => {
   };
 };
 
+const emptyFixture: Fixture = {
+  topics: [],
+  datatypes: new Map(),
+  frame: {},
+  capabilities: [],
+};
+
 const advancedJSON = `{\n  "data": ""\n}`;
-const publishConfig = (config: Partial<(typeof Publish)["defaultConfig"]>) => ({
+
+const baseConfig: Config = {
   topicName: "/sample_topic",
   schemaName: "std_msgs/String",
   buttonText: "Publish",
   buttonTooltip: "",
   buttonColor: "",
   advancedView: true,
-  value: "",
-  ...config,
-});
+  value: advancedJSON,
+};
+
+type StoryArgs = {
+  overrideConfig: Config;
+  allowPublish: boolean;
+  isEmpty: boolean;
+};
 
 export default {
   title: "panels/Publish",
-};
-
-export const ExampleCanPublishAdvanced: StoryObj = {
-  render: () => {
-    const allowPublish = true;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-      </PanelSetup>
-    );
+  component: Publish,
+  args: {
+    allowPublish: true,
+    isEmpty: false,
   },
+  decorators: [
+    (Story, { args: { allowPublish, isEmpty, ...args } }) => (
+      <PanelSetup fixture={isEmpty ? emptyFixture : getFixture({ allowPublish })}>
+        <Story {...{ args }} />
+      </PanelSetup>
+    ),
+  ],
+} as Meta<StoryArgs>;
 
+type Story = StoryObj<StoryArgs>;
+
+export const ExampleCanPublishAdvanced: Story = {
+  args: { overrideConfig: { ...baseConfig, advancedView: true } },
   name: "example can publish, advanced",
 };
 
-export const CustomButtonColor: StoryObj = {
-  render: () => {
-    const allowPublish = true;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish
-          overrideConfig={publishConfig({
-            advancedView: true,
-            value: advancedJSON,
-            buttonColor: "#ffbf49",
-          })}
-        />
-      </PanelSetup>
-    );
+export const CustomButtonColor: Story = {
+  args: {
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: true,
+      value: advancedJSON,
+      buttonColor: "#ffbf49",
+    },
   },
-
   name: "custom button color",
 };
 
-export const ExampleCantPublishAdvanced: StoryObj = {
-  render: () => {
-    const allowPublish = false;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-      </PanelSetup>
-    );
+export const ExampleCantPublishAdvanced: Story = {
+  args: {
+    allowPublish: false,
+    overrideConfig: { ...baseConfig, advancedView: true },
   },
-
   name: "example can't publish, advanced",
 };
 
-export const ExampleCantPublishNotAdvanced: StoryObj = {
-  render: () => {
-    const allowPublish = false;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish overrideConfig={publishConfig({ advancedView: false, value: advancedJSON })} />
-      </PanelSetup>
-    );
+export const ExampleCantPublishNotAdvanced: Story = {
+  args: {
+    allowPublish: false,
+    overrideConfig: { ...baseConfig, advancedView: false },
   },
-
   name: "example can't publish, not advanced",
 };
 
-export const ExampleWithDatatypeThatNoLongerExists: StoryObj = {
-  render: () => {
-    return (
-      <PanelSetup fixture={{ topics: [], datatypes: new Map(), frame: {}, capabilities: [] }}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-      </PanelSetup>
-    );
+export const ExampleWithDatatypeThatNoLongerExists: Story = {
+  args: {
+    isEmpty: true,
+    overrideConfig: { ...baseConfig, advancedView: true },
   },
-
   name: "Example with datatype that no longer exists",
 };
 
-export const ExampleWithValidPresetJson: StoryObj = {
-  render: () => {
-    const fixture = {
-      topics: [],
-      datatypes: new Map(
-        Object.entries({
-          "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-        }),
-      ),
-      frame: {},
-      capabilities: [PlayerCapabilities.advertise],
-      setPublishers: action("setPublishers"),
-      publish: action("publish"),
-    };
+const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
 
-    const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
-
-    return (
-      <PanelSetup fixture={fixture}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: validJSON })} />
-      </PanelSetup>
-    );
+export const ExampleWithValidPresetJson: Story = {
+  args: {
+    overrideConfig: { ...baseConfig, advancedView: true, value: validJSON },
   },
-
   name: "example with valid preset JSON",
 };
 
-export const ExampleWithInvalidPresetJson: StoryObj = {
-  render: () => {
-    const fixture = {
-      topics: [],
-      datatypes: new Map(
-        Object.entries({
-          "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-        }),
-      ),
-      frame: {},
-      capabilities: [PlayerCapabilities.advertise],
-      setPublishers: action("setPublishers"),
-      publish: action("publish"),
-    };
+const invalidJSON = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
 
-    const invalid = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
-
-    return (
-      <PanelSetup fixture={fixture}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: invalid })} />
-      </PanelSetup>
-    );
+export const ExampleWithInvalidPresetJson: Story = {
+  args: {
+    overrideConfig: { ...baseConfig, advancedView: true, value: invalidJSON },
   },
-
   name: "example with invalid preset JSON",
 };

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -53,9 +53,10 @@ const baseConfig: Config = {
 };
 
 type StoryArgs = {
-  overrideConfig: Config;
   allowPublish: boolean;
+  includeSettings: boolean;
   isEmpty: boolean;
+  overrideConfig: Config;
 };
 
 export default {
@@ -64,17 +65,32 @@ export default {
   args: {
     allowPublish: true,
     isEmpty: false,
+    includeSettings: false,
   },
   decorators: [
-    (Story, { args: { allowPublish, isEmpty, ...args } }) => (
-      <PanelSetup fixture={isEmpty ? emptyFixture : getFixture({ allowPublish })}>
-        <Story {...{ args }} />
-      </PanelSetup>
-    ),
+    (Story, ctx) => {
+      const {
+        args: { allowPublish, includeSettings, isEmpty, ...args },
+      } = ctx;
+      return (
+        <PanelSetup
+          includeSettings={includeSettings}
+          fixture={isEmpty ? emptyFixture : getFixture({ allowPublish })}
+        >
+          <Story {...{ args }} />
+        </PanelSetup>
+      );
+    },
   ],
 } as Meta<StoryArgs>;
 
 type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {};
+
+export const DefaultWithSettings: Story = {
+  args: { includeSettings: true },
+};
 
 export const ExampleCanPublishAdvanced: Story = {
   args: { overrideConfig: { ...baseConfig, advancedView: true } },

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -35,7 +35,7 @@ const getFixture = ({ allowPublish }: { allowPublish: boolean }) => {
 const advancedJSON = `{\n  "data": ""\n}`;
 const publishConfig = (config: Partial<(typeof Publish)["defaultConfig"]>) => ({
   topicName: "/sample_topic",
-  datatype: "std_msgs/String",
+  schemaName: "std_msgs/String",
   buttonText: "Publish",
   buttonTooltip: "",
   buttonColor: "",

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -38,7 +38,7 @@ const emptyFixture: Fixture = {
   topics: [],
   datatypes: new Map(),
   frame: {},
-  capabilities: [],
+  capabilities: [PlayerCapabilities.advertise],
 };
 
 const advancedJSON = `{\n  "data": ""\n}`;

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -14,9 +14,11 @@
 import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj } from "@storybook/react";
 
-import Publish, { Config } from "@foxglove/studio-base/panels/Publish";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
+
+import Publish from "./index";
+import { PublishConfig } from "./types";
 
 const getFixture = ({ allowPublish }: { allowPublish: boolean }): Fixture => {
   return {
@@ -42,7 +44,7 @@ const emptyFixture: Fixture = {
 
 const advancedJSON = `{\n  "data": ""\n}`;
 
-const baseConfig: Config = {
+const baseConfig: PublishConfig = {
   topicName: "/sample_topic",
   datatype: "std_msgs/String",
   buttonText: "Publish",
@@ -56,7 +58,7 @@ type StoryArgs = {
   allowPublish: boolean;
   includeSettings: boolean;
   isEmpty: boolean;
-  overrideConfig: Config;
+  overrideConfig: PublishConfig;
 };
 
 export default {

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -13,6 +13,7 @@
 
 import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/testing-library";
 
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
@@ -45,9 +46,6 @@ const advancedJSON = `{\n  "data": ""\n}`;
 const baseConfig: PublishConfig = {
   topicName: "/sample_topic",
   datatype: "std_msgs/String",
-  buttonText: "Publish",
-  buttonTooltip: "",
-  buttonColor: "",
   advancedView: true,
   value: advancedJSON,
 };
@@ -64,8 +62,8 @@ export default {
   component: Publish,
   args: {
     allowPublish: false,
+    includeSettings: true,
     isEmpty: false,
-    includeSettings: false,
   },
   parameters: {
     colorScheme: "both-column",
@@ -91,67 +89,74 @@ type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
 
-export const DefaultCanPublish: Story = {
+export const PublishEnabled: Story = {
   args: { allowPublish: true },
 };
 
-export const DefaultWithTopicSet: Story = {
+export const PublishEnabledWithTopicAndSchema: Story = {
   args: {
     allowPublish: true,
-    overrideConfig: {
-      topicName: "/sample_topic",
-      advancedView: true,
-    },
+    overrideConfig: { ...baseConfig },
   },
+  name: "Publish Enabled with topic and schema",
 };
 
-export const ExampleCanPublishAdvanced: Story = {
+export const PublishEnabledWithCustomButtonSettings: Story = {
   args: {
     allowPublish: true,
     overrideConfig: {
       ...baseConfig,
-      advancedView: true,
-    },
-  },
-  name: "example can publish, advanced",
-};
-
-export const CustomButtonColor: Story = {
-  args: {
-    allowPublish: true,
-    overrideConfig: {
-      ...baseConfig,
-      advancedView: true,
-      value: advancedJSON,
       buttonColor: "#ffbf49",
+      buttonTooltip: "I am a button tooltip",
+      buttonText: "Send message",
     },
   },
-  name: "custom button color",
-};
+  name: "Publish Enabled with custom button settings",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const buttons = await canvas.findAllByText("Send message");
 
-export const ExampleCantPublishAdvanced: Story = {
-  args: {
-    allowPublish: true,
-    overrideConfig: {
-      ...baseConfig,
-      advancedView: true,
-    },
+    buttons.forEach((button) => userEvent.hover(button));
   },
-  name: "example can't publish, advanced",
 };
 
-export const ExampleCantPublishNotAdvanced: Story = {
+export const PublishDisabledWithTopicAndSchema: Story = {
   args: {
     allowPublish: false,
     overrideConfig: {
       ...baseConfig,
-      advancedView: false,
     },
   },
-  name: "example can't publish, not advanced",
+  name: "Publish Disabled with topic and schema",
 };
 
-export const ExampleWithDatatypeThatNoLongerExists: Story = {
+const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
+
+export const WithValidJSON: Story = {
+  args: {
+    allowPublish: true,
+    overrideConfig: {
+      ...baseConfig,
+      value: validJSON,
+    },
+  },
+  name: "Publish Enabled with valid JSON",
+};
+
+const invalidJSON = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
+
+export const WithInvalidJSON: Story = {
+  args: {
+    allowPublish: true,
+    overrideConfig: {
+      ...baseConfig,
+      value: invalidJSON,
+    },
+  },
+  name: "Publish Enabled with invalid JSON",
+};
+
+export const WithSchemaThatNoLongerExists: Story = {
   args: {
     allowPublish: true,
     isEmpty: true,
@@ -160,33 +165,59 @@ export const ExampleWithDatatypeThatNoLongerExists: Story = {
       advancedView: true,
     },
   },
-  name: "Example with datatype that no longer exists",
+  name: "Publish Enabled with schema that no longer exists",
 };
 
-const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
+export const DefaultEditingModeOff: Story = {
+  args: { overrideConfig: { advancedView: false } },
+  name: "Default (editing mode off)",
+};
 
-export const ExampleWithValidPresetJson: Story = {
+export const PublishEnabledEditingOff: Story = {
+  args: {
+    allowPublish: true,
+    overrideConfig: { advancedView: false },
+  },
+  name: "Publish Enabled (editing mode off)",
+};
+
+export const PublishEnabledWithTopicAndSchemaEditingOff: Story = {
   args: {
     allowPublish: true,
     overrideConfig: {
       ...baseConfig,
-      advancedView: true,
-      value: validJSON,
+      advancedView: false,
     },
   },
-  name: "example with valid preset JSON",
+  name: "Publish Enabled with topic and schema (editing mode off)",
 };
 
-const invalidJSON = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
-
-export const ExampleWithInvalidPresetJson: Story = {
+export const PublishEnabledWithCustomButtonSettingsEditingOff: Story = {
   args: {
     allowPublish: true,
     overrideConfig: {
       ...baseConfig,
-      advancedView: true,
-      value: invalidJSON,
+      buttonColor: "#ffbf49",
+      buttonText: "Send message",
+      buttonTooltip: "I am a button tooltip",
+      advancedView: false,
     },
   },
-  name: "example with invalid preset JSON",
+  name: "Publish Enabled with custom button settings (editing mode off)",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const buttons = await canvas.findAllByText("Send message");
+
+    buttons.forEach((button) => userEvent.hover(button));
+  },
+};
+
+export const PublishDisabledEditingModeOff: Story = {
+  args: {
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: false,
+    },
+  },
+  name: "Publish Disabled (editing mode off)",
 };

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -44,7 +44,7 @@ const advancedJSON = `{\n  "data": ""\n}`;
 
 const baseConfig: Config = {
   topicName: "/sample_topic",
-  schemaName: "std_msgs/String",
+  datatype: "std_msgs/String",
   buttonText: "Publish",
   buttonTooltip: "",
   buttonColor: "",

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -91,12 +91,13 @@ export const WhenSelectingATopicSchemaIsSuggested: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    const topicInput = await canvas.findByPlaceholderText("/some_topic");
-    const schemaInput = await canvas.findByPlaceholderText("std_msgs/Type");
+    const inputs = await canvas.findAllByRole("combobox");
+    const topicInput = inputs[0];
+    const schemaInput = inputs[1];
     const valueTextarea = await canvas.findByPlaceholderText("Enter message content as JSON");
 
     await step("Select a topic", () => {
-      userEvent.type(topicInput, "/sample_");
+      userEvent.type(topicInput!, "/sample_");
       userEvent.keyboard("[ArrowDown]");
       userEvent.keyboard("[Enter]");
     });

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -22,11 +22,9 @@ import { PublishConfig } from "./types";
 
 const getFixture = ({ allowPublish }: { allowPublish: boolean }): Fixture => {
   return {
-    topics: [],
+    topics: [{ name: "/sample_topic", schemaName: "std_msgs/String" }],
     datatypes: new Map(
-      Object.entries({
-        "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-      }),
+      Object.entries({ "std_msgs/String": { definitions: [{ name: "data", type: "string" }] } }),
     ),
     frame: {},
     capabilities: allowPublish ? [PlayerCapabilities.advertise] : [],
@@ -65,9 +63,12 @@ export default {
   title: "panels/Publish",
   component: Publish,
   args: {
-    allowPublish: true,
+    allowPublish: false,
     isEmpty: false,
     includeSettings: false,
+  },
+  parameters: {
+    colorScheme: "both-column",
   },
   decorators: [
     (Story, ctx) => {
@@ -90,13 +91,13 @@ type Story = StoryObj<StoryArgs>;
 
 export const Default: Story = {};
 
-export const DefaultWithSettings: Story = {
-  args: { includeSettings: true },
+export const DefaultCanPublish: Story = {
+  args: { allowPublish: true },
 };
 
-export const DefaultWithSettingsAndTopicSet: Story = {
+export const DefaultWithTopicSet: Story = {
   args: {
-    includeSettings: true,
+    allowPublish: true,
     overrideConfig: {
       topicName: "/sample_topic",
       advancedView: true,
@@ -105,12 +106,19 @@ export const DefaultWithSettingsAndTopicSet: Story = {
 };
 
 export const ExampleCanPublishAdvanced: Story = {
-  args: { overrideConfig: { ...baseConfig, advancedView: true } },
+  args: {
+    allowPublish: true,
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: true,
+    },
+  },
   name: "example can publish, advanced",
 };
 
 export const CustomButtonColor: Story = {
   args: {
+    allowPublish: true,
     overrideConfig: {
       ...baseConfig,
       advancedView: true,
@@ -123,8 +131,11 @@ export const CustomButtonColor: Story = {
 
 export const ExampleCantPublishAdvanced: Story = {
   args: {
-    allowPublish: false,
-    overrideConfig: { ...baseConfig, advancedView: true },
+    allowPublish: true,
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: true,
+    },
   },
   name: "example can't publish, advanced",
 };
@@ -132,15 +143,22 @@ export const ExampleCantPublishAdvanced: Story = {
 export const ExampleCantPublishNotAdvanced: Story = {
   args: {
     allowPublish: false,
-    overrideConfig: { ...baseConfig, advancedView: false },
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: false,
+    },
   },
   name: "example can't publish, not advanced",
 };
 
 export const ExampleWithDatatypeThatNoLongerExists: Story = {
   args: {
+    allowPublish: true,
     isEmpty: true,
-    overrideConfig: { ...baseConfig, advancedView: true },
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: true,
+    },
   },
   name: "Example with datatype that no longer exists",
 };
@@ -149,7 +167,12 @@ const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
 
 export const ExampleWithValidPresetJson: Story = {
   args: {
-    overrideConfig: { ...baseConfig, advancedView: true, value: validJSON },
+    allowPublish: true,
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: true,
+      value: validJSON,
+    },
   },
   name: "example with valid preset JSON",
 };
@@ -158,7 +181,12 @@ const invalidJSON = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
 
 export const ExampleWithInvalidPresetJson: Story = {
   args: {
-    overrideConfig: { ...baseConfig, advancedView: true, value: invalidJSON },
+    allowPublish: true,
+    overrideConfig: {
+      ...baseConfig,
+      advancedView: true,
+      value: invalidJSON,
+    },
   },
   name: "example with invalid preset JSON",
 };

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -1,17 +1,9 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
 import { action } from "@storybook/addon-actions";
+import { expect } from "@storybook/jest";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 
@@ -91,6 +83,29 @@ export const Default: Story = {};
 
 export const PublishEnabled: Story = {
   args: { allowPublish: true },
+};
+
+export const WhenSelectingATopicSchemaIsSuggested: Story = {
+  args: { allowPublish: true },
+  name: "When selecting a topic schema is suggested",
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    const topicInput = await canvas.findByPlaceholderText("/some_topic");
+    const schemaInput = await canvas.findByPlaceholderText("std_msgs/Type");
+    const valueTextarea = await canvas.findByPlaceholderText("Enter message content as JSON");
+
+    await step("Select a topic", () => {
+      userEvent.type(topicInput, "/sample_");
+      userEvent.keyboard("[ArrowDown]");
+      userEvent.keyboard("[Enter]");
+    });
+
+    expect(topicInput).toHaveValue("/sample_topic");
+    expect(valueTextarea).toHaveValue(advancedJSON);
+    expect(schemaInput).toHaveValue("std_msgs/String");
+  },
+  parameters: { colorScheme: "light" },
 };
 
 export const PublishEnabledWithTopicAndSchema: Story = {

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -94,6 +94,16 @@ export const DefaultWithSettings: Story = {
   args: { includeSettings: true },
 };
 
+export const DefaultWithSettingsAndTopicSet: Story = {
+  args: {
+    includeSettings: true,
+    overrideConfig: {
+      topicName: "/sample_topic",
+      advancedView: true,
+    },
+  },
+};
+
 export const ExampleCanPublishAdvanced: Story = {
   args: { overrideConfig: { ...baseConfig, advancedView: true } },
   name: "example can publish, advanced",

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -11,15 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import {
-  Button,
-  Typography,
-  OutlinedInput,
-  inputBaseClasses,
-  TextField,
-  FormHelperText,
-  FormLabel,
-} from "@mui/material";
+import { Button, Typography, inputBaseClasses, TextField, FormHelperText } from "@mui/material";
 import { produce } from "immer";
 import { set } from "lodash";
 import { useCallback, useEffect, useMemo, useRef } from "react";

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -32,7 +32,7 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import buildSampleMessage from "./buildSampleMessage";
 
-type Config = Partial<{
+export type Config = Partial<{
   topicName: string;
   schemaName: string;
   buttonText: string;
@@ -218,26 +218,34 @@ function Publish(props: Props) {
     <Stack fullHeight>
       <PanelToolbar />
       <Stack flex="auto" gap={1} padding={1.5} position="relative">
-        <Typography variant="subtitle2">
-          {topicName === "" || schemaName === ""
-            ? "Configure a topic and message schema in the panel settings"
-            : `Publishing to ${topicName} (${schemaName})`}
-        </Typography>
         {advancedView && (
-          <Stack flexGrow="1">
-            <TextField
-              variant="outlined"
-              className={classes.textarea}
-              multiline
-              size="small"
-              placeholder="Enter message content as JSON"
-              value={value}
-              onChange={(event) => saveConfig({ value: event.target.value })}
-              error={error != undefined}
-            />
-          </Stack>
+          <>
+            <Typography variant="subtitle2">
+              {topicName === "" || schemaName === ""
+                ? "Configure a topic and message schema in the panel settings"
+                : `Publishing to ${topicName} (${schemaName})`}
+            </Typography>
+            <Stack flexGrow="1">
+              <TextField
+                variant="outlined"
+                className={classes.textarea}
+                multiline
+                size="small"
+                placeholder="Enter message content as JSON"
+                value={value}
+                onChange={(event) => saveConfig({ value: event.target.value })}
+                error={error != undefined}
+              />
+            </Stack>
+          </>
         )}
-        <Stack direction="row" flexGrow={0} gap={1} justifyContent="flex-end" alignItems="center">
+        <Stack
+          direction="row"
+          flexGrow={0}
+          gap={1}
+          justifyContent={advancedView ? "flex-end" : "center"}
+          alignItems="center"
+        >
           {error && (
             <FormHelperText
               error={!!error}

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -234,7 +234,7 @@ function Publish(props: Props) {
                 placeholder="Enter message content as JSON"
                 value={value}
                 onChange={(event) => saveConfig({ value: event.target.value })}
-                error={error != undefined}
+                error={error?.length !== 0}
               />
             </Stack>
           </>

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -34,7 +34,7 @@ import buildSampleMessage from "./buildSampleMessage";
 
 export type Config = Partial<{
   topicName: string;
-  schemaName: string;
+  datatype: string;
   buttonText: string;
   buttonTooltip: string;
   buttonColor: string;
@@ -52,12 +52,12 @@ function buildSettingsTree(config: Config, schemaNames: string[]): SettingsTreeN
     general: {
       fields: {
         topicName: { label: "Topic", input: "messagepath", value: config.topicName },
-        schemaName: {
+        datatype: {
           label: "Message schema",
           input: "autocomplete",
           placeholder: "Choose a message schema",
           items: schemaNames,
-          value: config.schemaName,
+          value: config.datatype,
         },
         advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
       },
@@ -137,7 +137,7 @@ function Publish(props: Props) {
   const {
     config: {
       topicName = "",
-      schemaName = "",
+      datatype = "",
       buttonText = "Publish",
       buttonTooltip = "",
       buttonColor = "#00A871",
@@ -152,7 +152,7 @@ function Publish(props: Props) {
   const publish = usePublisher({
     name: "Publish",
     topic: debouncedTopicName,
-    schemaName,
+    schemaName: datatype,
     datatypes,
   });
 
@@ -166,19 +166,19 @@ function Publish(props: Props) {
   const prevDatatype = useRef<string | undefined>();
   useEffect(() => {
     if (
-      schemaName.length > 0 &&
+      datatype.length > 0 &&
       prevDatatype.current != undefined &&
-      schemaName !== prevDatatype.current &&
-      datatypes.get(schemaName) != undefined
+      datatype !== prevDatatype.current &&
+      datatypes.get(datatype) != undefined
     ) {
-      const sampleMessage = buildSampleMessage(datatypes, schemaName);
+      const sampleMessage = buildSampleMessage(datatypes, datatype);
       if (sampleMessage != undefined) {
         const stringifiedSampleMessage = JSON.stringify(sampleMessage, undefined, 2);
         saveConfig({ value: stringifiedSampleMessage });
       }
     }
-    prevDatatype.current = schemaName;
-  }, [saveConfig, schemaName, datatypes]);
+    prevDatatype.current = datatype;
+  }, [saveConfig, datatype, datatypes]);
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
@@ -221,9 +221,9 @@ function Publish(props: Props) {
         {advancedView && (
           <>
             <Typography variant="subtitle2">
-              {topicName === "" || schemaName === ""
+              {topicName === "" || datatype === ""
                 ? "Configure a topic and message schema in the panel settings"
-                : `Publishing to ${topicName} (${schemaName})`}
+                : `Publishing to ${topicName} (${datatype})`}
             </Typography>
             <Stack flexGrow="1">
               <TextField

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -26,7 +26,7 @@ import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-import { usePublishPanelSettings } from "./settings";
+import { defaultConfig, usePublishPanelSettings } from "./settings";
 import { PublishConfig } from "./types";
 
 type Props = {
@@ -191,11 +191,6 @@ function Publish(props: Props) {
 export default Panel(
   Object.assign(React.memo(Publish), {
     panelType: "Publish",
-    defaultConfig: {
-      buttonText: "Publish",
-      buttonTooltip: "",
-      advancedView: true,
-      value: "{}",
-    },
+    defaultConfig,
   }),
 );

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -68,9 +68,7 @@ function buildSettingsTree(
           input: "autocomplete",
           placeholder: "Choose a message schema…",
           items: schemaNames,
-          value: config.datatype
-            ? config.datatype
-            : topics.find((t) => t.name === config.topicName)?.schemaName,
+          value: config.datatype,
         },
         advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
       },

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -25,6 +25,7 @@ import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
+import { Topic } from "@foxglove/studio-base/players/types";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -32,7 +33,7 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import buildSampleMessage from "./buildSampleMessage";
 
-export type Config = Partial<{
+export type Config = {
   topicName: string;
   datatype: string;
   buttonText: string;
@@ -40,24 +41,36 @@ export type Config = Partial<{
   buttonColor: string;
   advancedView: boolean;
   value: string;
-}>;
+};
 
 type Props = {
   config: Config;
   saveConfig: SaveConfig<Config>;
 };
 
-function buildSettingsTree(config: Config, schemaNames: string[]): SettingsTreeNodes {
+function buildSettingsTree(
+  config: Config,
+  schemaNames: string[],
+  topics: readonly Topic[],
+): SettingsTreeNodes {
   return {
     general: {
       fields: {
-        topicName: { label: "Topic", input: "messagepath", value: config.topicName },
+        topicName: {
+          label: "Topic",
+          input: "autocomplete",
+          placeholder: "Choose a topic…",
+          value: config.topicName,
+          items: topics.map((t) => t.name),
+        },
         datatype: {
           label: "Message schema",
           input: "autocomplete",
-          placeholder: "Choose a message schema",
+          placeholder: "Choose a message schema…",
           items: schemaNames,
-          value: config.datatype,
+          value: config.datatype
+            ? config.datatype
+            : topics.find((t) => t.name === config.topicName)?.schemaName,
         },
         advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
       },
@@ -133,7 +146,7 @@ function parseInput(value: string): { error?: string; parsedObject?: unknown } {
 }
 
 function Publish(props: Props) {
-  const { datatypes, capabilities } = useDataSourceInfo();
+  const { topics, datatypes, capabilities } = useDataSourceInfo();
   const {
     config: {
       topicName = "",
@@ -198,9 +211,9 @@ function Publish(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree({
       actionHandler,
-      nodes: buildSettingsTree(props.config, schemaNames),
+      nodes: buildSettingsTree(props.config, schemaNames, topics),
     });
-  }, [actionHandler, props.config, schemaNames, updatePanelSettingsTree]);
+  }, [actionHandler, props.config, schemaNames, topics, updatePanelSettingsTree]);
 
   const onPublishClicked = useRethrow(
     useCallback(() => {

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -278,7 +278,7 @@ export default Panel(
   Object.assign(React.memo(Publish), {
     panelType: "Publish",
     defaultConfig: {
-      schemaName: "",
+      datatype: "",
       topicName: "",
       buttonText: "Publish",
       buttonTooltip: "",

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Button, inputBaseClasses, TextField, Typography } from "@mui/material";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useDebounce } from "use-debounce";
 
@@ -27,7 +27,6 @@ import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-import buildSampleMessage from "./buildSampleMessage";
 import { usePublishPanelSettings } from "./settings";
 import { PublishConfig } from "./types";
 
@@ -90,7 +89,7 @@ function parseInput(value: string): { error?: string; parsedObject?: unknown } {
       parsedObject = parsedAny;
     }
   } catch (e) {
-    error = value.length !== 0 ? e.message : "";
+    error = value.length !== 0 ? e.message : "Enter valid message content as JSON";
   }
   return { error, parsedObject };
 }
@@ -111,26 +110,6 @@ function Publish(props: Props) {
   const schemaNames = useMemo(() => Array.from(datatypes.keys()).sort(), [datatypes]);
   const { error, parsedObject } = useMemo(() => parseInput(config.value ?? ""), [config.value]);
 
-  // when the selected datatype changes, replace the textarea contents with a sample message of the correct shape
-  // Make sure not to build a sample message on first load, though -- we don't want to overwrite
-  // the user's message just because prevDatatype hasn't been initialized.
-  const prevDatatype = useRef<string | undefined>();
-  useEffect(() => {
-    if (
-      config.datatype != undefined &&
-      prevDatatype.current != undefined &&
-      config.datatype !== prevDatatype.current &&
-      datatypes.get(config.datatype) != undefined
-    ) {
-      const sampleMessage = buildSampleMessage(datatypes, config.datatype);
-      if (sampleMessage != undefined) {
-        const stringifiedSampleMessage = JSON.stringify(sampleMessage, undefined, 2);
-        saveConfig({ value: stringifiedSampleMessage });
-      }
-    }
-    prevDatatype.current = config.datatype;
-  }, [saveConfig, config.datatype, datatypes]);
-
   usePublishPanelSettings(config, saveConfig, schemaNames, topics, datatypes);
 
   const onPublishClicked = useRethrow(
@@ -145,8 +124,13 @@ function Publish(props: Props) {
 
   const canPublish = capabilities.includes(PlayerCapabilities.advertise) && config.value !== "";
 
-  if (config.topicName == undefined) {
-    return <EmptyState>Configure a topic and message schema in the panel settings</EmptyState>;
+  if (config.topicName == undefined || config.topicName === "") {
+    return (
+      <Stack fullHeight>
+        <PanelToolbar />
+        <EmptyState>Configure a topic and message schema in the panel settings</EmptyState>
+      </Stack>
+    );
   }
 
   return (
@@ -209,7 +193,7 @@ export default Panel(
       buttonTooltip: "",
       buttonColor: "#00A871",
       advancedView: true,
-      value: "",
+      value: "{}",
     },
   }),
 );

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -11,78 +11,30 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Button, Typography, inputBaseClasses, TextField, FormHelperText } from "@mui/material";
-import { produce } from "immer";
-import { set } from "lodash";
+import { Button, inputBaseClasses, TextField, Typography } from "@mui/material";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useDebounce } from "use-debounce";
 
 import { useRethrow } from "@foxglove/hooks";
-import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
+import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
-import { Topic } from "@foxglove/studio-base/players/types";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import buildSampleMessage from "./buildSampleMessage";
-
-export type Config = {
-  topicName: string;
-  datatype: string;
-  buttonText: string;
-  buttonTooltip: string;
-  buttonColor: string;
-  advancedView: boolean;
-  value: string;
-};
+import { usePublishPanelSettings } from "./settings";
+import { PublishConfig } from "./types";
 
 type Props = {
-  config: Config;
-  saveConfig: SaveConfig<Config>;
+  config: PublishConfig;
+  saveConfig: SaveConfig<PublishConfig>;
 };
-
-function buildSettingsTree(
-  config: Config,
-  schemaNames: string[],
-  topics: readonly Topic[],
-): SettingsTreeNodes {
-  return {
-    general: {
-      fields: {
-        topicName: {
-          label: "Topic",
-          input: "autocomplete",
-          placeholder: "Choose a topic…",
-          value: config.topicName,
-          items: topics.map((t) => t.name),
-        },
-        datatype: {
-          label: "Message schema",
-          input: "autocomplete",
-          placeholder: "Choose a message schema…",
-          items: schemaNames,
-          value: config.datatype,
-        },
-        advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
-      },
-    },
-    styles: {
-      label: "Styling",
-      fields: {
-        buttonText: { label: "Button title", input: "string", value: config.buttonText },
-        buttonTooltip: { label: "Button tooltip", input: "string", value: config.buttonTooltip },
-        buttonColor: { label: "Button color", input: "rgb", value: config.buttonColor },
-      },
-    },
-  };
-}
 
 const useStyles = makeStyles<{ buttonColor?: string }>()((theme, { buttonColor }) => {
   const augmentedButtonColor = buttonColor
@@ -144,32 +96,20 @@ function parseInput(value: string): { error?: string; parsedObject?: unknown } {
 }
 
 function Publish(props: Props) {
+  const { saveConfig, config } = props;
   const { topics, datatypes, capabilities } = useDataSourceInfo();
-  const {
-    config: {
-      topicName = "",
-      datatype = "",
-      buttonText = "Publish",
-      buttonTooltip = "",
-      buttonColor = "#00A871",
-      advancedView = true,
-      value = "",
-    },
-    saveConfig,
-  } = props;
-  const { classes } = useStyles({ buttonColor });
-  const [debouncedTopicName] = useDebounce(topicName, 500);
+  const { classes } = useStyles({ buttonColor: config.buttonColor });
+  const [debouncedTopicName] = useDebounce(config.topicName ?? "", 500);
 
   const publish = usePublisher({
     name: "Publish",
     topic: debouncedTopicName,
-    schemaName: datatype,
+    schemaName: config.datatype ?? "",
     datatypes,
   });
 
   const schemaNames = useMemo(() => Array.from(datatypes.keys()).sort(), [datatypes]);
-  const { error, parsedObject } = useMemo(() => parseInput(value), [value]);
-  const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+  const { error, parsedObject } = useMemo(() => parseInput(config.value ?? ""), [config.value]);
 
   // when the selected datatype changes, replace the textarea contents with a sample message of the correct shape
   // Make sure not to build a sample message on first load, though -- we don't want to overwrite
@@ -177,107 +117,81 @@ function Publish(props: Props) {
   const prevDatatype = useRef<string | undefined>();
   useEffect(() => {
     if (
-      datatype.length > 0 &&
+      config.datatype != undefined &&
       prevDatatype.current != undefined &&
-      datatype !== prevDatatype.current &&
-      datatypes.get(datatype) != undefined
+      config.datatype !== prevDatatype.current &&
+      datatypes.get(config.datatype) != undefined
     ) {
-      const sampleMessage = buildSampleMessage(datatypes, datatype);
+      const sampleMessage = buildSampleMessage(datatypes, config.datatype);
       if (sampleMessage != undefined) {
         const stringifiedSampleMessage = JSON.stringify(sampleMessage, undefined, 2);
         saveConfig({ value: stringifiedSampleMessage });
       }
     }
-    prevDatatype.current = datatype;
-  }, [saveConfig, datatype, datatypes]);
+    prevDatatype.current = config.datatype;
+  }, [saveConfig, config.datatype, datatypes]);
 
-  const actionHandler = useCallback(
-    (action: SettingsTreeAction) => {
-      if (action.action !== "update") {
-        return;
-      }
-
-      saveConfig(
-        produce((draft) => {
-          set(draft, action.payload.path.slice(1), action.payload.value);
-        }),
-      );
-    },
-    [saveConfig],
-  );
-
-  useEffect(() => {
-    updatePanelSettingsTree({
-      actionHandler,
-      nodes: buildSettingsTree(props.config, schemaNames, topics),
-    });
-  }, [actionHandler, props.config, schemaNames, topics, updatePanelSettingsTree]);
+  usePublishPanelSettings(config, saveConfig, schemaNames, topics, datatypes);
 
   const onPublishClicked = useRethrow(
     useCallback(() => {
-      if (topicName.length !== 0 && parsedObject != undefined) {
+      if (config.topicName != undefined && parsedObject != undefined) {
         publish(parsedObject as Record<string, unknown>);
       } else {
         throw new Error(`called _publish() when input was invalid`);
       }
-    }, [publish, parsedObject, topicName]),
+    }, [publish, parsedObject, config.topicName]),
   );
 
-  const canPublish = capabilities.includes(PlayerCapabilities.advertise);
+  const canPublish = capabilities.includes(PlayerCapabilities.advertise) && config.value !== "";
+
+  if (config.topicName == undefined) {
+    return <EmptyState>Configure a topic and message schema in the panel settings</EmptyState>;
+  }
 
   return (
     <Stack fullHeight>
       <PanelToolbar />
       <Stack flex="auto" gap={1} padding={1.5} position="relative">
-        {advancedView && (
-          <>
-            <Typography variant="subtitle2">
-              {topicName === "" || datatype === ""
-                ? "Configure a topic and message schema in the panel settings"
-                : `Publishing to ${topicName} (${datatype})`}
-            </Typography>
-            <Stack flexGrow="1">
-              <TextField
-                variant="outlined"
-                className={classes.textarea}
-                multiline
-                size="small"
-                placeholder="Enter message content as JSON"
-                value={value}
-                onChange={(event) => saveConfig({ value: event.target.value })}
-                error={error?.length !== 0}
-              />
-            </Stack>
-          </>
+        {config.advancedView && (
+          <Stack flexGrow="1">
+            <TextField
+              variant="outlined"
+              className={classes.textarea}
+              multiline
+              size="small"
+              placeholder="Enter message content as JSON"
+              value={config.value}
+              onChange={(event) => saveConfig({ value: event.target.value })}
+              error={error != undefined}
+            />
+          </Stack>
         )}
         <Stack
-          direction="row"
-          flexGrow={0}
-          gap={1}
-          justifyContent={advancedView ? "flex-end" : "center"}
+          direction={config.advancedView ? "row" : "column"}
+          justifyContent={config.advancedView ? "flex-end" : "center"}
           alignItems="center"
+          overflow="hidden"
+          flexGrow={0}
+          gap={1.5}
         >
-          {error && (
-            <FormHelperText
-              error={!!error}
-              style={{
-                flex: "auto",
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              {error}
-            </FormHelperText>
+          {(error != undefined || !canPublish) && (
+            <Typography variant="caption" noWrap color={error != undefined ? "error" : undefined}>
+              {error ?? "Connect to a data source that supports publishing"}
+            </Typography>
           )}
           <Button
             className={classes.button}
             variant="contained"
-            title={canPublish ? buttonTooltip : "Connect to ROS to publish data"}
+            title={
+              canPublish
+                ? config.buttonTooltip
+                : "Connect to a data source that supports publishing"
+            }
             disabled={!canPublish || parsedObject == undefined}
             onClick={onPublishClicked}
           >
-            {buttonText}
+            {config.buttonText}
           </Button>
         </Stack>
       </Stack>

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -11,17 +11,16 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Button, inputBaseClasses, TextField, Typography } from "@mui/material";
-import { useCallback, useMemo } from "react";
+import { Button, inputBaseClasses, TextField, Tooltip, Typography } from "@mui/material";
+import { useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useDebounce } from "use-debounce";
 
-import { useRethrow } from "@foxglove/hooks";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
-import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
+import useCallbackWithToast from "@foxglove/studio-base/hooks/useCallbackWithToast";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -103,35 +102,38 @@ function Publish(props: Props) {
   const publish = usePublisher({
     name: "Publish",
     topic: debouncedTopicName,
-    schemaName: config.datatype ?? "",
+    schemaName: config.datatype,
     datatypes,
   });
 
-  const schemaNames = useMemo(() => Array.from(datatypes.keys()).sort(), [datatypes]);
   const { error, parsedObject } = useMemo(() => parseInput(config.value ?? ""), [config.value]);
 
-  usePublishPanelSettings(config, saveConfig, schemaNames, topics, datatypes);
+  usePublishPanelSettings(config, saveConfig, topics, datatypes);
 
-  const onPublishClicked = useRethrow(
-    useCallback(() => {
-      if (config.topicName != undefined && parsedObject != undefined) {
-        publish(parsedObject as Record<string, unknown>);
-      } else {
-        throw new Error(`called _publish() when input was invalid`);
-      }
-    }, [publish, parsedObject, config.topicName]),
-  );
+  const onPublishClicked = useCallbackWithToast(() => {
+    if (config.topicName != undefined && parsedObject != undefined) {
+      publish(parsedObject as Record<string, unknown>);
+    } else {
+      throw new Error(`called _publish() when input was invalid`);
+    }
+  }, [config.topicName, parsedObject, publish]);
 
-  const canPublish = capabilities.includes(PlayerCapabilities.advertise) && config.value !== "";
+  const canPublish =
+    capabilities.includes(PlayerCapabilities.advertise) &&
+    config.value !== "" &&
+    config.topicName !== "" &&
+    config.datatype !== "" &&
+    parsedObject != undefined;
 
-  if (config.topicName == undefined || config.topicName === "") {
-    return (
-      <Stack fullHeight>
-        <PanelToolbar />
-        <EmptyState>Configure a topic and message schema in the panel settings</EmptyState>
-      </Stack>
-    );
-  }
+  const statusMessage = useMemo(() => {
+    if (!capabilities.includes(PlayerCapabilities.advertise)) {
+      return "Connect to a data source that supports publishing";
+    }
+    if (config.topicName == undefined || config.topicName === "") {
+      return "Configure a topic and message schema in the panel settings";
+    }
+    return undefined;
+  }, [capabilities, config.topicName]);
 
   return (
     <Stack fullHeight>
@@ -152,31 +154,30 @@ function Publish(props: Props) {
           </Stack>
         )}
         <Stack
-          direction={config.advancedView ? "row" : "column"}
+          direction={config.advancedView ? "row" : "column-reverse"}
           justifyContent={config.advancedView ? "flex-end" : "center"}
           alignItems="center"
           overflow="hidden"
           flexGrow={0}
           gap={1.5}
         >
-          {(error != undefined || !canPublish) && (
-            <Typography variant="caption" noWrap color={error != undefined ? "error" : undefined}>
-              {error ?? "Connect to a data source that supports publishing"}
+          {(error || statusMessage) && (
+            <Typography variant="caption" noWrap color={error ? "error" : undefined}>
+              {error ?? statusMessage}
             </Typography>
           )}
-          <Button
-            className={classes.button}
-            variant="contained"
-            title={
-              canPublish
-                ? config.buttonTooltip
-                : "Connect to a data source that supports publishing"
-            }
-            disabled={!canPublish || parsedObject == undefined}
-            onClick={onPublishClicked}
-          >
-            {config.buttonText}
-          </Button>
+          <Tooltip title={config.buttonTooltip}>
+            <span>
+              <Button
+                className={classes.button}
+                variant="contained"
+                disabled={!canPublish}
+                onClick={onPublishClicked}
+              >
+                {config.buttonText}
+              </Button>
+            </span>
+          </Tooltip>
         </Stack>
       </Stack>
     </Stack>
@@ -187,8 +188,6 @@ export default Panel(
   Object.assign(React.memo(Publish), {
     panelType: "Publish",
     defaultConfig: {
-      datatype: "",
-      topicName: "",
       buttonText: "Publish",
       buttonTooltip: "",
       buttonColor: "#00A871",

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -118,22 +118,23 @@ function Publish(props: Props) {
     }
   }, [config.topicName, parsedObject, publish]);
 
-  const canPublish =
+  const canPublish = Boolean(
     capabilities.includes(PlayerCapabilities.advertise) &&
-    config.value !== "" &&
-    config.topicName !== "" &&
-    config.datatype !== "" &&
-    parsedObject != undefined;
+      config.value &&
+      config.topicName &&
+      config.datatype &&
+      parsedObject != undefined,
+  );
 
   const statusMessage = useMemo(() => {
     if (!capabilities.includes(PlayerCapabilities.advertise)) {
       return "Connect to a data source that supports publishing";
     }
-    if (config.topicName == undefined || config.topicName === "") {
+    if (!config.topicName || !config.datatype) {
       return "Configure a topic and message schema in the panel settings";
     }
     return undefined;
-  }, [capabilities, config.topicName]);
+  }, [capabilities, config.datatype, config.topicName]);
 
   return (
     <Stack fullHeight>
@@ -166,7 +167,10 @@ function Publish(props: Props) {
               {error ?? statusMessage}
             </Typography>
           )}
-          <Tooltip title={config.buttonTooltip}>
+          <Tooltip
+            placement={config.advancedView ? "left" : undefined}
+            title={config.buttonTooltip}
+          >
             <span>
               <Button
                 className={classes.button}
@@ -190,7 +194,6 @@ export default Panel(
     defaultConfig: {
       buttonText: "Publish",
       buttonTooltip: "",
-      buttonColor: "#00A871",
       advancedView: true,
       value: "{}",
     },

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -39,7 +39,7 @@ export function buildSettingsTree(
         topicName: {
           label: "Topic",
           input: "autocomplete",
-          placeholder: "Choose a topic…",
+          placeholder: "/some_topic",
           value: config.topicName,
           items: topics.map((t) => t.name),
         },
@@ -47,7 +47,7 @@ export function buildSettingsTree(
           label: "Message schema",
           input: "autocomplete",
           error: datatypeError(),
-          placeholder: "Choose a message schema…",
+          placeholder: "std_msgs/Type",
           items: schemaNames,
           value: config.datatype,
         },

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -26,7 +26,7 @@ export const defaultConfig: PublishConfig = {
 };
 
 function datatypeError(schemaNames: string[], datatype?: string) {
-  if (datatype === "" || datatype == undefined) {
+  if (!datatype) {
     return "Message schema cannot be empty";
   }
   if (!schemaNames.includes(datatype)) {
@@ -36,7 +36,7 @@ function datatypeError(schemaNames: string[], datatype?: string) {
 }
 
 function topicError(topicName?: string) {
-  if (topicName === "" || topicName == undefined) {
+  if (!topicName) {
     return "Topic cannot be empty";
   }
   return undefined;

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -6,7 +6,7 @@ import { produce } from "immer";
 import { isEqual, set } from "lodash";
 import { useCallback, useEffect } from "react";
 
-import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
+import { Immutable, SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
 import buildSampleMessage from "@foxglove/studio-base/panels/Publish/buildSampleMessage";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
@@ -56,7 +56,7 @@ export function usePublishPanelSettings(
   saveConfig: SaveConfig<PublishConfig>,
   schemaNames: string[],
   topics: readonly Topic[],
-  datatypes: RosDatatypes,
+  datatypes: Immutable<RosDatatypes>,
 ): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
@@ -71,7 +71,7 @@ export function usePublishPanelSettings(
               const topicSchemaName = topics.find((t) => t.name === value)?.schemaName;
 
               draft.topicName = value;
-              if (draft.datatype == undefined) {
+              if (draft.datatype == undefined || draft.datatype === "") {
                 draft.datatype = topicSchemaName;
               }
             } else if (input === "autocomplete" && isEqual(path, ["general", "datatype"])) {

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -104,9 +104,9 @@ export function usePublishPanelSettings(
                 if (sampleMessage) {
                   draft.value = sampleMessage;
                 }
-              } else {
-                set(draft, path.slice(1), value);
               }
+            } else {
+              set(draft, path.slice(1), value);
             }
           }),
         );

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -40,7 +40,7 @@ export function buildSettingsTree(
           label: "Topic",
           input: "autocomplete",
           placeholder: "/some_topic",
-          value: config.topicName,
+          value: config.topicName ?? "",
           items: topics.map((t) => t.name),
         },
         datatype: {
@@ -49,9 +49,13 @@ export function buildSettingsTree(
           error: datatypeError(),
           placeholder: "std_msgs/Type",
           items: schemaNames,
-          value: config.datatype,
+          value: config.datatype ?? "",
         },
-        advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
+        advancedView: {
+          label: "Editing mode",
+          input: "boolean",
+          value: config.advancedView,
+        },
       },
     },
     button: {
@@ -103,7 +107,7 @@ export function usePublishPanelSettings(
 
               draft.topicName = value;
 
-              if (topicSchemaName != undefined) {
+              if (topicSchemaName) {
                 draft.datatype = topicSchemaName;
               }
               if (sampleMessage) {

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -23,7 +23,15 @@ export function buildSettingsTree(
   schemaNames: string[],
   topics: readonly Topic[],
 ): SettingsTreeNodes {
-  const datatypeError = config.datatype === "" ? "Message schema cannot be empty" : undefined;
+  const datatypeError = () => {
+    if (config.datatype === "") {
+      return "Message schema cannot be empty";
+    }
+    if (config.datatype != undefined && !schemaNames.includes(config.datatype)) {
+      return "Schema name not found";
+    }
+    return undefined;
+  };
 
   return {
     general: {
@@ -38,7 +46,7 @@ export function buildSettingsTree(
         datatype: {
           label: "Message schema",
           input: "autocomplete",
-          error: datatypeError,
+          error: datatypeError(),
           placeholder: "Choose a message schema…",
           items: schemaNames,
           value: config.datatype,

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -4,7 +4,7 @@
 
 import { produce } from "immer";
 import { isEqual, set } from "lodash";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { Immutable, SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
 import buildSampleMessage from "@foxglove/studio-base/panels/Publish/buildSampleMessage";
@@ -23,6 +23,8 @@ export function buildSettingsTree(
   schemaNames: string[],
   topics: readonly Topic[],
 ): SettingsTreeNodes {
+  const datatypeError = config.datatype === "" ? "Message schema cannot be empty" : undefined;
+
   return {
     general: {
       fields: {
@@ -36,6 +38,7 @@ export function buildSettingsTree(
         datatype: {
           label: "Message schema",
           input: "autocomplete",
+          error: datatypeError,
           placeholder: "Choose a message schema…",
           items: schemaNames,
           value: config.datatype,
@@ -68,49 +71,50 @@ const getSampleMessage = (
 export function usePublishPanelSettings(
   config: PublishConfig,
   saveConfig: SaveConfig<PublishConfig>,
-  schemaNames: string[],
   topics: readonly Topic[],
   datatypes: Immutable<RosDatatypes>,
 ): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
   const [, setDefaultPanelTitle] = useDefaultPanelTitle();
+  const schemaNames = useMemo(() => Array.from(datatypes.keys()).sort(), [datatypes]);
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
-      if (action.action === "update") {
-        const { path, value, input } = action.payload;
-
-        saveConfig(
-          produce<PublishConfig>((draft) => {
-            if (input === "autocomplete") {
-              if (isEqual(path, ["general", "topicName"])) {
-                const topicSchemaName = topics.find((t) => t.name === value)?.schemaName;
-                const sampleMessage = getSampleMessage(datatypes, topicSchemaName);
-                setDefaultPanelTitle(value ? `Publish ${value}` : "Publish");
-
-                draft.topicName = value;
-
-                if (topicSchemaName != undefined) {
-                  draft.datatype = topicSchemaName;
-                }
-                if (sampleMessage) {
-                  draft.value = sampleMessage;
-                }
-              } else if (isEqual(path, ["general", "datatype"])) {
-                const sampleMessage = getSampleMessage(datatypes, value);
-
-                draft.datatype = value;
-
-                if (sampleMessage) {
-                  draft.value = sampleMessage;
-                }
-              }
-            } else {
-              set(draft, path.slice(1), value);
-            }
-          }),
-        );
+      if (action.action !== "update") {
+        return;
       }
+      const { path, value, input } = action.payload;
+
+      saveConfig(
+        produce<PublishConfig>((draft) => {
+          if (input === "autocomplete") {
+            if (isEqual(path, ["general", "topicName"])) {
+              const topicSchemaName = topics.find((t) => t.name === value)?.schemaName;
+              const sampleMessage = getSampleMessage(datatypes, topicSchemaName);
+              setDefaultPanelTitle(value ? `Publish ${value}` : "Publish");
+
+              draft.topicName = value;
+
+              if (topicSchemaName != undefined) {
+                draft.datatype = topicSchemaName;
+              }
+              if (sampleMessage) {
+                draft.value = sampleMessage;
+              }
+            } else if (isEqual(path, ["general", "datatype"])) {
+              const sampleMessage = getSampleMessage(datatypes, value);
+
+              draft.datatype = value;
+
+              if (sampleMessage) {
+                draft.value = sampleMessage;
+              }
+            }
+          } else {
+            set(draft, path.slice(1), value);
+          }
+        }),
+      );
     },
     [datatypes, saveConfig, setDefaultPanelTitle, topics],
   );

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -26,11 +26,18 @@ export const defaultConfig: PublishConfig = {
 };
 
 function datatypeError(schemaNames: string[], datatype?: string) {
-  if (datatype === "") {
+  if (datatype === "" || datatype == undefined) {
     return "Message schema cannot be empty";
   }
-  if (datatype != undefined && !schemaNames.includes(datatype)) {
+  if (!schemaNames.includes(datatype)) {
     return "Schema name not found";
+  }
+  return undefined;
+}
+
+function topicError(topicName?: string) {
+  if (topicName === "" || topicName == undefined) {
+    return "Topic cannot be empty";
   }
   return undefined;
 }
@@ -45,7 +52,7 @@ export const buildSettingsTree = (
       topicName: {
         label: "Topic",
         input: "autocomplete",
-        placeholder: "/some_topic",
+        error: topicError(config.topicName),
         value: config.topicName ?? "",
         items: topics.map((t) => t.name),
       },
@@ -53,7 +60,6 @@ export const buildSettingsTree = (
         label: "Message schema",
         input: "autocomplete",
         error: datatypeError(schemaNames, config.datatype),
-        placeholder: "std_msgs/Type",
         items: schemaNames,
         value: config.datatype ?? "",
       },

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { produce } from "immer";
+import { isEqual, set } from "lodash";
+import { useCallback, useEffect } from "react";
+
+import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
+import buildSampleMessage from "@foxglove/studio-base/panels/Publish/buildSampleMessage";
+import { Topic } from "@foxglove/studio-base/players/types";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
+
+import { PublishConfig } from "./types";
+
+export function buildSettingsTree(
+  config: PublishConfig,
+  schemaNames: string[],
+  topics: readonly Topic[],
+): SettingsTreeNodes {
+  return {
+    general: {
+      fields: {
+        topicName: {
+          label: "Topic",
+          input: "autocomplete",
+          placeholder: "Choose a topic…",
+          value: config.topicName,
+          items: topics.map((t) => t.name),
+        },
+        datatype: {
+          label: "Message schema",
+          input: "autocomplete",
+          placeholder: "Choose a message schema…",
+          items: schemaNames,
+          value: config.datatype,
+        },
+        advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
+      },
+    },
+    styles: {
+      label: "Styling",
+      fields: {
+        buttonText: { label: "Button title", input: "string", value: config.buttonText },
+        buttonTooltip: { label: "Button tooltip", input: "string", value: config.buttonTooltip },
+        buttonColor: { label: "Button color", input: "rgb", value: config.buttonColor },
+      },
+    },
+  };
+}
+
+export function usePublishPanelSettings(
+  config: PublishConfig,
+  saveConfig: SaveConfig<PublishConfig>,
+  schemaNames: string[],
+  topics: readonly Topic[],
+  datatypes: RosDatatypes,
+): void {
+  const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+
+  const actionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.action === "update") {
+        const { path, value, input } = action.payload;
+
+        saveConfig(
+          produce<PublishConfig>((draft) => {
+            if (input === "autocomplete" && isEqual(path, ["general", "topicName"])) {
+              const topicSchemaName = topics.find((t) => t.name === value)?.schemaName;
+
+              draft.topicName = value;
+              if (draft.datatype == undefined) {
+                draft.datatype = topicSchemaName;
+              }
+            } else if (input === "autocomplete" && isEqual(path, ["general", "datatype"])) {
+              draft.datatype = value;
+
+              if (config.datatype != undefined) {
+                const sampleMessage = buildSampleMessage(datatypes, config.datatype);
+
+                if (sampleMessage != undefined) {
+                  const stringifiedSampleMessage = JSON.stringify(sampleMessage, undefined, 2);
+                  draft.value = stringifiedSampleMessage;
+                }
+              }
+            } else {
+              set(draft, path.slice(1), value);
+            }
+          }),
+        );
+      }
+    },
+    [config, datatypes, saveConfig, topics],
+  );
+
+  useEffect(() => {
+    updatePanelSettingsTree({
+      actionHandler,
+      nodes: buildSettingsTree(config, schemaNames, topics),
+    });
+  }, [actionHandler, config, schemaNames, topics, updatePanelSettingsTree]);
+}

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -9,7 +9,10 @@ import { useCallback, useEffect } from "react";
 import { Immutable, SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
 import buildSampleMessage from "@foxglove/studio-base/panels/Publish/buildSampleMessage";
 import { Topic } from "@foxglove/studio-base/players/types";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import {
+  useDefaultPanelTitle,
+  usePanelSettingsTreeUpdate,
+} from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
@@ -51,6 +54,17 @@ export function buildSettingsTree(
   };
 }
 
+const getSampleMessage = (
+  datatypes: Immutable<RosDatatypes>,
+  datatype?: string,
+): string | undefined => {
+  if (datatype == undefined) {
+    return undefined;
+  }
+  const sampleMessage = buildSampleMessage(datatypes, datatype);
+  return sampleMessage != undefined ? JSON.stringify(sampleMessage, undefined, 2) : "{}";
+};
+
 export function usePublishPanelSettings(
   config: PublishConfig,
   saveConfig: SaveConfig<PublishConfig>,
@@ -59,6 +73,7 @@ export function usePublishPanelSettings(
   datatypes: Immutable<RosDatatypes>,
 ): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+  const [, setDefaultPanelTitle] = useDefaultPanelTitle();
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
@@ -67,32 +82,37 @@ export function usePublishPanelSettings(
 
         saveConfig(
           produce<PublishConfig>((draft) => {
-            if (input === "autocomplete" && isEqual(path, ["general", "topicName"])) {
-              const topicSchemaName = topics.find((t) => t.name === value)?.schemaName;
+            if (input === "autocomplete") {
+              if (isEqual(path, ["general", "topicName"])) {
+                const topicSchemaName = topics.find((t) => t.name === value)?.schemaName;
+                const sampleMessage = getSampleMessage(datatypes, topicSchemaName);
+                setDefaultPanelTitle(value ? `Publish ${value}` : "Publish");
 
-              draft.topicName = value;
-              if (draft.datatype == undefined || draft.datatype === "") {
-                draft.datatype = topicSchemaName;
-              }
-            } else if (input === "autocomplete" && isEqual(path, ["general", "datatype"])) {
-              draft.datatype = value;
+                draft.topicName = value;
 
-              if (config.datatype != undefined) {
-                const sampleMessage = buildSampleMessage(datatypes, config.datatype);
-
-                if (sampleMessage != undefined) {
-                  const stringifiedSampleMessage = JSON.stringify(sampleMessage, undefined, 2);
-                  draft.value = stringifiedSampleMessage;
+                if (topicSchemaName != undefined) {
+                  draft.datatype = topicSchemaName;
                 }
+                if (sampleMessage) {
+                  draft.value = sampleMessage;
+                }
+              } else if (isEqual(path, ["general", "datatype"])) {
+                const sampleMessage = getSampleMessage(datatypes, value);
+
+                draft.datatype = value;
+
+                if (sampleMessage) {
+                  draft.value = sampleMessage;
+                }
+              } else {
+                set(draft, path.slice(1), value);
               }
-            } else {
-              set(draft, path.slice(1), value);
             }
           }),
         );
       }
     },
-    [config, datatypes, saveConfig, topics],
+    [datatypes, saveConfig, setDefaultPanelTitle, topics],
   );
 
   useEffect(() => {

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -25,56 +25,54 @@ export const defaultConfig: PublishConfig = {
   value: "{}",
 };
 
-export function buildSettingsTree(
+function datatypeError(schemaNames: string[], datatype?: string) {
+  if (datatype === "") {
+    return "Message schema cannot be empty";
+  }
+  if (datatype != undefined && !schemaNames.includes(datatype)) {
+    return "Schema name not found";
+  }
+  return undefined;
+}
+
+export const buildSettingsTree = (
   config: PublishConfig,
   schemaNames: string[],
   topics: readonly Topic[],
-): SettingsTreeNodes {
-  const datatypeError = () => {
-    if (config.datatype === "") {
-      return "Message schema cannot be empty";
-    }
-    if (config.datatype != undefined && !schemaNames.includes(config.datatype)) {
-      return "Schema name not found";
-    }
-    return undefined;
-  };
-
-  return {
-    general: {
-      fields: {
-        topicName: {
-          label: "Topic",
-          input: "autocomplete",
-          placeholder: "/some_topic",
-          value: config.topicName ?? "",
-          items: topics.map((t) => t.name),
-        },
-        datatype: {
-          label: "Message schema",
-          input: "autocomplete",
-          error: datatypeError(),
-          placeholder: "std_msgs/Type",
-          items: schemaNames,
-          value: config.datatype ?? "",
-        },
-        advancedView: {
-          label: "Editing mode",
-          input: "boolean",
-          value: config.advancedView,
-        },
+): SettingsTreeNodes => ({
+  general: {
+    fields: {
+      topicName: {
+        label: "Topic",
+        input: "autocomplete",
+        placeholder: "/some_topic",
+        value: config.topicName ?? "",
+        items: topics.map((t) => t.name),
+      },
+      datatype: {
+        label: "Message schema",
+        input: "autocomplete",
+        error: datatypeError(schemaNames, config.datatype),
+        placeholder: "std_msgs/Type",
+        items: schemaNames,
+        value: config.datatype ?? "",
+      },
+      advancedView: {
+        label: "Editing mode",
+        input: "boolean",
+        value: config.advancedView,
       },
     },
-    button: {
-      label: "Button",
-      fields: {
-        buttonText: { label: "Title", input: "string", value: config.buttonText },
-        buttonTooltip: { label: "Tooltip", input: "string", value: config.buttonTooltip },
-        buttonColor: { label: "Color", input: "rgb", value: config.buttonColor },
-      },
+  },
+  button: {
+    label: "Button",
+    fields: {
+      buttonText: { label: "Title", input: "string", value: config.buttonText },
+      buttonTooltip: { label: "Tooltip", input: "string", value: config.buttonTooltip },
+      buttonColor: { label: "Color", input: "rgb", value: config.buttonColor },
     },
-  };
-}
+  },
+});
 
 const getSampleMessage = (
   datatypes: Immutable<RosDatatypes>,

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -18,6 +18,13 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { PublishConfig } from "./types";
 
+export const defaultConfig: PublishConfig = {
+  buttonText: "Publish",
+  buttonTooltip: "",
+  advancedView: true,
+  value: "{}",
+};
+
 export function buildSettingsTree(
   config: PublishConfig,
   schemaNames: string[],

--- a/packages/studio-base/src/panels/Publish/settings.ts
+++ b/packages/studio-base/src/panels/Publish/settings.ts
@@ -43,12 +43,12 @@ export function buildSettingsTree(
         advancedView: { label: "Editing mode", input: "boolean", value: config.advancedView },
       },
     },
-    styles: {
-      label: "Styling",
+    button: {
+      label: "Button",
       fields: {
-        buttonText: { label: "Button title", input: "string", value: config.buttonText },
-        buttonTooltip: { label: "Button tooltip", input: "string", value: config.buttonTooltip },
-        buttonColor: { label: "Button color", input: "rgb", value: config.buttonColor },
+        buttonText: { label: "Title", input: "string", value: config.buttonText },
+        buttonTooltip: { label: "Tooltip", input: "string", value: config.buttonTooltip },
+        buttonColor: { label: "Color", input: "rgb", value: config.buttonColor },
       },
     },
   };

--- a/packages/studio-base/src/panels/Publish/types.ts
+++ b/packages/studio-base/src/panels/Publish/types.ts
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type PublishConfig = {
+  topicName?: string;
+  datatype?: string;
+  buttonText?: string;
+  buttonTooltip?: string;
+  buttonColor?: string;
+  advancedView: boolean;
+  value?: string;
+};

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -481,7 +481,16 @@ export type SettingsIcon =
  * in the settings editor.
  */
 export type SettingsTreeFieldValue =
-  | { input: "autocomplete"; value?: string; items: string[] }
+  | {
+      input: "autocomplete";
+      value?: string;
+      items: string[];
+
+      /**
+       * Optional placeholder text displayed in the field input when value is undefined
+       */
+      placeholder?: string;
+    }
   | { input: "boolean"; value?: boolean }
   | {
       input: "rgb";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12118,6 +12118,7 @@ __metadata:
     "@storybook/addon-actions": 7.0.20
     "@storybook/addon-essentials": 7.0.20
     "@storybook/addon-interactions": 7.0.20
+    "@storybook/csf-tools": 7.0.20
     "@storybook/react": 7.0.20
     "@storybook/react-webpack5": 7.0.20
     "@types/babel__core": ^7.20.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -10376,17 +10376,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dom-accessibility-api@npm:^0.5.6":
+"dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
   version: 0.5.16
   resolution: "dom-accessibility-api@npm:0.5.16"
   checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
-  languageName: node
-  linkType: hard
-
-"dom-accessibility-api@npm:^0.5.9":
-  version: 0.5.10
-  resolution: "dom-accessibility-api@npm:0.5.10"
-  checksum: c05949889b02f5313d100778e9f736f9bddfb1da47387d351833f0b5d60d6230d4fcb849e124a8a1591706b6200337fa40f0f4f3817dce1459309e075f48371c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,6 +61,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@adobe/css-tools@npm:4.2.0"
+  checksum: dc5cc92ba3d562e7ffddb79d6d222c7e00b65f255fd2725b3d71490ff268844be322f917415d8c4ab39eca646343b632058db8bd5b1d646193fcc94d1d3e420b
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -5143,6 +5150,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/expect@npm:storybook-jest":
+  version: 27.5.2-0
+  resolution: "@storybook/expect@npm:27.5.2-0"
+  dependencies:
+    "@types/jest": ">=26.0.0"
+  checksum: 09738a8f8e0b9d3d5a909c80ce0c101080cf376316ceca1f3820e88877d6b5ef92abd847b4c4a4e9687c43c2168a6e3e8cdd74947b6af622688797f74cf523df
+  languageName: node
+  linkType: hard
+
 "@storybook/global@npm:^5.0.0":
   version: 5.0.0
   resolution: "@storybook/global@npm:5.0.0"
@@ -5160,6 +5176,18 @@ __metadata:
     "@storybook/global": ^5.0.0
     "@storybook/preview-api": 7.0.20
   checksum: f4fd7d74f8d7eacd2da1826bf908b2ead5fd2b82b1e9e3eeb3eea58c9574a56e6e6f20355e66a7a99459c8c93b495505b709df6e2be7db04367f57e5e275ba8e
+  languageName: node
+  linkType: hard
+
+"@storybook/jest@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@storybook/jest@npm:0.1.0"
+  dependencies:
+    "@storybook/expect": storybook-jest
+    "@storybook/instrumenter": ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
+    "@testing-library/jest-dom": ^5.16.2
+    jest-mock: ^27.3.0
+  checksum: 74a4b9dc0ce921f72c2f4fbba053e4a4c84a6a16d07406492a26733f55438229197e547364d0848ac3df38ab5ce9e20829029196d376a267033d8e75904ab611
   languageName: node
   linkType: hard
 
@@ -5628,6 +5656,23 @@ __metadata:
     lz-string: ^1.4.4
     pretty-format: ^27.0.2
   checksum: 1e599129a2fe91959ce80900a0a4897232b89e2a8e22c1f5950c36d39c97629ea86b4986b60b173b5525a05de33fde1e35836ea597b03de78cc51b122835c6f0
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^5.16.2":
+  version: 5.16.5
+  resolution: "@testing-library/jest-dom@npm:5.16.5"
+  dependencies:
+    "@adobe/css-tools": ^4.0.1
+    "@babel/runtime": ^7.9.2
+    "@types/testing-library__jest-dom": ^5.9.1
+    aria-query: ^5.0.0
+    chalk: ^3.0.0
+    css.escape: ^1.5.1
+    dom-accessibility-api: ^0.5.6
+    lodash: ^4.17.15
+    redent: ^3.0.0
+  checksum: 94911f901a8031f3e489d04ac057cb5373621230f5d92bed80e514e24b069fb58a3166d1dd86963e55f078a1bd999da595e2ab96ed95f452d477e272937d792a
   languageName: node
   linkType: hard
 
@@ -6126,7 +6171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:29.5.2":
+"@types/jest@npm:*, @types/jest@npm:29.5.2, @types/jest@npm:>=26.0.0":
   version: 29.5.2
   resolution: "@types/jest@npm:29.5.2"
   dependencies:
@@ -6579,6 +6624,15 @@ __metadata:
   version: 1.0.8
   resolution: "@types/tapable@npm:1.0.8"
   checksum: b4b754dd0822c407b8f29ef6b766490721c276880f9e976d92ee2b3ef915f11a05a2442ae36c8978bcd872ad6bc833b0a2c4d267f2d611590668a366bad50652
+  languageName: node
+  linkType: hard
+
+"@types/testing-library__jest-dom@npm:^5.9.1":
+  version: 5.14.6
+  resolution: "@types/testing-library__jest-dom@npm:5.14.6"
+  dependencies:
+    "@types/jest": "*"
+  checksum: 92f81cefeacba3b5c06d4b3fbea0341fe2bcaa6e425c026ae262de39f1148c2588cf3003112aa4ac0880c3972ffb77641a863f3be71518d1d8080402c944e326
   languageName: node
   linkType: hard
 
@@ -9720,6 +9774,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "cssesc@npm:^3.0.0":
   version: 3.0.0
   resolution: "cssesc@npm:3.0.0"
@@ -10312,6 +10373,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.6":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 005eb283caef57fc1adec4d5df4dd49189b628f2f575af45decb210e04d634459e3f1ee64f18b41e2dcf200c844bc1d9279d80807e686a30d69a4756151ad248
   languageName: node
   linkType: hard
 
@@ -12118,6 +12186,7 @@ __metadata:
     "@storybook/addon-actions": 7.0.20
     "@storybook/addon-essentials": 7.0.20
     "@storybook/addon-interactions": 7.0.20
+    "@storybook/jest": 0.1.0
     "@storybook/react": 7.0.20
     "@storybook/react-webpack5": 7.0.20
     "@types/babel__core": ^7.20.1
@@ -14337,7 +14406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^27.0.6":
+"jest-mock@npm:^27.0.6, jest-mock@npm:^27.3.0":
   version: 27.5.1
   resolution: "jest-mock@npm:27.5.1"
   dependencies:
@@ -18589,6 +18658,16 @@ __metadata:
   dependencies:
     resolve: ^1.20.0
   checksum: ad3caed8afdefbc33fbc30e6d22b86c35b3d51c2005546f4e79bcc03c074df804b3640ad18945e6bef9ed12caedc035655ec1082f64a5e94c849ff939dc0a788
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: ^4.0.0
+    strip-indent: ^3.0.0
+  checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,6 +2959,7 @@ __metadata:
     "@popperjs/core": 2.11.8
     "@protobufjs/base64": 1.1.2
     "@storybook/addon-actions": 7.0.20
+    "@storybook/jest": 0.1.0
     "@storybook/react": 7.0.20
     "@storybook/testing-library": 0.1.0
     "@svgr/webpack": 8.0.1
@@ -12179,7 +12180,6 @@ __metadata:
     "@storybook/addon-actions": 7.0.20
     "@storybook/addon-essentials": 7.0.20
     "@storybook/addon-interactions": 7.0.20
-    "@storybook/jest": 0.1.0
     "@storybook/react": 7.0.20
     "@storybook/react-webpack5": 7.0.20
     "@types/babel__core": ^7.20.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -12118,7 +12118,6 @@ __metadata:
     "@storybook/addon-actions": 7.0.20
     "@storybook/addon-essentials": 7.0.20
     "@storybook/addon-interactions": 7.0.20
-    "@storybook/csf-tools": 7.0.20
     "@storybook/react": 7.0.20
     "@storybook/react-webpack5": 7.0.20
     "@types/babel__core": ^7.20.1


### PR DESCRIPTION
**User-Facing Changes**
<img width="945" alt="Screen Shot 2023-06-15 at 10 06 46 am" src="https://github.com/foxglove/studio/assets/924528/e20632a9-3c8e-4ff3-ae9a-aeb971a44118">

Also add placeholder to Autocomplete fields in PanelSettings

**Description**
Moves Topic and Schema inputs into panel settings and renames datatypes to message schema

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
