### PR TITLE
Fix unregistering event handlers across the electron context bridge

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -215,11 +215,13 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
     useCallback(() => dialogActions.preferences.open("general"), [dialogActions.preferences]),
   );
 
-  useNativeAppMenuEvent("open-help-docs", () => window.open("https://foxglove.dev/docs", "_blank"));
+  useNativeAppMenuEvent("open-help-docs", () => {
+    window.open("https://foxglove.dev/docs", "_blank");
+  });
 
-  useNativeAppMenuEvent("open-help-slack", () =>
-    window.open("https://foxglove.dev/slack", "_blank"),
-  );
+  useNativeAppMenuEvent("open-help-slack", () => {
+    window.open("https://foxglove.dev/slack", "_blank");
+  });
 
   const nativeAppMenu = useNativeAppMenu();
 

--- a/packages/studio-base/src/context/NativeAppMenuContext.ts
+++ b/packages/studio-base/src/context/NativeAppMenuContext.ts
@@ -15,13 +15,13 @@ export type NativeAppMenuEvent =
   | "open-help-slack";
 
 type Handler = () => void;
+type UnregisterFn = () => void;
 
 export interface INativeAppMenu {
   addFileEntry(name: string, handler: Handler): void;
   removeFileEntry(name: string): void;
 
-  on(name: NativeAppMenuEvent, handler: Handler): void;
-  off(name: NativeAppMenuEvent, handler: Handler): void;
+  on(name: NativeAppMenuEvent, handler: Handler): UnregisterFn | undefined;
 }
 
 const NativeAppMenuContext = createContext<INativeAppMenu | undefined>(undefined);

--- a/packages/studio-base/src/context/NativeWindowContext.ts
+++ b/packages/studio-base/src/context/NativeWindowContext.ts
@@ -12,7 +12,6 @@ export interface INativeWindow {
   setRepresentedFilename(filename: string | undefined): Promise<void>;
 
   on(name: NativeWindowEvent, handler: Handler): void;
-  off(name: NativeWindowEvent, handler: Handler): void;
 }
 
 const NativeWindowContext = createContext<INativeWindow | undefined>(undefined);

--- a/packages/studio-base/src/hooks/useNativeAppMenuEvent.ts
+++ b/packages/studio-base/src/hooks/useNativeAppMenuEvent.ts
@@ -22,11 +22,6 @@ export default function useNativeAppMenuEvent(
       return;
     }
 
-    const fn = handler;
-    nativeAppMenu.on(eventName, fn);
-
-    return () => {
-      nativeAppMenu.off(eventName, fn);
-    };
+    return nativeAppMenu.on(eventName, handler);
   }, [eventName, handler, nativeAppMenu]);
 }

--- a/packages/studio-desktop/src/common/types.ts
+++ b/packages/studio-desktop/src/common/types.ts
@@ -19,10 +19,25 @@ export type ForwardedWindowEvent =
   | "maximize"
   | "unmaximize";
 
