### PR TITLE
Fix raw messages value hover icon opacity

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -31,6 +31,7 @@ const StyledIconButton = withStyles(HoverableIconButton, (theme) => ({
   root: {
     "&.MuiIconButton-root": {
       fontSize: theme.typography.pxToRem(16),
+      opacity: 0.6,
       padding: 0,
     },
   },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Restore partial raw messages icon opacity inadvertently set in https://github.com/foxglove/studio/pull/6344.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
