### PR TITLE
Fix LaunchPreference dialog's remember preference behavior

### DIFF
--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -44,22 +44,15 @@ export function LaunchPreferenceScreen(): ReactElement {
 
   async function launchInWeb() {
     setSessionPreference(LaunchPreferenceValue.WEB); // always set session preference to allow overriding the URL param
-    if (rememberPreference) {
-      await setGlobalPreference(LaunchPreferenceValue.WEB);
-    }
+    await setGlobalPreference(rememberPreference ? LaunchPreferenceValue.WEB : undefined);
   }
 
   async function launchInDesktop() {
     setSessionPreference(LaunchPreferenceValue.DESKTOP); // always set session preference to allow overriding the URL param
-    if (rememberPreference) {
-      await setGlobalPreference(LaunchPreferenceValue.DESKTOP);
-    }
+    await setGlobalPreference(rememberPreference ? LaunchPreferenceValue.DESKTOP : undefined);
   }
 
-  async function toggleRememberPreference() {
-    if (rememberPreference) {
-      await setGlobalPreference(undefined);
-    }
+  function toggleRememberPreference() {
     setRememberPreference(!rememberPreference);
   }
 


### PR DESCRIPTION
**User-Facing Changes**

Fixes a bug where unchecking the "Remember my preference" button would make the LaunchPreference dialog disappear, and open the link in the browser:

<img width="772" alt="web" src="https://github.com/foxglove/studio/assets/349687/e33a7d32-e191-4f56-8e41-e46f2a42afef">

**Description**

Besides toggling the `rememberPreference` variable, the checkbox used to also call `setGlobalPreference` to clear the globally stored value ahead of a button click. This then caused the "side-useEffect" whereby `useDefaultWebLaunchPreference` called `setLaunchPreference(LaunchPreferenceValue.WEB)`, causing the confusing user experience.
This PR changes the checkbox to only controls rememberPreference, and leave it to the web/desktop buttons to explicitly store the setting globally depending on what the user decided to do.