### PR TITLE
Plot setting to turn off lines

### DIFF
--- a/packages/studio-base/src/i18n/en/plot.ts
+++ b/packages/studio-base/src/i18n/en/plot.ts
@@ -25,6 +25,7 @@ export const plot = {
   showValues: "Show values",
   yAxis: "Y Axis",
   showLabels: "Show labels",
+  showLine: "Show lines",
   min: "Min",
   max: "Max",
   xAxis: "X Axis",

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -126,7 +126,7 @@ function getDatasetsFromMessagePlotPath({
   dataset: DataSet;
   hasMismatchedData: boolean;
 } {
-  let showLine = true;
+  let showLine = path.showLine !== false;
   let hasMismatchedData =
     isCustomScale(xAxisVal) &&
     xAxisRanges != undefined &&

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -730,6 +730,46 @@ export const DisabledPath: StoryObj = {
   },
 };
 
+export const HiddenConnectingLines: StoryObj = {
+  render: function Story() {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PlotWrapper
+        pauseFrame={pauseFrame}
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              showLine: false,
+              timestampMethod: "receiveTime",
+            },
+            {
+              value: "/some_topic/location.pose.acceleration",
+              enabled: true,
+              showLine: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+        }}
+      />
+    );
+  },
+
+  name: "hidden connecting lines",
+
+  parameters: {
+    useReadySignal: true,
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
 export const ReferenceLine: StoryObj = {
   render: function Story() {
     const readySignal = useReadySignal({ count: 3 });

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -27,6 +27,7 @@ export type PlotPath = BasePlotPath & {
   color?: string;
   label?: string;
   timestampMethod: TimestampMethod;
+  showLine?: boolean;
 };
 
 // X-axis values:

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -49,6 +49,11 @@ const makeSeriesNode = memoizeWeak(
           label: t("color"),
           value: path.color ?? lineColors[index % lineColors.length],
         },
+        showLine: {
+          label: t("showLine"),
+          input: "boolean",
+          value: path.showLine !== false,
+        },
         timestampMethod: {
           input: "select",
           label: t("timestamp"),


### PR DESCRIPTION
**User-Facing Changes**

Introduces a setting for the Plot panel, to show/hide lines:

<img width="1266" alt="demo" src="https://github.com/foxglove/studio/assets/349687/a76303a5-ab56-4b6e-93e2-4f8c4c1a0d05">

**Description**

Not 100% sure whether this switch is more a per-dataset or a per-panel setting, but to err on the side of more granular config, we can show/hide lines for each individual dataset:

https://github.com/foxglove/studio/assets/349687/96097d86-a1da-4161-9d6e-64adeea7c14d
