### PR TITLE
Align app menu and native menu

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -267,52 +267,8 @@ function WorkspaceContent(props: WorkspaceContentProps): JSX.Element {
   }, []);
 
   useNativeAppMenuEvent(
-    "open-layouts",
-    useCallback(() => {
-      sidebarActions.legacy.selectItem("layouts");
-    }, [sidebarActions.legacy]),
-  );
-
-  useNativeAppMenuEvent(
-    "open-add-panel",
-    useCallback(() => {
-      sidebarActions.legacy.selectItem("add-panel");
-    }, [sidebarActions.legacy]),
-  );
-
-  useNativeAppMenuEvent(
-    "open-panel-settings",
-    useCallback(() => {
-      sidebarActions.legacy.selectItem("panel-settings");
-    }, [sidebarActions.legacy]),
-  );
-
-  useNativeAppMenuEvent(
-    "open-variables",
-    useCallback(() => {
-      sidebarActions.legacy.selectItem("variables");
-    }, [sidebarActions.legacy]),
-  );
-
-  useNativeAppMenuEvent(
-    "open-extensions",
-    useCallback(() => {
-      sidebarActions.legacy.selectItem("extensions");
-    }, [sidebarActions.legacy]),
-  );
-
-  useNativeAppMenuEvent(
-    "open-account",
-    useCallback(() => {
-      sidebarActions.legacy.selectItem("account");
-    }, [sidebarActions.legacy]),
-  );
-
-  useNativeAppMenuEvent(
-    "open-app-settings",
-    useCallback(() => {
-      dialogActions.preferences.open();
-    }, [dialogActions.preferences]),
+    "open",
+    useCallback(async () => dialogActions.dataSource.open("start"), [dialogActions.dataSource]),
   );
 
   useNativeAppMenuEvent(
@@ -321,13 +277,24 @@ function WorkspaceContent(props: WorkspaceContentProps): JSX.Element {
   );
 
   useNativeAppMenuEvent(
-    "open-remote-file",
-    useCallback(() => dialogActions.dataSource.open("remote"), [dialogActions.dataSource]),
+    "open-connection",
+    useCallback(() => dialogActions.dataSource.open("connection"), [dialogActions.dataSource]),
   );
 
   useNativeAppMenuEvent(
-    "open-sample-data",
+    "open-demo",
     useCallback(() => dialogActions.dataSource.open("demo"), [dialogActions.dataSource]),
+  );
+
+  useNativeAppMenuEvent(
+    "open-help-about",
+    useCallback(() => dialogActions.preferences.open("about"), [dialogActions.preferences]),
+  );
+
+  useNativeAppMenuEvent("open-help-docs", () => window.open("https://foxglove.dev/docs", "_blank"));
+
+  useNativeAppMenuEvent("open-help-slack", () =>
+    window.open("https://foxglove.dev/slack", "_blank"),
   );
 
   const nativeAppMenu = useNativeAppMenu();

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -291,6 +291,11 @@ function WorkspaceContent(props: WorkspaceContentProps): JSX.Element {
     useCallback(() => dialogActions.preferences.open("about"), [dialogActions.preferences]),
   );
 
+  useNativeAppMenuEvent(
+    "open-help-general",
+    useCallback(() => dialogActions.preferences.open("general"), [dialogActions.preferences]),
+  );
+
   useNativeAppMenuEvent("open-help-docs", () => window.open("https://foxglove.dev/docs", "_blank"));
 
   useNativeAppMenuEvent("open-help-slack", () =>

--- a/packages/studio-base/src/context/NativeAppMenuContext.ts
+++ b/packages/studio-base/src/context/NativeAppMenuContext.ts
@@ -5,17 +5,13 @@
 import { createContext, useContext } from "react";
 
 export type NativeAppMenuEvent =
+  | "open"
   | "open-file"
-  | "open-remote-file"
-  | "open-sample-data"
-  | "open-layouts"
-  | "open-add-panel"
-  | "open-panel-settings"
-  | "open-variables"
-  | "open-extensions"
-  | "open-help"
-  | "open-account"
-  | "open-app-settings";
+  | "open-connection"
+  | "open-demo"
+  | "open-help-about"
+  | "open-help-docs"
+  | "open-help-slack";
 
 type Handler = () => void;
 

--- a/packages/studio-base/src/context/NativeAppMenuContext.ts
+++ b/packages/studio-base/src/context/NativeAppMenuContext.ts
@@ -11,6 +11,7 @@ export type NativeAppMenuEvent =
   | "open-demo"
   | "open-help-about"
   | "open-help-docs"
+  | "open-help-general"
   | "open-help-slack";
 
 type Handler = () => void;

--- a/packages/studio-desktop/src/common/types.ts
+++ b/packages/studio-desktop/src/common/types.ts
@@ -4,17 +4,13 @@
 
 // Events that are forwarded from the main process
 export type ForwardedMenuEvent =
+  | "open"
   | "open-file"
-  | "open-remote-file"
-  | "open-sample-data"
-  | "open-app-settings"
-  | "open-layouts"
-  | "open-add-panel"
-  | "open-panel-settings"
-  | "open-variables"
-  | "open-extensions"
-  | "open-help"
-  | "open-account";
+  | "open-connection"
+  | "open-demo"
+  | "open-help-about"
+  | "open-help-docs"
+  | "open-help-slack";
 
 export type ForwardedWindowEvent =
   | "enter-full-screen"

--- a/packages/studio-desktop/src/common/types.ts
+++ b/packages/studio-desktop/src/common/types.ts
@@ -10,6 +10,7 @@ export type ForwardedMenuEvent =
   | "open-demo"
   | "open-help-about"
   | "open-help-docs"
+  | "open-help-general"
   | "open-help-slack";
 
 export type ForwardedWindowEvent =

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -3,23 +3,23 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import {
-  app,
-  dialog,
   BrowserWindow,
   BrowserWindowConstructorOptions,
   Menu,
-  MenuItemConstructorOptions,
-  shell,
   MenuItem,
-  systemPreferences,
-  nativeTheme,
+  MenuItemConstructorOptions,
   TitleBarOverlayOptions,
+  app,
+  nativeTheme,
+  shell,
+  systemPreferences,
 } from "electron";
 import path from "path";
 
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
 import { APP_BAR_HEIGHT } from "@foxglove/studio-base/src/components/AppBar/constants";
+import { NativeAppMenuEvent } from "@foxglove/studio-base/src/context/NativeAppMenuContext";
 import * as palette from "@foxglove/studio-base/src/theme/palette";
 
 import StudioAppUpdater from "./StudioAppUpdater";
@@ -28,7 +28,7 @@ import { getAppSetting } from "./settings";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
 import { encodeRendererArg } from "../common/rendererArgs";
-import { FOXGLOVE_PRODUCT_NAME, FOXGLOVE_PRODUCT_VERSION } from "../common/webpackDefines";
+import { FOXGLOVE_PRODUCT_NAME } from "../common/webpackDefines";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
@@ -40,61 +40,6 @@ const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
 
 const closeMenuItem: MenuItemConstructorOptions = isMac ? { role: "close" } : { role: "quit" };
 const log = Logger.getLogger(__filename);
-
-type SectionKey = "app" | "panels" | "resources" | "products" | "contact" | "legal";
-type HelpInfo = {
-  title: string;
-  content?: React.ReactNode;
-  url?: string;
-};
-const helpMenuItems: Map<SectionKey, { subheader: string; links: HelpInfo[] }> = new Map([
-  [
-    "resources",
-    {
-      subheader: "External resources",
-      links: [
-        { title: "Browse docs", url: "https://foxglove.dev/docs" },
-        { title: "Join our community", url: "https://foxglove.dev/community" },
-      ],
-    },
-  ],
-  [
-    "products",
-    {
-      subheader: "Products",
-      links: [
-        { title: "Foxglove Studio", url: "https://foxglove.dev/studio" },
-        { title: "Foxglove Data Platform", url: "https://foxglove.dev/data-platform" },
-      ],
-    },
-  ],
-  [
-    "contact",
-    {
-      subheader: "Contact",
-      links: [
-        { title: "Give feedback", url: "https://foxglove.dev/contact" },
-        { title: "Schedule a demo", url: "https://foxglove.dev/demo" },
-      ],
-    },
-  ],
-  [
-    "legal",
-    {
-      subheader: "Legal",
-      links: [
-        { title: "License terms", url: "https://foxglove.dev/legal/studio-license" },
-        { title: "Privacy policy", url: "https://foxglove.dev/legal/privacy" },
-      ],
-    },
-  ],
-]);
-
-const getTitleCase = (baseString: string): string =>
-  baseString
-    .split(" ")
-    .map((word) => `${word[0]?.toUpperCase()}${word.substring(1)}`)
-    .join(" ");
 
 type ClearableMenu = Menu & { clear: () => void };
 
@@ -252,6 +197,10 @@ function newStudioWindow(deepLinks: string[] = [], reloadMainWindow: () => void)
   return browserWindow;
 }
 
+function sendNativeAppMenuEvent(event: NativeAppMenuEvent, browserWindow: BrowserWindow) {
+  browserWindow.webContents.send(event);
+}
+
 function buildMenu(browserWindow: BrowserWindow): Menu {
   const menuTemplate: MenuItemConstructorOptions[] = [];
 
@@ -269,12 +218,6 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
         { role: "about" },
         checkForUpdatesItem,
         { type: "separator" },
-
-        {
-          label: "Settings…",
-          accelerator: "CommandOrControl+,",
-          click: () => browserWindow.webContents.send("open-app-settings"),
-        },
         { role: "services" },
         { type: "separator" },
 
@@ -299,16 +242,6 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
           new StudioWindow().load();
         },
       },
