### PR TITLE
Add extra capability check when advertising channels on foxglove websocket

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -876,8 +876,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
     // Filter out duplicates.
     const uniquePublications = uniqWith(publishers, isEqual);
 
-    // Save publications and return early if we are not connected.
-    if (!this.#client || this.#closed) {
+    // Save publications and return early if we are not connected or the advertise capability is missing.
+    if (
+      !this.#client ||
+      this.#closed ||
+      !this.#playerCapabilities.includes(PlayerCapabilities.advertise)
+    ) {
       this.#unresolvedPublications = uniquePublications;
       return;
     }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds an extra check for the `advertise` capability when advertising channels for the foxglove websocket data source.