### PR TITLE
Fix handling of index-based x axis plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/usePlotPanelDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelDatasets.ts
@@ -332,7 +332,10 @@ export function usePlotPanelDatasets(params: Params): {
 
       const mergedDatasets: DataSets = {
         bounds: unionBounds(accumulated.bounds, newDatasets.bounds),
-        datasets: zipWith(accumulated.datasets, newDatasets.datasets, mergeDatasets),
+        // If showing a single current message replace instead of concatenating datasets.
+        datasets: showSingleCurrentMessage
+          ? newDatasets.datasets
+          : zipWith(accumulated.datasets, newDatasets.datasets, mergeDatasets),
         pathsWithMismatchedDataLengths: union(
           accumulated.pathsWithMismatchedDataLengths,
           newDatasets.pathsWithMismatchedDataLengths,


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with x-axis index based plots.

**Description**
Fixes a regression introduced in https://github.com/foxglove/studio/pull/6291.

If we are displaying one message at a time we shouldn't append to previous accumulated datasets.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
Fixes https://github.com/foxglove/studio/issues/5862