### PR TITLE
Fix ordering of values in plot legend with disabled series

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -13,6 +13,7 @@
 
 import { StoryObj } from "@storybook/react";
 import { screen, userEvent } from "@storybook/testing-library";
+import { produce } from "immer";
 import { shuffle } from "lodash";
 import { useCallback, useRef, useState } from "react";
 import { makeStyles } from "tss-react/mui";
@@ -385,6 +386,30 @@ export const LineGraph: StoryObj = {
   },
 
   name: "line graph",
+
+  parameters: {
+    useReadySignal: true,
+  },
+};
+
+export const LineGraphWithValuesAndDisabledSeries: StoryObj = {
+  render: function Story() {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    const config = produce(exampleConfig, (draft) => {
+      draft.paths[1]!.enabled = false;
+      draft.showPlotValuesInLegend = true;
+    });
+
+    return <PlotWrapper pauseFrame={pauseFrame} config={config} />;
+  },
+
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+
+  name: "line graph with values and disabled series",
 
   parameters: {
     useReadySignal: true,

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
@@ -105,7 +105,12 @@ describe("usePlotPanelDatasets", () => {
 
     expect(result.current).toEqual({
       bounds: expect.any(Object),
-      datasets: [],
+      datasets: [
+        {
+          data: [],
+          label: "/topic.value",
+        },
+      ],
       pathsWithMismatchedDataLengths: [],
     });
   });

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -392,7 +392,15 @@ export function usePlotPanelData(params: Params): Immutable<{
 
     return {
       bounds: sortedData.bounds,
-      datasets: filterMap(yAxisPaths, (path) => sortedData.datasetsByPath.get(path)),
+      // Return a dataset for all paths here so that the ordering of datasets corresponds
+      // to yAxisPaths as expected by downstream components like the legend.
+      //
+      // Label is needed so that TimeBasedChart doesn't discard the empty dataset and mess
+      // up the ordering.
+      datasets: yAxisPaths.map(
+        (path) =>
+          sortedData.datasetsByPath.get(path) ?? { label: path.label ?? path.value, data: [] },
+      ),
       pathsWithMismatchedDataLengths: sortedData.pathsWithMismatchedDataLengths,
     };
   }, [state.data, trimmedCurrentFrameData, yAxisPaths]);


### PR DESCRIPTION
**User-Facing Changes**
Fix ordering of values in plot legend with disabled series.

**Description**
Datasets sent to the plot must have the same order and count as the plot series in order for the legend to display the right values alongside the series path/label.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
