### PR TITLE
Image: add missing legacy types

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -39,16 +39,20 @@ interface ImageAnnotationsContext {
   messageHandler: MessageHandler;
 }
 
-const ALL_SUPPORTED_SCHEMAS = new Set([
-  ...IMAGE_ANNOTATIONS_DATATYPES,
-  ...IMAGE_MARKER_DATATYPES,
-  ...IMAGE_MARKER_ARRAY_DATATYPES,
-  // For backwards compatibility with older studio versions and webviz
+/** For backwards compatibility with older studio versions and webviz */
+const LEGACY_ANNOTATION_SCHEMAS = new Set([
   "foxglove_msgs/ImageMarkerArray",
   "foxglove_msgs/msg/ImageMarkerArray",
   "studio_msgs/ImageMarkerArray",
   "studio_msgs/msg/ImageMarkerArray",
   "webviz_msgs/ImageMarkerArray",
+]);
+
+const ALL_SUPPORTED_SCHEMAS = new Set([
+  ...IMAGE_ANNOTATIONS_DATATYPES,
+  ...IMAGE_MARKER_DATATYPES,
+  ...IMAGE_MARKER_ARRAY_DATATYPES,
+  ...LEGACY_ANNOTATION_SCHEMAS,
 ]);
 
 /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -43,6 +43,12 @@ const ALL_SUPPORTED_SCHEMAS = new Set([
   ...IMAGE_ANNOTATIONS_DATATYPES,
   ...IMAGE_MARKER_DATATYPES,
   ...IMAGE_MARKER_ARRAY_DATATYPES,
+  // For backwards compatibility with older studio versions and webviz
+  "foxglove_msgs/ImageMarkerArray",
+  "foxglove_msgs/msg/ImageMarkerArray",
+  "studio_msgs/ImageMarkerArray",
+  "studio_msgs/msg/ImageMarkerArray",
+  "webviz_msgs/ImageMarkerArray",
 ]);
 
 /**


### PR DESCRIPTION
**User-Facing Changes**
None (restoring old image panel functionality)

**Description**
Fixes FG-3923

Copied these items from https://github.com/foxglove/studio/blob/f23e993460db86f9fe6de3ee59046fbea3211086/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts#L22C1-L42