### PR TITLE
Allow custom layer URDF to use param:// URLs, add frame prefix setting

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -245,7 +245,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         const fields: SettingsTreeFields = {
           url: { label: "URL", input: "string", placeholder, help, value: config.url ?? "" },
           framePrefix: {
-            label: "frame prefix",
+            label: "Frame prefix",
             input: "string",
             help: "Prefix to apply to all frame names (also often called tfPrefix)",
             value: config.framePrefix ?? "",
@@ -580,6 +580,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
 
     // Clear any previous parsed data for this instanceId
+    const transforms = this.#transformsByInstanceId.get(instanceId) ?? [];
+    for (const transform of transforms) {
+      this.renderer.removeTransform(transform.child, transform.parent, 0n);
+    }
     this.#transformsByInstanceId.delete(instanceId);
     this.#framesByInstanceId.delete(instanceId);
     this.updateSettingsTree();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -4,7 +4,7 @@
 
 import { vec3 } from "gl-matrix";
 import i18next from "i18next";
-import { maxBy } from "lodash";
+import { debounce, maxBy } from "lodash";
 import * as THREE from "three";
 
 import { UrdfGeometryMesh, UrdfRobot, UrdfVisual, parseRobot, UrdfJoint } from "@foxglove/den/urdf";
@@ -427,7 +427,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       if (path[1] === PARAM_KEY) {
         this.#loadUrdf(instanceId, this.renderer.parameters?.get(PARAM_NAME) as string | undefined);
       } else {
-        this.#loadUrdf(instanceId, undefined);
+        this.#debouncedLoadUrdf(instanceId, undefined);
       }
     }
   };
@@ -647,6 +647,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         );
       });
   }
+
+  #debouncedLoadUrdf = debounce(this.#loadUrdf.bind(this), 500);
 
   #loadRobot(renderable: UrdfRenderable, { robot, frames, transforms }: ParsedUrdf): void {
     const renderer = this.renderer;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -451,10 +451,21 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
 
   #handleParametersChange = (parameters: ReadonlyMap<string, unknown> | undefined): void => {
     const robotDescription = parameters?.get(PARAM_NAME);
-    if (typeof robotDescription !== "string") {
-      return;
+    if (typeof robotDescription === "string") {
+      this.#loadUrdf(PARAM_KEY, robotDescription);
     }
-    this.#loadUrdf(PARAM_KEY, robotDescription);
+
+    // Update custom layer URDFs that use param:// URLs.
+    for (const [instanceId, renderable] of this.renderables.entries()) {
+      const url = (renderable.userData.settings as Partial<LayerSettingsCustomUrdf>).url ?? "";
+      if (url.startsWith("param://")) {
+        const paramName = url.slice("param://".length);
+        const urdf = parameters?.get(paramName);
+        if (typeof urdf === "string") {
+          this.#loadUrdf(instanceId, urdf);
+        }
+      }
+    }
   };
 
   #handleAddUrdf = (instanceId: string): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -423,11 +423,13 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     } else if (path.length === 3) {
       // ["layers", instanceId, field]
       this.saveSetting(path, action.payload.value);
-      const instanceId = path[1]!;
+      const [_layers, instanceId, field] = path as [string, string, string];
       if (path[1] === PARAM_KEY) {
         this.#loadUrdf(instanceId, this.renderer.parameters?.get(PARAM_NAME) as string | undefined);
-      } else {
+      } else if (field === "framePrefix") {
         this.#debouncedLoadUrdf(instanceId, undefined);
+      } else {
+        this.#loadUrdf(instanceId, undefined);
       }
     }
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
@@ -97,6 +97,29 @@ const URDF2 = `<?xml version="1.0"?>
   </joint>
 </robot>`;
 
