### PR TITLE
Fix problem title only fully visible when resizing sidebar

### DIFF
--- a/packages/studio-base/src/components/ProblemsList.tsx
+++ b/packages/studio-base/src/components/ProblemsList.tsx
@@ -153,6 +153,7 @@ export function ProblemsList(): JSX.Element {
           <AccordionSummary
             className={classes.acccordionSummary}
             expandIcon={<ArrowDropDownIcon />}
+            title={problem.message}
           >
             <ProblemIcon severity={problem.severity} />
             <Typography variant="inherit" noWrap>


### PR DESCRIPTION
**User-Facing Changes**
Not worthy to be mentioned in release notes

**Description**
Adds a `title` attribute to the problem accordion which allows to see the full error text without having to make the sidebar wider.

@2metres, for copying the error message one would still have to resize the sidebar. I could add a copy icon button for this? WDYT? 

[Screencast from 25.07.2023 11:43:31.webm](https://github.com/foxglove/studio/assets/9250155/8b8c0b80-ff0c-4efa-bda5-1c6176b384d7)