### PR TITLE
fix async setUpdateError on unmounted component

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -304,16 +304,21 @@ function Chart(props: Props): JSX.Element {
     }
 
     running.current = true;
+    // Prevent setState if component unmounted
+    let canceled = false;
     updateChart(newUpdate)
       .catch((err: Error) => {
-        if (isMounted()) {
+        if (!canceled) {
           setUpdateError(err);
         }
       })
       .finally(() => {
         running.current = false;
       });
-  }, [getNewUpdateMessage, isMounted, updateChart]);
+    return () => {
+      canceled = true;
+    };
+  }, [getNewUpdateMessage, updateChart]);
 
   useLayoutEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

I did see https://github.com/foxglove/studio/pull/6209. But since `isMount()` only prevent `setState` if the current chart component is unmounted.

Think of this scenario:

1. Chart component fire `updateChart` call, then component unmount. -> isMount() false
2. New Chart component mount, but old component `updateChart` promise is still waiting -> isMount() true because it's useRef
3. Old component `updateChart` promise resolved and because isMount is true, it will call `usesetUpdateError`

This is exactly what happens in react 18 strict mode development environment. If it's new component, then it only throw warning on console, setState for unmounted component. But react 18 component capture all state of old component and put it in new component, which cause new chart pannel throw rpc terminate error.


This is only a quick fix.  I think the better way is in RPC, we can provide a cancelable main -> worker callback, when chart unmount, cancel pending callback, and on terminate time won't throw error for canceled callback. But this fix is still valid for prevent unmounted component async callback setState.