+const URDF3 = `<?xml version="1.0"?>
+<robot name="URDF Test3">
+  <material name="base-sphere-material"><color rgba="${BLUE}"/></material>
+  <material name="sphere-material"><color rgba="${RED}"/></material>
+  <link name="base_link">
+    <visual>
+      <geometry><sphere radius="0.2"/></geometry>
+      <material name="base-sphere-material"/>
+    </visual>
+  </link>
+  <joint name="base_sphere_box_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="sphere_link"/>
+    <origin rpy="0 0 0" xyz="0 0 0.3"/>
+  </joint>
+  <link name="sphere_link">
+    <visual>
+      <geometry><sphere radius="0.1"/></geometry>
+      <material name="sphere-material"/>
+    </visual>
+  </link>
+</robot>`;
+
 export default {
   title: "panels/ThreeDeeRender",
   component: ThreeDeePanel,
@@ -104,7 +127,10 @@ export default {
 
 export const Urdfs: StoryObj = {
   render: function Story() {
-    const topics: Topic[] = [{ name: "/robot_description", schemaName: "std_msgs/String" }];
+    const topics: Topic[] = [
+      { name: "/robot_description", schemaName: "std_msgs/String" },
+      { name: "/tf_static", schemaName: "tf2_msgs/TFMessage" },
+    ];
     const robot_description: MessageEvent<{ data: string }> = {
       topic: "/robot_description",
       receiveTime: { sec: 10, nsec: 0 },
@@ -114,7 +140,29 @@ export const Urdfs: StoryObj = {
       schemaName: "std_msgs/String",
       sizeInBytes: 0,
     };
+    const mesh_T_robot_1 = {
+      header: {
+        frame_id: "mesh-no-material",
+      },
+      child_frame_id: "robot_1/base_link",
+      transform: {
+        translation: {
+          x: 0,
+          y: -3,
+          z: 0,
+        },
+        rotation: {
+          w: 1,
+        },
+      },
+    };
+    const mesh_T_robot_2 = {
+      ...mesh_T_robot_1,
+      child_frame_id: "robot_2/base_link",
+      transform: { ...mesh_T_robot_1.transform, translation: { x: 1, y: -1 } },
+    };
 
+    const urdfParamName = "/some_ns/robot_description";
     const fixture = useDelayedFixture({
       topics,
       frame: {
@@ -122,7 +170,21 @@ export const Urdfs: StoryObj = {
       },
       capabilities: [],
       activeData: {
-        currentTime: undefined,
+        currentTime: { sec: 0, nsec: 0 },
+        parameters: new Map([[urdfParamName, URDF3]]),
+        messages: [
+          // Add transforms for the URDF instances that use a `framePrefix`, as these use the
+          // same URDF and would otherwise displayed on top of each other.
+          {
+            topic: "/tf_static",
+            schemaName: "tf2_msgs/TFMessage",
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 0,
+            message: {
+              transforms: [mesh_T_robot_1, mesh_T_robot_2],
+            },
+          },
+        ],
       },
     });
 
@@ -143,6 +205,16 @@ export const Urdfs: StoryObj = {
               urdf: {
                 layerId: "foxglove.Urdf",
                 url: encodeURI(`data:text/xml;utf8,${URDF2}`),
+              },
+              paramUrdfRobot1: {
+                layerId: "foxglove.Urdf",
+                url: `param://${urdfParamName}`,
+                framePrefix: `robot_1/`,
+              },
+              paramUrdfRobot2: {
+                layerId: "foxglove.Urdf",
+                url: `param://${urdfParamName}`,
+                framePrefix: `robot_2/`,
               },
             },
             cameraState: {


### PR DESCRIPTION
**User-Facing Changes**
- Custom layer URDF: Allow `param://` URLs and add frame prefix setting

**Description**
Adds the possibility to specify `param://<param_name>` URLs in the custom layer URDF. This will make it easier to visualize multiple URDFs when using datasources that provide parameter support (foxglove websocket, rosbridge, ros1 native). Besides allowing to load URDFs from a parameter, this PR also adds support for the frame prefix (also commonly called tfPrefix) setting. This setting allows to visualize different robots that share the same URDF definition but the [robot_state_publisher](https://index.ros.org/p/robot_state_publisher/github-ros-robot_state_publisher) publishes their transforms with a individual prefix.

Fixes FG-3292
Fixes FG-4057

Related: 
- https://github.com/orgs/foxglove/discussions/407
- https://github.com/orgs/foxglove/discussions/759
- https://github.com/orgs/foxglove/discussions/712

![image](https://github.com/foxglove/studio/assets/9250155/d064ed1f-28c6-473b-8e43-b3f3b52caa7c)


