### PR TITLE
flatbuffers: set readDefaults=true

### DIFF
--- a/packages/mcap-support/src/parseFlatbufferSchema.test.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.test.ts
@@ -352,7 +352,14 @@ describe("parseFlatbufferSchema", () => {
     Type.addIndex(builder, 123);
     builder.finish(Type.endType(builder));
 
-    expect(deserialize(builder.asUint8Array())).toEqual({ base_type: 7, index: 123 });
+    expect(deserialize(builder.asUint8Array())).toEqual({
+      base_size: 4n,
+      base_type: 7,
+      element: 0n,
+      element_size: 0n,
+      fixed_length: 0n,
+      index: 123,
+    });
   });
   it("converts uint8 vectors to uint8arrays", () => {
     const builder = new Builder();

--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -191,6 +191,10 @@ export function parseFlatbufferSchema(
     }
   }
   const parser = new Parser(rawSchema);
+  // We set readDefaults=true to ensure that the reader receives default values for unset fields, or
+  // fields that were explicitly set but with ForceDefaults(false) on the writer side. This is
+  // necessary because `datatypes` does not include information about default values from the
+  // schema. See discussion: <https://github.com/foxglove/studio/pull/6256>
   const toObject = parser.toObjectLambda(typeIndex, /*readDefaults=*/ true);
   const deserialize = (buffer: ArrayBufferView) => {
     const byteBuffer = new ByteBuffer(

--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -191,7 +191,7 @@ export function parseFlatbufferSchema(
     }
   }
   const parser = new Parser(rawSchema);
-  const toObject = parser.toObjectLambda(typeIndex);
+  const toObject = parser.toObjectLambda(typeIndex, /*readDefaults=*/ true);
   const deserialize = (buffer: ArrayBufferView) => {
     const byteBuffer = new ByteBuffer(
       new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),


### PR DESCRIPTION
**User-Facing Changes**
FlatBuffer messages will now appear with all default values populated, even if they were not serialized explicitly in the binary data.

**Description**
Studio generally needs default values (such as `quaternion.w=1`) to be present in order to render things properly (at least, in panels that have a fixed set of supported schemas). Since the published flatbuffer schemas [here](https://github.com/foxglove/schemas/tree/main/schemas/flatbuffer) use [default values](https://github.com/foxglove/schemas/blob/a4fe2a8af0d837e7d413be6a325e47b8f0b81a0b/schemas/flatbuffer/Quaternion.fbs#L16-L17), a writer currently has to use `builder.ForceDefaults(true);` in order to ensure their values are written into the buffer if they match the defaults. With this change, defaults will always be populated based on the schema when Studio deserializes an object, even if the values were not present in the buffer.

This matches (roughly) what we do for protobuf: https://github.com/foxglove/studio/blob/f23e993460db86f9fe6de3ee59046fbea3211086/packages/mcap-support/src/parseProtobufSchema.ts#L68-L71