### PR TITLE
[Map Panel] Display covariance as ellipse

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -123,6 +123,7 @@
     "jszip": "3.10.1",
     "just-diff": "6.0.2",
     "leaflet": "1.9.4",
+    "leaflet-ellipse": "0.9.1",
     "lodash": "4.17.21",
     "mathjs": "11.8.0",
     "memoize-weak": "1.0.2",

--- a/packages/studio-base/src/panels/Map/getAccuracy.test.ts
+++ b/packages/studio-base/src/panels/Map/getAccuracy.test.ts
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { getAccuracy } from "@foxglove/studio-base/panels/Map/getAccuracy";
+import {
+  NavSatFixMsg,
+  NavSatFixPositionCovarianceType,
+} from "@foxglove/studio-base/panels/Map/types";
+
+describe("getAccuracy", () => {
+  const position = {
+    latitude: 0,
+    longitude: 0,
+    altitude: 0,
+  };
+
+  it("handles 'diagonal' covariance type", () => {
+    const msg: NavSatFixMsg = {
+      ...position,
+      position_covariance: [25, 0, 0, 0, 100, 0, 0, 0, 10000],
+      position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN,
+    };
+    const {
+      radii: [r1, r2],
+      tilt,
+    } = getAccuracy(msg)!;
+    expect(r1).toBeCloseTo(5);
+    expect(r2).toBeCloseTo(10);
+    expect(tilt).toBeCloseTo(0);
+  });
+
+  describe("'known' covariance type", () => {
+    it("may return circular variance", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [25, 0, 0, 0, 25, 0, 0, 0, 0],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
+      };
+      const {
+        radii: [r1, r2],
+      } = getAccuracy(msg)!;
+      expect(r1).toBe(5);
+      expect(r2).toBe(5);
+    });
+
+    it("may return a NW ellipsoid", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [3, -2, 0, -2, 3, 0, 0, 0, 0],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
+      };
+      const {
+        radii: [r1, r2],
+        tilt,
+      } = getAccuracy(msg)!;
+      expect(r1).toBeCloseTo(2.236);
+      expect(r2).toBeCloseTo(1);
+      expect(tilt).toBeCloseTo(45);
+    });
+
+    it("may return a NE ellipsoid", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [3, 2, 0, 2, 3, 0, 0, 0, 0],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
+      };
+      const {
+        radii: [r1, r2],
+        tilt,
+      } = getAccuracy(msg)!;
+      expect(r1).toBeCloseTo(2.236);
+      expect(r2).toBeCloseTo(1);
+      expect(tilt).toBeCloseTo(-45);
+    });
+
+    it("handles zero invariance", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
+      };
+      const {
+        radii: [r1, r2],
+      } = getAccuracy(msg)!;
+      expect(r1).toBeCloseTo(0);
+      expect(r2).toBeCloseTo(0);
+    });
+
+    it("returns undefined for invalid input", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [1, -1, 0, 1, 1, 0, 0, 0, 0],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
+      };
+      expect(getAccuracy(msg)).toBeUndefined();
+    });
+  });
+});

