### PR TITLE
Remove GITHUB_TOKEN from chromatic CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
       - uses: chromaui/action@v1
         if: ${{ github.event.repository.full_name == 'foxglove/studio' }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: f50040a29fb8
           storybookBuildDir: storybook-static
           autoAcceptChanges: main


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This is no longer needed as of https://github.com/chromaui/chromatic-cli/pull/465 (credit to @ethriel3695 for finding the relevant PR)