### PR TITLE
Fix comparison of message definitions

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -25,7 +25,7 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@foxglove/message-definition": "0.2.0",
+    "@foxglove/message-definition": "0.3.0",
     "@foxglove/omgidl-parser": "0.1.0",
     "@foxglove/omgidl-serialization": "0.1.0",
     "@foxglove/rosmsg": "4.2.2",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -27,7 +27,7 @@
     "@foxglove/hooks": "workspace:*",
     "@foxglove/log": "workspace:*",
     "@foxglove/mcap-support": "workspace:*",
-    "@foxglove/message-definition": "0.2.0",
+    "@foxglove/message-definition": "0.3.0",
     "@foxglove/ros1": "2.0.0",
     "@foxglove/rosbag": "0.4.0",
     "@foxglove/rosbag2-web": "4.1.1",

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -3,13 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as base64 from "@protobufjs/base64";
-import { isEqual, isMatch, uniqWith } from "lodash";
+import { isEqual, uniqWith } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { debouncePromise } from "@foxglove/den/async";
 import Log from "@foxglove/log";
 import { parseChannel, ParsedChannel } from "@foxglove/mcap-support";
-import { MessageDefinition } from "@foxglove/message-definition";
+import { MessageDefinition, isMsgDefEqual } from "@foxglove/message-definition";
 import CommonRosTypes from "@foxglove/rosmsg-msgs-common";
 import { MessageWriter as Ros1MessageWriter } from "@foxglove/rosmsg-serialization";
 import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
@@ -1198,7 +1198,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     const maybeRos = ["ros1", "ros2"].includes(this.#profile ?? "");
     for (const [name, types] of datatypes) {
       const knownTypes = this.#datatypes.get(name);
-      if (knownTypes && !isMatch(types, knownTypes)) {
+      if (knownTypes && !isMsgDefEqual(types, knownTypes as MessageDefinition)) {
         this.#problems.addProblem(`schema-changed-${name}`, {
           message: `Definition of schema '${name}' has changed during the server's runtime`,
           severity: "error",

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -1198,7 +1198,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     const maybeRos = ["ros1", "ros2"].includes(this.#profile ?? "");
     for (const [name, types] of datatypes) {
       const knownTypes = this.#datatypes.get(name);
-      if (knownTypes && !isMsgDefEqual(types, knownTypes as MessageDefinition)) {
+      if (knownTypes && !isMsgDefEqual(types, knownTypes)) {
         this.#problems.addProblem(`schema-changed-${name}`, {
           message: `Definition of schema '${name}' has changed during the server's runtime`,
           severity: "error",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,7 +2400,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
-    "@foxglove/message-definition": 0.2.0
+    "@foxglove/message-definition": 0.3.0
     "@foxglove/omgidl-parser": 0.1.0
     "@foxglove/omgidl-serialization": 0.1.0
     "@foxglove/rosmsg": 4.2.2
@@ -2420,7 +2420,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/message-definition@npm:0.2.0, @foxglove/message-definition@npm:^0.2.0":
+"@foxglove/message-definition@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@foxglove/message-definition@npm:0.3.0"
+  checksum: 48edc4e57b7b1152514fafe3eb0652ebd85032524d6a8c102db5e3a53b0311fde6200b5aeada6a76bafd6033d3d6ac1bd38e6aa331219f4421c356b8b6d7fd94
+  languageName: node
+  linkType: hard
+
+"@foxglove/message-definition@npm:^0.2.0":
   version: 0.2.0
   resolution: "@foxglove/message-definition@npm:0.2.0"
   checksum: 8f972dd52cf2f44e8357c8f13ee2136b23548d49d9251fc47c68569a33effe5d082c0681e3b0761751dd27759ac778f1e45de9f52d5925298ccc80e607784159
@@ -2602,7 +2609,7 @@ __metadata:
     "@foxglove/hooks": "workspace:*"
     "@foxglove/log": "workspace:*"
     "@foxglove/mcap-support": "workspace:*"
-    "@foxglove/message-definition": 0.2.0
+    "@foxglove/message-definition": 0.3.0
     "@foxglove/ros1": 2.0.0
     "@foxglove/rosbag": 0.4.0
     "@foxglove/rosbag2-web": 4.1.1


### PR DESCRIPTION

**User-Facing Changes**
Fix comparison of message definitions

**Description**
The existing message definition comparison would wrongly flag definitions as unequal when parsed from a `IDL` and `MSG` file.

See also https://github.com/foxglove/message-definition/pull/1
Fixes https://github.com/foxglove/ros-foxglove-bridge/issues/253