### PR TITLE
Ignore invalid diagonal covariance

### DIFF
--- a/packages/studio-base/src/panels/Map/getAccuracy.test.ts
+++ b/packages/studio-base/src/panels/Map/getAccuracy.test.ts
@@ -15,19 +15,30 @@ describe("getAccuracy", () => {
     altitude: 0,
   };
 
-  it("handles 'diagonal' covariance type", () => {
-    const msg: NavSatFixMsg = {
-      ...position,
-      position_covariance: [25, 0, 0, 0, 100, 0, 0, 0, 10000],
-      position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN,
-    };
-    const {
-      radii: [r1, r2],
-      tilt,
-    } = getAccuracy(msg)!;
-    expect(r1).toBeCloseTo(5);
-    expect(r2).toBeCloseTo(10);
-    expect(tilt).toBeCloseTo(0);
+  describe("'diagaonal' covariance type", () => {
+    it("returns an ellipsoid", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [25, 0, 0, 0, 100, 0, 0, 0, 10000],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN,
+      };
+      const {
+        radii: [r1, r2],
+        tilt,
+      } = getAccuracy(msg)!;
+      expect(r1).toBeCloseTo(5);
+      expect(r2).toBeCloseTo(10);
+      expect(tilt).toBeCloseTo(0);
+    });
+
+    it("returns undefined for invalid input", () => {
+      const msg: NavSatFixMsg = {
+        ...position,
+        position_covariance: [NaN, 0, 0, 0, NaN, 0, 0, 0, NaN],
+        position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN,
+      };
+      expect(getAccuracy(msg)).toBeUndefined();
+    });
   });
 
   describe("'known' covariance type", () => {

--- a/packages/studio-base/src/panels/Map/getAccuracy.ts
+++ b/packages/studio-base/src/panels/Map/getAccuracy.ts
@@ -35,6 +35,9 @@ export function getAccuracy(
       // Tilt is degrees from west
       const eastVariance = covariance[0];
       const northVariance = covariance[4];
+      if (isNaN(eastVariance) || isNaN(northVariance)) {
+        return undefined;
+      }
       return { radii: [Math.sqrt(eastVariance), Math.sqrt(northVariance)], tilt: 0 };
     }
     case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_APPROXIMATED:

--- a/packages/studio-base/src/panels/Map/getAccuracy.ts
+++ b/packages/studio-base/src/panels/Map/getAccuracy.ts
@@ -35,7 +35,7 @@ export function getAccuracy(
       // Tilt is degrees from west
       const eastVariance = covariance[0];
       const northVariance = covariance[4];
-      if (isNaN(eastVariance) || isNaN(northVariance)) {
+      if (!isFinite(eastVariance) || !isFinite(northVariance)) {
         return undefined;
       }
       return { radii: [Math.sqrt(eastVariance), Math.sqrt(northVariance)], tilt: 0 };
@@ -79,7 +79,7 @@ export function getAccuracy(
         const primaryRadius = Math.sqrt(eigenvalues[1]);
         const secondaryRadius = Math.sqrt(eigenvalues[0]);
 
-        if (isNaN(tilt) || isNaN(primaryRadius) || isNaN(secondaryRadius)) {
+        if (!isFinite(tilt) || !isFinite(primaryRadius) || !isFinite(secondaryRadius)) {
           return undefined;
         }
 


### PR DESCRIPTION
**User-Facing Changes**

Fix: return `undefined` accuracy when we receive an invalid value as part of a `COVARIANCE_TYPE_DIAGONAL_KNOWN` matrix.

**Description**

This returns undefined if either value is invalid. I don't imagine there's an expected case where only one value would be valid, but we could instead fall back to 0 there.

FG-4091