### PR TITLE
Try fix for flaky plot legend story

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj, StoryFn } from "@storybook/react";
+import { waitFor } from "@storybook/testing-library";
 import { useCallback } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -152,10 +153,11 @@ export const LimitWidth: StoryObj = {
     );
   },
 
+  play: async (ctx) => {
+    await waitFor(() => ctx.parameters.storyReady);
+  },
+
   parameters: {
-    chromatic: {
-      delay: 500,
-    },
     colorScheme: "light",
     useReadySignal: true,
   },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Try fix to flaky plot legend story by explicitly waiting for the ready signal instead of increasing delay.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
