### PR TITLE
Improve raw messages panel rendering performance

### DIFF
--- a/packages/studio-base/src/components/CopyButton.tsx
+++ b/packages/studio-base/src/components/CopyButton.tsx
@@ -17,7 +17,7 @@ import { useCallback, useState, PropsWithChildren } from "react";
 
 import clipboard from "@foxglove/studio-base/util/clipboard";
 
-export default function CopyButton(
+function CopyButtonComponent(
   props: PropsWithChildren<{
     getText: () => string;
     size?: "small" | "medium" | "large";
@@ -84,3 +84,5 @@ export default function CopyButton(
     </Button>
   );
 }
+
+export default React.memo(CopyButtonComponent);

--- a/packages/studio-base/src/panels/RawMessages/DiffSpan.tsx
+++ b/packages/studio-base/src/panels/RawMessages/DiffSpan.tsx
@@ -2,12 +2,30 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { withStyles } from "tss-react/mui";
+import { CSSProperties, ReactNode } from "react";
+import { makeStyles } from "tss-react/mui";
 
-export const DiffSpan = withStyles("span", (theme) => ({
+const useStyles = makeStyles()((theme) => ({
   root: {
     padding: theme.spacing(0, 0.5),
     textDecoration: "inherit",
     whiteSpace: "pre-line",
   },
 }));
+
+type Props = {
+  children?: ReactNode;
+  style?: CSSProperties;
+};
+
+export function DiffSpan(props: Props): JSX.Element {
+  const { children, style } = props;
+
+  const { classes } = useStyles();
+
+  return (
+    <span className={classes.root} style={style}>
+      {children}
+    </span>
+  );
+}

--- a/packages/studio-base/src/panels/RawMessages/MaybeCollapsedValue.tsx
+++ b/packages/studio-base/src/panels/RawMessages/MaybeCollapsedValue.tsx
@@ -30,6 +30,11 @@ export default function MaybeCollapsedValue({ itemLabel }: Props): JSX.Element {
     ? itemLabel
     : itemLabel.slice(0, COLLAPSE_TEXT_OVER_LENGTH);
 
+  // Tooltip is expensive to render. Skip it if we're not truncating.
+  if (!lengthOverLimit) {
+    return <span>{itemLabel}</span>;
+  }
+
   return (
     <Tooltip
       title={!showingEntireLabel ? "Text was truncated, click to see all" : ""}

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -13,6 +13,7 @@
 
 import { Link, Typography } from "@mui/material";
 import { useCallback } from "react";
+import { useLatest } from "react-use";
 import { makeStyles } from "tss-react/mui";
 
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
@@ -57,13 +58,21 @@ export default function Metadata({
   diffMessage,
 }: Props): JSX.Element {
   const { classes } = useStyles();
+
+  const latestData = useLatest(data);
+  const latestDiffData = useLatest(diffData);
+
   const docsLink = datatype ? getMessageDocumentationLink(datatype) : undefined;
-  const copyData = useCallback(() => JSON.stringify(data, copyMessageReplacer, 2) ?? "", [data]);
+  const copyData = useCallback(
+    () => JSON.stringify(latestData.current, copyMessageReplacer, 2) ?? "",
+    [latestData],
+  );
   const copyDiffData = useCallback(
-    () => JSON.stringify(diffData, copyMessageReplacer, 2) ?? "",
-    [diffData],
+    () => JSON.stringify(latestDiffData.current, copyMessageReplacer, 2) ?? "",
+    [latestDiffData],
   );
   const copyDiff = useCallback(() => JSON.stringify(diff, copyMessageReplacer, 2) ?? "", [diff]);
+
   return (
     <Stack alignItems="flex-start" paddingInline={0.25} paddingBlockStart={0.75}>
       <Stack direction="row" alignItems="center" gap={0.5}>

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -59,7 +59,8 @@ export default function Metadata({
 }: Props): JSX.Element {
   const { classes } = useStyles();
 
-  // Access these by ref so that CopyButton memoization works.
+  // Access these by ref so that our callbacks aren't invalidated and CopyButton
+  // memoization is stable.
   const latestData = useLatest(data);
   const latestDiffData = useLatest(diffData);
 

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -59,6 +59,7 @@ export default function Metadata({
 }: Props): JSX.Element {
   const { classes } = useStyles();
 
+  // Access these by ref so that CopyButton memoization works.
   const latestData = useLatest(data);
   const latestDiffData = useLatest(diffData);
 

--- a/packages/studio-base/src/panels/RawMessages/Toolbar.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Toolbar.tsx
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import DiffIcon from "@mui/icons-material/Difference";
+import DiffOutlinedIcon from "@mui/icons-material/DifferenceOutlined";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
+import { IconButton, MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
+
+import { Topic } from "@foxglove/studio";
+import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
+import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import Stack from "@foxglove/studio-base/components/Stack";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
+
+import { Constants, RawMessagesPanelConfig } from "./types";
+
+type Props = {
+  canExpandAll: boolean;
+  diffEnabled: boolean;
+  diffMethod: RawMessagesPanelConfig["diffMethod"];
+  diffTopicPath: string;
+  onDiffTopicPathChange: (path: string) => void;
+  onToggleDiff: () => void;
+  onToggleExpandAll: () => void;
+  onTopicPathChange: (path: string) => void;
+  saveConfig: SaveConfig<RawMessagesPanelConfig>;
+  topic?: Topic;
+  topicPath: string;
+};
+
+const useStyles = makeStyles()((theme) => ({
+  iconButton: {
+    "&.MuiIconButton-root": {
+      padding: theme.spacing(0.25),
+    },
+  },
+}));
+
+function ToolbarComponent(props: Props): JSX.Element {
+  const {
+    canExpandAll,
+    diffEnabled,
+    diffMethod,
+    diffTopicPath,
+    onDiffTopicPathChange,
+    onToggleDiff,
+    onToggleExpandAll,
+    onTopicPathChange,
+    saveConfig,
+    topic,
+    topicPath,
+  } = props;
+
+  const { classes } = useStyles();
+
+  return (
+    <PanelToolbar>
+      <IconButton
+        className={classes.iconButton}
+        title="Toggle diff"
+        onClick={onToggleDiff}
+        color={diffEnabled ? "default" : "inherit"}
+        size="small"
+      >
+        {diffEnabled ? <DiffIcon fontSize="small" /> : <DiffOutlinedIcon fontSize="small" />}
+      </IconButton>
+      <IconButton
+        className={classes.iconButton}
+        title={canExpandAll ? "Expand all" : "Collapse all"}
+        onClick={onToggleExpandAll}
+        data-testid="expand-all"
+        size="small"
+      >
+        {canExpandAll ? <UnfoldMoreIcon fontSize="small" /> : <UnfoldLessIcon fontSize="small" />}
+      </IconButton>
+      <Stack fullWidth paddingLeft={0.25}>
+        <MessagePathInput
+          index={0}
+          path={topicPath}
+          onChange={onTopicPathChange}
+          inputStyle={{ height: 20 }}
+        />
+        {diffEnabled && (
+          <Stack direction="row" flex="auto">
+            <Select
+              variant="filled"
+              size="small"
+              title="Diff method"
+              value={diffMethod}
+              MenuProps={{ MenuListProps: { dense: true } }}
+              onChange={(event: SelectChangeEvent) =>
+                saveConfig({
+                  diffMethod: event.target.value as RawMessagesPanelConfig["diffMethod"],
+                })
+              }
+            >
+              <MenuItem value={Constants.PREV_MSG_METHOD}>{Constants.PREV_MSG_METHOD}</MenuItem>
+              <MenuItem value={Constants.CUSTOM_METHOD}>custom</MenuItem>
+            </Select>
+            {diffMethod === Constants.CUSTOM_METHOD && (
+              <MessagePathInput
+                index={1}
+                path={diffTopicPath}
+                onChange={onDiffTopicPathChange}
+                inputStyle={{ height: "100%" }}
+                {...(topic ? { prioritizedDatatype: topic.schemaName } : {})}
+              />
+            )}
+          </Stack>
+        )}
+      </Stack>
+    </PanelToolbar>
+  );
+}
+
+export const Toolbar = React.memo(ToolbarComponent);

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -13,8 +13,7 @@
 
 import { StoryObj } from "@storybook/react";
 
-import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
-import { RawMessagesPanelConfig } from "@foxglove/studio-base/panels/RawMessages/types";
+import RawMessages from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import {
@@ -27,6 +26,7 @@ import {
   topicsWithIdsToDiffFixture,
   withMissingData,
 } from "./fixture";
+import { Constants, RawMessagesPanelConfig } from "./types";
 
 const noDiffConfig = {
   diffMethod: "custom",
@@ -313,7 +313,7 @@ export const DiffConsecutiveMessages: StoryObj = {
       <RawMessages
         overrideConfig={{
           topicPath: "/foo",
-          diffMethod: PREV_MSG_METHOD,
+          diffMethod: Constants.PREV_MSG_METHOD,
           diffTopicPath: "",
           diffEnabled: true,
           showFullMessageForDiff: true,
@@ -330,7 +330,7 @@ export const DiffConsecutiveMessagesWithFilter: StoryObj = {
       <RawMessages
         overrideConfig={{
           topicPath: "/foo{type==2}",
-          diffMethod: PREV_MSG_METHOD,
+          diffMethod: Constants.PREV_MSG_METHOD,
           diffTopicPath: "",
           diffEnabled: true,
           showFullMessageForDiff: true,
@@ -347,7 +347,7 @@ export const DiffConsecutiveMessagesWithBigint: StoryObj = {
       <RawMessages
         overrideConfig={{
           topicPath: "/baz/bigint",
-          diffMethod: PREV_MSG_METHOD,
+          diffMethod: Constants.PREV_MSG_METHOD,
           diffTopicPath: "",
           diffEnabled: true,
           showFullMessageForDiff: true,
@@ -364,7 +364,7 @@ export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet: 
       <RawMessages
         overrideConfig={{
           topicPath: "/foo",
-          diffMethod: PREV_MSG_METHOD,
+          diffMethod: Constants.PREV_MSG_METHOD,
           diffTopicPath: "/another/baz/enum_advanced",
           diffEnabled: false,
           showFullMessageForDiff: true,

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -11,23 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import DiffIcon from "@mui/icons-material/Difference";
-import DiffOutlinedIcon from "@mui/icons-material/DifferenceOutlined";
-import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
-import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
-import {
-  Checkbox,
-  FormControlLabel,
-  IconButton,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-  useTheme,
-  Typography,
-} from "@mui/material";
+import { Checkbox, FormControlLabel, Typography, useTheme } from "@mui/material";
 // eslint-disable-next-line no-restricted-imports
-import { first, isEqual, get, last, padStart } from "lodash";
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { first, get, isEqual, last, padStart } from "lodash";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
 import { makeStyles } from "tss-react/mui";
@@ -36,10 +23,9 @@ import { Immutable } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import useGetItemStringWithTimezone from "@foxglove/studio-base/components/JsonTree/useGetItemStringWithTimezone";
-import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import {
-  RosPath,
   MessagePathStructureItem,
+  RosPath,
 } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
 import {
   messagePathStructures,
@@ -50,12 +36,12 @@ import { MessagePathDataItem } from "@foxglove/studio-base/components/MessagePat
 import { useMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useMessageDataItem";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { Toolbar } from "@foxglove/studio-base/panels/RawMessages/Toolbar";
 import getDiff, {
+  DiffObject,
   diffLabels,
   diffLabelsByLabelText,
-  DiffObject,
 } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -70,14 +56,11 @@ import Metadata from "./Metadata";
 import Value from "./Value";
 import {
   ValueAction,
-  getValueActionForValue,
   getStructureItemForPath,
+  getValueActionForValue,
 } from "./getValueActionForValue";
-import { RawMessagesPanelConfig } from "./types";
+import { Constants, RawMessagesPanelConfig } from "./types";
 import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths } from "./utils";
-
-export const CUSTOM_METHOD = "custom";
-export const PREV_MSG_METHOD = "previous message";
 
 type Props = {
   config: Immutable<RawMessagesPanelConfig>;
@@ -105,11 +88,6 @@ function maybeDeepParse(val: unknown) {
 }
 
 const useStyles = makeStyles()((theme) => ({
-  iconButton: {
-    "&.MuiIconButton-root": {
-      padding: theme.spacing(0.25),
-    },
-  },
   topic: {
     fontFamily: fonts.SANS_SERIF,
     fontFeatureSettings: `${theme.typography.fontFeatureSettings}, "zero"`,
@@ -170,7 +148,7 @@ function RawMessages(props: Props) {
   const currTickObj = matchedMessages[matchedMessages.length - 1];
   const prevTickObj = matchedMessages[matchedMessages.length - 2];
 
-  const inTimetickDiffMode = diffEnabled && diffMethod === PREV_MSG_METHOD;
+  const inTimetickDiffMode = diffEnabled && diffMethod === Constants.PREV_MSG_METHOD;
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
@@ -400,7 +378,7 @@ function RawMessages(props: Props) {
     if (topicPath.length === 0) {
       return <EmptyState>No topic selected</EmptyState>;
     }
-    if (diffEnabled && diffMethod === CUSTOM_METHOD && (!baseItem || !diffItem)) {
+    if (diffEnabled && diffMethod === Constants.CUSTOM_METHOD && (!baseItem || !diffItem)) {
       return (
         <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${diffTopicPath}"`}</EmptyState>
       );
@@ -659,62 +637,18 @@ function RawMessages(props: Props) {
 
   return (
     <Stack flex="auto" overflow="hidden" position="relative">
-      <PanelToolbar>
-        <IconButton
-          className={classes.iconButton}
-          title="Toggle diff"
-          onClick={onToggleDiff}
-          color={diffEnabled ? "default" : "inherit"}
-          size="small"
-        >
-          {diffEnabled ? <DiffIcon fontSize="small" /> : <DiffOutlinedIcon fontSize="small" />}
-        </IconButton>
-        <IconButton
-          className={classes.iconButton}
-          title={canExpandAll ? "Expand all" : "Collapse all"}
-          onClick={onToggleExpandAll}
-          data-testid="expand-all"
-          size="small"
-        >
-          {canExpandAll ? <UnfoldMoreIcon fontSize="small" /> : <UnfoldLessIcon fontSize="small" />}
-        </IconButton>
-        <Stack fullWidth paddingLeft={0.25}>
-          <MessagePathInput
-            index={0}
-            path={topicPath}
-            onChange={onTopicPathChange}
-            inputStyle={{ height: 20 }}
-          />
-          {diffEnabled && (
-            <Stack direction="row" flex="auto">
-              <Select
-                variant="filled"
-                size="small"
-                title="Diff method"
-                value={diffMethod}
-                MenuProps={{ MenuListProps: { dense: true } }}
-                onChange={(event: SelectChangeEvent) =>
-                  saveConfig({
-                    diffMethod: event.target.value as RawMessagesPanelConfig["diffMethod"],
-                  })
-                }
-              >
-                <MenuItem value={PREV_MSG_METHOD}>{PREV_MSG_METHOD}</MenuItem>
-                <MenuItem value={CUSTOM_METHOD}>custom</MenuItem>
-              </Select>
-              {diffMethod === CUSTOM_METHOD && (
-                <MessagePathInput
-                  index={1}
-                  path={diffTopicPath}
-                  onChange={onDiffTopicPathChange}
-                  inputStyle={{ height: "100%" }}
-                  {...(topic ? { prioritizedDatatype: topic.schemaName } : {})}
-                />
-              )}
-            </Stack>
-          )}
-        </Stack>
-      </PanelToolbar>
+      <Toolbar
+        canExpandAll={canExpandAll}
+        diffEnabled={diffEnabled}
+        diffMethod={diffMethod}
+        diffTopicPath={diffTopicPath}
+        onDiffTopicPathChange={onDiffTopicPathChange}
+        onToggleDiff={onToggleDiff}
+        onToggleExpandAll={onToggleExpandAll}
+        onTopicPathChange={onTopicPathChange}
+        saveConfig={saveConfig}
+        topicPath={topicPath}
+      />
       {renderSingleTopicOrDiffOutput()}
     </Stack>
   );
@@ -722,7 +656,7 @@ function RawMessages(props: Props) {
 
 const defaultConfig: RawMessagesPanelConfig = {
   diffEnabled: false,
-  diffMethod: CUSTOM_METHOD,
+  diffMethod: Constants.CUSTOM_METHOD,
   diffTopicPath: "",
   showFullMessageForDiff: false,
   topicPath: "",

--- a/packages/studio-base/src/panels/RawMessages/types.ts
+++ b/packages/studio-base/src/panels/RawMessages/types.ts
@@ -13,3 +13,8 @@ export type RawMessagesPanelConfig = {
   showFullMessageForDiff: boolean;
   topicPath: string;
 };
+
+export const Constants = {
+  CUSTOM_METHOD: "custom",
+  PREV_MSG_METHOD: "previous message",
+} as const;


### PR DESCRIPTION
**User-Facing Changes**
Improve raw messages panel rendering performance.

**Description**
Improve raw messages panel rendering performance.

Includes the following changes:
1. Factor out the toolbar into a separate memoized component.
2. Memoize the CopyButton component and stabilize its properties.
3. Optimize rendering of the `MaybeCollapsedValue` component for the non-truncated case.

This improves rendering framerate for a layout with 7 panels rendering `/imu` from nuscenes from ~18fps to ~40fps:

before:
<img width="1723" alt="Screenshot 2023-07-03 at 10 23 34 AM" src="https://github.com/foxglove/studio/assets/93935560/828adecc-48b3-477e-a066-697c8ceea9a2">

after:
<img width="1730" alt="Screenshot 2023-07-03 at 10 22 30 AM" src="https://github.com/foxglove/studio/assets/93935560/894077fa-2f7a-4a20-a1ae-438ec1b09010">

And the flame chart no longer shows emotion as a significant contributor to render time:
<img width="1727" alt="Screenshot 2023-07-03 at 10 23 01 AM" src="https://github.com/foxglove/studio/assets/93935560/383bc045-7616-4aff-b16c-11f849c2543b">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
