### PR TITLE
Fail on reading `omgidl` schemas that have `mutable` or `appendable` annotations

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@foxglove/message-definition": "0.2.0",
-    "@foxglove/omgidl-parser": "0.0.1",
+    "@foxglove/omgidl-parser": "0.1.0",
     "@foxglove/omgidl-serialization": "0.0.2",
     "@foxglove/rosmsg": "4.2.2",
     "@foxglove/rosmsg-serialization": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,7 +2748,7 @@ __metadata:
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
     "@foxglove/message-definition": 0.2.0
-    "@foxglove/omgidl-parser": 0.0.1
+    "@foxglove/omgidl-parser": 0.1.0
     "@foxglove/omgidl-serialization": 0.0.2
     "@foxglove/rosmsg": 4.2.2
     "@foxglove/rosmsg-serialization": 2.0.1
@@ -2784,12 +2784,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/omgidl-parser@npm:0.0.1":
-  version: 0.0.1
-  resolution: "@foxglove/omgidl-parser@npm:0.0.1"
+"@foxglove/omgidl-parser@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@foxglove/omgidl-parser@npm:0.1.0"
   dependencies:
     tslib: ^2
-  checksum: 2d1c768d612a22f8f61bc433ab4695e016a02fe4ac2a2f52fce4c0433b5dcacf02ade9c221fa0edaa042a0388267021a21d9c09f7f7f74b8db8d9f5d61492857
+  checksum: 0aba062c3870ac7bbaf804f8d9c11a7dca4024b9910f699739bba4ff4a0b32ec6f4f19ebdcbebdda22f46249aefd7442f184d0470d85901e404610549226ebd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 n/a

**Description**
 Upgrade `@foxglove/omgidl-parser` to v0.1.0 to fail on schemas that contain `mutable` or `appendable` tags. This will produce an error in the application that looks like this:

<img width="412" alt="image" src="https://github.com/foxglove/studio/assets/10187776/e4b01018-1c17-4a55-8b13-162634832e94">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
