### PR TITLE
Improve raw messages panel rendering performance

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -196,6 +196,9 @@ function Value(props: ValueProps): JSX.Element {
     };
   }, []);
 
+  // The Tooltip and StyledIconButton components seem to be expensive to render so we
+  // track our hover state and render them conditionally only when this component is
+  // hovered.
   const [pointerOver, setPointerOver] = useState(false);
 
   return (

--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -32,9 +32,6 @@ const StyledIconButton = withStyles(HoverableIconButton, (theme) => ({
     "&.MuiIconButton-root": {
       fontSize: theme.typography.pxToRem(16),
       padding: 0,
-
-      "&:hover": { backgroundColor: "transparent" },
-      "&:not(:hover)": { opacity: 0.6 },
     },
   },
 }));

--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -196,27 +196,39 @@ function Value(props: ValueProps): JSX.Element {
     };
   }, []);
 
+  const [pointerOver, setPointerOver] = useState(false);
+
   return (
-    <Stack inline flexWrap="wrap" direction="row" alignItems="center" gap={0.25}>
+    <Stack
+      inline
+      flexWrap="wrap"
+      direction="row"
+      alignItems="center"
+      gap={0.25}
+      onPointerEnter={() => setPointerOver(true)}
+      onPointerLeave={() => setPointerOver(false)}
+    >
       <HighlightedValue itemLabel={itemLabel} />
       {arrLabel}
-      {availableActions.map((action) => (
-        <Tooltip key={action.key} arrow title={action.tooltip} placement="top">
-          <StyledIconButton
-            size="small"
-            activeColor={action.activeColor}
-            onClick={action.onClick}
-            color="inherit"
-            icon={action.icon}
-          />
-        </Tooltip>
-      ))}
-      <span className={cx(classes.placeholderActionContainer)}>
-        {placeholderActionsForSpacing.map((action) => (
+      {pointerOver &&
+        availableActions.map((action) => (
           <Tooltip key={action.key} arrow title={action.tooltip} placement="top">
-            <StyledIconButton size="small" color="inherit" icon={action.icon} />
+            <StyledIconButton
+              size="small"
+              activeColor={action.activeColor}
+              onClick={action.onClick}
+              color="inherit"
+              icon={action.icon}
+            />
           </Tooltip>
         ))}
+      <span className={cx(classes.placeholderActionContainer)}>
+        {pointerOver &&
+          placeholderActionsForSpacing.map((action) => (
+            <Tooltip key={action.key} arrow title={action.tooltip} placement="top">
+              <StyledIconButton size="small" color="inherit" icon={action.icon} />
+            </Tooltip>
+          ))}
       </span>
     </Stack>
   );


### PR DESCRIPTION
**User-Facing Changes**
Improve raw messages panel rendering performance.

**Description**
The `Tooltip` and `StyledIconButton` components in `Value` seem to be expensive to render. Render them conditionally only when the value element is hovered.

This brings the FPS of a 3 panel layout on `/imu` on nuscenes from about 13fps to 37.

<img width="1760" alt="Screenshot 2023-06-30 at 10 45 56 AM" src="https://github.com/foxglove/studio/assets/93935560/a58737c9-d381-494c-a99c-708aa5d6b657">
<img width="1765" alt="Screenshot 2023-06-30 at 10 46 15 AM" src="https://github.com/foxglove/studio/assets/93935560/259cb999-51c1-44cf-a68a-e5480648ffbb">


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
