### PR TITLE
Fix reporting of cache full error state in block loader

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -230,7 +230,7 @@ describe("BlockLoader", () => {
     });
     expect(consoleErrorMock.mock.calls[0] ?? []).toContain("cache-full");
     consoleErrorMock.mockClear();
-    expect.assertions(2);
+    expect.assertions(3);
   });
 
   it("should remove unused topics on blocks if cache is full", async () => {

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -318,6 +318,9 @@ export class BlockLoader {
               )}] has stopped on block ${currentBlockId + 1}/${this.#blocks.length}.`,
               tip: "Try reducing the number of topics that require preloading at a given time (e.g. in plots), or try to reduce the time range of the file.",
             });
+            // We need to emit progress here so the player will emit a new state
+            // containing the problem.
+            progress(this.#calculateProgress(topics));
             return;
           }
         }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix reporting of cache full error state in block loader.

When the block loader hits the cache limit and generates a player problem it needs to call `progress` again so the player can see the problem and emit a new state.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
