### PR TITLE
[3D] Fix selection backdrop glitches

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -191,6 +191,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   public ros = false;
 
   #picker: Picker;
+  #selectionBackdropScene: THREE.Scene;
   #selectionBackdrop: ScreenOverlay;
   #selectedRenderable: PickedRenderable | undefined;
   public colorScheme: "dark" | "light" = "light";
@@ -289,8 +290,8 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.#picker = new Picker(this.gl, this.#scene);
 
     this.#selectionBackdrop = new ScreenOverlay(this);
-    this.#selectionBackdrop.visible = false;
-    this.#scene.add(this.#selectionBackdrop);
+    this.#selectionBackdropScene = new THREE.Scene();
+    this.#selectionBackdropScene.add(this.#selectionBackdrop);
 
     const samples = msaaSamples(this.gl.capabilities);
     const renderSize = this.gl.getDrawingBufferSize(tempVec2);
@@ -1039,7 +1040,6 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
     const camera = this.cameraHandler.getActiveCamera();
     camera.layers.set(LAYER_DEFAULT);
-    this.#selectionBackdrop.visible = this.#selectedRenderable != undefined;
 
     // use the FALLBACK_FRAME_ID if renderFrame is undefined and there are no options for transforms
     const renderFrameId =
@@ -1055,9 +1055,9 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.gl.render(this.#scene, camera);
 
     if (this.#selectedRenderable) {
+      this.gl.render(this.#selectionBackdropScene, camera);
       this.gl.clearDepth();
       camera.layers.set(LAYER_SELECTED);
-      this.#selectionBackdrop.visible = false;
       this.gl.render(this.#scene, camera);
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ScreenOverlay.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ScreenOverlay.ts
@@ -16,6 +16,8 @@ export class ScreenOverlay extends THREE.Object3D {
 
     this.#material = new THREE.ShaderMaterial({
       transparent: true,
+      depthTest: false,
+      depthWrite: false,
       uniforms: { color: { value: [1, 0, 1, 1] } },
       vertexShader: /* glsl */ `
         void main() {


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**

The selection overlay had two problems:
- It can completely occlude some items that undergo depth sorting (see cube colors disappearing)
- It can be occluded by some items that are close to the camera (see axes & grid appearing in front of the overlay)

This fixes the issues by using a totally separate Scene for the overlay and disabling its use of the depth buffer, rather than relying on its sort order with other objects in the scene.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

https://github.com/foxglove/studio/assets/14237/101da5a6-ec21-4b22-a6c7-6db7a6161d60

</td><td>

https://github.com/foxglove/studio/assets/14237/334fdf1b-6ef9-4e08-8b96-57c074ba9fff

</td></tr></table>