### PR TITLE
Auto-save when leaving unsaved userscript

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -320,26 +320,22 @@ function NodePlayground(props: Props) {
     [scriptBackStack],
   );
 
-  const askSaveOnLeave = useCallback(() => {
+  const saveOnLeave = useCallback(() => {
     if (isNodeSaved) {
       return;
     }
-    const response = confirm(
-      `You have unsaved changes in your user script: ${currentScript.filePath}. Would you like to save?`,
-    );
-    if (response) {
-      saveCurrentNode();
-    }
-  }, [isNodeSaved, saveCurrentNode, currentScript?.filePath]);
+    // automatically save script on panel leave
+    saveCurrentNode();
+  }, [isNodeSaved, saveCurrentNode]);
 
   // The cleanup function below should only run when this component unmounts.
   // We're using a ref here so that the cleanup useEffect doesn't run whenever one of the callback
   // dependencies changes, only when the component unmounts and with the most up-to-date callback.
-  const askSaveOnLeaveRef = useRef(askSaveOnLeave);
-  askSaveOnLeaveRef.current = askSaveOnLeave;
+  const saveOnLeaveRef = useRef(saveOnLeave);
+  saveOnLeaveRef.current = saveOnLeave;
   useEffect(() => {
     return () => {
-      askSaveOnLeaveRef.current();
+      saveOnLeaveRef.current();
     };
   }, []);
 

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -24,7 +24,7 @@ import {
   Typography,
   inputClasses,
 } from "@mui/material";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
 
@@ -319,6 +319,24 @@ function NodePlayground(props: Props) {
     },
     [scriptBackStack],
   );
+
+  const askSaveOnLeave = useCallback(() => {
+    if (isNodeSaved) {
+      return;
+    }
+    const response = confirm("You have unsaved changes. Would you like to save before leaving?");
+    if (response) {
+      saveCurrentNode();
+    }
+  }, [isNodeSaved, saveCurrentNode]);
+
+  const cleanupRef = useRef(askSaveOnLeave);
+  cleanupRef.current = askSaveOnLeave;
+  useEffect(() => {
+    return () => {
+      cleanupRef.current();
+    };
+  }, []);
 
   return (
     <Stack fullHeight>

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -324,17 +324,22 @@ function NodePlayground(props: Props) {
     if (isNodeSaved) {
       return;
     }
-    const response = confirm("You have unsaved changes. Would you like to save before leaving?");
+    const response = confirm(
+      `You have unsaved changes in your user script: ${currentScript.filePath}. Would you like to save?`,
+    );
     if (response) {
       saveCurrentNode();
     }
-  }, [isNodeSaved, saveCurrentNode]);
+  }, [isNodeSaved, saveCurrentNode, currentScript?.filePath]);
 
-  const cleanupRef = useRef(askSaveOnLeave);
-  cleanupRef.current = askSaveOnLeave;
+  // The cleanup function below should only run when this component unmounts.
+  // We're using a ref here so that the cleanup useEffect doesn't run whenever one of the callback
+  // dependencies changes, only when the component unmounts and with the most up-to-date callback.
+  const askSaveOnLeaveRef = useRef(askSaveOnLeave);
+  askSaveOnLeaveRef.current = askSaveOnLeave;
   useEffect(() => {
     return () => {
-      cleanupRef.current();
+      askSaveOnLeaveRef.current();
     };
   }, []);
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Autosave when leaving unsaved userscript

**Description**
Auto save user script when the panel unmounts, like when switching tabs in the layout.

<!-- link relevant GitHub issues -->

<!-- add `docs` label if this PR requires documentation updates -->
FG-4161
<!-- add relevant metric tracking for experimental / new features -->
