### PR TITLE
Fall back to existing datatypes if not specified in advertise options

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -1051,9 +1051,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       // Try to retrieve the ROS message definition for this topic
       let msgdef: MessageDefinition[];
       try {
-        const datatypes = options?.["datatypes"] as RosDatatypes | undefined;
-        if (!datatypes || !(datatypes instanceof Map)) {
-          throw new Error("The datatypes option is required for publishing");
+        const datatypes = (options?.["datatypes"] as RosDatatypes | undefined) ?? this.#datatypes;
+        if (!(datatypes instanceof Map)) {
+          throw new Error("Datatypes option must be a map");
         }
         msgdef = rosDatatypesToMessageDefinition(datatypes, schemaName);
       } catch (error) {


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Fall back to existing datatypes when advertising a ROS topic

**Description**
When calling `context.advertise?.("topicName", "schemaName")` without passing the schema's datatypes as options, advertisement should not fail if the player can resolve datatypes by the given schema name.

See https://foxglove.slack.com/archives/C01T10L5QJX/p1686859619483039 for context

