### PR TITLE
Add support for `omgidl` schemas in foxglove studio

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -26,6 +26,8 @@
   },
   "dependencies": {
     "@foxglove/message-definition": "0.2.0",
+    "@foxglove/omgidl-parser": "0.0.1",
+    "@foxglove/omgidl-serialization": "0.0.2",
     "@foxglove/rosmsg": "4.2.2",
     "@foxglove/rosmsg-serialization": "2.0.1",
     "@foxglove/rosmsg2-serialization": "2.0.1",

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -94,7 +94,7 @@ describe("parseChannel", () => {
   });
   it("works with omgidl xcdr2", () => {
     const channel = parseChannel({
-      messageEncoding: "xcdr2",
+      messageEncoding: "cdr",
       schema: {
         name: "foo_msgs::Bar",
         encoding: "omgidl",

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -92,4 +92,25 @@ describe("parseChannel", () => {
     const obj = channel.deserialize(new Uint8Array([0, 1, 0, 0, 5, 0, 0, 0, 65, 66, 67, 68, 0]));
     expect(obj).toEqual({ data: "ABCD" });
   });
+  it("works with omgidl xcdr2", () => {
+    const channel = parseChannel({
+      messageEncoding: "xcdr2",
+      schema: {
+        name: "foo_msgs::Bar",
+        encoding: "omgidl",
+        data: new TextEncoder().encode(`
+        enum Color {RED, GREEN, BLUE};
+        module foo_msgs {
+          struct NonRootBar {string data;};
+          struct Bar {foo_msgs::NonRootBar data; Color color;};
+        };
+        `),
+      },
+    });
+
+    const obj = channel.deserialize(
+      new Uint8Array([0, 1, 0, 0, 5, 0, 0, 0, 65, 66, 67, 68, 0, 0, 0, 0, 2, 0, 0, 0]),
+    );
+    expect(obj).toEqual({ data: { data: "ABCD" }, color: 2 });
+  });
 });

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -123,7 +123,7 @@ export function parseChannel(channel: Channel): ParsedChannel {
     };
   }
 
-  if (channel.messageEncoding === "cdr" || channel.messageEncoding === "xcdr2") {
+  if (channel.messageEncoding === "cdr") {
     if (
       channel.schema?.encoding !== "ros2msg" &&
       channel.schema?.encoding !== "ros2idl" &&

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageDefinition } from "@foxglove/message-definition";
+import { parseIdl } from "@foxglove/omgidl-parser";
+import { MessageReader as OmgidlMessageReader } from "@foxglove/omgidl-serialization";
 import { parse as parseMessageDefinition, parseRos2idl } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
@@ -24,11 +26,11 @@ export type ParsedChannel = {
 
 function parsedDefinitionsToDatatypes(
   parsedDefinitions: MessageDefinition[],
-  rootName: string,
+  rootName?: string,
 ): MessageDefinitionMap {
   const datatypes: MessageDefinitionMap = new Map();
   parsedDefinitions.forEach(({ name, definitions }, index) => {
-    if (index === 0) {
+    if (rootName != undefined && index === 0) {
       datatypes.set(rootName, { name: rootName, definitions });
     } else if (name != undefined) {
       datatypes.set(name, { name, definitions });
@@ -121,8 +123,12 @@ export function parseChannel(channel: Channel): ParsedChannel {
     };
   }
 
-  if (channel.messageEncoding === "cdr") {
-    if (channel.schema?.encoding !== "ros2msg" && channel.schema?.encoding !== "ros2idl") {
+  if (channel.messageEncoding === "cdr" || channel.messageEncoding === "xcdr2") {
+    if (
+      channel.schema?.encoding !== "ros2msg" &&
+      channel.schema?.encoding !== "ros2idl" &&
+      channel.schema?.encoding !== "omgidl"
+    ) {
       throw new Error(
         `Message encoding ${channel.messageEncoding} with ${
           channel.schema == undefined
@@ -132,17 +138,28 @@ export function parseChannel(channel: Channel): ParsedChannel {
       );
     }
     const schema = new TextDecoder().decode(channel.schema.data);
-    const isIdl = channel.schema.encoding === "ros2idl";
+    if (channel.schema.encoding === "omgidl") {
+      const parsedDefinitions = parseIdl(schema);
+      const reader = new OmgidlMessageReader(channel.schema.name, parsedDefinitions);
+      const datatypes = parsedDefinitionsToDatatypes(parsedDefinitions);
+      return {
+        datatypes,
+        deserialize: (data) => reader.readMessage(data),
+      };
+    } else {
+      const isIdl = channel.schema.encoding === "ros2idl";
 
-    const parsedDefinitions = isIdl
-      ? parseRos2idl(schema)
-      : parseMessageDefinition(schema, { ros2: true });
+      const parsedDefinitions = isIdl
+        ? parseRos2idl(schema)
+        : parseMessageDefinition(schema, { ros2: true });
 
-    const reader = new ROS2MessageReader(parsedDefinitions);
-    return {
-      datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),
-      deserialize: (data) => reader.readMessage(data),
-    };
+      const reader = new ROS2MessageReader(parsedDefinitions);
+
+      return {
+        datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),
+        deserialize: (data) => reader.readMessage(data),
+      };
+    }
   }
 
   throw new Error(`Unsupported encoding ${channel.messageEncoding}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2635,17 +2635,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/cdr@npm:2.1.0":
+"@foxglove/cdr@npm:2.1.0, @foxglove/cdr@npm:^2.0.0":
   version: 2.1.0
   resolution: "@foxglove/cdr@npm:2.1.0"
   checksum: 153632a8911a76d047d896f0a17e12b5a6779465a35790c2fe349efc0eb8a618c877d015a066d8b13a804f0c72131a7e9ca0bf48ed116aa3095a3d7252ab1062
-  languageName: node
-  linkType: hard
-
-"@foxglove/cdr@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@foxglove/cdr@npm:2.0.0"
-  checksum: 2a42f9bc04a04078573c18060a173079db213818a739ea7e93b1701394336bc86a5e7ccbcdf93d747f15a734ea6da5250932a475a55593285a496badddddd450
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2635,6 +2635,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/cdr@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@foxglove/cdr@npm:2.1.0"
+  checksum: 153632a8911a76d047d896f0a17e12b5a6779465a35790c2fe349efc0eb8a618c877d015a066d8b13a804f0c72131a7e9ca0bf48ed116aa3095a3d7252ab1062
+  languageName: node
+  linkType: hard
+
 "@foxglove/cdr@npm:^2.0.0":
   version: 2.0.0
   resolution: "@foxglove/cdr@npm:2.0.0"
@@ -2753,6 +2760,8 @@ __metadata:
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
     "@foxglove/message-definition": 0.2.0
+    "@foxglove/omgidl-parser": 0.0.1
+    "@foxglove/omgidl-serialization": 0.0.2
     "@foxglove/rosmsg": 4.2.2
     "@foxglove/rosmsg-serialization": 2.0.1
     "@foxglove/rosmsg2-serialization": 2.0.1
@@ -2784,6 +2793,25 @@ __metadata:
     data-uri-to-buffer: ^3.0.1
     fetch-blob: ^2.1.1
   checksum: 68d0c28d85622853752a221eeae78c5b0e750901a7eb603d05a0174556a690640a68b246751327a42f46e4447bd072784f81606cc7729bf49c6df8f0f5afa19d
+  languageName: node
+  linkType: hard
+
+"@foxglove/omgidl-parser@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@foxglove/omgidl-parser@npm:0.0.1"
+  dependencies:
+    tslib: ^2
+  checksum: 2d1c768d612a22f8f61bc433ab4695e016a02fe4ac2a2f52fce4c0433b5dcacf02ade9c221fa0edaa042a0388267021a21d9c09f7f7f74b8db8d9f5d61492857
+  languageName: node
+  linkType: hard
+
+"@foxglove/omgidl-serialization@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@foxglove/omgidl-serialization@npm:0.0.2"
+  dependencies:
+    "@foxglove/cdr": 2.1.0
+    "@foxglove/message-definition": ^0.2.0
+  checksum: 13639f349a639b9175dd48e5d26cebf75880efada8760ec79ab94ac3cd776765e302fccebc73e01d2e8c47c26b1ed767b4a5e0d6cf804690e64e62c5206f4ef0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- add support for `omgidl`-encoded schemas for messages using `cdr` message encoding in foxglove studio

**Description**
Add support for cdr message encoding alongside omgidl schemas. 


<!-- link relevant GitHub issues -->
FG-4304
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
