### PR TITLE
Remove Promise.race from installChromeExtensions

### DIFF
--- a/packages/studio-desktop/package.json
+++ b/packages/studio-desktop/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@actions/exec": "1.1.1",
     "@actions/tool-cache": "2.0.1",
+    "@foxglove/den": "workspace:*",
     "@foxglove/electron-socket": "2.1.1",
     "@foxglove/log": "workspace:*",
     "@foxglove/mcap-support": "workspace:*",

--- a/packages/studio-desktop/src/main/installChromeExtensions.ts
+++ b/packages/studio-desktop/src/main/installChromeExtensions.ts
@@ -4,29 +4,26 @@
 
 import installExtension, { REACT_DEVELOPER_TOOLS } from "electron-devtools-installer";
 
+import { PromiseTimeoutError, promiseTimeout } from "@foxglove/den/async";
 import Logger from "@foxglove/log";
 
 const log = Logger.getLogger(__filename);
 
 export default async function installChromeExtensions(): Promise<void> {
   log.info("Installing Chrome extensions for development...");
-  // Extension installation sometimes gets stuck between the download step and the extension loading step, for unknown reasons.
-  // So don't wait indefinitely for installation to complete.
-  let finished = false;
-  await Promise.race([
-    Promise.allSettled([installExtension(REACT_DEVELOPER_TOOLS)]).then((results) => {
-      finished = true;
-      log.info("Finished:", results);
-    }),
-    new Promise<void>((resolve) => {
-      setTimeout(() => {
-        if (!finished) {
-          console.warn(
-            "Warning: extension installation may be stuck; try relaunching electron or deleting its extensions directory. Continuing for now.",
-          );
-        }
-        resolve();
-      }, 5000);
-    }),
-  ]);
+
+  try {
+    // Extension installation sometimes gets stuck between the download step and the extension loading step, for unknown reasons.
+    // So don't wait indefinitely for installation to complete.
+    const result = await promiseTimeout(installExtension(REACT_DEVELOPER_TOOLS), 5000);
+    log.info("Finished extension install:", result);
+  } catch (err) {
+    if (err instanceof PromiseTimeoutError) {
+      console.warn(
+        "Warning: extension installation may be stuck; try relaunching electron or deleting its extensions directory. Continuing for now.",
+      );
+      return;
+    }
+    throw err;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,6 +3086,7 @@ __metadata:
   dependencies:
     "@actions/exec": 1.1.1
     "@actions/tool-cache": 2.0.1
+    "@foxglove/den": "workspace:*"
     "@foxglove/electron-socket": 2.1.1
     "@foxglove/log": "workspace:*"
     "@foxglove/mcap-support": "workspace:*"


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Instead of using `Promise.race` to timeout `installChromeExtensions` we use a single promise wrapper with a timeout. Our goal is to discourage the use of `Promise.race` which has memory leaks for unresolved promises.