+/** Registering an event listener returns a function that will un-register the listener */
+export type UnregisterFn = () => void;
+
 interface NativeMenuBridge {
-  // Events from the native window are available in the main process but not the renderer, so we forward them through the bridge.
-  addIpcEventListener(eventName: ForwardedMenuEvent, handler: () => void): void;
-  removeIpcEventListener(eventName: ForwardedMenuEvent, handler: () => void): void;
+  /**
+   * Events from the native window are available in the main process but not the renderer, so we
+   * forward them through the bridge.
+   *
+   * Return a function to remove the registered event handler.
+   *
+   * NOTE: We use an unregister function return value because the preload <-> renderer bridge
+   * intercepts the function. This changes the reference value of the _handler_ function and breaks
+   * the conventional event emitter API of using `.off(event, handler)` to unregister an event
+   * handler since the handler function that renderer would provided will get wrapped and won't
+   * resolve to the same instance as the one in the `.on` call.
+   *
+   * https://www.electronjs.org/docs/latest/api/context-bridge#parameter--error--return-type-support
+   */
+  addIpcEventListener(eventName: ForwardedMenuEvent, handler: () => void): UnregisterFn;
 
   // Manage file menu input source menu items
   menuAddInputSource(name: string, handler: () => void): Promise<void>;
@@ -61,9 +76,7 @@ interface Desktop {
   /** https://www.electronjs.org/docs/tutorial/represented-file */
   setRepresentedFilename(path: string | undefined): Promise<void>;
 
-  // Events from the native window are available in the main process but not the renderer, so we forward them through the bridge.
-  addIpcEventListener(eventName: ForwardedWindowEvent, handler: () => void): void;
-  removeIpcEventListener(eventName: ForwardedWindowEvent, handler: () => void): void;
+  addIpcEventListener(eventName: ForwardedWindowEvent, handler: () => void): UnregisterFn;
 
   /**
    * Notify the app that the color scheme setting has changed and the native theme may need to be

--- a/packages/studio-desktop/src/renderer/Root.tsx
+++ b/packages/studio-desktop/src/renderer/Root.tsx
@@ -102,19 +102,21 @@ export default function Root(props: {
   const onCloseWindow = useCallback(() => nativeWindow.close(), [nativeWindow]);
 
   useEffect(() => {
-    const onEnterFullScreen = () => setFullScreen(true);
-    const onLeaveFullScreen = () => setFullScreen(false);
-    const onMaximize = () => setMaximized(true);
-    const onUnmaximize = () => setMaximized(false);
-    desktopBridge.addIpcEventListener("enter-full-screen", onEnterFullScreen);
-    desktopBridge.addIpcEventListener("leave-full-screen", onLeaveFullScreen);
-    desktopBridge.addIpcEventListener("maximize", onMaximize);
-    desktopBridge.addIpcEventListener("unmaximize", onUnmaximize);
+    const unregisterFull = desktopBridge.addIpcEventListener("enter-full-screen", () =>
+      setFullScreen(true),
+    );
+    const unregisterLeave = desktopBridge.addIpcEventListener("leave-full-screen", () =>
+      setFullScreen(false),
+    );
+    const unregisterMax = desktopBridge.addIpcEventListener("maximize", () => setMaximized(true));
+    const unregisterUnMax = desktopBridge.addIpcEventListener("unmaximize", () =>
+      setMaximized(false),
+    );
     return () => {
-      desktopBridge.removeIpcEventListener("enter-full-screen", onEnterFullScreen);
-      desktopBridge.removeIpcEventListener("leave-full-screen", onLeaveFullScreen);
-      desktopBridge.removeIpcEventListener("maximize", onMaximize);
-      desktopBridge.removeIpcEventListener("unmaximize", onUnmaximize);
+      unregisterFull();
+      unregisterLeave();
+      unregisterMax();
+      unregisterUnMax();
     };
   }, []);
 

--- a/packages/studio-desktop/src/renderer/services/NativeAppMenu.ts
+++ b/packages/studio-desktop/src/renderer/services/NativeAppMenu.ts
@@ -4,7 +4,7 @@
 
 import { INativeAppMenu, NativeAppMenuEvent } from "@foxglove/studio-base";
 
-import { NativeMenuBridge } from "../../common/types";
+import { NativeMenuBridge, UnregisterFn } from "../../common/types";
 
 type Handler = () => void;
 
@@ -20,10 +20,7 @@ export class NativeAppMenu implements INativeAppMenu {
   public removeFileEntry(name: string): void {
     void this.#bridge?.menuRemoveInputSource(name);
   }
-  public on(name: NativeAppMenuEvent, listener: Handler): void {
-    this.#bridge?.addIpcEventListener(name, listener);
-  }
-  public off(name: NativeAppMenuEvent, listener: Handler): void {
-    this.#bridge?.removeIpcEventListener(name, listener);
+  public on(name: NativeAppMenuEvent, listener: Handler): UnregisterFn | undefined {
+    return this.#bridge?.addIpcEventListener(name, listener);
   }
 }

--- a/packages/studio-desktop/src/renderer/services/NativeWindow.ts
+++ b/packages/studio-desktop/src/renderer/services/NativeWindow.ts
@@ -21,9 +21,6 @@ export class NativeWindow implements INativeWindow {
   public on(name: NativeWindowEvent, listener: Handler): void {
     this.#bridge?.addIpcEventListener(name, listener);
   }
-  public off(name: NativeWindowEvent, listener: Handler): void {
-    this.#bridge?.removeIpcEventListener(name, listener);
-  }
 
   public handleTitleBarDoubleClick(): void {
     this.#bridge?.handleTitleBarDoubleClick();


### PR DESCRIPTION
**User-Facing Changes**
Fix opening too many windows when using `Help -> View docs` in desktop app.

**Description**
The native app menu handlers are setup in `Workspace` using the `useNativeAppMenuEvent` hook. This hook registers and unregisters the handler via a `useEffect`. However, the api provided for unregistering the handler does not work across the context bridge between renderer and preloader. Electron uses structured cloning for the context bridge ( https://www.electronjs.org/docs/latest/api/context-bridge#parameter--error--return-type-support) which results in copies of values on the receiving side.

This means that a caller in renderer that calls a register handler API like `.on(event, handler);` causes the preloader (the other side of the bridge) to receive a `handler` function that is not the same instance as the one seen in the renderer side. So when renderer goes to call `.off(event, handler);` and provides the same `handler` function instance to `.off` that it provided to `.on`, the preloader sees proxies of the function and none of the copies equal each other. The result is that the renderer call to `.off` fails to un-register the event listener and we end up with multiple handlers for the listener being registered. This is what caused the many windows to open.

This PR fixes the issue by changing the `.on(event, handler)` API to return an unregister function. The returned function from preloader closes over the correct instance of the _handler_ to use for removing the event handler when called. The renderer side of the bridge can call this proxy function to unregister the correct handler.
