### PR TITLE
Recreate a new MessagePipeline store when the player changes

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -3,15 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { debounce } from "lodash";
-import {
-  createContext,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { createContext, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { StoreApi, useStore } from "zustand";
 
 import { useGuaranteedContext } from "@foxglove/hooks";
@@ -84,13 +76,10 @@ export function MessagePipelineProvider({
   globalVariables,
 }: ProviderProps): React.ReactElement {
   const promisesToWaitForRef = useRef<FramePromise[]>([]);
-  const [store] = useState(() =>
-    createMessagePipelineStore({ promisesToWaitForRef, initialPlayer: player }),
-  );
-  useEffect(() => {
-    store.getState().dispatch({ type: "set-player", player });
-    player?.setPublishers(store.getState().allPublishers);
-  }, [player, store]);
+
+  const store = useMemo(() => {
+    return createMessagePipelineStore({ promisesToWaitForRef, initialPlayer: player });
+  }, [player]);
 
   const subscriptions = useStore(store, selectSubscriptions);
 

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -77,6 +77,13 @@ export function MessagePipelineProvider({
 }: ProviderProps): React.ReactElement {
   const promisesToWaitForRef = useRef<FramePromise[]>([]);
 
+  // We make a new store when the player changes. This throws away any state from the previous store
+  // and re-creates the pipeline functions and references. We make a new store to avoid holding onto
+  // any state from the previous store.
+  //
+  // Note: This throws away any publishers, subscribers, etc that panels may have registered. We
+  // are ok with this behavior because the <Workspace> re-mounts all panels when a player changes.
+  // The re-mounted panels will re-initialize and setup new publishers and subscribers.
   const store = useMemo(() => {
     return createMessagePipelineStore({ promisesToWaitForRef, initialPlayer: player });
   }, [player]);

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -68,7 +68,6 @@ type UpdatePlayerStateAction = {
 export type MessagePipelineStateAction =
   | UpdateSubscriberAction
   | UpdatePlayerStateAction
-  | { type: "set-player"; player: Player | undefined }
   | { type: "set-publishers"; id: string; payloads: AdvertiseOptions[] };
 
 export function createMessagePipelineStore({
@@ -328,28 +327,6 @@ export function reducer(
         allPublishers: flatten(Object.values(newPublishersById)),
       };
     }
-
-    case "set-player":
-      if (action.player === prevState.player) {
-        return prevState;
-      }
-      return {
-        ...prevState,
-        player: action.player,
-        lastCapabilities: [],
-        lastMessageEventByTopic: new Map(),
-        public: {
-          ...prevState.public,
-          sortedTopics: [],
-          datatypes: new Map(),
-          messageEventsBySubscriberId: new Map(),
-          startPlayback: undefined,
-          pausePlayback: undefined,
-          playUntil: undefined,
-          setPlaybackSpeed: undefined,
-          seekPlayback: undefined,
-        },
-      };
   }
 
   assertNever(


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Rather than attempting a manual cleanup of the pipeline store, create a new store when the player changes. This avoids situations where downstream (or even the store itself) is holding references through player changes. We want to treat player changes like a "reset the world" action.

I stumbled upon this while doing some memory/heap analysis during player changes. I wouldn't say this change is _strictly_ necessary but I did find it easier to reason about a clean "reset" more than a reset that preserved some bits of old state.

