### PR TITLE
Get typescript enums working in user script code

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -693,6 +693,15 @@ describe("pipeline", () => {
         datatypes: numDataType,
       },
       {
+        description: "Enum as return type",
+        sourceCode: `
+          enum MyEnum { A = 1 };
+          export default (msg: any): MyEnum => {
+            return MyEnum.A;
+          };`,
+        datatypes: numDataType,
+      },
+      {
         description: "Imported type from 'ros' in return type",
         sourceCode: `
           import { Messages } from 'ros';

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -425,6 +425,22 @@ describe("pipeline", () => {
       }),
     );
 
+    const uint32DataType: RosDatatypes = new Map(
+      Object.entries({
+        [baseNodeData.name]: {
+          definitions: [
+            {
+              name: "val",
+              isArray: false,
+              isComplex: false,
+              arrayLength: undefined,
+              type: "uint32",
+            },
+          ],
+        },
+      }),
+    );
+
     const posDatatypes: RosDatatypes = new Map(
       Object.entries({
         [baseNodeData.name]: {
@@ -695,11 +711,11 @@ describe("pipeline", () => {
       {
         description: "Enum as return type",
         sourceCode: `
-          enum MyEnum { A = 1 };
+          enum MyEnum { A = 1, B = 2, C };
           export default (msg: any): { val: MyEnum } => {
             return { val: MyEnum.A };
           };`,
-        datatypes: numDataType,
+        datatypes: uint32DataType,
       },
       {
         description: "Imported type from 'ros' in return type",

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -696,8 +696,8 @@ describe("pipeline", () => {
         description: "Enum as return type",
         sourceCode: `
           enum MyEnum { A = 1 };
-          export default (msg: any): MyEnum => {
-            return MyEnum.A;
+          export default (msg: any): { val: MyEnum } => {
+            return { val: MyEnum.A };
           };`,
         datatypes: numDataType,
       },

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -301,6 +301,7 @@ export const constructDatatypes = (
     typeMap: TypeMap = {},
     innerDepth: number = 1,
   ): MessageDefinitionField => {
+    console.log("NODE", tsNode);
     if (innerDepth > MAX_DEPTH) {
       throw new Error(`Max AST traversal depth exceeded.`);
     }

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -301,7 +301,6 @@ export const constructDatatypes = (
     typeMap: TypeMap = {},
     innerDepth: number = 1,
   ): MessageDefinitionField => {
-    console.log("NODE", tsNode);
     if (innerDepth > MAX_DEPTH) {
       throw new Error(`Max AST traversal depth exceeded.`);
     }
@@ -464,6 +463,7 @@ export const constructDatatypes = (
           ts.SyntaxKind.InterfaceDeclaration,
           ts.SyntaxKind.ImportSpecifier,
           ts.SyntaxKind.ClassDeclaration,
+          ts.SyntaxKind.EnumDeclaration,
         ]);
 
         if (!nextNode) {
@@ -511,7 +511,14 @@ export const constructDatatypes = (
       case ts.SyntaxKind.ClassDeclaration: {
         throw new DatatypeExtractionError(classError);
       }
-
+      case ts.SyntaxKind.EnumDeclaration:
+        return {
+          name,
+          type: "uint32",
+          isArray,
+          isComplex,
+          arrayLength: undefined,
+        };
       case ts.SyntaxKind.UnionType: {
         throw new DatatypeExtractionError(unionsError);
       }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Generate datatypes from typescript enums in user script code by treating them as uint32 types.

This of course doesn't cover all types of typescript enums but should enough to support the enums we use in @foxglove/schemas.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
