### PR TITLE
Add padding to input when clear indicator is present

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import ClearIcon from "@mui/icons-material/Clear";
+import CancelIcon from "@mui/icons-material/Cancel";
 import {
   MenuItem,
   Autocomplete as MuiAutocomplete,
@@ -77,9 +77,22 @@ const useStyles = makeStyles()((theme) => {
       ".MuiInputBase-root.MuiInputBase-sizeSmall": {
         backgroundColor: "transparent",
         paddingInline: 0,
+
         "&:focus-within": {
           backgroundColor: inputBackgroundColor,
         },
+        "&:hover, &:focus-within": {
+          paddingRight: theme.spacing(2.5),
+        },
+      },
+    },
+    clearIndicator: {
+      marginRight: theme.spacing(-0.25),
+      opacity: theme.palette.action.disabledOpacity,
+
+      ":hover": {
+        background: "transparent",
+        opacity: 1,
       },
     },
     inputError: {
@@ -288,10 +301,13 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   return (
     <MuiAutocomplete
       className={classes.root}
-      clearIcon={<ClearIcon fontSize="small" />}
+      clearIcon={<CancelIcon fontSize="small" />}
       componentsProps={{
-        clearIndicator: { size: "small" },
         paper: { elevation: 8 },
+        clearIndicator: {
+          size: "small",
+          className: classes.clearIndicator,
+        },
       }}
       disableCloseOnSelect
       disabled={disabled}


### PR DESCRIPTION
**User-Facing Changes**
Prevents clear indicator from overlapping text

<img width="357" alt="Screen Shot 2023-06-22 at 8 49 01 am" src="https://github.com/foxglove/studio/assets/924528/bcd21ade-c7ff-4e84-a365-c6eada857b82">

**Description**
Resolves FG-3940
