### PR TITLE
Improve selection of thin LinePrimitives in the 3D panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -88,6 +88,8 @@ export class RenderableLines extends RenderablePrimitive {
   }
 }
 
+const MIN_PICKING_WIDTH_PX = 5;
+
 class LinePrimitiveRenderable extends THREE.Object3D {
   #geometry: LineSegmentsGeometry | LineGeometry | undefined;
   #positionBuffer: Float32Array | undefined;
@@ -117,12 +119,15 @@ class LinePrimitiveRenderable extends THREE.Object3D {
       depthWrite: !this.#transparent,
       resolution: canvasSize.clone(),
     });
-    this.#material.linewidth = primitive.thickness; // Fix for THREE.js type annotations
+    this.#material.lineWidth = primitive.thickness; // Fix for THREE.js type annotations
 
     this.#pickingMaterial = new PickingMaterial();
     this.#pickingMaterial.resolution.set(canvasSize.x, canvasSize.y);
-    this.#pickingMaterial.linewidth = primitive.thickness;
     this.#pickingMaterial.worldUnits = !primitive.scale_invariant;
+    // make sure thin, scale_invariant lines are still pickable
+    this.#pickingMaterial.lineWidth = primitive.scale_invariant
+      ? Math.max(primitive.thickness, MIN_PICKING_WIDTH_PX)
+      : primitive.thickness;
     this.#pickingMaterial.needsUpdate = true;
   }
 
@@ -275,8 +280,11 @@ class LinePrimitiveRenderable extends THREE.Object3D {
     this.#material.worldUnits = !this.#primitive.scale_invariant;
     this.#material.needsUpdate = true;
 
-    this.#pickingMaterial.lineWidth = this.#primitive.thickness;
     this.#pickingMaterial.worldUnits = !this.#primitive.scale_invariant;
+    // make sure thin, scale invariant lines are still pickable
+    this.#pickingMaterial.lineWidth = this.#primitive.scale_invariant
+      ? Math.max(this.#primitive.thickness, MIN_PICKING_WIDTH_PX)
+      : this.#primitive.thickness;
     this.#pickingMaterial.uniformsNeedUpdate = true;
     this.#pickingMaterial.needsUpdate = true;
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -88,7 +88,7 @@ export class RenderableLines extends RenderablePrimitive {
   }
 }
 
-const MIN_PICKING_WIDTH_PX = 5;
+const MIN_PICKING_LINE_WIDTH_PX = 5;
 
 class LinePrimitiveRenderable extends THREE.Object3D {
   #geometry: LineSegmentsGeometry | LineGeometry | undefined;
@@ -126,7 +126,7 @@ class LinePrimitiveRenderable extends THREE.Object3D {
     this.#pickingMaterial.worldUnits = !primitive.scale_invariant;
     // make sure thin, scale_invariant lines are still pickable
     this.#pickingMaterial.lineWidth = primitive.scale_invariant
-      ? Math.max(primitive.thickness, MIN_PICKING_WIDTH_PX)
+      ? Math.max(primitive.thickness, MIN_PICKING_LINE_WIDTH_PX)
       : primitive.thickness;
     this.#pickingMaterial.needsUpdate = true;
   }
@@ -283,7 +283,7 @@ class LinePrimitiveRenderable extends THREE.Object3D {
     this.#pickingMaterial.worldUnits = !this.#primitive.scale_invariant;
     // make sure thin, scale invariant lines are still pickable
     this.#pickingMaterial.lineWidth = this.#primitive.scale_invariant
-      ? Math.max(this.#primitive.thickness, MIN_PICKING_WIDTH_PX)
+      ? Math.max(this.#primitive.thickness, MIN_PICKING_LINE_WIDTH_PX)
       : this.#primitive.thickness;
     this.#pickingMaterial.uniformsNeedUpdate = true;
     this.#pickingMaterial.needsUpdate = true;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Improve selection of thin, scale_invaraint LinePrimitives in the 3D panel

**Description**
I made the picking material for scale_invariant LinePrimitives not go below a MIN_PICKING_WIDTH_PX of 5px. I only did scale_invariant because otherwise they are in world units and can be zoomed in on to be picked, and it would be hard to calculate what the min picking size of a line should be in world units. 

To make this all generic beyond LinePrimitives to all `Lines` I could check materials in `#processItem` in the Picker for `worldUnits = = false && typeof lineWidth == 'number'`, but I wanted to keep it scoped to just the `LinePrimitive` for now to avoid potentially unwanted side affects elsewhere. 

FG-3892


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
