### PR TITLE
Fix BlockLoader to update progress even when there are no results

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -105,7 +105,7 @@ describe("BlockLoader", () => {
     let count = 0;
     await loader.startLoading({
       progress: async (progress) => {
-        if (++count < 4) {
+        if (++count < 5) {
           return;
         }
 
@@ -161,6 +161,7 @@ describe("BlockLoader", () => {
         await loader.stopLoading();
       },
     });
+
     expect.assertions(1);
   });
 


### PR DESCRIPTION
**User-Facing Changes**
More consistent progress updates for `allFrames` when loading preloaded data.

**Description**
When loading blocks, the logic would bail early to the next block when the current block had no new messages. This early bail would not call `progress` to compute a new update for player state. By removing this early bail we correctly call `progress` when we update blocks. We can remove the early bail because the _for_ loop on results will be a no-op and the block update logic is otherwise the same for the bail and no-bail code paths.