-      ...(isMac
-        ? []
-        : [
-            { type: "separator" } as const,
-            {
-              label: "Settings…",
-              accelerator: "CommandOrControl+,",
-              click: () => browserWindow.webContents.send("open-app-settings"),
-            } as const,
-          ]),
       { type: "separator" },
       closeMenuItem,
     ],
@@ -318,16 +251,6 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     role: "editMenu",
     label: "Edit",
     submenu: [
-      {
-        label: "Add Panel to Layout",
-        click: () => browserWindow.webContents.send("open-add-panel"),
-      },
-      {
-        label: "Edit Panel Settings",
-        click: () => browserWindow.webContents.send("open-panel-settings"),
-      },
-      { type: "separator" },
-
       { role: "undo" },
       { role: "redo" },
       { type: "separator" },
@@ -374,12 +297,6 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     role: "viewMenu",
     label: "View",
     submenu: [
-      { label: "Layouts", click: () => browserWindow.webContents.send("open-layouts") },
-      { label: "Variables", click: () => browserWindow.webContents.send("open-variables") },
-      { label: "Extensions", click: () => browserWindow.webContents.send("open-extensions") },
-      { label: "Account", click: () => browserWindow.webContents.send("open-account") },
-      { type: "separator" },
-
       { role: "resetZoom" },
       { role: "zoomIn" },
       { role: "zoomOut" },
@@ -403,50 +320,29 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     ],
   });
 
