### PR TITLE
perf: optimized useDeepMemo with dependencies

### DIFF
--- a/packages/hooks/src/useDeepMemo.test.ts
+++ b/packages/hooks/src/useDeepMemo.test.ts
@@ -18,7 +18,7 @@ import useDeepMemo from "./useDeepMemo";
 
 describe("useDeepMemo", () => {
   it("returns original object when deep equal", () => {
-    let obj: unknown = { x: 1 };
+    let obj: object = { x: 1 };
     const { result, rerender } = renderHook((val) => useDeepMemo(val), { initialProps: obj });
     expect(result.current).toBe(obj);
     rerender({ x: 1 });


### PR DESCRIPTION
**User-Facing Changes**
None.

Analysis
--------

I'm looking at invocations of `useDeepMemo` inside `useCachedGetMessagePathDataItems` and found that `useDeepMemo` is doing a deep equal on basically every iteration in some cases where user scripts are registered. This is due to the following chain of events:

1. The deep memo inputs are `unmemoizedRelevantDatatypes` and `unmemoizedRelevantTopics`. These are computed via an `useMemo` with the effective dependencies of `[providerTopics, datatypes, memoizedPaths]`. So as long as the message path is not changing (it's not) and the provider topics&datatypes are not changing (not while during normal playback), the `unmemoizedRelevant*` references shouldn't be changing.
2. However, at the startup of the UI, the `providerTopics` and `datatypes` can change rapidly, due to the registration of user scripts. Let's say `useCachedGetMessagePathDataItems` is called first before the user-script-derived topics and datatypes are registered with the player. Let's use `A` to denote the references to the computed `unmemoizedRelevant*` at this point. `A` is passed to `useDeepMemo`, which internally sets `ref.current = A`. _Note: assume the message paths are for non-user-script topics._
3. If `useCachedGetMessagePathDataItems` is called multiple times during this window when user script has not been registered, the `useDeepMemo` will be "free" as the lodash `isEqual` call internally will basically check `if A === A` and return.
4. At some point, the user scripts registers, changing `providerTopics` and `datatypes`. When `useCachedGetMessagePathDataItems` gets called again, it will recompute the `unmemoizedRelevant*` values and their references change. Let's denote the references to these values at this point to be `B`. `B` is passed to `useDeepMemo`.
5. Inside `useDeepMemo`, `ref.current` is set to `A` . `B` is the same as `A` in value, but it's a different reference, which means `isEqual` is going to do a deep equal comparison. This comparison returns true and the `useDeepMemo` returns `A`.
6. Since the `providerTopics` and `datatypes` no longer change after all user scripts have been registered, the `unmemoizedRelevant*` references will always be `B`, which is passed to `useDeepMemo`, which retains a reference to `A`. This means a deep comparison will be on every frame!

Testing
-------

Note this problem only shows up occasionally and sometimes unpredictably, as this only shows up when the
`useCachedGetMessagePathDataItems` function wins the race with the user script topic registration. Depending on (1) the data type structures and (2) how often `useCachedGetMessagePathDataItems` is called, the deep comparison can have a significant performance impact on the UI. In our case, our data structure can be quite wide and nested and the function can be invoked very often as our custom panels are filtering for a relatively large number of user-specified message paths, this can be up to 10-15% of the sampled CPU stacks from the Chrome profiler.

With Foxglove studio, it's harder to replicate this bug's performance impact. Foxglove-native panels filters for less paths than our custom panels (Raw message, plot, and table), and that the race condition with the user scripts are more difficult to replicate. More testing is required here and I haven't had a chance to fully replicate this.

Solution
--------

I changed `useDeepMemo` to retain all deep equaled copies into a `WeakSet`. The hook first does a check to see if an object is in that `WeakSet` before performing the deep equal, which gets around this performance problem. `useDeepMemo` has to accept `undefined` as this is used in `useStateToURLSynchronization`.