### PR TITLE
Use ready marker to wait for stories to complete

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -11,19 +11,22 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { StoryObj } from "@storybook/react";
-import { isEqual } from "lodash";
 import cloneDeep from "lodash/cloneDeep";
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import TestUtils from "react-dom/test-utils";
 import { useAsync } from "react-use";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+import {
+  StoryReadyMarker,
+  waitForStoryReadyMarker,
+} from "@foxglove/studio-base/stories/StoryReadyMarker";
 import delay from "@foxglove/studio-base/util/delay";
 
-import TimeBasedChart from "./index";
 import type { Props } from "./index";
+import TimeBasedChart from "./index";
 
 const dataX = 0.000057603000000000004;
 const dataY = 5.544444561004639;
@@ -110,8 +113,6 @@ export const CanZoomAndUpdate: StoryObj = {
     const [chartProps, setChartProps] = useState(structuredClone(commonProps));
     const callCountRef = useRef(0);
 
-    const readySignal = useReadySignal();
-
     const doScroll = useCallback(async () => {
       const canvasEl = document.querySelector("canvas");
       if (!canvasEl) {
@@ -138,34 +139,25 @@ export const CanZoomAndUpdate: StoryObj = {
       return () => {
         // first render of the chart triggers scrolling
         if (callCountRef.current === 0) {
-          void doScroll();
+          doScroll().catch(console.error);
         }
-
         ++callCountRef.current;
       };
     }, [doScroll]);
-
-    // Fire ready signal after chart props are updated.
-    useEffect(() => {
-      if (!isEqual(chartProps, commonProps)) {
-        readySignal();
-      }
-    }, [chartProps, readySignal]);
 
     return (
       <div style={{ width: 800, height: 800, background: "black" }}>
         <MockMessagePipelineProvider pauseFrame={pauseFrame}>
           <TimeBasedChart {...chartProps} width={800} height={800} />
         </MockMessagePipelineProvider>
+        <StoryReadyMarker count={callCountRef.current} />
       </div>
     );
   },
 
-  play: async (ctx) => {
-    await ctx.parameters.storyReady;
+  play: async () => {
+    await waitForStoryReadyMarker(3);
   },
-
-  parameters: { useReadySignal: true },
 };
 
 export const CleansUpTooltipOnUnmount: StoryObj = {

--- a/packages/studio-base/src/stories/StoryReadyMarker.tsx
+++ b/packages/studio-base/src/stories/StoryReadyMarker.tsx
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { screen, within } from "@testing-library/react";
+
+function storyReadyMarkerText(count: number): string {
+  return Array(count).fill("🤖").join("");
+}
+
+/**
+ * Waits for the story reader marker to appear, with an expected count of `count`.
+ *
+ * @param count expected count passed to the StoryReadyMarker component
+ * @param options element to query within, or `screen` if unspecified
+ */
+export async function waitForStoryReadyMarker(
+  count: number,
+  options?: { element?: HTMLElement },
+): Promise<void> {
+  const target = options?.element ? within(options.element) : screen;
+  await target.findByText(storyReadyMarkerText(count), { selector: "caption" }, { timeout: 5000 });
+}
+
+/**
+ * Used to provide easily searched for text for testing-library findByX queries.
+ */
+export function StoryReadyMarker(props: { count: number }): JSX.Element {
+  return (
+    <caption style={{ position: "absolute", left: "1em", top: "1em", fontSize: "2em" }}>
+      {storyReadyMarkerText(props.count)}
+    </caption>
+  );
+}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Use a superimposed DOM element as a ready marker for stories. Hopefully this will be less flaky since it's relying on the storybook mechanism for waiting for stories to complete instead of a ready signal.

To make use of this stories can include the `StoryReadyMarker` component with a count like this:

```typescript
<StoryReadyMarker count={callCountRef.current} />
```

For chart stories `count` should generally be a count of the number of `pauseFrame` calls the chart has made.

And then in their play function wait for the expected text:

```typescript
play: async () => {
  await screen.findByText(storyReadyMarkerText(3));
}
```

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
