### PR TITLE
Remove Promise.race from IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import EventEmitter from "eventemitter3";
+
 import { Condvar } from "@foxglove/den/async";
 import { VecQueue } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
@@ -27,6 +29,10 @@ type Options = {
   readAheadDuration?: Time;
 };
 
+interface EventTypes {
+  rangeChange: () => void;
+}
+
 /**
  * BufferedIterableSource proxies access to IIterableSource. It buffers the messageIterator by
  * reading ahead in the underlying source.
@@ -35,7 +41,7 @@ type Options = {
  * is the consumer and reads messages from cache while the startProducer method produces messages by
  * reading from the underlying source and populating the cache.
  */
-class BufferedIterableSource implements IIterableSource {
+class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterableSource {
   #source: CachingIterableSource;
 
   #readDone = false;
@@ -63,8 +69,13 @@ class BufferedIterableSource implements IIterableSource {
   #readAheadDuration: Time;
 
   public constructor(source: IIterableSource, opt?: Options) {
+    super();
+
     this.#readAheadDuration = opt?.readAheadDuration ?? DEFAULT_READ_AHEAD_DURATION;
     this.#source = new CachingIterableSource(source);
+
+    // pass-through the range change event
+    this.#source.on("rangeChange", () => this.emit("rangeChange"));
   }
 
   public async initialize(): Promise<Initalization> {
@@ -168,6 +179,7 @@ class BufferedIterableSource implements IIterableSource {
 
   public async terminate(): Promise<void> {
     this.#cache.clear();
+    this.#source.removeAllListeners("rangeChange");
     await this.#source.terminate();
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -30,7 +30,8 @@ type Options = {
 };
 
 interface EventTypes {
-  rangeChange: () => void;
+  /** Dispatched when the loaded ranges have changed. Use `loadedRanges()` to get the new ranges. */
+  loadedRangesChange: () => void;
 }
 
 /**
@@ -75,7 +76,7 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
     this.#source = new CachingIterableSource(source);
 
     // pass-through the range change event
-    this.#source.on("rangeChange", () => this.emit("rangeChange"));
+    this.#source.on("loadedRangesChange", () => this.emit("loadedRangesChange"));
   }
 
   public async initialize(): Promise<Initalization> {
@@ -179,7 +180,7 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
 
   public async terminate(): Promise<void> {
     this.#cache.clear();
-    this.#source.removeAllListeners("rangeChange");
+    this.#source.removeAllListeners("loadedRangesChange");
     await this.#source.terminate();
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -54,7 +54,8 @@ type Options = {
 };
 
 interface EventTypes {
-  rangeChange: () => void;
+  /** Dispatched when the loaded ranges have changed. Use `loadedRanges()` to get the new ranges. */
+  loadedRangesChange: () => void;
 }
 
 /**
@@ -457,13 +458,13 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     const rangeNs = Number(toNanoSec(subtract(this.#initResult.end, this.#initResult.start)));
     if (rangeNs === 0) {
       this.#loadedRangesCache = [{ start: 0, end: 1 }];
-      this.emit("rangeChange");
+      this.emit("loadedRangesChange");
       return;
     }
 
     if (this.#cache.length === 0) {
       this.#loadedRangesCache = [{ start: 0, end: 0 }];
-      this.emit("rangeChange");
+      this.emit("loadedRangesChange");
       return;
     }
 
@@ -497,7 +498,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     }
 
     this.#loadedRangesCache = ranges;
-    this.emit("rangeChange");
+    this.emit("loadedRangesChange");
   }
 
   // Purge the oldest cache block if adding sizeInBytes to the cache would exceed the maxTotalSizeBytes

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import EventEmitter from "eventemitter3";
 import { isEqual, sortedIndexBy } from "lodash";
 
 import { minIndexBy, sortedIndexByTuple } from "@foxglove/den/collection";
@@ -52,6 +53,10 @@ type Options = {
   maxTotalSize?: number;
 };
 
+interface EventTypes {
+  rangeChange: () => void;
+}
+
 /**
  * CachingIterableSource proxies access to IIterableSource through a memory buffer.
  *
@@ -59,7 +64,7 @@ type Options = {
  * buffer for previously read messages, then the underlying source is used and the messages are
  * cached when read.
  */
-class CachingIterableSource implements IIterableSource {
+class CachingIterableSource extends EventEmitter<EventTypes> implements IIterableSource {
   #source: IIterableSource;
 
   // Stores which topics we have been caching. See notes at usage site for why we store this.
@@ -82,6 +87,8 @@ class CachingIterableSource implements IIterableSource {
   #maxBlockSizeBytes: number;
 
   public constructor(source: IIterableSource, opt?: Options) {
+    super();
+
     this.#source = source;
     this.#maxTotalSizeBytes = opt?.maxTotalSize ?? 1073741824; // 1GB
     this.#maxBlockSizeBytes = opt?.maxBlockSize ?? 52428800; // 50MB
@@ -450,11 +457,13 @@ class CachingIterableSource implements IIterableSource {
     const rangeNs = Number(toNanoSec(subtract(this.#initResult.end, this.#initResult.start)));
     if (rangeNs === 0) {
       this.#loadedRangesCache = [{ start: 0, end: 1 }];
+      this.emit("rangeChange");
       return;
     }
 
     if (this.#cache.length === 0) {
       this.#loadedRangesCache = [{ start: 0, end: 0 }];
+      this.emit("rangeChange");
       return;
     }
 
@@ -488,6 +497,7 @@ class CachingIterableSource implements IIterableSource {
     }
 
     this.#loadedRangesCache = ranges;
+    this.emit("rangeChange");
   }
 
   // Purge the oldest cache block if adding sizeInBytes to the cache would exceed the maxTotalSizeBytes

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -192,7 +192,7 @@ describe("IterablePlayer", () => {
     await store.done;
 
     // Reset store to get state from the seeks
-    store.reset(3);
+    store.reset(2);
 
     // replace the message iterator with our own implementation
     // This implementation performs a seekPlayback during backfill.
@@ -273,7 +273,7 @@ describe("IterablePlayer", () => {
     // The state order:
     // 1. a state update completing the second seek
     // 1. a state update for moving to idle
-    expect(playerStates).toEqual([withMessages, baseState, baseState]);
+    expect(playerStates).toEqual([withMessages, baseState]);
 
     player.close();
   });
@@ -293,7 +293,7 @@ describe("IterablePlayer", () => {
     await store.done;
 
     // Reset store to get state from the seeks
-    store.reset(4);
+    store.reset(3);
 
     // replace the message iterator with our own implementation
     source.getBackfillMessages = async function () {
@@ -351,7 +351,7 @@ describe("IterablePlayer", () => {
     // The state order:
     // 1. a state update completing the second seek
     // 1. a state update for moving to idle
-    expect(playerStates).toEqual([bufferingState, baseState, baseState, baseState]);
+    expect(playerStates).toEqual([bufferingState, baseState, baseState]);
 
     player.close();
   });
@@ -410,7 +410,7 @@ describe("IterablePlayer", () => {
       enablePreload: false,
       sourceId: "test",
     });
-    const store = new PlayerStateStore(5);
+    const store = new PlayerStateStore(4);
     player.setSubscriptions([{ topic: "foo" }]);
     player.setListener(async (state) => await store.add(state));
 
@@ -455,7 +455,6 @@ describe("IterablePlayer", () => {
         presence: PlayerPresence.INITIALIZING,
         progress: {},
       },
-      { ...baseState, progress: {} },
       { ...baseState, progress: {} },
       { ...baseState, progress: {} },
       baseState,
@@ -574,7 +573,7 @@ describe("IterablePlayer", () => {
     await store.done;
 
     // Call set subscriptions and add a new topic
-    store.reset(3);
+    store.reset(2);
     player.setSubscriptions([{ topic: "foo" }, { topic: "bar" }]);
 
     await store.done;

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -947,33 +947,21 @@ export class IterablePlayer implements Player {
     const abort = (this.#abort = new AbortController());
     const aborted = new Promise((resolve) => abort.signal.addEventListener("abort", resolve));
 
-    // While idle, the buffered source might still be loading so we check it for range changes
-    // and queue and emit if there are changes.
-    //
-    // 100 ms second updates from the buffered source.
-    // The loadedRanges() call is memoized so this is cheap and will not queue state emit if
-    // there are no changes to the ranges.
-    const interval = setInterval(() => {
-      const newRanges = this.#bufferedSource.loadedRanges();
-      // Ranges are unchanged, so we don't need to update progress
-      if (newRanges === this.#progress.fullyLoadedFractionRanges) {
-        return;
-      }
-
-      // Ranges changed so update progress and queue an emit
+    const rangeChangeHandler = () => {
       this.#progress = {
         fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
         messageCache: this.#progress.messageCache,
       };
       this.#queueEmitState();
-    }, 100);
+    };
+
+    // While idle, the buffered source might still be loading and we still want to update downstream
+    // with the new ranges we've buffered. This event will update progress and queue state emits
+    this.#bufferedSource.on("rangeChange", rangeChangeHandler);
 
     this.#queueEmitState();
-    try {
-      await aborted;
-    } finally {
-      clearInterval(interval);
-    }
+    await aborted;
+    this.#bufferedSource.off("rangeChange", rangeChangeHandler);
   }
 
   async #statePlay() {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -957,11 +957,11 @@ export class IterablePlayer implements Player {
 
     // While idle, the buffered source might still be loading and we still want to update downstream
     // with the new ranges we've buffered. This event will update progress and queue state emits
-    this.#bufferedSource.on("rangeChange", rangeChangeHandler);
+    this.#bufferedSource.on("loadedRangesChange", rangeChangeHandler);
 
     this.#queueEmitState();
     await aborted;
-    this.#bufferedSource.off("rangeChange", rangeChangeHandler);
+    this.#bufferedSource.off("loadedRangesChange", rangeChangeHandler);
   }
 
   async #statePlay() {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import assert from "assert";
 import { isEqual } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
@@ -932,35 +933,46 @@ export class IterablePlayer implements Player {
   }
 
   async #stateIdle() {
+    assert(this.#abort == undefined, "Invariant: some other abort controller exists");
+
     this.#isPlaying = false;
     this.#presence = PlayerPresence.PRESENT;
-    this.#queueEmitState();
 
-    if (this.#abort) {
-      throw new Error("Invariant: some other abort controller exists");
-    }
+    // set the latest value of the loaded ranges for the next emit state
+    this.#progress = {
+      fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+      messageCache: this.#progress.messageCache,
+    };
+
     const abort = (this.#abort = new AbortController());
+    const aborted = new Promise((resolve) => abort.signal.addEventListener("abort", resolve));
 
-    const aborted = new Promise<void>((resolve) => {
-      abort.signal.addEventListener("abort", () => {
-        resolve();
-      });
-    });
+    // While idle, the buffered source might still be loading so we check it for range changes
+    // and queue and emit if there are changes.
+    //
+    // 100 ms second updates from the buffered source.
+    // The loadedRanges() call is memoized so this is cheap and will not queue state emit if
+    // there are no changes to the ranges.
+    const interval = setInterval(() => {
+      const newRanges = this.#bufferedSource.loadedRanges();
+      // Ranges are unchanged, so we don't need to update progress
+      if (newRanges === this.#progress.fullyLoadedFractionRanges) {
+        return;
+      }
 
-    for (;;) {
+      // Ranges changed so update progress and queue an emit
       this.#progress = {
         fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
         messageCache: this.#progress.messageCache,
       };
       this.#queueEmitState();
+    }, 100);
 
-      // When idling nothing is querying the source, but our buffered source might be
-      // buffering behind the scenes. Every second we emit state with an update to show that
-      // buffering is happening.
-      await Promise.race([delay(1000), aborted]);
-      if (this.#nextState) {
-        break;
-      }
+    this.#queueEmitState();
+    try {
+      await aborted;
+    } finally {
+      clearInterval(interval);
     }
   }
 
@@ -997,6 +1009,13 @@ export class IterablePlayer implements Player {
           return;
         }
 
+        // Update with the latest loaded ranges from the buffered source
+        // The messageCache is updated separately by block loader events
+        this.#progress = {
+          fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
+          messageCache: this.#progress.messageCache,
+        };
+
         // If subscriptions changed, update to the new subscriptions
         if (this.#allTopics !== allTopics) {
           // Discard any last message event since the new iterator will repeat it
@@ -1007,11 +1026,6 @@ export class IterablePlayer implements Player {
           this.#setState("reset-playback-iterator");
           return;
         }
-
-        this.#progress = {
-          fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
-          messageCache: this.#progress.messageCache,
-        };
 
         const time = Date.now() - start;
         // make sure we've slept at least 16 millis or so (aprox 1 frame)
@@ -1045,6 +1059,11 @@ export class IterablePlayer implements Player {
           fullyLoadedFractionRanges: this.#progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache,
         };
+
+        // If we are in playback, we will let playback queue state updates
+        if (this.#state === "play") {
+          return;
+        }
 
         this.#queueEmitState();
       },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When paused, the IterablePlayer would be in an idle state. In this state, we still want to emit updates if the buffered ranges have changed (to display in the playback bar). Prior to this change, the logic to do this would use an infinite loop that would emit an update every loop iteration. The loop iteration speed was controlled with a `Promise.race` between a 1 second delay and an abort signal that we want to change state.

We have recently learned of the evils of `Promise.race` with respect to long-running or un-resolved promises and leaking the return values of all contenders. For this particular case, there would be a "leak" when a user paused playback and leaves playback paused for a long time. The "leak" would be small since neither the delay promise or the abort promise return values that take up significant space.

However, since our goal is to banish `Promise.race` from the codebase and install a lint rule banning its use, this logic can be re-written to avoid the `Promise.race`. This change avoids the race and uses an event notification when there are updates to the cached ranges to queue an emit. The idle state function then waits on an abort signal (signaling the desire to change state) and removes the handler before moving to the next state.
