### PR TITLE
Remove Layout ID from AppBar

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -188,7 +188,7 @@ type AppBarProps = CustomWindowControlsProps & {
   disableSignIn?: boolean;
 };
 
-const selectCurrentLayoutId = ({ selectedLayout }: LayoutState) => selectedLayout?.id;
+const selectHasCurrentLayout = (state: LayoutState) => state.selectedLayout != undefined;
 const selectWorkspace = (store: WorkspaceContextStore) => store;
 
 export function AppBar(props: AppBarProps): JSX.Element {
@@ -215,7 +215,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
 
-  const currentLayoutId = useCurrentLayoutSelector(selectCurrentLayoutId);
+  const hasCurrentLayout = useCurrentLayoutSelector(selectHasCurrentLayout);
 
   const {
     sidebars: {
@@ -282,7 +282,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
               <AppBarIconButton
                 className={cx({ "Mui-selected": panelMenuOpen })}
                 color="inherit"
-                disabled={currentLayoutId == undefined}
+                disabled={!hasCurrentLayout}
                 id="add-panel-button"
                 data-tourid="add-panel-button"
                 title="Add panel"


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The AddPanel button on the app bar becomes disabled when there is no active layout. This change updates the logic for detecting whether there is an active layout to check the layout being defined rather than tracking the _id_. If there is a defined layout that is sufficient for the add panel button to work.