### PR TITLE
Distortion patch fix for raitonal-polynomial model

### DIFF
--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -133,8 +133,8 @@ export class PinholeCameraModel {
   // Question: Do I need this ut as input if I'm returning ?
   // I added it just to keep the similarity with other functions.
   // I don't see the use of it.
-  public undistort (out: Vector2, pixel: Readonly<Vector2>, iterations = 5): Vector2 {
-    const D  = this.D;
+  public undistort(out: Vector2, pixel: Readonly<Vector2>, iterations = 5): Vector2 {
+    const D = this.D;
     const [k1, k2, p1, p2, k3, k4, k5, k6] = D;
 
     let x0 = pixel.x;
@@ -142,22 +142,21 @@ export class PinholeCameraModel {
     out.x = pixel.x;
     out.y = pixel.y;
     const count = k1 !== 0 || k2 !== 0 || p1 !== 0 || p2 !== 0 || k3 !== 0 ? iterations : 1;
-    for(let i = 0; i < count; ++i)
-    {
-      const xx = out.x*out.x;
-      const yy = out.y*out.y;
-      const xy = out.x*out.y;
+    for (let i = 0; i < count; ++i) {
+      const xx = out.x * out.x;
+      const yy = out.y * out.y;
+      const xy = out.x * out.y;
       const r2 = xx + yy;
-      const r4 = r2*r2;
-      const r6 = r4*r2;
+      const r4 = r2 * r2;
+      const r6 = r4 * r2;
 
       //TODO(saching13): THis can be improved by adding a termination criteria and cross validation loop
       const cdist = 1 + k1 * r2 + k2 * r4 + k3 * r6;
-      const  icdist = (1 + k4 * r2 + k5 * r4 + k6 * r6) / cdist;
-      let deltaX = 2*p1*xy+ p2*(r2 + 2*xx);
-      let deltaY = p1*(r2 + 2*yy) + 2*p2*xy;
-      out.x = (x0 - deltaX)*icdist;
-      out.y = (y0 - deltaY)*icdist;
+      const icdist = (1 + k4 * r2 + k5 * r4 + k6 * r6) / cdist;
+      let deltaX = 2 * p1 * xy + p2 * (r2 + 2 * xx);
+      let deltaY = p1 * (r2 + 2 * yy) + 2 * p2 * xy;
+      out.x = (x0 - deltaX) * icdist;
+      out.y = (y0 - deltaY) * icdist;
     }
 
     return out;
@@ -182,8 +181,10 @@ export class PinholeCameraModel {
     const cy = P[6];
     const tx = P[3];
     const ty = P[7];
-    let normalizedFramePixel: Vector2 = {x: (pixel.x - cx - tx) / fx,
-                                         y: (pixel.y - cy - ty) / fy};
+    let normalizedFramePixel: Vector2 = {
+      x: (pixel.x - cx - tx) / fx,
+      y: (pixel.y - cy - ty) / fy,
+    };
     let undistortedPixel = this.undistort(out, normalizedFramePixel);
 
     /*
@@ -265,8 +266,8 @@ export class PinholeCameraModel {
     // You can read more about the equations used in the pinhole camera model at
     // <https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#details>
 
-    let normalizedFramePixel: Vector2 ={ x: (point.x - cx) / fx, y: (point.y - cy) / fy };
-    let undistortedPixel: Vector2 = { x: 0, y: 0};
+    let normalizedFramePixel: Vector2 = { x: (point.x - cx) / fx, y: (point.y - cy) / fy };
+    let undistortedPixel: Vector2 = { x: 0, y: 0 };
 
     undistortedPixel = this.undistort(undistortedPixel, normalizedFramePixel, iterations);
 
@@ -275,8 +276,8 @@ export class PinholeCameraModel {
     return out;
   }
 
-  public distort(out: Vector2, normalizedPoint: Readonly<Vector2>, ): Vector2 {
-    const D  = this.D;
+  public distort(out: Vector2, normalizedPoint: Readonly<Vector2>): Vector2 {
+    const D = this.D;
     const [k1, k2, p1, p2, k3, k4, k5, k6] = D;
 
     // x'' <- x'(1+k1*r^2+k2*r^4+k3*r^6) / (1 + k4_ * r2 + k5_ * r4 + k6_ * r6) + 2p1*x'*y' + p2(r^2+2x'^2)
@@ -290,9 +291,9 @@ export class PinholeCameraModel {
     const r4 = r2 * r2;
     const r6 = r4 * r2;
 
-    const cdist =  (1 + k1 * r2 + k2 * r4 + k3 * r6)/(1 + k4 * r2 + k5 * r4 + k6 * r6);
-    const deltaX = 2*p1*xy + p2*(r2 + 2*xx);
-    const deltaY = 2*p2*xy + p1*(r2 + 2*yy);
+    const cdist = (1 + k1 * r2 + k2 * r4 + k3 * r6) / (1 + k4 * r2 + k5 * r4 + k6 * r6);
+    const deltaX = 2 * p1 * xy + p2 * (r2 + 2 * xx);
+    const deltaY = 2 * p2 * xy + p1 * (r2 + 2 * yy);
     out.x = normalizedPoint.x * cdist + deltaX;
     out.y = normalizedPoint.y * cdist + deltaY;
     return out;
@@ -324,7 +325,6 @@ export class PinholeCameraModel {
     // x <- (u - c'x) / f'x
     // y <- (v - c'y) / f'y
     // c'x, f'x, etc. (primed) come from "new camera matrix" P[0:3, 0:3].
-    // Question ? Does this tx needs to be considered since the info from TF already exists?
     const x1 = (point.x - cx - tx) / fx;
     const y1 = (point.y - cy - ty) / fy;
     // [X Y W]^T <- R^-1 * [x y 1]^T
@@ -333,7 +333,7 @@ export class PinholeCameraModel {
     const X = R[0] * x1 + R[3] * y1 + R[6];
     const Y = R[1] * x1 + R[4] * y1 + R[7];
     const W = R[2] * x1 + R[5] * y1 + R[8];
-    let normalizedPoint : Vector2 = { x: X / W, y: Y / W };
+    let normalizedPoint: Vector2 = { x: X / W, y: Y / W };
 
     out = this.distort(out, normalizedPoint);
 

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -327,11 +327,13 @@ export class PinholeCameraModel {
     // removing tx and ty for same reason as in projectPixelTo3dPlane
     const x1 = (point.x - cx) / fx;
     const y1 = (point.y - cy) / fy;
+
     // [X Y W]^T <- R^-1 * [x y 1]^T
-    const X = R[0] * x1 + R[3] * y1 + R[6];
-    const Y = R[1] * x1 + R[4] * y1 + R[7];
-    const W = R[2] * x1 + R[5] * y1 + R[8];
-    let normalizedPoint: Vector2 = { x: X / W, y: Y / W };
+    // const X = R[0] * x1 + R[3] * y1 + R[6];
+    // const Y = R[1] * x1 + R[4] * y1 + R[7];
+    // const W = R[2] * x1 + R[5] * y1 + R[8];
+    // let normalizedPoint: Vector2 = { x: X / W, y: Y / W };
+    let normalizedPoint: Vector2 = { x: x1, y: y1};
 
     out = this.distort(out, normalizedPoint);
 

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -335,8 +335,8 @@ export class PinholeCameraModel {
     // map_x(u,v) <- x''fx + cx
     // map_y(u,v) <- y''fy + cy
     // cx, fx, etc. come from original camera matrix K.
-    out.x = out.x * fx + cx;
-    out.y = out.y * fy + cy;
+    out.x = out.x * K[0] + K[2];
+    out.y = out.y * K[4] + K[5];
     return out;
   }
 }

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -329,13 +329,10 @@ export class PinholeCameraModel {
     const y1 = (point.y - cy) / fy;
 
     // [X Y W]^T <- R^-1 * [x y 1]^T
-    // R is the rectification matrix, which is the identity matrix if the image is already rectified.
-    // or use a rectifiedImage TF to see the rectifiedImage.
-    // const X = R[0] * x1 + R[3] * y1 + R[6];
-    // const Y = R[1] * x1 + R[4] * y1 + R[7];
-    // const W = R[2] * x1 + R[5] * y1 + R[8];
-    // let normalizedPoint: Vector2 = { x: X / W, y: Y / W };
-    let normalizedPoint: Vector2 = { x: x1, y: y1};
+    const X = R[0] * x1 + R[3] * y1 + R[6];
+    const Y = R[1] * x1 + R[4] * y1 + R[7];
+    const W = R[2] * x1 + R[5] * y1 + R[8];
+    let normalizedPoint: Vector2 = { x: X / W, y: Y / W };
 
     out = this.distort(out, normalizedPoint);
 

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -182,9 +182,8 @@ export class PinholeCameraModel {
     const cy = P[6];
     const tx = P[3];
     const ty = P[7];
-    let normalizedFramePixel: Vector2;
-    normalizedFramePixel.x = (pixel.x - cx) / fx;
-    normalizedFramePixel.y = (pixel.y - cy) / fy;
+    let normalizedFramePixel: Vector2 = {x: (pixel.x - cx - tx) / fx,
+                                         y: (pixel.y - cy - ty) / fy};
     let undistortedPixel = this.undistort(out, normalizedFramePixel);
 
     /*
@@ -267,7 +266,7 @@ export class PinholeCameraModel {
     // <https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html#details>
 
     let normalizedFramePixel: Vector2 ={ x: (point.x - cx) / fx, y: (point.y - cy) / fy };
-    let undistortedPixel: Vector2;
+    let undistortedPixel: Vector2 = { x: 0, y: 0};
 
     undistortedPixel = this.undistort(undistortedPixel, normalizedFramePixel, iterations);
 

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -170,7 +170,7 @@ export class PinholeCameraModel {
    *   projection matrix `P` is not set.
    */
   public projectPixelTo3dPlane(out: Vector3, pixel: Readonly<Vector2>): Vector3 {
-    const { K, P} = this;
+    const { K, P } = this;
 
     const fx = K[0];
     const fy = K[4];
@@ -232,7 +232,7 @@ export class PinholeCameraModel {
    * @returns The rectified pixel, a reference to `out`.
    */
   public undistortPixel(out: Vector2, point: Readonly<Vector2>, iterations = 5): Vector2 {
-    const { K, P} = this;
+    const { K, P } = this;
 
     const fx = P[0];
     const fy = P[5];

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -329,6 +329,8 @@ export class PinholeCameraModel {
     const y1 = (point.y - cy) / fy;
 
     // [X Y W]^T <- R^-1 * [x y 1]^T
+    // R is the rectification matrix, which is the identity matrix if the image is already rectified.
+    // or use a rectifiedImage TF to see the rectifiedImage.
     // const X = R[0] * x1 + R[3] * y1 + R[6];
     // const Y = R[1] * x1 + R[4] * y1 + R[7];
     // const W = R[2] * x1 + R[5] * y1 + R[8];

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -130,9 +130,6 @@ export class PinholeCameraModel {
     }
   }
 
-  // Question: Do I need this ut as input if I'm returning ?
-  // I added it just to keep the similarity with other functions.
-  // I don't see the use of it.
   public undistort(out: Vector2, pixel: Readonly<Vector2>, iterations = 5): Vector2 {
     const D = this.D;
     const [k1, k2, p1, p2, k3, k4, k5, k6] = D;
@@ -269,7 +266,7 @@ export class PinholeCameraModel {
     let normalizedFramePixel: Vector2 = { x: (point.x - cx) / fx, y: (point.y - cy) / fy };
     let undistortedPixel: Vector2 = { x: 0, y: 0 };
 
-    undistortedPixel = this.undistort(undistortedPixel, normalizedFramePixel, iterations);
+    this.undistort(undistortedPixel, normalizedFramePixel, iterations);
 
     out.x = undistortedPixel.x * fx + cx;
     out.y = undistortedPixel.y * fy + cy;
@@ -328,8 +325,6 @@ export class PinholeCameraModel {
     const x1 = (point.x - cx - tx) / fx;
     const y1 = (point.y - cy - ty) / fy;
     // [X Y W]^T <- R^-1 * [x y 1]^T
-    // Question? This is not R^-1. R is in Row major order as per CameraInfo.
-    // Please correct me if I'm wrong here. (Changed it to R^-1 below)
     const X = R[0] * x1 + R[3] * y1 + R[6];
     const Y = R[1] * x1 + R[4] * y1 + R[7];
     const W = R[2] * x1 + R[5] * y1 + R[8];

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/projections.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/projections.ts
@@ -27,15 +27,14 @@ export function projectPixel(
   cameraModel: PinholeCameraModel,
   settings: { distance: number; planarProjectionFactor: number },
 ): Vector3 {
-  cameraModel.undistortPixel(tempVec2, uv);
 
   if (settings.planarProjectionFactor === 0) {
-    cameraModel.projectPixelTo3dRay(out, tempVec2);
+    cameraModel.projectPixelTo3dRay(out, uv);
   } else if (settings.planarProjectionFactor === 1) {
-    cameraModel.projectPixelTo3dPlane(out, tempVec2);
+    cameraModel.projectPixelTo3dPlane(out, uv);
   } else {
-    cameraModel.projectPixelTo3dRay(tempVec3a, tempVec2);
-    cameraModel.projectPixelTo3dPlane(tempVec3b, tempVec2);
+    cameraModel.projectPixelTo3dRay(tempVec3a, uv);
+    cameraModel.projectPixelTo3dPlane(tempVec3b, uv);
     lerpVec3(out, tempVec3a, tempVec3b, settings.planarProjectionFactor);
   }
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
This PR adds the capability to take account of k4, k5 and k6 parameters of the distortion coefficients in undisotrting and projecting the camera view on the 3D Panel and the new Image beta panel.

Refer [here](https://docs.opencv.org/3.4/d9/d0c/group__calib3d.html) for more details on the Distortion model

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
