### PR TITLE
[3D Panel] Fix display of marker "Show outline" default value

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -72,7 +72,11 @@ export class Markers extends SceneExtension<TopicMarkers> {
         order: topic.name.toLocaleLowerCase(),
         fields: {
           color: { label: "Color", input: "rgba", value: config.color },
-          showOutlines: { label: "Show outline", input: "boolean", value: config.showOutlines },
+          showOutlines: {
+            label: "Show outline",
+            input: "boolean",
+            value: config.showOutlines ?? DEFAULT_SETTINGS.showOutlines,
+          },
           selectedIdVariable: {
             label: "Selection Variable",
             input: "string",


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix display of marker "Show outline" default value

**Description**
- update show outline settings field to use value specified in DEFAULT_SETTINGS.showOutlines

<!-- link relevant GitHub issues -->
FG-3852
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
