### PR TITLE
Fix copying of text from the TextMiddleTruncate component

### DIFF
--- a/packages/studio-base/src/components/TextMiddleTruncate.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { CSSProperties } from "react";
+import { CSSProperties, ClipboardEvent, useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
 
 const DEFAULT_END_TEXT_LENGTH = 16;
@@ -65,6 +65,18 @@ export default function TextMiddleTruncate({
   const startText = text.substring(0, startTextLen);
   const endText = text.substring(startTextLen);
 
+  // Copy the full text to the clipboard manually. Otherwise the browser will insert a
+  // newline into the copied text since it spans two DOM nodes.
+  const onCopy = useCallback(
+    (event: ClipboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const clipboardData = event.clipboardData;
+      clipboardData.setData("text/plain", text);
+    },
+    [text],
+  );
+
   if (!startText) {
     return (
       <div className={cx(classes.end, className)} style={style}>
@@ -79,6 +91,7 @@ export default function TextMiddleTruncate({
       className={cx(className, classes.root)}
       title={text}
       style={style}
+      onCopy={onCopy}
     >
       <div className={classes.start}>{startText}</div>
       <div className={classes.end}>{endText}</div>


### PR DESCRIPTION
**User-Facing Changes**
Fix copying of text from the TextMiddleTruncate component, used in the datasource name in the app bar.

**Description**
Overrides the `onCopy` handler of the wrapper div to copy the entire text content to the clipboard.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
Fixes #6403 