-  const showAboutDialog = () => {
-    void dialog.showMessageBox(browserWindow, {
-      type: "info",
-      title: `About ${FOXGLOVE_PRODUCT_NAME}`,
-      message: FOXGLOVE_PRODUCT_NAME,
-      detail: `Version: ${FOXGLOVE_PRODUCT_VERSION}`,
-    });
-  };
-
-  const helpSidebarItems = Array.from(helpMenuItems.values(), ({ subheader, links }) => ({
-    label: getTitleCase(subheader),
-    submenu: links.map(({ title, url }) => ({
-      label: getTitleCase(title),
-      click: url
-        ? async () => await shell.openExternal(url)
-        : () => browserWindow.webContents.send("open-help"),
-    })),
-  }));
-
   menuTemplate.push({
     role: "help",
     submenu: [
       {
-        label: "Explore Sample Data",
-        click: () => browserWindow.webContents.send("open-sample-data"),
+        label: "About",
+        click: () => sendNativeAppMenuEvent("open-help-about", browserWindow),
+      },
+      {
+        label: "View our docs",
+        click: () => sendNativeAppMenuEvent("open-help-docs", browserWindow),
+      },
+      {
+        label: "Join our Slack",
+        click: () => sendNativeAppMenuEvent("open-help-slack", browserWindow),
       },
       { type: "separator" },
-      ...helpSidebarItems,
       {
-        label: "Learn More",
-        click: async () => await shell.openExternal("https://foxglove.dev"),
+        label: "Explore sample data",
+        click: async () => {
+          await simulateUserClick(browserWindow);
+          sendNativeAppMenuEvent("open-demo", browserWindow);
+        },
       },
-      ...(isMac
-        ? []
-        : [
-            { type: "separator" } as const,
-            {
-              label: "About",
-              click() {
-                showAboutDialog();
-              },
-            },
-            checkForUpdatesItem,
-          ]),
     ],
   });
 
