### PR TITLE
Make settings in storybook actually work for non-extension panels

### DIFF
--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -48,7 +48,7 @@ export const TopicButNoDataSourceHovered: StoryObj = {
   parameters: { colorScheme: "dark" },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    userEvent.hover(await canvas.findByTestId("panel-mouseenter-container"));
+    userEvent.hover(await canvas.findByTestId(/panel-mouseenter-container/));
   },
 };
 

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -287,7 +287,6 @@ function Plot(props: Props) {
 }
 
 const defaultConfig: PlotConfig = {
-  title: "Plot",
   paths: [{ value: "", enabled: true, timestampMethod: "receiveTime" }],
   minYValue: undefined,
   maxYValue: undefined,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -533,7 +533,7 @@ export const ImageModePick: StoryObj<React.ComponentProps<typeof ImageModeFoxglo
   args: { imageType: "raw" },
 
   play: async () => {
-    userEvent.hover(await screen.findByTestId("panel-mouseenter-container"));
+    userEvent.hover(await screen.findByTestId(/panel-mouseenter-container/));
     const canvas = document.querySelector("canvas")!;
     const inspectObjects = screen.getByRole("button", { name: /inspect objects/i });
     userEvent.click(inspectObjects);

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -188,8 +188,15 @@ function PanelWrapper({
   includeSettings?: boolean;
   settingsWidth?: number;
 }): JSX.Element {
-  const settings =
-    usePanelStateStore((store) => Object.values(store.settingsTrees)[0]) ?? EmptyTree;
+  const settings = usePanelStateStore((store) => {
+    const trees = Object.values(store.settingsTrees);
+    if (trees.length > 1) {
+      throw new Error(
+        `includeSettings requires there to be at most 1 panel, found ${trees.length}`,
+      );
+    }
+    return trees[0] ?? EmptyTree;
+  });
 
   return (
     <>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
With `<PanelSetup includeSettings>`, the settings weren't actually usable for non-extension panels, because the saveConfig call wouldn't do anything (childId was undefined).

For extension panels this doesn't matter, because the panel is responsible for managing its own copy of the config and does not rely on being re-rendered automatically with new config.