### PR TITLE
[Map Panel] Fix rendering of points with NO_FIX status

### DIFF
--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -330,47 +330,6 @@ export const MultipleTopics: StoryObj = {
   },
 };
 
-export const SinglePointNoFix: StoryObj = {
-  render: function Story() {
-    return <MapPanel />;
-  },
-
-  decorators: [Wrapper],
-
-  parameters: {
-    chromatic: {
-      delay: 1000,
-    },
-    decorators: [Wrapper],
-    panelSetup: {
-      fixture: {
-        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
-        frame: {
-          "/gps": [
-            {
-              topic: "/gps",
-              schemaName: "sensor_msgs/NavSatFix",
-              sizeInBytes: 0,
-              receiveTime: { sec: 123, nsec: 456 },
-              message: {
-                latitude: 0,
-                longitude: 0,
-                altitude: 0,
-                status: {
-                  status: NavSatFixStatus.STATUS_NO_FIX,
-                  service: NavSatFixService.SERVICE_GPS,
-                },
-                position_covariance: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-                position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_UNKNOWN,
-              },
-            },
-          ],
-        },
-      } as Fixture,
-    },
-  },
-};
-
 export const SinglePointDiagonalCovariance: StoryObj = {
   render: function Story() {
     return (

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -187,6 +187,44 @@ export const SinglePointWithMissingValues: StoryObj = {
   },
 };
 
+export const SinglePointWithInvalidData: StoryObj = {
+  render: function Story() {
+    return <MapPanel />;
+  },
+
+  decorators: [Wrapper],
+
+  parameters: {
+    chromatic: {
+      delay: 1000,
+    },
+    panelSetup: {
+      fixture: {
+        topics: [{ name: "/gps", schemaName: "sensor_msgs/NavSatFix" }],
+        frame: {
+          "/gps": [
+            {
+              topic: "/gps",
+              schemaName: "sensor_msgs/NavSatFix",
+              sizeInBytes: 0,
+              receiveTime: { sec: 123, nsec: 456 },
+              message: {
+                latitude: NaN,
+                longitude: NaN,
+                altitude: 0,
+                status: {
+                  status: NavSatFixStatus.STATUS_NO_FIX,
+                  service: NavSatFixService.SERVICE_GPS,
+                },
+              },
+            },
+          ],
+        },
+      } as Fixture,
+    },
+  },
+};
+
 export const SinglePointWithNoFix: StoryObj = {
   render: function Story() {
     return <MapPanel />;

--- a/packages/studio-base/src/panels/Map/support.ts
+++ b/packages/studio-base/src/panels/Map/support.ts
@@ -39,8 +39,8 @@ export function isGeoJSONMessage(msgEvent: MessageEvent): msgEvent is GeoJsonMes
 }
 
 /**
- * Verify that the message is either a GeoJSON message or a NavSatFix message with a
- * position fix and finite latitude and longitude so we can actually display it.
+ * Verify that the message is either a GeoJSON message or a NavSatFix message with
+ * finite latitude and longitude so we can actually display it.
  */
 export function isValidMapMessage(msgEvent: MessageEvent): msgEvent is MapPanelMessage {
   if (isGeoJSONMessage(msgEvent)) {
@@ -52,8 +52,7 @@ export function isValidMapMessage(msgEvent: MessageEvent): msgEvent is MapPanelM
     message.latitude != undefined &&
     isFinite(message.latitude) &&
     message.longitude != undefined &&
-    isFinite(message.longitude) &&
-    message.status?.status !== NavSatFixStatus.STATUS_NO_FIX
+    isFinite(message.longitude)
   );
 }
 


### PR DESCRIPTION
**User-Facing Changes**

Fix rendering of map points having NO_FIX status.

**Description**

This loosens the map panel's definition of a valid message. In response to https://github.com/foxglove/studio/issues/4763, we began filtering points which had invalid coordinates or no fix. However, per https://github.com/orgs/foxglove/discussions/775, a device may still estimate good coordinates through other means, and we should continue to display those coordinates even when status is NO_FIX.
