### PR TITLE
Fix moving mouse off playback bar while scrubbing

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -31,7 +31,7 @@ import { EventsOverlay } from "./EventsOverlay";
 import PlaybackBarHoverTicks from "./PlaybackBarHoverTicks";
 import { PlaybackControlsTooltipContent } from "./PlaybackControlsTooltipContent";
 import { ProgressPlot } from "./ProgressPlot";
-import Slider from "./Slider";
+import Slider, { HoverOverEvent } from "./Slider";
 
 const useStyles = makeStyles()((theme) => ({
   marker: {
@@ -79,9 +79,12 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const setHoverValue = useSetHoverValue();
 
-  const [hoverInfo, setHoverInfo] = useState<
-    { stamp: Time; position: { clientX: number; clientY: number } } | undefined
-  >();
+  type HoverInfo = {
+    stamp: Time;
+    clientX: number;
+    clientY: number;
+  };
+  const [hoverInfo, setHoverInfo] = useState<HoverInfo | undefined>();
   const latestHoverInfo = useLatest(hoverInfo);
 
   const latestStartTime = useLatest(startTime);
@@ -103,13 +106,13 @@ export default function Scrubber(props: Props): JSX.Element {
   );
 
   const onHoverOver = useCallback(
-    (fraction: number, position: { clientX: number; clientY: number }) => {
+    ({ fraction, clientX, clientY }: HoverOverEvent) => {
       if (!latestStartTime.current || !latestEndTime.current) {
         return;
       }
       const duration = toSec(subtractTimes(latestEndTime.current, latestStartTime.current));
       const timeFromStart = fromSec(fraction * duration);
-      setHoverInfo({ stamp: addTimes(latestStartTime.current, timeFromStart), position });
+      setHoverInfo({ stamp: addTimes(latestStartTime.current, timeFromStart), clientX, clientY });
       setHoverValue({
         componentId: hoverComponentId,
         type: "PLAYBACK_SECONDS",
@@ -173,8 +176,8 @@ export default function Scrubber(props: Props): JSX.Element {
       anchorEl: {
         getBoundingClientRect: () => {
           return new DOMRect(
-            latestHoverInfo.current?.position.clientX ?? 0,
-            latestHoverInfo.current?.position.clientY ?? 0,
+            latestHoverInfo.current?.clientX ?? 0,
+            latestHoverInfo.current?.clientY ?? 0,
             0,
             0,
           );

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -2,9 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Fade, Tooltip } from "@mui/material";
+import { Fade, PopperProps, Tooltip } from "@mui/material";
 import type { Instance } from "@popperjs/core";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
@@ -70,7 +70,6 @@ export default function Scrubber(props: Props): JSX.Element {
   const { classes, cx } = useStyles();
 
   const [hoverComponentId] = useState<string>(() => uuidv4());
-  const hoverElRef = useRef<HTMLDivElement>(ReactNull);
 
   const startTime = useMessagePipeline(selectStartTime);
   const currentTime = useMessagePipeline(selectCurrentTime);
@@ -80,7 +79,10 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const setHoverValue = useSetHoverValue();
 
-  const [hoverStamp, setHoverStamp] = useState<Time | undefined>();
+  const [hoverInfo, setHoverInfo] = useState<
+    { stamp: Time; position: { clientX: number; clientY: number } } | undefined
+  >();
+  const latestHoverInfo = useLatest(hoverInfo);
 
   const latestStartTime = useLatest(startTime);
   const latestEndTime = useLatest(endTime);
@@ -101,13 +103,13 @@ export default function Scrubber(props: Props): JSX.Element {
   );
 
   const onHoverOver = useCallback(
-    (fraction: number) => {
-      if (!latestStartTime.current || !latestEndTime.current || hoverElRef.current == undefined) {
+    (fraction: number, position: { clientX: number; clientY: number }) => {
+      if (!latestStartTime.current || !latestEndTime.current) {
         return;
       }
       const duration = toSec(subtractTimes(latestEndTime.current, latestStartTime.current));
       const timeFromStart = fromSec(fraction * duration);
-      setHoverStamp(addTimes(latestStartTime.current, timeFromStart));
+      setHoverInfo({ stamp: addTimes(latestStartTime.current, timeFromStart), position });
       setHoverValue({
         componentId: hoverComponentId,
         type: "PLAYBACK_SECONDS",
@@ -121,6 +123,7 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const onHoverOut = useCallback(() => {
     clearHoverValue(hoverComponentId);
+    setHoverInfo(undefined);
   }, [clearHoverValue, hoverComponentId]);
 
   // Clean up the hover value when we are unmounted -- important for storybook.
@@ -147,57 +150,60 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const popperRef = React.useRef<Instance>(ReactNull);
 
-  const positionRef = React.useRef({ x: 0, y: 0 });
+  const isHovered = hoverInfo != undefined;
+  const popperProps: Partial<PopperProps> = useMemo(
+    () => ({
+      open: isHovered, // Keep the tooltip visible while dragging even when the mouse is outside the playback bar
+      popperRef,
+      modifiers: [
+        {
+          name: "computeStyles",
+          options: {
+            gpuAcceleration: false, // Fixes hairline seam on arrow in chrome.
+          },
+        },
+        {
+          name: "offset",
+          options: {
+            // Offset popper to hug the track better.
+            offset: [0, 4],
+          },
+        },
+      ],
+      anchorEl: {
+        getBoundingClientRect: () => {
+          return new DOMRect(
+            latestHoverInfo.current?.position.clientX ?? 0,
+            latestHoverInfo.current?.position.clientY ?? 0,
+            0,
+            0,
+          );
+        },
+      },
+    }),
+    [isHovered, latestHoverInfo],
+  );
 
-  const handlePointerMove = (event: React.PointerEvent) => {
-    positionRef.current = { x: event.clientX, y: event.clientY };
-
+  useEffect(() => {
     if (popperRef.current != undefined) {
       void popperRef.current.update();
     }
-  };
+  }, [hoverInfo]);
 
   return (
     <Tooltip
-      title={hoverStamp != undefined ? <PlaybackControlsTooltipContent stamp={hoverStamp} /> : ""}
+      title={
+        hoverInfo != undefined ? <PlaybackControlsTooltipContent stamp={hoverInfo.stamp} /> : ""
+      }
       placement="top"
       disableInteractive
       TransitionComponent={Fade}
       TransitionProps={{ timeout: 0 }}
-      PopperProps={{
-        popperRef,
-        modifiers: [
-          {
-            name: "computeStyles",
-            options: {
-              gpuAcceleration: false, // Fixes hairline seam on arrow in chrome.
-            },
-          },
-          {
-            name: "offset",
-            options: {
-              // Offset popper to hug the track better.
-              offset: [0, -12],
-            },
-          },
-        ],
-        anchorEl: {
-          getBoundingClientRect: () => {
-            return new DOMRect(
-              positionRef.current.x,
-              hoverElRef.current?.getBoundingClientRect().y ?? 0,
-              0,
-              0,
-            );
-          },
-        },
-      }}
+      PopperProps={popperProps}
     >
       <Stack
-        ref={hoverElRef}
         direction="row"
         flexGrow={1}
-        onPointerMove={handlePointerMove}
         alignItems="center"
         position="relative"
         style={{ height: 32 }}

--- a/packages/studio-base/src/components/PlaybackControls/Slider.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Slider.tsx
@@ -12,7 +12,11 @@ type Props = {
   fraction: number | undefined;
   disabled?: boolean;
   onChange: (value: number) => void;
-  onHoverOver?: (value: number) => void;
+  /**
+   * @param value Hovered `fraction` value
+   * @param position Current hovered position in client coordinates
+   */
+  onHoverOver?: (value: number, position: { clientX: number; clientY: number }) => void;
   onHoverOut?: () => void;
   renderSlider?: (value?: number) => ReactNode;
 };
@@ -113,7 +117,8 @@ export default function Slider(props: Props): JSX.Element {
 
       const val = getValueAtMouse(ev);
       if (elRef.current) {
-        onHoverOver?.(val);
+        const elRect = elRef.current.getBoundingClientRect();
+        onHoverOver?.(val, { clientX: ev.clientX, clientY: elRect.y + elRect.height / 2 });
       }
       if (!mouseDownRef.current) {
         return;

--- a/packages/studio-base/src/components/PlaybackControls/Slider.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Slider.tsx
@@ -101,11 +101,17 @@ export default function Slider(props: Props): JSX.Element {
 
   const onPointerMove = useCallback(
     (ev: React.PointerEvent | PointerEvent): void => {
-      const val = getValueAtMouse(ev);
+      if (mouseDownRef.current && ev.currentTarget !== window) {
+        // onPointerMove is used on the <div/> for hovering, and on the window for dragging. While
+        // dragging we only want to pay attention to the window events (otherwise we'd be handling
+        // each event twice).
+        return;
+      }
       if (disabled) {
         return;
       }
 
+      const val = getValueAtMouse(ev);
       if (elRef.current) {
         onHoverOver?.(val);
       }
@@ -135,8 +141,10 @@ export default function Slider(props: Props): JSX.Element {
   useEffect(() => {
     if (mouseDown) {
       window.addEventListener("pointerup", onPointerUp);
+      window.addEventListener("pointermove", onPointerMove);
       return () => {
         window.removeEventListener("pointerup", onPointerUp);
+        window.removeEventListener("pointermove", onPointerMove);
       };
     }
     return undefined;

--- a/packages/studio-base/src/components/PlaybackControls/Slider.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Slider.tsx
@@ -8,15 +8,20 @@ import { makeStyles } from "tss-react/mui";
 
 import { scaleValue } from "@foxglove/den/math";
 
+export type HoverOverEvent = {
+  /** Hovered `fraction` value */
+  fraction: number;
+  /** Current hovered X position in client coordinates */
+  clientX: number;
+  /** Current hovered Y position in client coordinates */
+  clientY: number;
+};
+
 type Props = {
   fraction: number | undefined;
   disabled?: boolean;
   onChange: (value: number) => void;
-  /**
-   * @param value Hovered `fraction` value
-   * @param position Current hovered position in client coordinates
-   */
-  onHoverOver?: (value: number, position: { clientX: number; clientY: number }) => void;
+  onHoverOver?: (event: HoverOverEvent) => void;
   onHoverOut?: () => void;
   renderSlider?: (value?: number) => ReactNode;
 };
@@ -118,7 +123,11 @@ export default function Slider(props: Props): JSX.Element {
       const val = getValueAtMouse(ev);
       if (elRef.current) {
         const elRect = elRef.current.getBoundingClientRect();
-        onHoverOver?.(val, { clientX: ev.clientX, clientY: elRect.y + elRect.height / 2 });
+        onHoverOver?.({
+          fraction: val,
+          clientX: ev.clientX,
+          clientY: elRect.y + elRect.height / 2,
+        });
       }
       if (!mouseDownRef.current) {
         return;


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**

- Allows scrubbing to continue even if the mouse moves outside the playback bar or window
- Tooltip remains visible the entire time

I made this work in https://github.com/foxglove/studio/pull/2912, then I broke it again in https://github.com/foxglove/studio/pull/4514. The pendulum swings back again.

Additionally I believe the behavior of showing the tooltip even when the mouse is outside the bar changed in https://github.com/foxglove/studio/pull/4392.

Before


https://github.com/foxglove/studio/assets/14237/620511de-f16d-446f-a538-11a80373e186



After


https://github.com/foxglove/studio/assets/14237/98b41e2a-4732-4e77-8362-87683d385625

