### PR TITLE
Remove legacy workspace state for old sidebar

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -81,21 +81,6 @@ const useStyles = makeStyles()({
   },
 });
 
-function activeElementIsInput() {
-  return (
-    document.activeElement instanceof HTMLInputElement ||
-    document.activeElement instanceof HTMLTextAreaElement
-  );
-}
-
-function keyboardEventHasModifier(event: KeyboardEvent) {
-  if (navigator.userAgent.includes("Mac")) {
-    return event.metaKey;
-  } else {
-    return event.ctrlKey;
-  }
-}
-
 type WorkspaceProps = CustomWindowControlsProps & {
   deepLinks?: string[];
   appBarLeftInset?: number;
@@ -117,7 +102,6 @@ const selectEventsSupported = (store: EventsStore) => store.eventsSupported;
 const selectSelectEvent = (store: EventsStore) => store.selectEvent;
 
 const selectWorkspaceDataSourceDialog = (store: WorkspaceContextStore) => store.dialogs.dataSource;
-const selectWorkspaceSidebarItem = (store: WorkspaceContextStore) => store.sidebars.legacy.item;
 const selectWorkspaceLeftSidebarItem = (store: WorkspaceContextStore) => store.sidebars.left.item;
 const selectWorkspaceLeftSidebarOpen = (store: WorkspaceContextStore) => store.sidebars.left.open;
 const selectWorkspaceLeftSidebarSize = (store: WorkspaceContextStore) => store.sidebars.left.size;
@@ -132,7 +116,6 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems);
 
-  const sidebarItem = useWorkspaceStore(selectWorkspaceSidebarItem);
   const dataSourceDialog = useWorkspaceStore(selectWorkspaceDataSourceDialog);
   const leftSidebarItem = useWorkspaceStore(selectWorkspaceLeftSidebarItem);
   const leftSidebarOpen = useWorkspaceStore(selectWorkspaceLeftSidebarOpen);
@@ -389,18 +372,10 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
 
   const keyDownHandlers = useMemo(() => {
     return {
-      b: (ev: KeyboardEvent) => {
-        if (!keyboardEventHasModifier(ev) || activeElementIsInput() || sidebarItem == undefined) {
-          return;
-        }
-
-        ev.preventDefault();
-        sidebarActions.legacy.selectItem(undefined);
-      },
       "[": () => sidebarActions.left.setOpen((oldValue) => !oldValue),
       "]": () => sidebarActions.right.setOpen((oldValue) => !oldValue),
     };
-  }, [sidebarActions.left, sidebarActions.legacy, sidebarActions.right, sidebarItem]);
+  }, [sidebarActions.left, sidebarActions.right]);
 
   const play = useMessagePipeline(selectPlay);
   const playUntil = useMessagePipeline(selectPlayUntil);

