### PR TITLE
[FG-3927] Image flickering in adjacent Image panels

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -212,6 +212,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   #prevResolution = new THREE.Vector2();
   #pickingEnabled = false;
+  #rendering = false;
   #animationFrame?: number;
   #cameraSyncError: undefined | string;
   #devicePixelRatioMediaQuery?: MediaQueryList;
@@ -1024,7 +1025,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
 
   public animationFrame = (): void => {
     this.#animationFrame = undefined;
-    this.#frameHandler(this.currentTime);
+    if (!this.#rendering) {
+      this.#frameHandler(this.currentTime);
+      this.#rendering = false;
+    }
   };
 
   public queueAnimationFrame(): void {
@@ -1045,6 +1049,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   }
 
   #frameHandler = (currentTime: bigint): void => {
+    this.#rendering = true;
     this.currentTime = currentTime;
     this.#updateFrameErrors();
     this.#updateFixedFrameId();


### PR DESCRIPTION
**User-Facing Changes**
Before, users experienced periodic "flashes" under certain circumstances in the Image panel. This was caused by coincident calls to `Renderer.#frameHandler` which could cause two frames to be rendered on top of each other without the frame being cleared.

Before:

https://github.com/foxglove/studio/assets/4588553/4fdb354a-ad56-4fea-8244-220bef69fdb1

After:

https://github.com/foxglove/studio/assets/4588553/40875a99-e427-44fc-9e02-70e13a73977f

**Description**
This change prevents `#frameHandler` calls from interfering with each other. It's stupid, but it works. (I didn't bother investigating why or how several `#frameHandler` calls could overlap in the way they were, but at any rate this forces it to be consistent. Perhaps it's worth deep-diving our rendering pipeline timing at some point.)


