### PR TITLE
Fix state transition panel zooming behavior

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -23,6 +23,8 @@ import { RpcElement, RpcScales } from "@foxglove/studio-base/components/Chart/ty
 import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+import { lineSegmentLabelColor } from "./lineSegments";
+
 const log = Logger.getLogger(__filename);
 
 export type InitOpts = {
@@ -195,6 +197,14 @@ export default class ChartJSManager {
     const instance = this.#chartInstance;
     if (instance == undefined) {
       return {};
+    }
+
+    for (const ds of data?.datasets ?? []) {
+      // Apply a line segment coloring function, if the label color is present in the data points.
+      // This has to happen here because functions can't be serialized to the chart worker.
+      ds.segment = {
+        borderColor: lineSegmentLabelColor,
+      };
     }
 
     if (options != undefined) {

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -201,7 +201,9 @@ export default class ChartJSManager {
 
     for (const ds of data?.datasets ?? []) {
       // Apply a line segment coloring function, if the label color is present in the data points.
-      // This has to happen here because functions can't be serialized to the chart worker.
+      // This has to happen here because functions can't be serialized to the chart worker. The
+      // state transition panel uses this to apply different colors to each segment of a single
+      // line.
       ds.segment = {
         borderColor: lineSegmentLabelColor,
       };

--- a/packages/studio-base/src/components/Chart/worker/lineSegments.ts
+++ b/packages/studio-base/src/components/Chart/worker/lineSegments.ts
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PointElement, ScriptableLineSegmentContext } from "chart.js";
+
+type PointElementWithRawData = PointElement & {
+  raw: {
+    labelColor: undefined | string;
+  };
+};
+
+function isPointElementWithRawData(element: PointElement): element is PointElementWithRawData {
+  return "raw" in element;
+}
+
+/**
+ * Returns the labelColor from the point, if available.
+ */
+export function lineSegmentLabelColor(context: ScriptableLineSegmentContext): undefined | string {
+  if (isPointElementWithRawData(context.p0)) {
+    return context.p0.raw.labelColor as string;
+  }
+  return undefined;
+}

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -51,7 +51,7 @@ export default function messagesToDatasets(args: Args): ChartDatasets {
     borderWidth: 10,
     data: [],
     label: pathIndex.toString(),
-    pointBackgroundColor: "black",
+    pointBackgroundColor: "rgba(0, 0, 0, 0.4)",
     pointBorderColor: "transparent",
     pointHoverRadius: 3,
     pointRadius: 1.25,

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -4,14 +4,10 @@
 
 import stringHash from "string-hash";
 
-import { Time, toSec, subtract as subtractTimes } from "@foxglove/rostime";
+import { Time, subtract as subtractTimes, toSec } from "@foxglove/rostime";
 import { MessageAndData } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
-import {
-  ChartDataset,
-  ChartDatasets,
-  ChartDatum,
-} from "@foxglove/studio-base/components/TimeBasedChart/types";
-import { darkColor, expandedLineColors } from "@foxglove/studio-base/util/plotColors";
+import { ChartDataset, ChartDatasets } from "@foxglove/studio-base/components/TimeBasedChart/types";
+import { expandedLineColors } from "@foxglove/studio-base/util/plotColors";
 import { getTimestampForMessageEvent } from "@foxglove/studio-base/util/time";
 import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 
@@ -19,6 +15,22 @@ import positiveModulo from "./positiveModulo";
 import { StateTransitionPath } from "./types";
 
 const baseColors = [grey, ...expandedLineColors];
+
+/**
+ * Returns a function that can be used to assign unique indexes to distinct values. Returns the
+ * previous index if the value has been seen before otherwise a new index.
+ */
+function makeValueIndexer() {
+  const seenValues = new Map<unknown, number>();
+  return (val: unknown) => {
+    const seen = seenValues.get(val);
+    if (seen != undefined) {
+      return seen;
+    }
+    seenValues.set(val, seenValues.size);
+    return seenValues.size - 1;
+  };
+}
 
 type Args = {
   path: StateTransitionPath;
@@ -28,22 +40,32 @@ type Args = {
   blocks: readonly (readonly MessageAndData[] | undefined)[];
 };
 
+/**
+ * Processes messages into datasets. For performance reasons all values are condensed into a single
+ * dataset with different labels and colors applied per-point.
+ */
 export default function messagesToDatasets(args: Args): ChartDatasets {
   const { path, pathIndex, startTime, y, blocks } = args;
 
-  const datasets = [];
+  const dataset: ChartDataset = {
+    borderWidth: 10,
+    data: [],
+    label: pathIndex.toString(),
+    pointBackgroundColor: "black",
+    pointBorderColor: "transparent",
+    pointHoverRadius: 3,
+    pointRadius: 1.25,
+    pointStyle: "circle",
+    showLine: true,
+  };
 
   let previousTimestamp: Time | undefined;
-  let currentData: ChartDatum[] = [];
 
-  const datasetIndexMap = new Map<unknown, number>();
+  const indexer = makeValueIndexer();
   let lastDatasetIndex: undefined | number = undefined;
 
   for (const messages of blocks) {
     if (!messages) {
-      currentData.push({ x: NaN, y: NaN });
-      lastDatasetIndex = undefined;
-      previousTimestamp = undefined;
       continue;
     }
 
@@ -60,7 +82,7 @@ export default function messagesToDatasets(args: Args): ChartDatasets {
 
       const { constantName, value } = queriedData;
 
-      const datasetIndex = datasetIndexMap.get(value);
+      const datasetIndex = indexer(value);
 
       // Skip duplicates.
       if (
@@ -93,64 +115,25 @@ export default function messagesToDatasets(args: Args): ChartDatasets {
 
       const x = toSec(subtractTimes(timestamp, startTime));
 
-      // If the value maps to a different dataset than the last value, close the previous segment
-      // and insert a gap.
-      const newSegment = datasetIndex !== lastDatasetIndex;
-      if (newSegment) {
-        currentData.push({ x, y });
-        currentData.push({ x: NaN, y: NaN });
-      }
       const label =
         constantName != undefined ? `${constantName} (${String(value)})` : String(value);
-      if (datasetIndex == undefined) {
-        datasetIndexMap.set(value, datasets.length);
-        const elementWithLabel = {
-          x,
-          y,
-          label,
-          labelColor: color,
-          value,
-          constantName,
-        };
 
-        // new data starts with our current point, the current point
-        currentData = [elementWithLabel];
-        const dataset: ChartDataset = {
-          borderWidth: 10,
-          borderColor: color,
-          data: currentData,
-          label: pathIndex.toString(),
-          pointBackgroundColor: darkColor(color),
-          pointBorderColor: "transparent",
-          pointHoverRadius: 3,
-          pointRadius: 1.25,
-          pointStyle: "circle",
-          showLine: true,
-          datalabels: {
-            color,
-          },
-        };
+      const isNewSegment = datasetIndex !== lastDatasetIndex;
 
-        lastDatasetIndex = datasets.length;
-        datasets.push(dataset);
-      } else {
-        currentData = datasets[datasetIndex]?.data ?? [];
-        if (newSegment) {
-          currentData.push({
-            x,
-            y,
-            label,
-            labelColor: color,
-            value,
-            constantName,
-          });
-        } else {
-          currentData.push({ x, y, value, constantName });
-        }
-        lastDatasetIndex = datasetIndex;
-      }
+      const elementWithLabel = {
+        x,
+        y,
+        label: isNewSegment ? label : "",
+        labelColor: color,
+        value,
+        constantName,
+      };
+
+      dataset.data.push(elementWithLabel);
+
+      lastDatasetIndex = datasetIndex;
     }
   }
 
-  return datasets;
+  return [dataset];
 }


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with state transition panel zooming behavior.

**Description**
ChartJS seems to get confused when zooming into datasets with segmented and discontinuous datasets. This simplifies our state transition dataset generation by putting everything into a single dataset and using per-point labels and segment colors to distinguish different states. This should also help performance.

This requires applying a per-segment coloring function in `ChartJSManager` because functions can't be serialized when sending data to the worker.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
