### PR TITLE
Remove `id` field from LayoutState

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -188,7 +188,7 @@ type AppBarProps = CustomWindowControlsProps & {
   disableSignIn?: boolean;
 };
 
-const selectCurrentLayoutId = ({ selectedLayout }: LayoutState) => selectedLayout?.id;
+const selectHasCurrentLayout = ({ selectedLayout }: LayoutState) => selectedLayout != undefined;
 const selectWorkspace = (store: WorkspaceContextStore) => store;
 
 export function AppBar(props: AppBarProps): JSX.Element {
@@ -215,7 +215,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
 
-  const currentLayoutId = useCurrentLayoutSelector(selectCurrentLayoutId);
+  const hasCurrentLayout = useCurrentLayoutSelector(selectHasCurrentLayout);
 
   const {
     sidebars: {
@@ -282,7 +282,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
               <AppBarIconButton
                 className={cx({ "Mui-selected": panelMenuOpen })}
                 color="inherit"
-                disabled={currentLayoutId == undefined}
+                disabled={!hasCurrentLayout}
                 id="add-panel-button"
                 data-tourid="add-panel-button"
                 title="Add panel"

--- a/packages/studio-base/src/components/CurrentLayoutLocalStorageSyncAdapter.tsx
+++ b/packages/studio-base/src/components/CurrentLayoutLocalStorageSyncAdapter.tsx
@@ -8,7 +8,6 @@ import { useDebounce } from "use-debounce";
 
 import Log from "@foxglove/log";
 import {
-  LayoutID,
   LayoutState,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
@@ -36,7 +35,6 @@ export function CurrentLayoutLocalStorageSyncAdapter(): JSX.Element {
     if (selectedSource?.sampleLayout) {
       setCurrentLayoutState({
         selectedLayout: {
-          id: "default" as LayoutID,
           data: selectedSource.sampleLayout,
         },
       });
@@ -71,7 +69,6 @@ export function CurrentLayoutLocalStorageSyncAdapter(): JSX.Element {
     );
     setCurrentLayoutState({
       selectedLayout: {
-        id: "default" as LayoutID,
         data: layoutData,
       },
     });

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -31,12 +31,9 @@ import {
   SwapPanelPayload,
 } from "./actions";
 
-export type LayoutID = string & { __brand: "LayoutID" };
-
 export type LayoutState = Readonly<{
   selectedLayout:
     | {
-        id: LayoutID;
         loading?: boolean;
         data: LayoutData | undefined;
         name?: string;

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -21,7 +21,6 @@ export type {
 } from "./context/AppConfigurationContext";
 export { AppContext } from "./context/AppContext";
 export type { IAppContext } from "./context/AppContext";
-export type { LayoutID } from "./context/CurrentLayoutContext";
 export { migratePanelsState } from "./services/migrateLayout";
 export type { INativeAppMenu, NativeAppMenuEvent } from "./context/NativeAppMenuContext";
 export { default as NativeWindowContext } from "./context/NativeWindowContext";

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
@@ -7,7 +7,6 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { useShallowMemo } from "@foxglove/hooks";
 import CurrentLayoutContext, {
   ICurrentLayout,
-  LayoutID,
   LayoutState,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import {
@@ -41,7 +40,6 @@ export default function MockCurrentLayoutProvider({
 
   const [layoutState, setLayoutStateInternal] = useState<LayoutState>({
     selectedLayout: {
-      id: "mock-layout" as LayoutID,
       data: {
         configById: {},
         globalVariables: {},
@@ -69,7 +67,6 @@ export default function MockCurrentLayoutProvider({
       setLayoutState({
         ...layoutStateRef.current,
         selectedLayout: {
-          id: "mock-layout" as LayoutID,
           ...layoutStateRef.current.selectedLayout,
           data: layoutStateRef.current.selectedLayout?.data
             ? panelsReducer(layoutStateRef.current.selectedLayout.data, action)

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -10,7 +10,6 @@ import { useEffect } from "react";
 
 import {
   CurrentLayoutActions,
-  LayoutID,
   LayoutState,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
@@ -44,7 +43,6 @@ describe("CurrentLayoutProvider", () => {
 
         actions.setCurrentLayoutState({
           selectedLayout: {
-            id: "example" as LayoutID,
             data: expectedState,
           },
         });

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -126,7 +126,6 @@ export default function CurrentLayoutProvider({
 
       setLayoutState({
         selectedLayout: {
-          id: layoutStateRef.current.selectedLayout.id,
           data: newData,
           loading: false,
           name: layoutStateRef.current.selectedLayout.name,

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -187,8 +187,6 @@ function hasSameKeys(
 
 const createHasSameKeySelector = createSelectorCreator(defaultMemoize, hasSameKeys);
 
-const selectCurrentLayoutId = (state: LayoutState) => state.selectedLayout?.id;
-
 const selectLayoutConfigById = createHasSameKeySelector(
   (state: LayoutState) => state.selectedLayout?.data?.configById,
   (config) => config,
@@ -212,13 +210,6 @@ export function PanelStateContextProvider(props: Props): JSX.Element {
   useEffect(() => {
     store.setState((old) => ({ sharedPanelState: pick(old.sharedPanelState, panelTypesInUse) }));
   }, [panelTypesInUse, store]);
-
-  // clear shared panel state on layout change
-  const currentLayoutId = useCurrentLayoutSelector(selectCurrentLayoutId);
-  useEffect(() => {
-    void currentLayoutId;
-    store.setState({ sharedPanelState: {} });
-  }, [currentLayoutId, store]);
 
   return <PanelStateContext.Provider value={store}>{children}</PanelStateContext.Provider>;
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This change removes the _id_ field from the `LayoutState` used in `CurrentLayoutContext`. There is no concept of an `id` for a layout for `studio-base` and `CurrentLayoutContext` deals with setting and updating the layout displayed to the user in the workspace.

I've opted to land this change separately from re-working the `LayoutState` in https://github.com/foxglove/studio/pull/6460 to have a more focused discussion and smaller change to review.