### PR TITLE
Fix `ros2idl` `Time` and `Duration` schemas for use in Studio

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -28,6 +28,7 @@
     "@foxglove/message-definition": "0.2.0",
     "@foxglove/omgidl-parser": "0.1.0",
     "@foxglove/omgidl-serialization": "0.1.0",
+    "@foxglove/ros2idl-parser": "0.1.1",
     "@foxglove/rosmsg": "4.2.2",
     "@foxglove/rosmsg-serialization": "2.0.1",
     "@foxglove/rosmsg2-serialization": "2.0.2",

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -5,7 +5,8 @@
 import { MessageDefinition } from "@foxglove/message-definition";
 import { parseIdl } from "@foxglove/omgidl-parser";
 import { MessageReader as OmgidlMessageReader } from "@foxglove/omgidl-serialization";
-import { parse as parseMessageDefinition, parseRos2idl } from "@foxglove/rosmsg";
+import { parseRos2idl } from "@foxglove/ros2idl-parser";
+import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,6 +2403,7 @@ __metadata:
     "@foxglove/message-definition": 0.2.0
     "@foxglove/omgidl-parser": 0.1.0
     "@foxglove/omgidl-serialization": 0.1.0
+    "@foxglove/ros2idl-parser": 0.1.1
     "@foxglove/rosmsg": 4.2.2
     "@foxglove/rosmsg-serialization": 2.0.1
     "@foxglove/rosmsg2-serialization": 2.0.2
@@ -2469,6 +2470,17 @@ __metadata:
   bin:
     roscore: dist/nodejs/roscore.js
   checksum: 87ba6c9749888ba2445575ae54efc0f042c917b439a56e31d1743f3b7e9d151754c1575e06fefc7b8e5fda5bbff52585e23d80bf7336582030bbb0a5140d7d44
+  languageName: node
+  linkType: hard
+
+"@foxglove/ros2idl-parser@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@foxglove/ros2idl-parser@npm:0.1.1"
+  dependencies:
+    "@foxglove/message-definition": ^0.2.0
+    "@foxglove/omgidl-parser": 0.1.0
+    md5-typescript: ^1.0.5
+  checksum: 12010ffe91285a130bd4ea1dc9be0d63ad31a071d3f55ce0b1ca0cec50fe2e047c96a512207d1d1f5d2faff66e82f1c411811e8f617534aa7ded4a623850eed6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


**User-Facing Changes**
<!-- will be used as a changelog entry -->
- `ros2idl` `Time` and `Duration` schemas now compatible with studio time type {sec, nsec}

**Description**
- update studio to use `ros2idl-parser` package instead of parser provided by `rosmsg`
- Fixes Time and Duration schemas showing `nanosec` instead of `nsec`
<!-- link relevant GitHub issues -->
Fixes: FG-3942
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
