### PR TITLE
fix seek forward for players that don't implement playUntil

### DIFF
--- a/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
@@ -120,7 +120,11 @@ export class TopicAliasingPlayer implements Player {
   }
 
   public playUntil?(time: Time): void {
-    this.#player.playUntil?.(time);
+    if (this.#player.playUntil) {
+      this.#player.playUntil(time);
+      return;
+    }
+    this.#player.seekPlayback?.(time);
   }
 
   public setPlaybackSpeed?(speedFraction: number): void {


### PR DESCRIPTION
** User-facing changes **
Fix a bug where "Seek forward" would start to play instead of stopping after seeking.

** Description **

Since the introduction of `TopicAliasingPlayer` between `UserNodePlayer` and the underlying player, the seek forward button is broken for underlying players that do not implement the `playUntil` method and relied on the fallback `seekPlayback` method call. The `PlaybackControls` and `UserNodePlayer` both has the fallback code paths for calling `seekPlayback` in case `playUntil` is undefined. This is not implemented in `TopicAliasingPlayer`. This patch introduces this fallback code in `TopicAliasingPlayer` to fix this issue.

Fixes: FG-4440