### PR TITLE
[FG-4201] Update color attribute when new triangles arrive

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -120,6 +120,9 @@ export class RenderableTriangles extends RenderablePrimitive {
         geometry.computeBoundingSphere();
         geometry.attributes.position!.needsUpdate = true;
       }
+      if (colorChanged) {
+        geometry.attributes.color!.needsUpdate = true;
+      }
 
       // covers the case where a geometry went from being defined by a single color to vertex colors
       // but there was no difference in the vertex colors that already existed and the new ones


### PR DESCRIPTION
**User-Facing Changes**

Fix rendering bug with vertex-colored triangle meshes.

**Description**

`RenderableTriangles.#updateTriangleMeshes` only made ThreeJS aware of updates to a mesh's colors if the material had not been initialized. This seems to be a mistake; we do all of this work to build `colorChanged` and then [throw out the result](https://github.com/foxglove/studio/blob/main/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts?plain=1#L127). If `colorChanged` is true at all we know that (a) `geometry.colors` is defined and (b) we need to flag it for update. That's what this PR does.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
