### PR TITLE
Support orgSlug in data source url params

### DIFF
--- a/packages/studio-base/src/components/AppBar/DataSource.tsx
+++ b/packages/studio-base/src/components/AppBar/DataSource.tsx
@@ -4,6 +4,7 @@
 
 import { ErrorCircle20Filled } from "@fluentui/react-icons";
 import { CircularProgress, IconButton } from "@mui/material";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
@@ -14,8 +15,11 @@ import {
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 import WssErrorModal from "@foxglove/studio-base/components/WssErrorModal";
+import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
+import { useConfirm } from "@foxglove/studio-base/hooks/useConfirm";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
+import { OrgSwitchRequiredError } from "@foxglove/studio-base/types/OrgSwitchRequiredError";
 
 import { EndTimestamp } from "./EndTimestamp";
 
@@ -84,6 +88,9 @@ export function DataSource(): JSX.Element {
   const playerProblems = useMessagePipeline(selectPlayerProblems) ?? [];
   const seek = useMessagePipeline(selectSeek);
 
+  const [confirm, confirmModal] = useConfirm();
+  const { signOut } = useCurrentUser();
+
   const { sidebarActions } = useWorkspaceActions();
 
   // A crude but correct proxy (for our current architecture) for whether a connection is live
@@ -94,10 +101,24 @@ export function DataSource(): JSX.Element {
   const error =
     playerPresence === PlayerPresence.ERROR ||
     playerProblems.some((problem) => problem.severity === "error");
+
   const loading = reconnecting || initializing;
 
   const playerDisplayName =
     initializing && playerName == undefined ? "Initializing..." : playerName;
+
+  const orgSwitchProblem = playerProblems.find(
+    (problem) => problem.error?.name === OrgSwitchRequiredError.name,
+  );
+  useEffect(() => {
+    if (orgSwitchProblem != undefined) {
+      void confirm({ title: orgSwitchProblem.message, ok: "Sign out" }).then((response) => {
+        if (response === "ok") {
+          void signOut?.();
+        }
+      });
+    }
+  }, [confirm, orgSwitchProblem, signOut]);
 
   if (playerPresence === PlayerPresence.NOT_PRESENT) {
     return <div className={classes.sourceName}>{t("noDataSource")}</div>;
@@ -106,6 +127,7 @@ export function DataSource(): JSX.Element {
   return (
     <>
       <WssErrorModal playerProblems={playerProblems} />
+      {confirmModal}
       <Stack direction="row" alignItems="center">
         <div className={classes.sourceName}>
           <div className={classes.textTruncate}>

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -48,6 +48,9 @@ export function LaunchingInDesktopScreen(): ReactElement {
           case "ds.url":
             desktopURL.searchParams.set("url", v);
             break;
+          case "ds.orgSlug":
+            desktopURL.searchParams.set("orgSlug", v);
+            break;
           case "time":
             desktopURL.searchParams.set("seekTo", v);
             break;

--- a/packages/studio-base/src/types/OrgSwitchRequiredError.ts
+++ b/packages/studio-base/src/types/OrgSwitchRequiredError.ts
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export class OrgSwitchRequiredError extends Error {
+  public override name = "OrgSwitchRequiredError";
+}


### PR DESCRIPTION
**User-Facing Changes**

When accessing files from data-platform, the logged in user may not be signed in with the correct org for that resource.  Previously an error was thrown in case, and with this PR we'll help the user understand the problem and help take the necessary next step:

<img width="1318" alt="belongs-elsewhere" src="https://github.com/foxglove/studio/assets/349687/1d62fae3-a150-48a7-bb32-6c7cbad5759d">

Also works in desktop and with the sidebar DataSource:

<img width="500" alt="desktop" src="https://github.com/foxglove/studio/assets/349687/8412854e-1ea5-4d1e-9e43-052b94ae2b66">

<img width="500" alt="switch" src="https://github.com/foxglove/studio/assets/349687/a40655f0-7bb1-44af-90dc-4510327175df">

(Keeping it a draft until the proposed solution is confirmed)