### PR TITLE
Remove stacktrace from Problems list error display

### DIFF
--- a/packages/studio-base/src/components/ProblemsList.tsx
+++ b/packages/studio-base/src/components/ProblemsList.tsx
@@ -111,7 +111,7 @@ function ProblemDetails(props: { details: DetailsType; tip?: string }): JSX.Elem
 
   const content = useMemo(() => {
     if (details instanceof Error) {
-      return <div className={classes.detailsText}>{details.stack}</div>;
+      return <div className={classes.detailsText}>{details.message}</div>;
     } else if (details != undefined && details !== "") {
       return (
         <Typography style={{ whiteSpace: "pre-line" /* allow newlines in the details message */ }}>
@@ -135,9 +135,9 @@ function ProblemDetails(props: { details: DetailsType; tip?: string }): JSX.Elem
 
 export function ProblemsList(): JSX.Element {
   const { classes } = useStyles();
-  const playerProblems = useMessagePipeline(selectPlayerProblems) ?? [];
+  const playerProblems = useMessagePipeline(selectPlayerProblems);
 
-  if (playerProblems.length === 0) {
+  if (playerProblems == undefined || playerProblems.length === 0) {
     return <EmptyState>No problems found</EmptyState>;
   }
 


### PR DESCRIPTION
**User-Facing Changes**
Remove un-actionable stack traces from problems list sidebar.

Before:
<img width="449" alt="Screenshot 2023-06-27 at 2 00 27 PM" src="https://github.com/foxglove/studio/assets/84792/cf0a60a4-f1a5-4b55-bff6-3572132c3e09">

After:
<img width="398" alt="Screenshot 2023-06-27 at 2 00 04 PM" src="https://github.com/foxglove/studio/assets/84792/579c8aed-3bed-4b36-9620-99f08ad3ea12">

**Description**
Rather than displaying a mangled and un-actionable stacktrace in the problems sidebar, show the message from the error. This is cleaner and typically contains actionable information.
