### PR TITLE
[FG-4246] Don't add new point cloud history entries unnecessarily

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -274,53 +274,6 @@ export class PointCloudHistoryRenderable extends Renderable<PointCloudHistoryUse
       return;
     }
 
-    const topic = this.userData.topic;
-    const isDecay = settings.decayTime > 0;
-    if (isDecay) {
-      // Push a new (empty) entry to the history of points
-      const geometry = createGeometry(topic, THREE.StaticDrawUsage);
-      const points = new PointCloudRenderable(
-        topic,
-        {
-          receiveTime: -1n, // unused
-          messageTime: -1n, // unused
-          frameId: "", //unused
-          pose: getPose(pointCloud),
-          settingsPath: [], //unused
-          settings: { visible: true }, //unused
-          topic,
-          pointCloud,
-          originalMessage,
-        },
-        geometry,
-        material,
-        this.userData.pickingMaterial,
-        this.userData.instancePickingMaterial,
-      );
-      pointsHistory.addHistoryEntry({ receiveTime, messageTime, renderable: points });
-      this.add(points);
-
-      if (settings.stixelsEnabled) {
-        const stixelGeometry = createStixelGeometry(topic, THREE.StaticDrawUsage);
-        const stixels = new StixelsRenderable(
-          topic,
-          {
-            receiveTime: -1n, // unused
-            messageTime: -1n, // unused
-            frameId: "", //unused
-            pose: getPose(pointCloud),
-            settingsPath: [], //unused
-            settings: { visible: true }, //unused
-            topic,
-          },
-          stixelGeometry,
-          stixelMaterial,
-        );
-        stixelsHistory.addHistoryEntry({ receiveTime, messageTime, renderable: stixels });
-        this.add(stixels);
-      }
-    }
-
     const latestPointsEntry = pointsHistory.latest();
     latestPointsEntry.receiveTime = receiveTime;
     latestPointsEntry.messageTime = messageTime;
@@ -336,6 +289,7 @@ export class PointCloudHistoryRenderable extends Renderable<PointCloudHistoryUse
 
     const latestStixelEntry = stixelsHistory.latest();
 
+    const isDecay = settings.decayTime > 0;
     if (!isDecay && prevIsDecay !== isDecay) {
       latestPointsEntry.renderable.geometry.setUsage(THREE.DynamicDrawUsage);
       latestStixelEntry.renderable.geometry.setUsage(THREE.DynamicDrawUsage);
@@ -370,6 +324,68 @@ export class PointCloudHistoryRenderable extends Renderable<PointCloudHistoryUse
     if (this.userData.settings.stixelsEnabled) {
       this.#stixelsHistory.updateHistoryFromCurrentTime(currentTime);
       this.#stixelsHistory.updatePoses(currentTime, renderFrameId, fixedFrameId);
+    }
+  }
+
+  public pushHistory(
+    this: PointCloudHistoryRenderable,
+    pointCloud: PointCloud | PointCloud2,
+    originalMessage: RosObject | undefined,
+    settings: LayerSettingsPointClouds,
+    receiveTime: bigint,
+  ): void {
+    const messageTime = toNanoSec(getTimestamp(pointCloud));
+    const pointsHistory = this.#pointsHistory;
+    const stixelsHistory = this.#stixelsHistory;
+    const material = this.userData.material;
+    const stixelMaterial = this.userData.stixelMaterial;
+    const topic = this.userData.topic;
+    const isDecay = settings.decayTime > 0;
+    if (!isDecay) {
+      return;
+    }
+
+    // Push a new (empty) entry to the history of points
+    const geometry = createGeometry(topic, THREE.StaticDrawUsage);
+    const points = new PointCloudRenderable(
+      topic,
+      {
+        receiveTime: -1n, // unused
+        messageTime: -1n, // unused
+        frameId: "", //unused
+        pose: getPose(pointCloud),
+        settingsPath: [], //unused
+        settings: { visible: true }, //unused
+        topic,
+        pointCloud,
+        originalMessage,
+      },
+      geometry,
+      material,
+      this.userData.pickingMaterial,
+      this.userData.instancePickingMaterial,
+    );
+    pointsHistory.addHistoryEntry({ receiveTime, messageTime, renderable: points });
+    this.add(points);
+
+    if (settings.stixelsEnabled) {
+      const stixelGeometry = createStixelGeometry(topic, THREE.StaticDrawUsage);
+      const stixels = new StixelsRenderable(
+        topic,
+        {
+          receiveTime: -1n, // unused
+          messageTime: -1n, // unused
+          frameId: "", //unused
+          pose: getPose(pointCloud),
+          settingsPath: [], //unused
+          settings: { visible: true }, //unused
+          topic,
+        },
+        stixelGeometry,
+        stixelMaterial,
+      );
+      stixelsHistory.addHistoryEntry({ receiveTime, messageTime, renderable: stixels });
+      this.add(stixels);
     }
   }
 
