### PR TITLE
Add picking story for image annotations

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -6,6 +6,7 @@ import * as THREE from "three";
 import { assert } from "ts-essentials";
 
 import { PinholeCameraModel } from "@foxglove/den/image";
+import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { BaseUserData, Renderable } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderable";
@@ -17,6 +18,8 @@ import { RosValue } from "@foxglove/studio-base/players/types";
 import { AnyImage } from "./ImageTypes";
 import { RawImageOptions, decodeCompressedImageToBitmap } from "./decodeImage";
 import { CameraInfo } from "../../ros";
+
+const log = Logger.getLogger(__filename);
 
 export interface ImageRenderableSettings {
   visible: boolean;
@@ -195,6 +198,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         this.renderer.queueAnimationFrame();
       })
       .catch((err) => {
+        log.error(err);
         if (this.#disposed) {
           return;
         }

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
+import { screen, userEvent } from "@storybook/testing-library";
 import { cloneDeep } from "lodash";
 import { useEffect, useState } from "react";
 
@@ -23,7 +24,10 @@ export default {
   },
 };
 
-const AnnotationsStory = (imageModeConfigOverride: Partial<ImageModeConfig> = {}): JSX.Element => {
+const AnnotationsStory = (
+  args: { debugPicking?: boolean; imageModeConfigOverride?: Partial<ImageModeConfig> } = {},
+): JSX.Element => {
+  const { debugPicking, imageModeConfigOverride } = args;
   const width = 60;
   const height = 45;
   const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
@@ -249,6 +253,7 @@ const AnnotationsStory = (imageModeConfigOverride: Partial<ImageModeConfig> = {}
   return (
     <PanelSetup fixture={fixture}>
       <ImagePanel
+        debugPicking={debugPicking}
         overrideConfig={{
           ...ImagePanel.defaultConfig,
           imageMode: {
@@ -267,9 +272,27 @@ export const Annotations: StoryObj = {
   render: AnnotationsStory,
 };
 
+export const AnnotationsPicking: StoryObj = {
+  render: AnnotationsStory,
+  args: {
+    debugPicking: true,
+  },
+  async play() {
+    await userEvent.hover(await screen.findByTestId(/panel-mouseenter-container/));
+    await userEvent.click(await screen.findByTestId("ExpandingToolbar-Inspect objects"));
+    await userEvent.pointer({
+      target: document.querySelector("canvas")!,
+      keys: "[MouseLeft]",
+      coords: { clientX: 0, clientY: 0 },
+    });
+  },
+};
+
 export const AnnotationsWithoutCalibration: StoryObj = {
   render: AnnotationsStory,
-  args: { calibrationTopic: undefined },
+  args: {
+    imageModeConfigOverride: { calibrationTopic: undefined },
+  },
 };
 
 export const MessageConverterSupport: StoryObj = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -281,7 +281,7 @@ export const AnnotationsPicking: StoryObj = {
     debugPicking: true,
   },
   async play() {
-    await delay(100);
+    await delay(1000);
     await userEvent.hover(await screen.findByTestId(/panel-mouseenter-container/));
     await userEvent.click(await screen.findByTestId("ExpandingToolbar-Inspect objects"));
     await userEvent.pointer({

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -13,6 +13,7 @@ import { ImageModeConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/IRe
 import { makeRawImageAndCalibration } from "@foxglove/studio-base/panels/ThreeDeeRender/stories/ImageMode/imageCommon";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+import delay from "@foxglove/studio-base/util/delay";
 
 import { ImagePanel } from "../../index";
 
@@ -278,6 +279,7 @@ export const AnnotationsPicking: StoryObj = {
     debugPicking: true,
   },
   async play() {
+    await delay(100);
     await userEvent.hover(await screen.findByTestId(/panel-mouseenter-container/));
     await userEvent.click(await screen.findByTestId("ExpandingToolbar-Inspect objects"));
     await userEvent.pointer({

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -252,20 +252,22 @@ const AnnotationsStory = (
     },
   };
   return (
-    <PanelSetup fixture={fixture}>
-      <ImagePanel
-        debugPicking={debugPicking}
-        overrideConfig={{
-          ...ImagePanel.defaultConfig,
-          imageMode: {
-            calibrationTopic: "calibration",
-            imageTopic: "camera",
-            annotations: { annotations: { visible: true } },
-            ...imageModeConfigOverride,
-          },
-        }}
-      />
-    </PanelSetup>
+    <div style={{ width: 1200, height: 900, flexShrink: 0 }}>
+      <PanelSetup fixture={fixture}>
+        <ImagePanel
+          debugPicking={debugPicking}
+          overrideConfig={{
+            ...ImagePanel.defaultConfig,
+            imageMode: {
+              calibrationTopic: "calibration",
+              imageTopic: "camera",
+              annotations: { annotations: { visible: true } },
+              ...imageModeConfigOverride,
+            },
+          }}
+        />
+      </PanelSetup>
+    </div>
   );
 };
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds a story showing the ImageAnnotations hitmap.

<img width="580" alt="image" src="https://github.com/foxglove/studio/assets/14237/f090814d-e23f-4a69-baa4-3c3840c12e8f">


I also updated default picking material implementation to make distinct materials based on `depthTest` and `depthWrite`. I did this because the ImageRenderable uses these material flags to always render behind the annotations (see `renderBehindScene`). Without this change, the image would overlap some annotations in the hitmap even though it did not actually overlap them in a normal render. The multi-pass picking would be able to handle this and correctly show both the image and annotation in the dropdown menu, but I disabled multi-pass picking when `debugPicking==true` in #6419.

Blocked on #6419 