### PR TITLE
Fix user script memory leak due to Promise.race

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -449,6 +449,7 @@ export default class UserNodePlayer implements Player {
       // These are lazily created in the first message we process and cleared on
       // terminate.
       let terminateCondvar: undefined | Condvar;
+      let terminateSignal: undefined | Promise<void>;
 
       const registration = async (msgEvent: MessageEvent, globalVariables: GlobalVariables) => {
         // Register the node within a web worker to be executed.
@@ -523,6 +524,7 @@ export default class UserNodePlayer implements Player {
         // processing that is in-flight.
         if (!terminateCondvar) {
           terminateCondvar = new Condvar();
+          terminateSignal = terminateCondvar.wait();
         }
 
         // To send the message over RPC we invoke maybePlainObject which calls toJSON on the message
@@ -538,7 +540,7 @@ export default class UserNodePlayer implements Player {
             },
             globalVariables,
           }),
-          terminateCondvar.wait(),
+          terminateSignal,
         ]);
 
         if (!result) {
@@ -547,9 +549,6 @@ export default class UserNodePlayer implements Player {
             severity: "warn",
           });
           return;
-        } else {
-          // Let terminateCondvar.wait() above resolve to avoid memory leaking in Promise.race()
-          terminateCondvar.notifyOne();
         }
 
         const allDiagnostics = result.userNodeDiagnostics;