--- a/packages/studio-base/src/panels/Map/getAccuracy.ts
+++ b/packages/studio-base/src/panels/Map/getAccuracy.ts
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MathNumericType, atan2, eigs, isNumber, unit } from "mathjs";
+
+import {
+  NavSatFixMsg,
+  NavSatFixPositionCovarianceType,
+} from "@foxglove/studio-base/panels/Map/types";
+
+type NumericPair = [MathNumericType, MathNumericType];
+
+/**
+ * Calculates the accuracy of a NavSatFix message, based on its type, and returns
+ * information suitable for display as a leaflet Ellipse.
+ *
+ * @param msg NavSatFix
+ * @returns radii and tilt (degrees from W)
+ */
+export function getAccuracy(
+  msg: NavSatFixMsg,
+): { radii: [number, number]; tilt: number } | undefined {
+  const covariance = msg.position_covariance;
+  if (!covariance) {
+    return undefined;
+  }
+
+  switch (msg.position_covariance_type) {
+    case undefined:
+      return undefined;
+    case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_UNKNOWN:
+      return undefined;
+    case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN: {
+      // Tilt is degrees from west
+      const eastVariance = covariance[0];
+      const northVariance = covariance[4];
+      return { radii: [Math.sqrt(eastVariance), Math.sqrt(northVariance)], tilt: 0 };
+    }
+    case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_APPROXIMATED:
+    case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN: {
+      // Discard altitude
+      const K = covariance;
+      const Klatlon = [
+        [K[0], K[1]],
+        [K[3], K[4]],
+      ];
+
+      // Compute the eigenvalues & vectors of the covariance matrix. They will
+      // be sorted in ascending order, so the largest value is eigenvalues[1]
+      // and the corresponding vector is in the rightmost column. Ellipse radii
+      // are based on the eigenvalues, and orientation on the vector.
+      try {
+        const eigen = eigs(Klatlon) as {
+          vectors: [NumericPair, NumericPair];
+          values: NumericPair;
+        };
+
+        // Eigenvectors are returned in columns
+        const eigenvector = [eigen.vectors[0][1], eigen.vectors[1][1]];
+        const eigenvalues = eigen.values;
+
+        if (
+          !isNumber(eigenvector[0]) ||
+          !isNumber(eigenvector[1]) ||
+          !isNumber(eigenvalues[0]) ||
+          !isNumber(eigenvalues[1])
+        ) {
+          return undefined;
+        }
+
+        // Ellipse `tilt` is defined as number of degrees from the negative x axis
+        const theta = unit(atan2(eigenvector[1], eigenvector[0]), "rad").toNumber("deg");
+        const tilt = -1 * theta;
+
+        const primaryRadius = Math.sqrt(eigenvalues[1]);
+        const secondaryRadius = Math.sqrt(eigenvalues[0]);
+
+        if (isNaN(tilt) || isNaN(primaryRadius) || isNaN(secondaryRadius)) {
+          throw new Error("Unable to calculate accuracy");
+        }
+
+        return {
+          radii: [primaryRadius, secondaryRadius],
+          tilt,
+        };
+      } catch (err) {
+        return undefined;
+      }
+    }
+  }
+}

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -335,7 +335,13 @@ export const SinglePointNoFix: StoryObj = {
 
 export const SinglePointDiagonalCovariance: StoryObj = {
   render: function Story() {
-    return <MapPanel />;
+    return (
+      <MapPanel
+        overrideConfig={{
+          zoomLevel: 12,
+        }}
+      />
+    );
   },
 
   decorators: [Wrapper],
@@ -377,7 +383,13 @@ export const SinglePointDiagonalCovariance: StoryObj = {
 
 export const SinglePointFullCovariance: StoryObj = {
   render: function Story() {
-    return <MapPanel />;
+    return (
+      <MapPanel
+        overrideConfig={{
+          zoomLevel: 21,
+        }}
+      />
+    );
   },
 
   decorators: [Wrapper],
@@ -405,7 +417,7 @@ export const SinglePointFullCovariance: StoryObj = {
                   status: NavSatFixStatus.STATUS_GBAS_FIX,
                   service: NavSatFixService.SERVICE_GPS,
                 },
-                position_covariance: [1, 2, 3, 2, 5000000, 6, 3, 6, 1000000000],
+                position_covariance: [5, -4, 0, -4, 6, 0, 0, 0, 1],
                 position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN,
               },
             },

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -339,6 +339,8 @@ export const SinglePointDiagonalCovariance: StoryObj = {
       <MapPanel
         overrideConfig={{
           zoomLevel: 12,
+          // increase contrast over water tile for diff threshold
+          topicColors: { "/gps": "#ff00ff" },
         }}
       />
     );
@@ -387,6 +389,8 @@ export const SinglePointFullCovariance: StoryObj = {
       <MapPanel
         overrideConfig={{
           zoomLevel: 21,
+          // increase contrast over water tile for diff threshold
+          topicColors: { "/gps": "#ff00ff" },
         }}
       />
     );

--- a/packages/studio-base/src/typings/index.d.ts
+++ b/packages/studio-base/src/typings/index.d.ts
@@ -9,3 +9,4 @@ import "./react";
 import "./overrides";
 import "./webpack-defines";
 import "./i18next";
+import "./leaflet-ellipse";

--- a/packages/studio-base/src/typings/leaflet-ellipse.d.ts
+++ b/packages/studio-base/src/typings/leaflet-ellipse.d.ts
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { LatLngExpression, Path, PathOptions } from "leaflet";
+
+// Types for leaflet-ellipse
+// http://jdfergason.github.io/Leaflet.Ellipse/
+
+declare module "leaflet" {
+  type Radii = [number, number];
+
+  class Ellipse extends Path {
+    public constructor(latlng: LatLngExpression, radii: Radii, tilt: number, options?: PathOptions);
+
+    public getLatLng(): LatLng;
+    public setLatLng(latlng: LatLngExpression): Ellipse;
+
+    public getTilt(): number;
+
+    public getRadius(): Radii;
+    public setRadius(radius: Radii): Ellipse;
+  }
+
+  function ellipse(
+    latlng: LatLngExpression,
+    radii: Radii,
+    tilt: number,
+    options?: PathOptions,
+  ): Ellipse;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,6 +3029,7 @@ __metadata:
     jszip: 3.10.1
     just-diff: 6.0.2
     leaflet: 1.9.4
+    leaflet-ellipse: 0.9.1
     lodash: 4.17.21
     mathjs: 11.8.0
     memoize-weak: 1.0.2
@@ -14979,6 +14980,13 @@ __metadata:
   version: 1.0.5
   resolution: "lazy-val@npm:1.0.5"
   checksum: 31e12e0b118826dfae74f8f3ff8ebcddfe4200ff88d0d448db175c7265ee537e0ba55488d411728246337f3ed3c9ec68416f10889f632a2ce28fb7a970909fb5
+  languageName: node
+  linkType: hard
+
+"leaflet-ellipse@npm:0.9.1":
+  version: 0.9.1
+  resolution: "leaflet-ellipse@npm:0.9.1"
+  checksum: 7882348084074bd12344ea962ef2cf42a1de2a97f0ad6d70a0455af9901f5e881c8da38698140351d5b559f33aec1b9e963cf2ec1a8c0b0b946b3c6935be2da8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**

Display NavSatFix covariances as ellipses on the Map Panel

**Description**

Currently, the map panel displays the accuracy of `NavSatFix` messages as a circle around the point, based on the max variance seen. There's enough information in the covariance matrix for us to display these as ellipses. We handle two cases of this, depending on the [covariance type](https://github.com/foxglove/studio/blob/50cf7b623ba307c5e5f5ccc77972ce7c5aeaecc4/packages/studio-base/src/panels/Map/types.ts#L17-L22).

This adds [leaflet-ellipse](https://www.npmjs.com/package/leaflet-ellipse) (Apache 2.0) as a dependency to render the ellipses.

The `getAccuracy` function has been moved to a separate file for testing, and extended in the following ways:

1. For the *diagonal known* type, we return both covariances as the radii for the ellipse, rather than the max of the two
2. For the *known* type, we use the two most significant eigenvalues from the matrix, and the eigenvector corresponding to the most significant value to determine the orientation.

FG-3873