### PR TITLE
Update time/duration in protobufDefinitionsToDatatypes to matching deserialized object

### DIFF
--- a/packages/mcap-support/src/parseProtobufSchema.test.ts
+++ b/packages/mcap-support/src/parseProtobufSchema.test.ts
@@ -194,6 +194,39 @@ describe("parseProtobufSchema", () => {
       }
     `);
 
+    expect(sceneUpdateChannel.datatypes.get("google.protobuf.Timestamp")).toMatchInlineSnapshot(`
+      {
+        "definitions": [
+          {
+            "isArray": false,
+            "name": "sec",
+            "type": "int64",
+          },
+          {
+            "isArray": false,
+            "name": "nsec",
+            "type": "int32",
+          },
+        ],
+      }
+    `);
+    expect(sceneUpdateChannel.datatypes.get("google.protobuf.Duration")).toMatchInlineSnapshot(`
+      {
+        "definitions": [
+          {
+            "isArray": false,
+            "name": "sec",
+            "type": "int64",
+          },
+          {
+            "isArray": false,
+            "name": "nsec",
+            "type": "int32",
+          },
+        ],
+      }
+    `);
+
     // Duration too large
     expect(() =>
       sceneUpdateChannel.deserialize(Buffer.from("EhMKBAgCEAMiCwiAgICAgICAEBAB", "base64")),


### PR DESCRIPTION
**User-Facing Changes**
Fixed the `google.protobuf.Duration` and `google.protobuf.Timestamp` generated type definitions in User Scripts so they match the way timestamps are represented in the rest of the app (`{sec, nsec}` instead of `{seconds, nanos}`).

**Description**
We modify the deserialization logic for Duration and Timestamp so we get `{sec, nsec}`, the same format as the rest of Studio expects. However, the generated types for User Scripts still showed the names as `{seconds, nanos}`.