@@ -538,6 +434,10 @@ class StudioWindow {
     return StudioWindow.#windowsByContentId.get(id);
   }
 
+  #sendNativeAppMenuEvent(event: NativeAppMenuEvent) {
+    this.#browserWindow.webContents.send(event);
+  }
+
   #reloadMainWindow(): void {
     const windowWasMaximized = this.#browserWindow.isMaximized();
     this.#browserWindow.close();
@@ -558,7 +458,6 @@ class StudioWindow {
       this.#reloadMainWindow();
     });
     const newMenu = buildMenu(browserWindow);
-
     const id = browserWindow.webContents.id;
 
     log.info(`New Foxglove Studio window ${id}`);
@@ -621,53 +520,33 @@ class StudioWindow {
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "Open File…",
+        label: "Open…",
         click: async () => {
           await simulateUserClick(browserWindow);
-          browserWindow.webContents.send("open-file");
+          this.#sendNativeAppMenuEvent("open");
         },
       }),
     );
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "Open Remote File…",
+        label: "Open local file…",
         click: async () => {
           await simulateUserClick(browserWindow);
-          browserWindow.webContents.send("open-remote-file");
+          this.#sendNativeAppMenuEvent("open-file");
         },
       }),
     );
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "Open Connection",
-        submenu: Array.from(this.#inputSources).map((name) => ({
-          // Electron menus require a preceding & to escape the & char
-          label: name.replace(/&/g, "&&"),
-          click: async () => {
-            await simulateUserClick(browserWindow);
-            browserWindow.webContents.send("menu.click-input-source", name);
-          },
-        })),
+        label: "Open connection...",
+        click: async () => {
+          await simulateUserClick(browserWindow);
+          this.#sendNativeAppMenuEvent("open-connection");
+        },
       }),
     );
-
-    if (!isMac) {
-      fileMenu.submenu?.append(
-        new MenuItem({
-          type: "separator",
-        }),
-      );
-
-      fileMenu.submenu?.append(
-        new MenuItem({
-          label: "Settings…",
-          accelerator: "CommandOrControl+,",
-          click: () => browserWindow.webContents.send("open-app-settings"),
-        }),
-      );
-    }
 
     fileMenu.submenu?.append(
       new MenuItem({

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -218,6 +218,11 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
         { role: "about" },
         checkForUpdatesItem,
         { type: "separator" },
+        {
+          label: "Settings…",
+          accelerator: "CommandOrControl+,",
+          click: () => sendNativeAppMenuEvent("open-help-general", browserWindow),
+        },
         { role: "services" },
         { type: "separator" },
 


### PR DESCRIPTION
**User-Facing Changes**
Bring desktop native menu and app menu closer to alignment.

**Description**
Bring desktop native menu and app menu closer to alignment.

This doesn't try to localize the menu items and omits the view menu items for toggling sidebar state. Both of those things could be accomplished with significantly more effort.

https://github.com/foxglove/studio/assets/93935560/cc8b8f24-d0a3-441c-8fe7-df5c998ceb02

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
