### PR TITLE
Use currentFrame messages in low memory conditions in plot panel

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotChart.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotChart.tsx
@@ -22,10 +22,10 @@ import TimeBasedChart, {
   ChartDefaultView,
   Props as TimeBasedChartProps,
 } from "@foxglove/studio-base/components/TimeBasedChart";
-import { DataSets } from "@foxglove/studio-base/panels/Plot/datasets";
 import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 
 import { PlotPath, PlotXAxisVal, isReferenceLinePlotPathType } from "./internalTypes";
+import { PlotData } from "./plotData";
 
 // A "reference line" plot path is a numeric value. It creates a horizontal line on the plot at the specified value.
 function getAnnotationFromReferenceLine(path: PlotPath, index: number): AnnotationOptions {
@@ -62,7 +62,7 @@ type PlotChartProps = {
   showXAxisLabels: boolean;
   showYAxisLabels: boolean;
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
-  datasetBounds: DataSets["bounds"];
+  datasetBounds: PlotData["bounds"];
   xAxisVal: PlotXAxisVal;
   currentTime?: number;
   defaultView?: ChartDefaultView;

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -16,6 +16,7 @@ import { ComponentProps, useCallback, useMemo, useRef } from "react";
 import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import { PANEL_TOOLBAR_MIN_HEIGHT } from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
@@ -27,7 +28,7 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 const minLegendWidth = 25;
 const maxLegendWidth = 800;
 
-type Props = {
+type Props = Immutable<{
   currentTime?: number;
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
   legendDisplay: "floating" | "top" | "left";
@@ -38,7 +39,7 @@ type Props = {
   showLegend: boolean;
   showPlotValuesInLegend: boolean;
   sidebarDimension: number;
-};
+}>;
 
 const useStyles = makeStyles<void, "container" | "toggleButton" | "toggleButtonFloating">()(
   ({ palette, shadows, shape, spacing }, _params, classes) => ({
@@ -249,14 +250,14 @@ export function PlotLegend(props: Props): JSX.Element {
             <div className={classes.container}>
               {paths.map((path, index) => (
                 <PlotLegendRow
-                  key={index}
+                  currentTime={currentTime}
+                  datasets={datasets}
+                  hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
                   index={index}
+                  key={index}
                   onClickPath={() => onClickPath(index)}
                   path={path}
                   paths={paths}
-                  hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
-                  datasets={datasets}
-                  currentTime={currentTime}
                   savePaths={savePaths}
                   showPlotValuesInLegend={showPlotValuesInLegend}
                 />

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -8,6 +8,7 @@ import { ComponentProps, useMemo, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
 
+import { Immutable } from "@foxglove/studio";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
@@ -19,7 +20,7 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { PlotPath } from "./internalTypes";
 
-type PlotLegendRowProps = {
+type PlotLegendRowProps = Immutable<{
   currentTime?: number;
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
   hasMismatchedDataLength: boolean;
@@ -29,7 +30,7 @@ type PlotLegendRowProps = {
   paths: PlotPath[];
   savePaths: (paths: PlotPath[]) => void;
   showPlotValuesInLegend: boolean;
-};
+}>;
 
 const ROW_HEIGHT = 28;
 

--- a/packages/studio-base/src/panels/Plot/csv.ts
+++ b/packages/studio-base/src/panels/Plot/csv.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Immutable } from "@foxglove/studio";
 import { downloadFiles } from "@foxglove/studio-base/util/download";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
@@ -23,7 +24,7 @@ const getCVSColName = (xAxisVal: PlotXAxisVal): string => {
   }[xAxisVal];
 };
 
-function generateCSV(datasets: DataSet[], xAxisVal: PlotXAxisVal): string {
+function generateCSV(datasets: Immutable<DataSet[]>, xAxisVal: PlotXAxisVal): string {
   const headLine = [getCVSColName(xAxisVal), "receive time", "header.stamp", "topic", "value"];
   const combinedLines = [];
   combinedLines.push(headLine);
@@ -35,7 +36,7 @@ function generateCSV(datasets: DataSet[], xAxisVal: PlotXAxisVal): string {
   return combinedLines.join("\n");
 }
 
-function downloadCSV(datasets: DataSet[], xAxisVal: PlotXAxisVal): void {
+function downloadCSV(datasets: Immutable<DataSet[]>, xAxisVal: PlotXAxisVal): void {
   const csvData = generateCSV(datasets, xAxisVal);
   const blob = new Blob([csvData], { type: "text/csv;charset=utf-8;" });
   downloadFiles([{ blob, fileName: `plot_data.csv` }]);

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -13,6 +13,7 @@
 
 import { compact, isNumber, uniq } from "lodash";
 import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
+import { DeepWritable } from "ts-essentials";
 
 import {
   Time,
@@ -36,7 +37,7 @@ import PanelToolbar, {
 } from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { ChartDefaultView } from "@foxglove/studio-base/components/TimeBasedChart";
-import { usePlotPanelDatasets } from "@foxglove/studio-base/panels/Plot/usePlotPanelDatasets";
+import { usePlotPanelData } from "@foxglove/studio-base/panels/Plot/usePlotPanelData";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
@@ -82,6 +83,11 @@ function selectCurrentTime(ctx: MessagePipelineContext) {
 
 function selectEndTime(ctx: MessagePipelineContext) {
   return ctx.playerState.activeData?.endTime;
+}
+
+// Hack until we can make all the downstream chart types immutable.
+function castWritable<T>(t: T) {
+  return t as DeepWritable<T>;
 }
 
 function Plot(props: Props) {
@@ -177,7 +183,7 @@ function Plot(props: Props) {
     bounds: datasetBounds,
     datasets,
     pathsWithMismatchedDataLengths,
-  } = usePlotPanelDatasets({
+  } = usePlotPanelData({
     allPaths,
     followingView,
     showSingleCurrentMessage,
@@ -242,32 +248,32 @@ function Plot(props: Props) {
       >
         {legendDisplay !== "none" && (
           <PlotLegend
-            paths={yAxisPaths}
-            datasets={datasets}
             currentTime={currentTimeSinceStart}
+            datasets={datasets}
+            legendDisplay={legendDisplay}
             onClickPath={(index: number) => setFocusedPath(["paths", String(index)])}
+            paths={yAxisPaths}
+            pathsWithMismatchedDataLengths={pathsWithMismatchedDataLengths}
             saveConfig={saveConfig}
             showLegend={showLegend}
-            pathsWithMismatchedDataLengths={pathsWithMismatchedDataLengths}
-            legendDisplay={legendDisplay}
             showPlotValuesInLegend={showPlotValuesInLegend}
             sidebarDimension={sidebarDimension}
           />
         )}
         <Stack flex="auto" alignItems="center" justifyContent="center" overflow="hidden">
           <PlotChart
+            currentTime={currentTimeSinceStart}
+            datasetBounds={datasetBounds}
+            datasets={castWritable(datasets)}
+            defaultView={defaultView}
             isSynced={xAxisVal === "timestamp" && isSynced}
-            paths={yAxisPaths}
-            minYValue={parseFloat((minYValue ?? "").toString())}
             maxYValue={parseFloat((maxYValue ?? "").toString())}
+            minYValue={parseFloat((minYValue ?? "").toString())}
+            onClick={onClick}
+            paths={yAxisPaths}
             showXAxisLabels={showXAxisLabels}
             showYAxisLabels={showYAxisLabels}
-            datasets={datasets}
-            datasetBounds={datasetBounds}
             xAxisVal={xAxisVal}
-            currentTime={currentTimeSinceStart}
-            onClick={onClick}
-            defaultView={defaultView}
           />
           <PanelContextMenu getItems={getPanelContextMenuItems} />
         </Stack>

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -46,6 +46,10 @@ export type Datum = ChartDatum & {
 
 export type DataSet = ChartDataset<"scatter", Datum[]>;
 
+// Key datasets by the full PlotPath instead of just the string value because we need to
+// generate a new dataset if the plot path is ordered by headerStamp.
+export type DatasetsByPath = Map<PlotPath, DataSet>;
+
 export type PlotDataItem = {
   queriedData: MessagePathDataItem[];
   receiveTime: Time;

--- a/packages/studio-base/src/panels/Plot/maps.test.ts
+++ b/packages/studio-base/src/panels/Plot/maps.test.ts
@@ -56,7 +56,7 @@ describe("pick", () => {
       ["d", 4],
     ]);
 
-    const picked = maps.pick(input, ["b", "d"]);
+    const picked = maps.pick(input, ["b", "d", "z"]);
 
     expect(picked).toEqual(
       new Map([

--- a/packages/studio-base/src/panels/Plot/maps.test.ts
+++ b/packages/studio-base/src/panels/Plot/maps.test.ts
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as maps from "./maps";
+
+describe("merges", () => {
+  it("merges maps", () => {
+    const inputA = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+
+    const inputB = new Map([
+      ["a", 10],
+      ["b", 20],
+      ["c", 30],
+    ]);
+
+    const assigned = maps.merge(inputA, inputB, (a, b) => a * b);
+
+    expect(assigned).toEqual(
+      new Map([
+        ["a", 10],
+        ["b", 40],
+        ["c", 30],
+      ]),
+    );
+  });
+});
+
+describe("mapValues", () => {
+  it("maps values", () => {
+    const input = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+
+    const mapped = maps.mapValues(input, (value, key) => `${key}/${value * 10}`);
+
+    expect(mapped).toEqual(
+      new Map([
+        ["a", "a/10"],
+        ["b", "b/20"],
+      ]),
+    );
+  });
+});
+
+describe("pick", () => {
+  it("picks by key", () => {
+    const input = new Map([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+      ["d", 4],
+    ]);
+
+    const picked = maps.pick(input, ["b", "d"]);
+
+    expect(picked).toEqual(
+      new Map([
+        ["b", 2],
+        ["d", 4],
+      ]),
+    );
+  });
+});

--- a/packages/studio-base/src/panels/Plot/maps.ts
+++ b/packages/studio-base/src/panels/Plot/maps.ts
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Merges values from a & b into a new map, applying fn at each key.
+ */
+export function merge<K, V1, V2, V3>(
+  a: ReadonlyMap<K, V1>,
+  b: ReadonlyMap<K, V2>,
+  fn: (aval: V1, bval: V2, key: K) => V3,
+): Map<K, V1 | V2 | V3> {
+  const dest: Map<K, V1 | V2 | V3> = new Map();
+
+  for (const [key, aVal] of a) {
+    const bVal = b.get(key);
+    if (bVal == undefined) {
+      dest.set(key, aVal);
+    } else {
+      dest.set(key, fn(aVal, bVal, key));
+    }
+  }
+
+  for (const [key, bVal] of b) {
+    if (dest.has(key)) {
+      continue;
+    }
+
+    const aVal = a.get(key);
+    if (aVal == undefined) {
+      dest.set(key, bVal);
+    } else {
+      dest.set(key, fn(aVal, bVal, key));
+    }
+  }
+
+  return dest;
+}
+
+/**
+ * Generates a new map from input with the same keys but with fn applied to each value.
+ */
+export function mapValues<K, V, V2>(
+  input: ReadonlyMap<K, V>,
+  fn: (val: V, key: K) => V2,
+): Map<K, V2> {
+  const newEntries: [K, V2][] = [];
+  for (const [key, value] of input) {
+    newEntries.push([key, fn(value, key)]);
+  }
+  return new Map(newEntries);
+}
+
+/**
+ * Returns a new map containing only the keys in keys.
+ */
+export function pick<K, V>(input: ReadonlyMap<K, V>, keys: readonly K[]): Map<K, V> {
+  const newEntries: [K, V][] = [];
+  for (const [key, value] of input) {
+    if (keys.includes(key)) {
+      newEntries.push([key, value]);
+    }
+  }
+  return new Map(newEntries);
+}

--- a/packages/studio-base/src/panels/Plot/messageProcessing.ts
+++ b/packages/studio-base/src/panels/Plot/messageProcessing.ts
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable } from "immer";
+
+import {
+  MessageDataItemsByPath,
+  useDecodeMessagePathsForMessagesByTopic,
+} from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
+
+import { PlotDataByPath } from "./internalTypes";
+
+type MessagePathDecoder = ReturnType<typeof useDecodeMessagePathsForMessagesByTopic>;
+
+/**
+ * Fetch the data we need from each item in itemsByPath and discard the rest of
+ * the message to save memory.
+ */
+const getByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath => {
+  const ret: PlotDataByPath = {};
+  Object.entries(itemsByPath).forEach(([path, items]) => {
+    ret[path] = items.map((messageAndData) => {
+      const headerStamp = getTimestampForMessage(messageAndData.messageEvent.message);
+      return {
+        queriedData: messageAndData.queriedData,
+        receiveTime: messageAndData.messageEvent.receiveTime,
+        headerStamp,
+      };
+    });
+  });
+  return ret;
+};
+
+function getMessagePathItems(
+  decodeMessagePathsForMessagesByTopic: MessagePathDecoder,
+  messages: Immutable<Record<string, MessageEvent[]>>,
+): PlotDataByPath {
+  return Object.freeze(getByPath(decodeMessagePathsForMessagesByTopic(messages)));
+}
+
+/**
+ * Fetch all the plot data we want for our current subscribed topics from blocks.
+ */
+export function getBlockItemsByPath(
+  decodeMessagePathsForMessagesByTopic: MessagePathDecoder,
+  messages: Immutable<Record<string, MessageEvent[]>>,
+): PlotDataByPath {
+  return getMessagePathItems(decodeMessagePathsForMessagesByTopic, messages);
+}

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { assignWith, isEmpty } from "lodash";
+import { isEmpty } from "lodash";
 import memoizeWeak from "memoize-weak";
 
 import { Time } from "@foxglove/rostime";
@@ -13,23 +13,24 @@ import { Range } from "@foxglove/studio-base/util/ranges";
 
 import {
   BasePlotPath,
-  DataSet,
+  DatasetsByPath,
   Datum,
   PlotDataByPath,
   PlotPath,
   PlotXAxisVal,
   isReferenceLinePlotPathType,
 } from "./internalTypes";
+import * as maps from "./maps";
 
 export type PlotData = {
   bounds: Bounds;
-  datasetsByPath: Record<string, DataSet>;
+  datasetsByPath: DatasetsByPath;
   pathsWithMismatchedDataLengths: string[];
 };
 
 export const EmptyPlotData: Im<PlotData> = Object.freeze({
   bounds: makeInvertedBounds(),
-  datasetsByPath: {},
+  datasetsByPath: new Map(),
   pathsWithMismatchedDataLengths: [],
 });
 
@@ -44,13 +45,13 @@ function findXRanges(data: Im<PlotData>): {
   const byPath: Record<string, Range> = {};
   let start = Number.MAX_SAFE_INTEGER;
   let end = Number.MIN_SAFE_INTEGER;
-  for (const [path, items] of Object.entries(data.datasetsByPath)) {
-    const thisPath = (byPath[path] = {
+  for (const [path, dataset] of data.datasetsByPath) {
+    const thisPath = (byPath[path.value] = {
       start: Number.MAX_SAFE_INTEGER,
       end: Number.MIN_SAFE_INTEGER,
     });
-    thisPath.start = Math.min(thisPath.start, items.data.at(0)?.x ?? Number.MAX_SAFE_INTEGER);
-    thisPath.end = Math.max(thisPath.end, items.data.at(-1)?.x ?? Number.MIN_SAFE_INTEGER);
+    thisPath.start = Math.min(thisPath.start, dataset.data.at(0)?.x ?? Number.MAX_SAFE_INTEGER);
+    thisPath.end = Math.max(thisPath.end, dataset.data.at(-1)?.x ?? Number.MIN_SAFE_INTEGER);
     start = Math.min(start, thisPath.start);
     end = Math.max(end, thisPath.end);
   }
@@ -74,20 +75,12 @@ export function appendPlotData(a: Im<PlotData>, b: Im<PlotData>): Im<PlotData> {
   return {
     ...a,
     bounds: unionBounds(a.bounds, b.bounds),
-    datasetsByPath: assignWith(
-      {},
-      a.datasetsByPath,
-      b.datasetsByPath,
-      (objValue: undefined | DataSet, srcValue: undefined | DataSet) => {
-        if (objValue == undefined) {
-          return srcValue;
-        }
-        return {
-          ...objValue,
-          data: objValue.data.concat(srcValue?.data ?? []),
-        };
-      },
-    ),
+    datasetsByPath: maps.merge(a.datasetsByPath, b.datasetsByPath, (aVal, bVal) => {
+      return {
+        ...aVal,
+        data: aVal.data.concat(bVal.data),
+      };
+    }),
   };
 }
 
@@ -108,27 +101,19 @@ function mergePlotData(a: Im<PlotData>, b: Im<PlotData>): Im<PlotData> {
   return {
     ...a,
     bounds: unionBounds(a.bounds, b.bounds),
-    datasetsByPath: assignWith(
-      {},
-      a.datasetsByPath,
-      b.datasetsByPath,
-      (objValue: undefined | DataSet, srcValue: undefined | DataSet) => {
-        if (objValue == undefined) {
-          return srcValue;
-        }
-        const lastTime = objValue.data.at(-1)?.x ?? Number.MIN_SAFE_INTEGER;
-        const newValues = srcValue?.data.filter((datum) => datum.x > lastTime) ?? [];
-        if (newValues.length > 0) {
-          return {
-            ...objValue,
-            // Insert NaN/NaN datum to cause a break in the line.
-            data: objValue.data.concat({ x: NaN, y: NaN } as Datum, newValues),
-          };
-        } else {
-          return objValue;
-        }
-      },
-    ),
+    datasetsByPath: maps.merge(a.datasetsByPath, b.datasetsByPath, (aVal, bVal) => {
+      const lastTime = aVal.data.at(-1)?.x ?? Number.MIN_SAFE_INTEGER;
+      const newValues = bVal.data.filter((datum) => datum.x > lastTime);
+      if (newValues.length > 0) {
+        return {
+          ...aVal,
+          // Insert NaN/NaN datum to cause a break in the line.
+          data: aVal.data.concat({ x: NaN, y: NaN } as Datum, newValues),
+        };
+      } else {
+        return aVal;
+      }
+    }),
   };
 }
 
@@ -144,9 +129,8 @@ function compare(a: Im<PlotData>, b: Im<PlotData>): number {
 }
 
 /**
- * Reduce multiple DatasetWithPath objects into a single PlotDataByPath object,
- * concatenating messages for each path after trimming messages that overlap
- * between items.
+ * Reduce multiple PlotData objects into a single PlotData object, concatenating messages
+ * for each path after trimming messages that overlap between items.
  */
 export function reducePlotData(data: Im<PlotData[]>): Im<PlotData> {
   const sorted = data.slice().sort(compare);
@@ -174,7 +158,7 @@ export function buildPlotData(
   const { paths, itemsByPath, startTime, xAxisVal, xAxisPath, invertedTheme } = args;
   const bounds: Bounds = makeInvertedBounds();
   const pathsWithMismatchedDataLengths: string[] = [];
-  const datasets: PlotData["datasetsByPath"] = {};
+  const datasets: DatasetsByPath = new Map();
   for (const [index, path] of paths.entries()) {
     const yRanges = itemsByPath[path.value] ?? [];
     const xRanges = xAxisPath && itemsByPath[xAxisPath.value];
@@ -205,7 +189,7 @@ export function buildPlotData(
           bounds.y.max = Math.max(bounds.y.max, datum.y);
         }
       }
-      datasets[path.value] = res.dataset;
+      datasets.set(path, res.dataset);
     }
   }
 

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -2,47 +2,216 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MessageEvent } from "@foxglove/studio";
-import { MessageDataItemsByPath } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
-import { PlotDataByPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
-import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
+import { assignWith, isEmpty } from "lodash";
+import memoizeWeak from "memoize-weak";
 
-/**
- * Fetch the data we need from each item in itemsByPath and discard the rest of
- * the message to save memory.
- */
-const getByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath => {
-  const ret: PlotDataByPath = {};
-  Object.entries(itemsByPath).forEach(([path, items]) => {
-    ret[path] = items.map((messageAndData) => {
-      const headerStamp = getTimestampForMessage(messageAndData.messageEvent.message);
-      return {
-        queriedData: messageAndData.queriedData,
-        receiveTime: messageAndData.messageEvent.receiveTime,
-        headerStamp,
-      };
-    });
-  });
-  return ret;
+import { Time } from "@foxglove/rostime";
+import { Immutable as Im } from "@foxglove/studio";
+import { getDatasetsFromMessagePlotPath } from "@foxglove/studio-base/panels/Plot/datasets";
+import { Bounds, makeInvertedBounds, unionBounds } from "@foxglove/studio-base/types/Bounds";
+import { Range } from "@foxglove/studio-base/util/ranges";
+
+import {
+  BasePlotPath,
+  DataSet,
+  Datum,
+  PlotDataByPath,
+  PlotPath,
+  PlotXAxisVal,
+  isReferenceLinePlotPathType,
+} from "./internalTypes";
+
+export type PlotData = {
+  bounds: Bounds;
+  datasetsByPath: Record<string, DataSet>;
+  pathsWithMismatchedDataLengths: string[];
 };
 
-function getMessagePathItems(
-  decodeMessagePathsForMessagesByTopic: (
-    Record: Record<string, readonly MessageEvent[]>,
-  ) => MessageDataItemsByPath,
-  messages: Record<string, readonly MessageEvent[]>,
-): PlotDataByPath {
-  return Object.freeze(getByPath(decodeMessagePathsForMessagesByTopic(messages)));
+export const EmptyPlotData: Im<PlotData> = Object.freeze({
+  bounds: makeInvertedBounds(),
+  datasetsByPath: {},
+  pathsWithMismatchedDataLengths: [],
+});
+
+/**
+ * Find the earliest and latest times of messages in data, for all messages and per-path.
+ * Assumes invidual ranges of messages are already sorted by receiveTime.
+ */
+function findXRanges(data: Im<PlotData>): {
+  all: Range;
+  byPath: Record<string, Range>;
+} {
+  const byPath: Record<string, Range> = {};
+  let start = Number.MAX_SAFE_INTEGER;
+  let end = Number.MIN_SAFE_INTEGER;
+  for (const [path, items] of Object.entries(data.datasetsByPath)) {
+    const thisPath = (byPath[path] = {
+      start: Number.MAX_SAFE_INTEGER,
+      end: Number.MIN_SAFE_INTEGER,
+    });
+    thisPath.start = Math.min(thisPath.start, items.data.at(0)?.x ?? Number.MAX_SAFE_INTEGER);
+    thisPath.end = Math.max(thisPath.end, items.data.at(-1)?.x ?? Number.MIN_SAFE_INTEGER);
+    start = Math.min(start, thisPath.start);
+    end = Math.max(end, thisPath.end);
+  }
+
+  return { all: { start, end }, byPath };
 }
 
 /**
- * Fetch all the plot data we want for our current subscribed topics from blocks.
+ * Appends new PlotData to existing PlotData. Assumes there are no time overlaps between
+ * the two items.
  */
-export function getBlockItemsByPath(
-  decodeMessagePathsForMessagesByTopic: (
-    msgs: Record<string, readonly MessageEvent[]>,
-  ) => MessageDataItemsByPath,
-  messages: Record<string, readonly MessageEvent[]>,
-): PlotDataByPath {
-  return getMessagePathItems(decodeMessagePathsForMessagesByTopic, messages);
+export function appendPlotData(a: Im<PlotData>, b: Im<PlotData>): Im<PlotData> {
+  if (a === EmptyPlotData) {
+    return b;
+  }
+
+  if (b === EmptyPlotData) {
+    return a;
+  }
+
+  return {
+    ...a,
+    bounds: unionBounds(a.bounds, b.bounds),
+    datasetsByPath: assignWith(
+      {},
+      a.datasetsByPath,
+      b.datasetsByPath,
+      (objValue: undefined | DataSet, srcValue: undefined | DataSet) => {
+        if (objValue == undefined) {
+          return srcValue;
+        }
+        return {
+          ...objValue,
+          data: objValue.data.concat(srcValue?.data ?? []),
+        };
+      },
+    ),
+  };
+}
+
+/**
+ * Merge two PlotData objects into a single PlotData object, discarding any overlapping
+ * messages between the two items. Assumes they represent non-contiguous segments of a
+ * chart.
+ */
+function mergePlotData(a: Im<PlotData>, b: Im<PlotData>): Im<PlotData> {
+  if (a === EmptyPlotData) {
+    return b;
+  }
+
+  if (b === EmptyPlotData) {
+    return a;
+  }
+
+  return {
+    ...a,
+    bounds: unionBounds(a.bounds, b.bounds),
+    datasetsByPath: assignWith(
+      {},
+      a.datasetsByPath,
+      b.datasetsByPath,
+      (objValue: undefined | DataSet, srcValue: undefined | DataSet) => {
+        if (objValue == undefined) {
+          return srcValue;
+        }
+        const lastTime = objValue.data.at(-1)?.x ?? Number.MIN_SAFE_INTEGER;
+        const newValues = srcValue?.data.filter((datum) => datum.x > lastTime) ?? [];
+        if (newValues.length > 0) {
+          return {
+            ...objValue,
+            // Insert NaN/NaN datum to cause a break in the line.
+            data: objValue.data.concat({ x: NaN, y: NaN } as Datum, newValues),
+          };
+        } else {
+          return objValue;
+        }
+      },
+    ),
+  };
+}
+
+const memoFindXRanges = memoizeWeak(findXRanges);
+
+// Sort by start time, then end time, so that folding from the left gives us the
+// right consolidated interval.
+function compare(a: Im<PlotData>, b: Im<PlotData>): number {
+  const rangeA = memoFindXRanges(a).all;
+  const rangeB = memoFindXRanges(b).all;
+  const startCompare = rangeA.start - rangeB.start;
+  return startCompare !== 0 ? startCompare : rangeA.end - rangeB.end;
+}
+
+/**
+ * Reduce multiple DatasetWithPath objects into a single PlotDataByPath object,
+ * concatenating messages for each path after trimming messages that overlap
+ * between items.
+ */
+export function reducePlotData(data: Im<PlotData[]>): Im<PlotData> {
+  const sorted = data.slice().sort(compare);
+
+  const reduced = sorted.reduce((acc, item) => {
+    if (isEmpty(acc)) {
+      return item;
+    }
+    return mergePlotData(acc, item);
+  }, EmptyPlotData);
+
+  return reduced;
+}
+
+export function buildPlotData(
+  args: Im<{
+    invertedTheme?: boolean;
+    itemsByPath: PlotDataByPath;
+    paths: PlotPath[];
+    startTime: Time;
+    xAxisPath?: BasePlotPath;
+    xAxisVal: PlotXAxisVal;
+  }>,
+): PlotData {
+  const { paths, itemsByPath, startTime, xAxisVal, xAxisPath, invertedTheme } = args;
+  const bounds: Bounds = makeInvertedBounds();
+  const pathsWithMismatchedDataLengths: string[] = [];
+  const datasets: PlotData["datasetsByPath"] = {};
+  for (const [index, path] of paths.entries()) {
+    const yRanges = itemsByPath[path.value] ?? [];
+    const xRanges = xAxisPath && itemsByPath[xAxisPath.value];
+    if (!path.enabled) {
+      continue;
+    } else if (!isReferenceLinePlotPathType(path)) {
+      const res = getDatasetsFromMessagePlotPath({
+        path,
+        yAxisRanges: yRanges,
+        index,
+        startTime,
+        xAxisVal,
+        xAxisRanges: xRanges,
+        xAxisPath,
+        invertedTheme,
+      });
+
+      if (res.hasMismatchedData) {
+        pathsWithMismatchedDataLengths.push(path.value);
+      }
+      for (const datum of res.dataset.data) {
+        if (isFinite(datum.x)) {
+          bounds.x.min = Math.min(bounds.x.min, datum.x);
+          bounds.x.max = Math.max(bounds.x.max, datum.x);
+        }
+        if (isFinite(datum.y)) {
+          bounds.y.min = Math.min(bounds.y.min, datum.y);
+          bounds.y.max = Math.max(bounds.y.max, datum.y);
+        }
+      }
+      datasets[path.value] = res.dataset;
+    }
+  }
+
+  return {
+    bounds,
+    datasetsByPath: datasets,
+    pathsWithMismatchedDataLengths,
+  };
 }

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -22,6 +22,11 @@ import {
 } from "./internalTypes";
 import * as maps from "./maps";
 
+/**
+ * Plot data bundles datasets with precomputed bounds and paths with mismatched data
+ * paths. It's used to contain data from blocks and currentFrame segments and eventually
+ * is merged into a single object and passed to the chart components.
+ */
 export type PlotData = {
   bounds: Bounds;
   datasetsByPath: DatasetsByPath;

--- a/packages/studio-base/src/panels/Plot/transformPlotRange.ts
+++ b/packages/studio-base/src/panels/Plot/transformPlotRange.ts
@@ -11,9 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Immutable } from "@foxglove/studio";
+
 export type MathFunction = (arg: number) => number;
 
-export function derivative<T extends { x: number; y: number }>(data: T[]): T[] {
+export function derivative<T extends { x: number; y: number }>(
+  data: Immutable<T[]>,
+): Immutable<T>[] {
   const newDatums = [];
   for (let i = 1; i < data.length; i++) {
     const item = data[i]!;

--- a/packages/studio-base/src/panels/Plot/useAllFramesByTopic.test.tsx
+++ b/packages/studio-base/src/panels/Plot/useAllFramesByTopic.test.tsx
@@ -9,9 +9,9 @@ import MockMessagePipelineProvider from "@foxglove/studio-base/components/Messag
 import { Progress } from "@foxglove/studio-base/players/types";
 import { mockMessage } from "@foxglove/studio-base/test/mocks/mockMessage";
 
-import { useFlattenedBlocksByTopic } from "./useFlattenedBlocksByTopic";
+import { useAllFramesByTopic } from "./useAllFramesByTopic";
 
-describe("useFlattenedBlocksPerTopic", () => {
+describe("useAllFramesByTopic", () => {
   it("flattens blocks", () => {
     const initialProgress: Progress = {
       messageCache: {
@@ -29,7 +29,7 @@ describe("useFlattenedBlocksPerTopic", () => {
 
     const topics = ["topic_a", "topic_b"];
 
-    const { result, rerender } = renderHook(() => useFlattenedBlocksByTopic(topics), {
+    const { result, rerender } = renderHook(() => useAllFramesByTopic(topics), {
       initialProps: { progress: initialProgress },
       wrapper: ({ children, progress }) => (
         <MockMessagePipelineProvider progress={progress}>{children}</MockMessagePipelineProvider>

--- a/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
+++ b/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
@@ -2,15 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { sumBy, transform } from "lodash";
-import { useMemo, useState } from "react";
+import { sumBy } from "lodash";
+import { useEffect, useMemo, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 import { Immutable } from "@foxglove/studio";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
-import { MessageBlock, MessageEvent } from "@foxglove/studio-base/players/types";
+import { MessageBlock, MessageEvent, SubscribePayload } from "@foxglove/studio-base/players/types";
 
 const EmptyBlocks: MessageBlock[] = [];
 
@@ -20,31 +21,47 @@ type State = {
   previousBlocks: Immutable<Array<undefined | MessageBlock>>;
 };
 
-function makeInitialState(): State {
-  return {
-    cursors: {},
-    messages: {},
-    previousBlocks: [],
-  };
-}
-
 const selectBlocks = (ctx: MessagePipelineContext) =>
   ctx.playerState.progress.messageCache?.blocks ?? EmptyBlocks;
 
+const selectSetSubscriptions = (ctx: MessagePipelineContext) => ctx.setSubscriptions;
+
 /**
- * Flattens incoming blocks into per-topic allFrames arrays.
+ * Maintains subscriptions and flattens incoming blocks into per-topic allFrames arrays.
  *
- * Internally this is implemented via cursor and an accumulating arrays instead of
+ * Internally this is implemented via cursor and accumulating arrays instead of
  * returning new arrays on each invocation to improve performance.
  *
- * @param blocks blocks containing messages
  * @param topics to load from blocks
  * @returns flattened per-topic arrays of messages
  */
-export function useFlattenedBlocksByTopic(
+export function useAllFramesByTopic(
   topics: readonly string[],
 ): Immutable<Record<string, MessageEvent[]>> {
-  const [state, setState] = useState<State>(makeInitialState);
+  const [state, setState] = useState<State>(() => ({
+    cursors: {},
+    messages: {},
+    previousBlocks: [],
+  }));
+
+  const [subscriberId] = useState(() => uuidv4());
+
+  const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
+
+  const subscriptions: SubscribePayload[] = useMemo(
+    () => topics.map((topic) => ({ topic, preloadType: "full" })),
+    [topics],
+  );
+
+  useEffect(() => {
+    setSubscriptions(subscriberId, subscriptions);
+
+    return () => {
+      setSubscriptions(subscriberId, []);
+    };
+  }, [subscriberId, setSubscriptions, subscriptions]);
+
+  useEffect(() => {}, [subscriberId, setSubscriptions]);
 
   const blocks = useMessagePipeline(selectBlocks);
 
@@ -66,22 +83,34 @@ export function useFlattenedBlocksByTopic(
     return true;
   }, [state.messages]);
 
-  // Reset cursors and buffers if the first block has changed.
+  // Reset cursors and buffers if the first block has changed or if our topic list doesn't
+  // match our accumulated message topic list. We have to check this because as the topics
+  // in the blocks can be a superset of the topics we're interested in.
   const shouldResetState = blocks[0]?.messagesByTopic !== state.previousBlocks[0]?.messagesByTopic;
 
   if (shouldResetState || (blocks !== state.previousBlocks && memoryAvailable)) {
     // setState directly here instead of a useEffect to avoid an extra render.
     setState((oldState) => {
       // Rebuild message buffers and cursors from last state, resetting if we are
-      // rebuilding from scratch.
-      const newState = transform(
-        topics,
-        (acc, topic) => {
-          acc.cursors[topic] = shouldResetState ? -1 : oldState.cursors[topic] ?? -1;
-          acc.messages[topic] = shouldResetState ? [] : oldState.messages[topic] ?? [];
-        },
-        { ...makeInitialState(), previousBlocks: blocks },
-      );
+      // rebuilding from scratch, making sure there is an entry in messages for all
+      // requested topics even if we don't find messages for each topic in loaded blocks.
+      const newState: State = {
+        cursors: topics.reduce(
+          (acc, topic) => ({
+            ...acc,
+            [topic]: shouldResetState ? -1 : oldState.cursors[topic] ?? -1,
+          }),
+          {},
+        ),
+        messages: topics.reduce(
+          (acc, topic) => ({
+            ...acc,
+            [topic]: shouldResetState ? [] : oldState.messages[topic] ?? [],
+          }),
+          {},
+        ),
+        previousBlocks: blocks,
+      };
 
       // append new messages to accumulating per-topic buffers and update cursors
       for (const [idx, block] of blocks.entries()) {
@@ -89,12 +118,10 @@ export function useFlattenedBlocksByTopic(
           break;
         }
 
-        for (const topic of topics) {
-          const blockMessages = block.messagesByTopic[topic];
-          if (blockMessages == undefined) {
-            continue;
-          }
-
+        // There is a delay between the time we set new subscriptions and the messages for
+        // those subscriptions appear in blocks so we load all topics we find in blocks
+        // here.
+        for (const [topic, blockMessages] of Object.entries(block.messagesByTopic)) {
           if (idx > (newState.cursors[topic] ?? -1)) {
             newState.messages[topic] = (newState.messages[topic] ?? []).concat(blockMessages);
             newState.cursors[topic] = idx;

--- a/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
+++ b/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { sumBy } from "lodash";
+import { sumBy, transform } from "lodash";
 import { useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
@@ -21,6 +21,14 @@ type State = {
   previousBlocks: Immutable<Array<undefined | MessageBlock>>;
 };
 
+function makeInitialState(): State {
+  return {
+    cursors: {},
+    messages: {},
+    previousBlocks: [],
+  };
+}
+
 const selectBlocks = (ctx: MessagePipelineContext) =>
   ctx.playerState.progress.messageCache?.blocks ?? EmptyBlocks;
 
@@ -38,11 +46,7 @@ const selectSetSubscriptions = (ctx: MessagePipelineContext) => ctx.setSubscript
 export function useAllFramesByTopic(
   topics: readonly string[],
 ): Immutable<Record<string, MessageEvent[]>> {
-  const [state, setState] = useState<State>(() => ({
-    cursors: {},
-    messages: {},
-    previousBlocks: [],
-  }));
+  const [state, setState] = useState(makeInitialState);
 
   const [subscriberId] = useState(() => uuidv4());
 
@@ -94,23 +98,14 @@ export function useAllFramesByTopic(
       // Rebuild message buffers and cursors from last state, resetting if we are
       // rebuilding from scratch, making sure there is an entry in messages for all
       // requested topics even if we don't find messages for each topic in loaded blocks.
-      const newState: State = {
-        cursors: topics.reduce(
-          (acc, topic) => ({
-            ...acc,
-            [topic]: shouldResetState ? -1 : oldState.cursors[topic] ?? -1,
-          }),
-          {},
-        ),
-        messages: topics.reduce(
-          (acc, topic) => ({
-            ...acc,
-            [topic]: shouldResetState ? [] : oldState.messages[topic] ?? [],
-          }),
-          {},
-        ),
-        previousBlocks: blocks,
-      };
+      const newState = transform(
+        topics,
+        (acc, topic) => {
+          acc.cursors[topic] = shouldResetState ? -1 : oldState.cursors[topic] ?? -1;
+          acc.messages[topic] = shouldResetState ? [] : oldState.messages[topic] ?? [];
+        },
+        { ...makeInitialState(), previousBlocks: blocks },
+      );
 
       // append new messages to accumulating per-topic buffers and update cursors
       for (const [idx, block] of blocks.entries()) {

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
@@ -105,12 +105,7 @@ describe("usePlotPanelDatasets", () => {
 
     expect(result.current).toEqual({
       bounds: expect.any(Object),
-      datasets: [
-        expect.objectContaining({
-          data: [],
-          label: "/topic.value",
-        }),
-      ],
+      datasets: [],
       pathsWithMismatchedDataLengths: [],
     });
   });

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
@@ -10,7 +10,7 @@ import { MessageEvent, PlayerStateActiveData, Topic } from "@foxglove/studio-bas
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
-import { usePlotPanelDatasets } from "./usePlotPanelDatasets";
+import { usePlotPanelData } from "./usePlotPanelData";
 
 const topics: Topic[] = [{ name: "/topic", schemaName: "datatype" }];
 const datatypes: RosDatatypes = new Map(
@@ -68,7 +68,7 @@ describe("usePlotPanelDatasets", () => {
     } as const;
 
     const { result, rerender } = renderHook(
-      ({ activeData: _, ...props }) => usePlotPanelDatasets(props),
+      ({ activeData: _, ...props }) => usePlotPanelData(props),
       {
         initialProps,
         wrapper: ({ children, activeData }) => {

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
-import { groupBy, intersection, isEmpty, transform, union, zipWith } from "lodash";
-import { useCallback, useMemo, useState } from "react";
+import { groupBy, intersection, isEmpty, mapValues, pick } from "lodash";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 
 import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
-import { isLessThan, subtract } from "@foxglove/rostime";
+import { isGreaterThan, isLessThan, isTimeInRangeInclusive, subtract } from "@foxglove/rostime";
 import { Immutable, Subscription, Time } from "@foxglove/studio";
 import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import parseRosPath, {
@@ -20,31 +20,22 @@ import {
   useDecodeMessagePathsForMessagesByTopic,
 } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { ChartDefaultView } from "@foxglove/studio-base/components/TimeBasedChart";
-import {
-  BasePlotPath,
-  DataSet,
-  PlotDataByPath,
-  PlotPath,
-  PlotXAxisVal,
-} from "@foxglove/studio-base/panels/Plot/internalTypes";
-import * as PlotData from "@foxglove/studio-base/panels/Plot/plotData";
 import { derivative } from "@foxglove/studio-base/panels/Plot/transformPlotRange";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { Bounds, makeInvertedBounds, unionBounds } from "@foxglove/studio-base/types/Bounds";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
-import { DataSets, getDatasets, mergeDatasets } from "./datasets";
-import { useFlattenedBlocksByTopic } from "./useFlattenedBlocksByTopic";
+import { calculateDatasetBounds } from "./datasets";
+import { BasePlotPath, DataSet, PlotDataByPath, PlotPath, PlotXAxisVal } from "./internalTypes";
+import { getBlockItemsByPath } from "./messageProcessing";
+import { EmptyPlotData, PlotData, appendPlotData, buildPlotData, reducePlotData } from "./plotData";
+import { useAllFramesByTopic } from "./useAllFramesByTopic";
 
-const ZERO_TIME = { sec: 0, nsec: 0 };
+const ZERO_TIME = Object.freeze({ sec: 0, nsec: 0 });
 
-const EmptyAllFrames: Record<string, MessageEvent[]> = {};
+const EmptyAllFrames: Immutable<Record<string, MessageEvent[]>> = Object.freeze({});
 
-const EmptyDatasets: DataSets = {
-  datasets: [],
-  bounds: makeInvertedBounds(),
-  pathsWithMismatchedDataLengths: [],
-};
+type TaggedPlotData = { tag: string; data: Immutable<PlotData> };
 
 type Params = Immutable<{
   allPaths: string[];
@@ -56,35 +47,34 @@ type Params = Immutable<{
   yAxisPaths: PlotPath[];
 }>;
 
-type State = DataSets & {
+type State = Immutable<{
   allFrames: Record<string, Immutable<MessageEvent[]>>;
   allPaths: readonly string[];
-  bounds: Bounds;
   cursors: Record<string, number>;
+  data: PlotData;
   subscriptions: Subscription[];
   xAxisVal: PlotXAxisVal;
   xAxisPath: undefined | BasePlotPath;
-};
+}>;
 
 /**
  * Applies the @derivative modifier to the dataset. This has to be done on the complete
  * dataset, not calculated incrementally.
  */
-function applyDerivativeToDatasets(datasets: DataSets["datasets"]): DataSets["datasets"] {
-  return datasets.map((dataset) => {
-    if (dataset == undefined) {
-      return undefined;
-    }
-
-    if (dataset.path.value.endsWith(".@derivative")) {
-      return {
-        path: dataset.path,
-        dataset: { ...dataset.dataset, data: derivative(dataset.dataset.data) },
-      };
-    } else {
-      return dataset;
-    }
-  });
+function applyDerivativeToPlotData(data: Immutable<PlotData>): Immutable<PlotData> {
+  return {
+    ...data,
+    datasetsByPath: mapValues(data.datasetsByPath, (dataset, path) => {
+      if (path.endsWith(".@derivative")) {
+        return {
+          ...dataset,
+          data: derivative(dataset.data),
+        };
+      } else {
+        return dataset;
+      }
+    }),
+  };
 }
 
 /**
@@ -99,45 +89,46 @@ function applyDerivativeToDatasets(datasets: DataSets["datasets"]): DataSets["da
  * time ordering is undefined (could be different for different data sources), but the header stamps
  * still need sorting so the plot renders correctly.
  */
-function sortDatasetsByHeaderStamp(datasets: DataSets["datasets"]): DataSets["datasets"] {
-  return datasets.map((dataset) => {
+function sortPlotDataByHeaderStamp(
+  paths: Immutable<PlotPath[]>,
+  data: Immutable<PlotData>,
+): Immutable<PlotData> {
+  const processedDatasets = filterMap(paths, (path) => {
+    const dataset = data.datasetsByPath[path.value];
     if (dataset == undefined) {
       return undefined;
     }
 
-    if (dataset.path.timestampMethod !== "headerStamp") {
-      return dataset;
+    if (path.timestampMethod !== "headerStamp") {
+      return [path.value, dataset];
     }
 
-    return {
-      path: dataset.path,
-      dataset: { ...dataset.dataset, data: dataset.dataset.data.sort((a, b) => a.x - b.x) },
-    };
+    return [path.value, { ...dataset, data: dataset.data.slice().sort((a, b) => a.x - b.x) }];
   });
+
+  return { ...data, datasetsByPath: Object.fromEntries(processedDatasets) };
 }
 
 function makeInitialState(): State {
   return {
     allFrames: {},
     allPaths: [],
-    bounds: makeInvertedBounds(),
     cursors: {},
-    datasets: [],
+    data: EmptyPlotData,
     subscriptions: [],
-    pathsWithMismatchedDataLengths: [],
     xAxisVal: "timestamp",
     xAxisPath: undefined,
   };
 }
 
 /**
- * Collates and combines datasets from alLFrames and currentFrame messages.
+ * Collates and combines data from alLFrames and currentFrame messages.
  */
-export function usePlotPanelDatasets(params: Params): {
+export function usePlotPanelData(params: Params): Immutable<{
   bounds: Bounds;
   datasets: DataSet[];
   pathsWithMismatchedDataLengths: string[];
-} {
+}> {
   const {
     allPaths,
     followingView,
@@ -165,9 +156,9 @@ export function usePlotPanelDatasets(params: Params): {
 
   const [state, setState] = useState(makeInitialState);
 
-  const allFramesFromBlocks = useFlattenedBlocksByTopic(subscribeTopics);
+  const allFramesByTopic = useAllFramesByTopic(subscribeTopics);
 
-  const allFrames = showSingleCurrentMessage ? EmptyAllFrames : allFramesFromBlocks;
+  const allFrames = showSingleCurrentMessage ? EmptyAllFrames : allFramesByTopic;
 
   const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(allPaths);
 
@@ -179,31 +170,21 @@ export function usePlotPanelDatasets(params: Params): {
     setState((oldState) => {
       const newState = resetDatasets ? makeInitialState() : oldState;
 
-      const newFramesByTopic = transform(
-        allFrames,
-        (acc, messages, topic) => {
-          acc[topic] = messages.slice(newState.cursors[topic] ?? 0);
-        },
-        {} as State["allFrames"],
+      const newFramesByTopic = mapValues(allFrames, (messages, topic) =>
+        messages.slice(newState.cursors[topic] ?? 0),
       );
 
-      const newCursors = transform(
-        allFrames,
-        (acc, messages, topic) => {
-          acc[topic] = messages.length;
-        },
-        {} as State["cursors"],
-      );
+      const newCursors = mapValues(allFrames, (messages) => messages.length);
 
-      const newBlockItems = PlotData.getBlockItemsByPath(
+      const newBlockItems = getBlockItemsByPath(
         decodeMessagePathsForMessagesByTopic,
         newFramesByTopic,
       );
 
       const anyNewFrames = Object.values(newFramesByTopic).some((msgs) => msgs.length > 0);
 
-      const newDatasets = anyNewFrames
-        ? getDatasets({
+      const newPlotData = anyNewFrames
+        ? buildPlotData({
             paths: yAxisPaths,
             itemsByPath: newBlockItems,
             startTime: startTime ?? ZERO_TIME,
@@ -211,24 +192,13 @@ export function usePlotPanelDatasets(params: Params): {
             xAxisPath,
             invertedTheme: theme.palette.mode === "dark",
           })
-        : EmptyDatasets;
-
-      const mergedDatasets: State["datasets"] = zipWith(
-        newState.datasets,
-        newDatasets.datasets,
-        mergeDatasets,
-      );
+        : EmptyPlotData;
 
       return {
         allFrames,
         allPaths,
-        bounds: unionBounds(newState.bounds, newDatasets.bounds),
         cursors: newCursors,
-        datasets: mergedDatasets,
-        pathsWithMismatchedDataLengths: union(
-          newState.pathsWithMismatchedDataLengths,
-          newDatasets.pathsWithMismatchedDataLengths,
-        ),
+        data: appendPlotData(newState.data, newPlotData),
         subscriptions,
         xAxisPath,
         xAxisVal,
@@ -238,34 +208,46 @@ export function usePlotPanelDatasets(params: Params): {
 
   const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(allPaths);
 
-  // When restoring, keep only the paths that are present in allPaths. Without this, the
-  // reducer value will grow unbounded with new paths as users add/remove series.
   const restore = useCallback(
-    (previous?: DataSets): DataSets => {
-      if (previous) {
-        return {
-          datasets: previous.datasets.filter((ds) => ds && allPaths.includes(ds.path.value)),
-          bounds: previous.bounds,
-          pathsWithMismatchedDataLengths: intersection(
-            previous.pathsWithMismatchedDataLengths,
-            allPaths,
-          ),
-        };
-      } else {
-        return {
-          datasets: [],
-          bounds: makeInvertedBounds(),
-          pathsWithMismatchedDataLengths: [],
-        };
+    (previous?: TaggedPlotData): TaggedPlotData => {
+      if (!previous) {
+        // If we're showing single frames, we don't want to accumulate chunks of messages
+        // across multiple frames, so we put everything into a single restore tag and
+        // each new frame replaces the old one.
+        const tag = showSingleCurrentMessage ? "single" : new Date().toISOString();
+        return { tag, data: EmptyPlotData };
       }
+
+      // Discard datasets no longer in current y paths and recompute bounds and mismatched
+      // paths so we don't hang onto data we no longer need.
+      const newYPathValues = yAxisPaths.map((path) => path.value);
+      const retainedDataSets = pick(previous.data.datasetsByPath, newYPathValues);
+      const newMismatchedPaths = intersection(
+        previous.data.pathsWithMismatchedDataLengths,
+        newYPathValues,
+      );
+      const newBounds = filterMap(Object.values(retainedDataSets), calculateDatasetBounds).reduce(
+        unionBounds,
+        makeInvertedBounds(),
+      );
+
+      return {
+        tag: previous.tag,
+        data: {
+          bounds: newBounds,
+          datasetsByPath: retainedDataSets,
+          pathsWithMismatchedDataLengths: newMismatchedPaths,
+        },
+      };
     },
-    [allPaths],
+    [showSingleCurrentMessage, yAxisPaths],
   );
 
-  const latestAllFramesDatasets = useLatest(state.datasets);
+  // Access allFrames by reference to avoid invalidating the addMessages callback.
+  const latestAllFrames = useLatest(allFrames);
 
   const addMessages = useCallback(
-    (accumulated: DataSets, msgEvents: Immutable<MessageEvent[]>) => {
+    (accumulated: TaggedPlotData, msgEvents: Immutable<MessageEvent[]>) => {
       const lastEventTime = msgEvents.at(-1)?.receiveTime;
       const isFollowing = followingView?.type === "following";
       const newMessages: PlotDataByPath = {};
@@ -276,18 +258,27 @@ export function usePlotPanelDatasets(params: Params): {
           continue;
         }
 
-        for (const [pathIndex, path] of paths.entries()) {
-          // Skip datasets we're getting from allFrames.
-          if ((latestAllFramesDatasets.current[pathIndex]?.dataset.data.length ?? 0) > 0) {
-            continue;
-          }
-
+        for (const path of paths) {
           const dataItem = cachedGetMessagePathDataItems(path, msgEvent);
           if (!dataItem) {
             continue;
           }
 
           const headerStamp = getTimestampForMessage(msgEvent.message);
+
+          const allFramesForPathStart = latestAllFrames.current[path]?.at(0)?.receiveTime;
+          const allFramesForPathEnd = latestAllFrames.current[path]?.at(-1)?.receiveTime;
+          if (
+            allFramesForPathStart &&
+            allFramesForPathEnd &&
+            isTimeInRangeInclusive(msgEvent.receiveTime, allFramesForPathStart, allFramesForPathEnd)
+          ) {
+            // Skip messages that fall within the range of our allFrames data since we
+            // would just filter them out later anyway. Note that this assumes allFrames
+            // are loaded contiguously starting from the beginning of message data.
+            continue;
+          }
+
           const plotDataItem = {
             queriedData: dataItem,
             receiveTime: msgEvent.receiveTime,
@@ -321,7 +312,7 @@ export function usePlotPanelDatasets(params: Params): {
         return accumulated;
       }
 
-      const newDatasets = getDatasets({
+      const newPlotData = buildPlotData({
         paths: yAxisPaths,
         itemsByPath: newMessages,
         startTime: startTime ?? ZERO_TIME,
@@ -330,24 +321,17 @@ export function usePlotPanelDatasets(params: Params): {
         invertedTheme: theme.palette.mode === "dark",
       });
 
-      const mergedDatasets: DataSets = {
-        bounds: unionBounds(accumulated.bounds, newDatasets.bounds),
-        // If showing a single current message replace instead of concatenating datasets.
-        datasets: showSingleCurrentMessage
-          ? newDatasets.datasets
-          : zipWith(accumulated.datasets, newDatasets.datasets, mergeDatasets),
-        pathsWithMismatchedDataLengths: union(
-          accumulated.pathsWithMismatchedDataLengths,
-          newDatasets.pathsWithMismatchedDataLengths,
-        ),
+      return {
+        tag: accumulated.tag,
+        data: showSingleCurrentMessage
+          ? newPlotData
+          : appendPlotData(accumulated.data, newPlotData),
       };
-
-      return mergedDatasets;
     },
     [
       cachedGetMessagePathDataItems,
       followingView,
-      latestAllFramesDatasets,
+      latestAllFrames,
       showSingleCurrentMessage,
       startTime,
       theme.palette.mode,
@@ -358,43 +342,67 @@ export function usePlotPanelDatasets(params: Params): {
     ],
   );
 
-  const currentFrameDatasets = useMessageReducer<DataSets>({
+  const currentFrameData = useMessageReducer<TaggedPlotData>({
     topics: subscribeTopics,
     preloadType: "full",
     restore,
     addMessages,
   });
 
+  // Accumulate separate message playback sequences into distinct intervals we
+  // can later combine into a single combined set of message data.
+  const [accumulatedPathIntervals, setAccumulatedPathIntervals] = useState<
+    Record<string, Immutable<PlotData>>
+  >({});
+
+  useEffect(() => {
+    if (!isEmpty(currentFrameData.data.datasetsByPath)) {
+      setAccumulatedPathIntervals((oldValue) => ({
+        ...oldValue,
+        [currentFrameData.tag]: currentFrameData.data,
+      }));
+    }
+  }, [currentFrameData.data, currentFrameData.tag]);
+
+  // Trim currentFrame data outside allFrames, assuming allFrames is contiguous from start
+  // time.
+  const trimmedCurrentFrameData = useMemo(() => {
+    return filterMap(Object.values(accumulatedPathIntervals), (dataset) => {
+      const trimmedDatasets = mapValues(dataset.datasetsByPath, (ds, path) => {
+        const topic = parseRosPath(path)?.topicName;
+        const end = topic ? allFrames[topic]?.at(-1)?.receiveTime : undefined;
+        if (end) {
+          return {
+            ...ds,
+            data: ds.data.filter((datum) => isGreaterThan(datum.receiveTime, end)),
+          };
+        } else {
+          return ds;
+        }
+      });
+
+      if (Object.values(trimmedDatasets).some((ds) => ds.data.length > 0)) {
+        return { ...dataset, datasetsByPath: trimmedDatasets };
+      } else {
+        return undefined;
+      }
+    });
+  }, [accumulatedPathIntervals, allFrames]);
+
   // Combine allFrames & currentFrames datasets, optionally applying the @derivative
   // modifier and sorting by header stamp, which can only be calculated on a complete
   // dataset, not point by point.
-  const combinedDatasets = useMemo(() => {
-    const stateWithDerivatives = applyDerivativeToDatasets(state.datasets);
-    const sortedStateWithDerivatives = sortDatasetsByHeaderStamp(stateWithDerivatives);
-    const currentFrameWithDerivatives = applyDerivativeToDatasets(currentFrameDatasets.datasets);
-    const sortedCurrentFrameWithDerivatives = sortDatasetsByHeaderStamp(
-      currentFrameWithDerivatives,
-    );
-    const allDatasets = Object.values(sortedStateWithDerivatives).concat(
-      Object.values(sortedCurrentFrameWithDerivatives),
-    );
-    const bounds = unionBounds(state.bounds, currentFrameDatasets.bounds);
-    return {
-      bounds,
-      datasets: filterMap(allDatasets, (ds) => (ds ? ds.dataset : undefined)),
-      pathsWithMismatchedDataLengths: union(
-        state.pathsWithMismatchedDataLengths,
-        currentFrameDatasets.pathsWithMismatchedDataLengths,
-      ),
-    };
-  }, [
-    currentFrameDatasets.bounds,
-    currentFrameDatasets.datasets,
-    currentFrameDatasets.pathsWithMismatchedDataLengths,
-    state.bounds,
-    state.datasets,
-    state.pathsWithMismatchedDataLengths,
-  ]);
+  const allData = useMemo(() => {
+    const combinedPlotData = reducePlotData([state.data, ...trimmedCurrentFrameData]);
+    const dataAfterDerivative = applyDerivativeToPlotData(combinedPlotData);
+    const sortedData = sortPlotDataByHeaderStamp(yAxisPaths, dataAfterDerivative);
 
-  return combinedDatasets;
+    return {
+      bounds: sortedData.bounds,
+      datasets: filterMap(yAxisPaths, (path) => sortedData.datasetsByPath[path.value]),
+      pathsWithMismatchedDataLengths: sortedData.pathsWithMismatchedDataLengths,
+    };
+  }, [state.data, trimmedCurrentFrameData, yAxisPaths]);
+
+  return allData;
 }

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
-import { groupBy, intersection, isEmpty, mapValues, pick } from "lodash";
+import { groupBy, intersection, isEmpty, mapValues } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 
@@ -27,6 +27,7 @@ import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import { calculateDatasetBounds } from "./datasets";
 import { BasePlotPath, DataSet, PlotDataByPath, PlotPath, PlotXAxisVal } from "./internalTypes";
+import * as maps from "./maps";
 import { getBlockItemsByPath } from "./messageProcessing";
 import { EmptyPlotData, PlotData, appendPlotData, buildPlotData, reducePlotData } from "./plotData";
 import { useAllFramesByTopic } from "./useAllFramesByTopic";
@@ -64,8 +65,8 @@ type State = Immutable<{
 function applyDerivativeToPlotData(data: Immutable<PlotData>): Immutable<PlotData> {
   return {
     ...data,
-    datasetsByPath: mapValues(data.datasetsByPath, (dataset, path) => {
-      if (path.endsWith(".@derivative")) {
+    datasetsByPath: maps.mapValues(data.datasetsByPath, (dataset, path) => {
+      if (path.value.endsWith(".@derivative")) {
         return {
           ...dataset,
           data: derivative(dataset.data),
@@ -89,24 +90,16 @@ function applyDerivativeToPlotData(data: Immutable<PlotData>): Immutable<PlotDat
  * time ordering is undefined (could be different for different data sources), but the header stamps
  * still need sorting so the plot renders correctly.
  */
-function sortPlotDataByHeaderStamp(
-  paths: Immutable<PlotPath[]>,
-  data: Immutable<PlotData>,
-): Immutable<PlotData> {
-  const processedDatasets = filterMap(paths, (path) => {
-    const dataset = data.datasetsByPath[path.value];
-    if (dataset == undefined) {
-      return undefined;
-    }
-
+function sortPlotDataByHeaderStamp(data: Immutable<PlotData>): Immutable<PlotData> {
+  const processedDatasets = maps.mapValues(data.datasetsByPath, (dataset, path) => {
     if (path.timestampMethod !== "headerStamp") {
-      return [path.value, dataset];
+      return dataset;
     }
 
-    return [path.value, { ...dataset, data: dataset.data.slice().sort((a, b) => a.x - b.x) }];
+    return { ...dataset, data: dataset.data.slice().sort((a, b) => a.x - b.x) };
   });
 
-  return { ...data, datasetsByPath: Object.fromEntries(processedDatasets) };
+  return { ...data, datasetsByPath: processedDatasets };
 }
 
 function makeInitialState(): State {
@@ -221,12 +214,12 @@ export function usePlotPanelData(params: Params): Immutable<{
       // Discard datasets no longer in current y paths and recompute bounds and mismatched
       // paths so we don't hang onto data we no longer need.
       const newYPathValues = yAxisPaths.map((path) => path.value);
-      const retainedDataSets = pick(previous.data.datasetsByPath, newYPathValues);
+      const retainedDataSets = maps.pick(previous.data.datasetsByPath, yAxisPaths);
       const newMismatchedPaths = intersection(
         previous.data.pathsWithMismatchedDataLengths,
         newYPathValues,
       );
-      const newBounds = filterMap(Object.values(retainedDataSets), calculateDatasetBounds).reduce(
+      const newBounds = filterMap([...retainedDataSets.values()], calculateDatasetBounds).reduce(
         unionBounds,
         makeInvertedBounds(),
       );
@@ -368,8 +361,8 @@ export function usePlotPanelData(params: Params): Immutable<{
   // time.
   const trimmedCurrentFrameData = useMemo(() => {
     return filterMap(Object.values(accumulatedPathIntervals), (dataset) => {
-      const trimmedDatasets = mapValues(dataset.datasetsByPath, (ds, path) => {
-        const topic = parseRosPath(path)?.topicName;
+      const trimmedDatasets = maps.mapValues(dataset.datasetsByPath, (ds, path) => {
+        const topic = parseRosPath(path.value)?.topicName;
         const end = topic ? allFrames[topic]?.at(-1)?.receiveTime : undefined;
         if (end) {
           return {
@@ -381,7 +374,7 @@ export function usePlotPanelData(params: Params): Immutable<{
         }
       });
 
-      if (Object.values(trimmedDatasets).some((ds) => ds.data.length > 0)) {
+      if ([...trimmedDatasets.values()].some((ds) => ds.data.length > 0)) {
         return { ...dataset, datasetsByPath: trimmedDatasets };
       } else {
         return undefined;
@@ -395,11 +388,11 @@ export function usePlotPanelData(params: Params): Immutable<{
   const allData = useMemo(() => {
     const combinedPlotData = reducePlotData([state.data, ...trimmedCurrentFrameData]);
     const dataAfterDerivative = applyDerivativeToPlotData(combinedPlotData);
-    const sortedData = sortPlotDataByHeaderStamp(yAxisPaths, dataAfterDerivative);
+    const sortedData = sortPlotDataByHeaderStamp(dataAfterDerivative);
 
     return {
       bounds: sortedData.bounds,
-      datasets: filterMap(yAxisPaths, (path) => sortedData.datasetsByPath[path.value]),
+      datasets: filterMap(yAxisPaths, (path) => sortedData.datasetsByPath.get(path)),
       pathsWithMismatchedDataLengths: sortedData.pathsWithMismatchedDataLengths,
     };
   }, [state.data, trimmedCurrentFrameData, yAxisPaths]);


### PR DESCRIPTION
**User-Facing Changes**
Allow users to seek to reveal segments of messages when memory is exhausted and we can't load any more message blocks.

**Description**
Accumulate ranges of currentFrame messages during playback, allowing the user to reveal portions of the plot even if we don't have enough memory to load blocks from that timerange.

Restores functionality of https://github.com/foxglove/studio/pull/5694, preserving recent performance optimizations from https://github.com/foxglove/studio/pull/6291.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
