### PR TITLE
Avoid re-processing messages on global variable changes

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
@@ -82,15 +82,6 @@ describe("MessagePipeline/MessageOrderTracker", () => {
       ]);
     });
 
-    it("doesn't report out of order error when messages have been recomputed", () => {
-      const orderTracker = new MessageOrderTracker();
-      const playerState = playerStateWithMessages([message(7, 10), message(8, 9)]);
-      playerState.activeData!.messagesRecomputed = true;
-      const problems = orderTracker.update(playerState);
-
-      expect(problems).toEqual([]);
-    });
-
     it("does not report an error when messages are in order", () => {
       const orderTracker = new MessageOrderTracker();
       const playerState = playerStateWithMessages([message(8, 9), message(7, 10)]);

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -51,7 +51,7 @@ class MessageOrderTracker {
 
     const problems: PlayerProblem[] = [];
 
-    const { messages, currentTime, lastSeekTime, messagesRecomputed } = playerState.activeData;
+    const { messages, currentTime, lastSeekTime } = playerState.activeData;
     let didSeek = false;
 
     if (this.#lastLastSeekTime !== lastSeekTime) {
@@ -105,8 +105,6 @@ class MessageOrderTracker {
         }
 
         if (
-          // If we have recomputed the current frame there could be messages from before the lastMessageTime
-          messagesRecomputed !== true &&
           this.#lastMessageTime &&
           this.#lastMessageTopic != undefined &&
           isLessThan(messageTime, this.#lastMessageTime)

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -1793,58 +1793,6 @@ describe("UserNodePlayer", () => {
           },
         ]);
       });
-      it("should re-compute message after global variable change with no new messages in active data", async () => {
-        const fakePlayer = new FakePlayer();
-        const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
-        const [done, done2] = setListenerHelper(userNodePlayer, 2);
-
-        userNodePlayer.setGlobalVariables({ globalValue: "aaa" });
-        userNodePlayer.setSubscriptions([{ topic: `${DEFAULT_STUDIO_NODE_PREFIX}1` }]);
-        await userNodePlayer.setUserNodes({
-          [nodeId]: {
-            name: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
-            sourceCode: nodeUserCodeWithGlobalVars,
-          },
-        });
-
-        const activeData: PlayerStateActiveData = {
-          ...basicPlayerState,
-          messages: [upstreamFirst],
-          currentTime: upstreamFirst.receiveTime,
-          topics: [{ name: "/np_input", schemaName: "std_msgs/Header" }],
-          datatypes: new Map(Object.entries({ foo: { definitions: [] } })),
-        };
-        await fakePlayer.emit({ activeData });
-
-        const { messages } = (await done)!;
-        expect(messages).toEqual([
-          upstreamFirst,
-          {
-            topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
-            receiveTime: upstreamFirst.receiveTime,
-            message: { custom_np_field: "aaa", value: "aaa" },
-            schemaName: "/studio_script/1",
-            sizeInBytes: 0,
-          },
-        ]);
-
-        userNodePlayer.setGlobalVariables({ globalValue: "bbb" });
-        activeData.messages = [];
-        await fakePlayer.emit({ activeData });
-
-        const { messages: messages2 } = (await done2)!;
-
-        // Should only emit the node messages and not upstream messages
-        expect(messages2).toEqual([
-          {
-            topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
-            receiveTime: upstreamFirst.receiveTime,
-            message: { custom_np_field: "bbb", value: "bbb" },
-            schemaName: "/studio_script/1",
-            sizeInBytes: 0,
-          },
-        ]);
-      });
     });
   });
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -921,8 +921,6 @@ export default class UserNodePlayer implements Player {
           this.#lastMessageByInputTopic.set(message.topic, message);
         }
 
-        const messagesRecomputed = messagesForRecompute.length > 0;
-
         // These are new messages generated from input messages
         const computed = await this.#getMessages(
           messages,
@@ -969,7 +967,6 @@ export default class UserNodePlayer implements Player {
             messages: currentFrameMessages,
             topics: this.#getTopics(topics, this.#memoizedNodeTopics),
             datatypes: allDatatypes,
-            messagesRecomputed,
           },
         };
       });

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -136,7 +136,6 @@ export default class UserNodePlayer implements Player {
   // keep track of last message on all topics to recompute output topic messages when user nodes change
   #lastMessageByInputTopic = new Map<string, MessageEvent>();
   #userNodeIdsNeedUpdate = new Set<string>();
-  #globalVariablesChanged = false;
 
   #protectedState = new MutexLocked<ProtectedState>({
     userNodes: {},
@@ -345,7 +344,6 @@ export default class UserNodePlayer implements Player {
 
   public setGlobalVariables(globalVariables: GlobalVariables): void {
     this.#globalVariables = globalVariables;
-    this.#globalVariablesChanged = true;
   }
 
   // Called when userNode state is updated (i.e. scripts are saved)
@@ -900,15 +898,6 @@ export default class UserNodePlayer implements Player {
 
           for (const topic of inputTopics) {
             inputTopicsForRecompute.add(topic);
-          }
-        }
-
-        // if the globalVariables have changed recompute all last messages for the current frame
-        // there's no way to know which nodes are affected by the globalVariables change to make this more specific
-        if (this.#globalVariablesChanged) {
-          this.#globalVariablesChanged = false;
-          for (const inputTopic of this.#lastMessageByInputTopic.keys()) {
-            inputTopicsForRecompute.add(inputTopic);
           }
         }
 

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -194,13 +194,6 @@ export type PlayerStateActiveData = {
   // A map of parameter names to parameter values, used to describe remote parameters such as
   // rosparams.
   parameters?: Map<string, ParameterValue>;
-
-  /** Set to true when `messages` has been recomputed without seek, backfill or playback.
-   * For example: when global variables changes, user-scripts needs to be rerun to recompute
-   * messages. This variable would be set to true to indicate that `messages` may have changed
-   * without a seek or backfill occurring.
-   */
-  messagesRecomputed?: boolean;
 };
 
 // Represents a ROS topic, though the actual data does not need to come from a ROS system.


### PR DESCRIPTION
**User-Facing Changes**
User script messages are not re-computed on global variable changes.

**Description**
Earlier this year @jtbandes filed an internal bug report that user-scripts do not re-run when global variables are changed which was the inherited behavior from webviz that we've had since Studio was created. This resulted in a bugfix PR https://github.com/foxglove/studio/pull/5173 which re-ran the scripts when variables changed.

However, this re-running of scripts behavior broke a message pipeline invariant. The invariant is that we do not re-emit already emitted messages into the message pipeline. This invariant went un-noticed but did trigger a player problem from the MessageOrderTracker when you had a user-script and made changes to global variables (i.e. selecting an object in the 3d panel). This would cause the user-scripts to run and re-emit already emitted messages and appear to panels like data went back in time.

We put together a workaround to silence this player problem https://github.com/foxglove/studio/pull/6164 but the invariant behavior remained. After an internal discussion we decided to revert the original PR which introduced the invariant behavior and wait for examples of real-world workflows around the variable behavior before considering it a "bug" that scripts do not emit when variables change. The current script behavior is to emit when input messages change (or the script is edited and saved).

This change reverts #5173 and the `messagesRecomputed` changes from #6164.

Fixes: FG-4059
Fixes: FG-3749