--- a/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
@@ -18,7 +18,6 @@ const SidebarItemKeys = [
   "connection",
   "extensions",
   "help",
-  "layouts",
   "panel-settings",
   "studio-logs-settings",
   "variables",

--- a/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
@@ -10,20 +10,6 @@ import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDial
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
 import { IDataSourceFactory } from "@foxglove/studio-base/context/PlayerSelectionContext";
 
-const SidebarItemKeys = [
-  "account",
-  "add-panel",
-  "app-bar-tour",
-  "app-settings",
-  "connection",
-  "extensions",
-  "help",
-  "panel-settings",
-  "studio-logs-settings",
-  "variables",
-] as const;
-export type SidebarItemKey = (typeof SidebarItemKeys)[number];
-
 export const LeftSidebarItemKeys = ["panel-settings", "topics", "problems"] as const;
 export type LeftSidebarItemKey = (typeof LeftSidebarItemKeys)[number];
 
@@ -50,9 +36,6 @@ export type WorkspaceContextStore = {
     repeat: boolean;
   };
   sidebars: {
-    legacy: {
-      item: undefined | SidebarItemKey;
-    };
     left: {
       item: undefined | LeftSidebarItemKey;
       open: boolean;
@@ -74,10 +57,7 @@ WorkspaceContext.displayName = "WorkspaceContext";
 
 export const WorkspaceStoreSelectors = {
   selectPanelSettingsOpen: (store: WorkspaceContextStore): boolean => {
-    return (
-      store.sidebars.legacy.item === "panel-settings" ||
-      (store.sidebars.left.open && store.sidebars.left.item === "panel-settings")
-    );
+    return store.sidebars.left.open && store.sidebars.left.item === "panel-settings";
   },
 };
 

--- a/packages/studio-base/src/context/Workspace/migrations.ts
+++ b/packages/studio-base/src/context/Workspace/migrations.ts
@@ -8,7 +8,6 @@ import { IDataSourceFactory } from "@foxglove/studio-base/context/PlayerSelectio
 import {
   LeftSidebarItemKey,
   RightSidebarItemKey,
-  SidebarItemKey,
   WorkspaceContextStore,
 } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 
@@ -36,7 +35,6 @@ type WorkspaceContextStoreV0 = {
     initialTab: undefined | AppSettingsTab;
     open: boolean;
   };
-  sidebarItem: undefined | SidebarItemKey;
 };
 
 export function migrateV0WorkspaceState(
@@ -63,9 +61,6 @@ export function migrateV0WorkspaceState(
       shown: v0State.featureTours.shown,
     },
     sidebars: {
-      legacy: {
-        item: v0State.sidebarItem,
-      },
       left: {
         item: v0State.leftSidebarItem,
         open: v0State.leftSidebarOpen,

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
@@ -9,7 +9,6 @@ import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
 import { useGuaranteedContext } from "@foxglove/hooks";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
-import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import {
   IDataSourceFactory,
   usePlayerSelection,
@@ -18,7 +17,6 @@ import {
 import {
   WorkspaceContext,
   WorkspaceContextStore,
-  SidebarItemKey,
   LeftSidebarItemKey,
   LeftSidebarItemKeys,
   RightSidebarItemKey,
@@ -46,7 +44,6 @@ export type WorkspaceActions = {
     finishTour: (tour: string) => void;
   };
 
-  openAccountSettings: () => void;
   openPanelSettings: () => void;
 
   playbackControlActions: {
@@ -54,9 +51,6 @@ export type WorkspaceActions = {
   };
 
   sidebarActions: {
-    legacy: {
-      selectItem: (selectedSidebarItem: undefined | SidebarItemKey) => void;
-    };
     left: {
       selectItem: (item: undefined | LeftSidebarItemKey) => void;
       setOpen: Dispatch<SetStateAction<boolean>>;
@@ -83,9 +77,6 @@ function setterValue<T>(action: SetStateAction<T>, value: T): T {
  */
 export function useWorkspaceActions(): WorkspaceActions {
   const { setState } = useGuaranteedContext(WorkspaceContext);
-
-  const { signIn } = useCurrentUser();
-  const supportsAccountSettings = signIn != undefined;
 
   const { availableSources } = usePlayerSelection();
 
@@ -156,12 +147,6 @@ export function useWorkspaceActions(): WorkspaceActions {
         },
       },
 
-      openAccountSettings: () =>
-        supportsAccountSettings &&
-        set((draft) => {
-          draft.sidebars.legacy.item = "account";
-        }),
-
       openPanelSettings: () =>
         set((draft) => {
           draft.sidebars.left.item = "panel-settings";
@@ -178,23 +163,6 @@ export function useWorkspaceActions(): WorkspaceActions {
       },
 
       sidebarActions: {
-        legacy: {
-          selectItem: (selectedSidebarItem: undefined | SidebarItemKey) => {
-            if (selectedSidebarItem === "app-settings") {
-              set((draft) => {
-                draft.dialogs.preferences = { open: true, initialTab: undefined };
-              });
-            } else if (selectedSidebarItem === "app-bar-tour") {
-              set((draft) => {
-                draft.featureTours.active = "appBar";
-              });
-            } else {
-              set((draft) => {
-                draft.sidebars.legacy.item = selectedSidebarItem;
-              });
-            }
-          },
-        },
         left: {
           selectItem: (selectedLeftSidebarItem: undefined | LeftSidebarItemKey) => {
             set((draft) => {
@@ -253,5 +221,5 @@ export function useWorkspaceActions(): WorkspaceActions {
         },
       },
     };
-  }, [openFile, set, supportsAccountSettings]);
+  }, [openFile, set]);
 }

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
@@ -48,7 +48,6 @@ export type WorkspaceActions = {
 
   openAccountSettings: () => void;
   openPanelSettings: () => void;
-  openLayoutBrowser: () => void;
 
   playbackControlActions: {
     setRepeat: Dispatch<SetStateAction<boolean>>;
@@ -167,11 +166,6 @@ export function useWorkspaceActions(): WorkspaceActions {
         set((draft) => {
           draft.sidebars.left.item = "panel-settings";
           draft.sidebars.left.open = true;
-        }),
-
-      openLayoutBrowser: () =>
-        set((draft) => {
-          draft.sidebars.legacy.item = "layouts";
         }),
 
       playbackControlActions: {

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -36,9 +36,6 @@ function createWorkspaceContextStore(
             shown: [],
           },
           sidebars: {
-            legacy: {
-              item: "connection",
-            },
             left: {
               item: "panel-settings",
               open: true,


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- n/a

**Description**
Removes obsolete sidebar state from workspace context.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
