### PR TITLE
Add check for fetch response status when fetching assets

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -8,7 +8,6 @@ import shallowequal from "shallowequal";
 import { createStore, StoreApi } from "zustand";
 
 import { Condvar } from "@foxglove/den/async";
-import Logger from "@foxglove/log";
 import { MessageEvent } from "@foxglove/studio";
 import {
   AdvertiseOptions,
@@ -23,8 +22,6 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 import { FramePromise } from "./pauseFrameForPromise";
 import { MessagePipelineContext } from "./types";
-
-const log = Logger.getLogger(__filename);
 
 export function defaultPlayerState(): PlayerState {
   return {
@@ -125,11 +122,9 @@ export function createMessagePipelineStore({
         try {
           protocol = new URL(uri).protocol;
         } catch (err) {
-          if (isDesktopApp()) {
-            // We only log the error here and continue with a normal _fetch_ call as the Desktop
-            // app may still be able to resolve the "URI" to a local file.
-            log.error("Invalid URI passed to fetchAsset", err);
-          } else {
+          // Bail out if this is not a desktop app. If this is a local file path, the Desktop app may
+          // still be able to resolve that to a local file with the _fetch_ call.
+          if (!isDesktopApp()) {
             throw new Error(`${uri} is not a valid URI`);
           }
         }

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -118,18 +118,9 @@ export function createMessagePipelineStore({
         return await player.callService(service, request);
       },
       async fetchAsset(uri, options) {
-        let protocol: string | undefined = undefined;
-        try {
-          protocol = new URL(uri).protocol;
-        } catch (err) {
-          // Bail out if this is not a desktop app. If this is a local file path, the Desktop app may
-          // still be able to resolve that to a local file with the _fetch_ call.
-          if (!isDesktopApp()) {
-            throw new Error(`${uri} is not a valid URI`);
-          }
-        }
-
+        const { protocol } = new URL(uri);
         const player = get().player;
+
         if (player?.fetchAsset && protocol === "package:") {
           try {
             return await player.fetchAsset(uri);

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -8,6 +8,7 @@ import shallowequal from "shallowequal";
 import { createStore, StoreApi } from "zustand";
 
 import { Condvar } from "@foxglove/den/async";
+import Logger from "@foxglove/log";
 import { MessageEvent } from "@foxglove/studio";
 import {
   AdvertiseOptions,
@@ -22,6 +23,8 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 import { FramePromise } from "./pauseFrameForPromise";
 import { MessagePipelineContext } from "./types";
+
+const log = Logger.getLogger(__filename);
 
 export function defaultPlayerState(): PlayerState {
   return {
@@ -118,9 +121,20 @@ export function createMessagePipelineStore({
         return await player.callService(service, request);
       },
       async fetchAsset(uri, options) {
-        const { protocol } = new URL(uri);
-        const player = get().player;
+        let protocol: string | undefined = undefined;
+        try {
+          protocol = new URL(uri).protocol;
+        } catch (err) {
+          if (isDesktopApp()) {
+            // We only log the error here and continue with a normal _fetch_ call as the Desktop
+            // app may still be able to resolve the "URI" to a local file.
+            log.error("Invalid URI passed to fetchAsset", err);
+          } else {
+            throw new Error(`${uri} is not a valid URI`);
+          }
+        }
 
+        const player = get().player;
         if (player?.fetchAsset && protocol === "package:") {
           try {
             return await player.fetchAsset(uri);
@@ -135,6 +149,10 @@ export function createMessagePipelineStore({
         }
 
         const response = await fetch(uri, options);
+        if (!response.ok) {
+          const errMsg = response.statusText;
+          throw new Error(`Error ${response.status}${errMsg ? ` (${errMsg})` : ``}`);
+        }
         return {
           uri,
           data: new Uint8Array(await response.arrayBuffer()),


### PR DESCRIPTION
**User-Facing Changes**
Not worth being mentioned in release notes

**Description**
~We were rejecting any asset uri that was not a valid URL. However, the Desktop app is able to resolve assets given as file path (e.g. `/home/foo/mesh.dae`). This patch changes the behavior to only throw an invalid URL error if it's not a desktop app.~

~Fixes #6519~

Update: We agreed on leaving it as it was and not support invalid URIs. This PR now only adds an additional check for the fetch response status.
