### PR TITLE
Limit text width in cells in table panel

### DIFF
--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -66,12 +66,10 @@ const useStyles = makeStyles<void, "tableData" | "tableHeader">()((theme, _param
     },
   },
   tableData: {
-    padding: `${theme.spacing(0.5)} !important`,
-    whiteSpace: "nowrap",
-    textOverflow: "ellipsis",
-    verticalAlign: "top",
     border: `1px solid ${theme.palette.divider}`,
     lineHeight: "1.3em",
+    padding: `${theme.spacing(0.5)} !important`,
+    verticalAlign: "top",
   },
   tableHeader: {
     color: theme.palette.text.primary,
@@ -128,8 +126,8 @@ function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonCl
           );
         }
 
-        // In case the value is null.
-        return `${value}`;
+        // Interpolate in case the value is null.
+        return <TextCellContent value={`${value}`} />;
       },
     });
   });
@@ -155,6 +153,21 @@ function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonCl
   }
 
   return columns;
+}
+
+function TextCellContent(props: { value: string }): JSX.Element {
+  return (
+    <div
+      style={{
+        display: "-webkit-box",
+        overflow: "hidden",
+        WebkitLineClamp: 1,
+        WebkitBoxOrient: "vertical",
+      }}
+    >
+      {`${props.value}`}
+    </div>
+  );
 }
 
 export default function Table({

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -159,10 +159,10 @@ function TextCellContent(props: { value: string }): JSX.Element {
   return (
     <div
       style={{
-        display: "-webkit-box",
+        maxWidth: "75vw",
         overflow: "hidden",
-        WebkitLineClamp: 1,
-        WebkitBoxOrient: "vertical",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
       }}
     >
       {`${props.value}`}

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -99,6 +99,12 @@ const useStyles = makeStyles<void, "tableData" | "tableHeader">()((theme, _param
       backgroundColor: "transparent",
     },
   },
+  textContent: {
+    maxWidth: "75vw",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
 }));
 
 const columnHelper = createColumnHelper<CellValue>();
@@ -156,18 +162,9 @@ function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonCl
 }
 
 function TextCellContent(props: { value: string }): JSX.Element {
-  return (
-    <div
-      style={{
-        maxWidth: "75vw",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-      }}
-    >
-      {`${props.value}`}
-    </div>
-  );
+  const { classes } = useStyles();
+
+  return <div className={classes.textContent}>{props.value}</div>;
 }
 
 export default function Table({

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -6,6 +6,7 @@ import { StoryObj } from "@storybook/react";
 import { fireEvent, userEvent, within } from "@storybook/testing-library";
 
 import Table from "@foxglove/studio-base/panels/Table";
+import { mockMessage } from "@foxglove/studio-base/players/TopicAliasingPlayer/mocks";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
 const makeArrayData = ({
@@ -58,6 +59,32 @@ const fixture: Fixture = {
   },
 };
 
+const longTextFixture: Fixture = {
+  datatypes: new Map([
+    [
+      "schema",
+      {
+        definitions: [
+          { type: "string", name: "value_a", isConstant: false, isArray: false },
+          { type: "string", name: "value_b", isConstant: false, isArray: false },
+        ],
+      },
+    ],
+  ]),
+  topics: [{ name: "topic", schemaName: "schema" }],
+  frame: {
+    topic: [
+      mockMessage(
+        {
+          value_a: Array(30).fill("Long string that could wrap.").join(" \n"),
+          value_b: "Another value",
+        },
+        { topic: "topic" },
+      ),
+    ],
+  },
+};
+
 export default {
   title: "panels/Table",
 };
@@ -74,6 +101,14 @@ export const NoData: StoryObj = {
   render: () => (
     <PanelSetup fixture={{ frame: {}, topics: [] }}>
       <Table overrideConfig={{ topicPath: "/unknown" }} />
+    </PanelSetup>
+  ),
+};
+
+export const LongTextValue: StoryObj = {
+  render: () => (
+    <PanelSetup fixture={longTextFixture}>
+      <Table overrideConfig={{ topicPath: "topic" }} />
     </PanelSetup>
   ),
 };


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Limit text width in cells in the table panel.

Set to `75vw` max width, which is somewhat arbitrary but seems like an ok compromise.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