@@ -888,6 +904,12 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
       this.renderables.set(topic, renderable);
     }
 
+    renderable.pushHistory(
+      pointCloud,
+      originalMessage,
+      renderable.userData.settings,
+      receiveTime,
+    );
     renderable.updatePointCloud(
       pointCloud,
       originalMessage,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -340,10 +340,6 @@ export class PointCloudHistoryRenderable extends Renderable<PointCloudHistoryUse
     const material = this.userData.material;
     const stixelMaterial = this.userData.stixelMaterial;
     const topic = this.userData.topic;
-    const isDecay = settings.decayTime > 0;
-    if (!isDecay) {
-      return;
-    }
 
     // Push a new (empty) entry to the history of points
     const geometry = createGeometry(topic, THREE.StaticDrawUsage);
@@ -904,13 +900,13 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    renderable.pushHistory(pointCloud, originalMessage, renderable.userData.settings, receiveTime);
-    renderable.updatePointCloud(
-      pointCloud,
-      originalMessage,
-      renderable.userData.settings,
-      receiveTime,
-    );
+    const { settings } = renderable.userData;
+
+    if (settings.decayTime > 0) {
+      renderable.pushHistory(pointCloud, originalMessage, settings, receiveTime);
+    }
+
+    renderable.updatePointCloud(pointCloud, originalMessage, settings, receiveTime);
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -904,12 +904,7 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
       this.renderables.set(topic, renderable);
     }
 
-    renderable.pushHistory(
-      pointCloud,
-      originalMessage,
-      renderable.userData.settings,
-      receiveTime,
-    );
+    renderable.pushHistory(pointCloud, originalMessage, renderable.userData.settings, receiveTime);
     renderable.updatePointCloud(
       pointCloud,
       originalMessage,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -399,6 +399,11 @@ export class RenderObjectHistory<TRenderable extends DisposableObject> {
   }
 
   public addHistoryEntry(entry: HistoryEntry<TRenderable>): void {
+    // UI controls call addHistoryEntry repeatedly; ensure it doesn't add new
+    // entries if the content is the same
+    if (this.#history.slice(-1)[0]?.receiveTime === entry.receiveTime) {
+      return;
+    }
     this.#history.push(entry);
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -1,4 +1,3 @@
-
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -469,4 +468,3 @@ export class RenderObjectHistory<TRenderable extends DisposableObject> {
     this.#history.length = 0;
   }
 }
-

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -1,3 +1,4 @@
+
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -399,11 +400,6 @@ export class RenderObjectHistory<TRenderable extends DisposableObject> {
   }
 
   public addHistoryEntry(entry: HistoryEntry<TRenderable>): void {
-    // UI controls call addHistoryEntry repeatedly; ensure it doesn't add new
-    // entries if the content is the same
-    if (this.#history.slice(-1)[0]?.receiveTime === entry.receiveTime) {
-      return;
-    }
     this.#history.push(entry);
   }
 
@@ -473,3 +469,4 @@ export class RenderObjectHistory<TRenderable extends DisposableObject> {
     this.#history.length = 0;
   }
 }
+


### PR DESCRIPTION
**User-Facing Changes**

Fix for bug where adjusting point cloud settings created copies of point cloud

**Description**

Adjusting the render settings for a point cloud with decay enabled created lots of duplicate history entries, in effect causing the point cloud to render many more times than necessary.

This fix is naive and tentative: when we attempt to add a new history entry whose `receiveTime` matches the history entry at the top of the stack, we ignore it. In practice this should never occur otherwise in production workloads, though I'll be the first to admit that this doesn't feel very clean.

Fixed:
https://github.com/foxglove/studio/assets/4588553/83939d1d-a5c7-4aa5-9b0b-b93580cf8b13



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