@@ -604,6 +603,7 @@ export default class UserNodePlayer implements Player {
         // re-initialize when the next message is processed.
         terminateCondvar?.notifyAll();
         terminateCondvar = undefined;
+        terminateSignal = undefined;
 
         if (rpc) {
           this.#unusedNodeRuntimeWorkers.push(rpc);

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -55,6 +55,7 @@ import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { UserNode, UserNodes } from "@foxglove/studio-base/types/panels";
 import Rpc from "@foxglove/studio-base/util/Rpc";
 import { basicDatatypes } from "@foxglove/studio-base/util/basicDatatypes";
+import safePromiseRace from "@foxglove/studio-base/util/safePromiseRace";
 
 const log = Log.getLogger(__filename);
 
@@ -530,7 +531,7 @@ export default class UserNodePlayer implements Player {
         // To send the message over RPC we invoke maybePlainObject which calls toJSON on the message
         // and builds a plain js object of the entire message. This is expensive so a future enhancement
         // would be to send the underlying message array and build a lazy message reader
-        const result = await Promise.race([
+        const result = await safePromiseRace([
           rpc.send<ProcessMessageOutput>("processMessage", {
             message: {
               topic: msgEvent.topic,
@@ -540,7 +541,7 @@ export default class UserNodePlayer implements Player {
             },
             globalVariables,
           }),
-          terminateSignal,
+          terminateSignal ?? Promise.resolve(undefined),
         ]);
 
         if (!result) {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -449,7 +449,6 @@ export default class UserNodePlayer implements Player {
       // These are lazily created in the first message we process and cleared on
       // terminate.
       let terminateCondvar: undefined | Condvar;
-      let terminateSignal: undefined | Promise<void>;
 
       const registration = async (msgEvent: MessageEvent, globalVariables: GlobalVariables) => {
         // Register the node within a web worker to be executed.
@@ -524,7 +523,6 @@ export default class UserNodePlayer implements Player {
         // processing that is in-flight.
         if (!terminateCondvar) {
           terminateCondvar = new Condvar();
-          terminateSignal = terminateCondvar.wait();
         }
 
         // To send the message over RPC we invoke maybePlainObject which calls toJSON on the message
@@ -540,7 +538,7 @@ export default class UserNodePlayer implements Player {
             },
             globalVariables,
           }),
-          terminateSignal,
+          terminateCondvar.wait(),
         ]);
 
         if (!result) {
@@ -549,6 +547,9 @@ export default class UserNodePlayer implements Player {
             severity: "warn",
           });
           return;
+        } else {
+          // Let terminateCondvar.wait() above resolve to avoid memory leaking in Promise.race()
+          terminateCondvar.notifyOne();
         }
 
         const allDiagnostics = result.userNodeDiagnostics;
@@ -603,7 +604,6 @@ export default class UserNodePlayer implements Player {
         // re-initialize when the next message is processed.
         terminateCondvar?.notifyAll();
         terminateCondvar = undefined;
-        terminateSignal = undefined;
 
         if (rpc) {
           this.#unusedNodeRuntimeWorkers.push(rpc);

--- a/packages/studio-base/src/util/safePromiseRace.test.ts
+++ b/packages/studio-base/src/util/safePromiseRace.test.ts
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import safePromiseRace from "@foxglove/studio-base/util/safePromiseRace";
+
+async function waitAndReturn<T>(ms: number, retVal: T): Promise<T> {
+  return await new Promise((resolve) => {
+    setTimeout(() => resolve(retVal), ms);
+  });
+}
+
+describe("save promise race", () => {
+  it("lets single promise win", async () => {
+    await expect(safePromiseRace([Promise.resolve(1)])).resolves.toEqual(1);
+  });
+
+  it("lets first resolved promise win", async () => {
+    await expect(
+      safePromiseRace([Promise.resolve("foo"), Promise.resolve("bar")]),
+    ).resolves.toEqual("foo");
+  });
+
+  it("lets faster resolving promise win", async () => {
+    await expect(
+      safePromiseRace([
+        waitAndReturn(750, "foo"),
+        waitAndReturn(750, 123),
+        waitAndReturn(500, "bar"),
+      ]),
+    ).resolves.toEqual("bar");
+  });
+
+  it("lets resolving promise win", async () => {
+    const nonResolvingPromise = new Promise(() => {});
+
+    await expect(
+      safePromiseRace([waitAndReturn(1000, "foo"), nonResolvingPromise]),
+    ).resolves.toEqual("foo");
+  });
+
+  it("lets faster resolving promise win on the second race", async () => {
+    const longerRunningPromise = waitAndReturn(1000, "long");
+
+    await expect(
+      safePromiseRace([waitAndReturn(750, "foo"), longerRunningPromise]),
+    ).resolves.toEqual("foo");
+
+    await expect(
+      safePromiseRace([waitAndReturn(750, "bar"), longerRunningPromise]),
+    ).resolves.toEqual("long");
+  });
+});

--- a/packages/studio-base/src/util/safePromiseRace.ts
+++ b/packages/studio-base/src/util/safePromiseRace.ts
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type Deferred = { resolve: (value: unknown) => void; reject: (reason?: unknown) => void };
+
+const deferredsByPromise = new WeakMap<
+  PromiseLike<unknown>,
+  { deferreds: Set<Deferred>; settled: boolean }
+>();
+
+/**
+ * The original `Promise.race` implementation can cause memory leaks when used with long running
+ * promises (see [1]). This function is a re-implementation of `Promise.race` that does not suffer
+ * from this drawback. It is an adaption of Brian Kim's [1] version including the improvement by
+ * Dan Bornstein [2].
+ *
+ * [1]: https://github.com/nodejs/node/issues/17469#issuecomment-685216777
+ * [2]: https://github.com/danfuzz/lactoserv/pull/173
+ *
+ */
+export default async function safePromiseRace<T extends readonly PromiseLike<unknown>[]>(
+  contenders: T,
+): Promise<Awaited<T[number]>> {
+  let deferred: Deferred | undefined;
+  const result = new Promise((resolve, reject) => {
+    deferred = { resolve, reject };
+
+    for (const contender of contenders) {
+      const record = deferredsByPromise.get(contender);
+      if (record == undefined) {
+        addRaceContender(contender, deferred);
+      } else if (record.settled) {
+        // If the value has settled, it is safe to call
+        // `Promise.resolve(contender).then` on it.
+        Promise.resolve(contender).then(resolve, reject);
+      } else {
+        record.deferreds.add(deferred);
+      }
+    }
+  });
+
+  // The finally callback executes when any value settles, preventing any of
+  // the unresolved values from retaining a reference to the resolved value.
+  return await ((await result.finally(() => {
+    for (const contender of contenders) {
+      const record = deferredsByPromise.get(contender);
+      if (record) {
+        record.deferreds.delete(deferred!);
+      }
+    }
+  })) as Promise<Awaited<T[number]>>);
+}
+
+function addRaceContender(contender: PromiseLike<unknown>, deferred: Deferred): void {
+  const record = { deferreds: new Set([deferred]), settled: false };
+  deferredsByPromise.set(contender, record);
+  // This call to `then` happens once for the lifetime of the value.
+  Promise.resolve(contender).then(
+    (value) => {
+      for (const { resolve } of record.deferreds) {
+        resolve(value);
+      }
+
+      record.deferreds.clear();
+      record.settled = true;
+    },
+    (err) => {
+      for (const { reject } of record.deferreds) {
+        reject(err);
+      }
+
+      record.deferreds.clear();
+      record.settled = true;
+    },
+  );
+}


### PR DESCRIPTION
**User-Facing Changes**
- Fix memory leak in user scripts

**Description**
There is a potential memory leak when using `Promise.race` with long-running promises. This is very well described here: https://github.com/nodejs/node/issues/17469#issuecomment-685216777

> In actuality, when you call `Promise.race` with a long-running promise, the resolved value of the returned promise gets retained for as long as each of its promises do not settle.

This is the case for user scripts: User script outputs are retained in memory as long as `terminateSignal` does not resolve. For live connections, the promise `terminateSignal` never resolves and every user script output is retained until the app finally runs out of memory (memory grows faster with larger user script outputs). 

~This patch fixes the memory leak by ensuring that none of the promises in `Promise.race` is long-running. A cleaner fix might be to use a replacement for `Promise.race` which does not suffer from the leaking behavior. See the link above for a possible implementation that uses a `WeakMap` under the hood.~

Edit: This PR now ships a non-leaking re-implementation of `Promise.race`

There are other occurrences of `Promise.race` in the code base where memory might leak, but this one is by far the most severe with respect to retained memory.




