### PR TITLE
Add Font Settings for Raw Messages Panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/types.ts
+++ b/packages/studio-base/src/panels/RawMessages/types.ts
@@ -22,4 +22,5 @@ export type RawMessagesPanelConfig = {
 export const Constants = {
   CUSTOM_METHOD: "custom",
   PREV_MSG_METHOD: "previous message",
+  FONT_SIZE_OPTIONS: [8, 9, 10, 11, 12, 14, 16, 18, 24, 30, 36, 48, 60, 72],
 } as const;


### PR DESCRIPTION
**User-Facing Changes**
- Add font setting for Raw Message panel
- Make single-value raw message display respect font setting

**Description**
Add option to overrule automatic large text display for primitive values in Raw Messages panel (as discussed in https://github.com/orgs/foxglove/discussions/618), as this takes a lot of screen real estate and might be counter-productive e.g. for long (multi-line) strings. For this, the font settings can be changed via the settings tree.