### PR TITLE
Reduce plot legend rerendering

### DIFF
--- a/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
+++ b/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
@@ -88,11 +88,12 @@ export function useSetHoverValue(): TimelineInteractionStateStore["setHoverValue
 const undefinedSelector = () => undefined;
 
 /**
- * Encapsulates logic for selecting the current hover value depending
- * on which component registered the hover value.
+ * Encapsulates logic for selecting the current hover value depending on which component registered
+ * the hover value.
  *
  * @param componentId the component to scope updates to
- * @param disableUpdates if true then return undefined, for performance reasons
+ * @param disableUpdates if true then return undefined, for performance reasons so that clients can
+ * avoid using hooks conditionally but opt out of updates
  * @param isTimestampScale override componentId scoping for timestamp based charts
  */
 export function useHoverValue(args: {

--- a/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
+++ b/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
@@ -85,24 +85,26 @@ export function useSetHoverValue(): TimelineInteractionStateStore["setHoverValue
   return useTimelineInteractionState(selectSetHoverValue);
 }
 
+const undefinedSelector = () => undefined;
+
 /**
  * Encapsulates logic for selecting the current hover value depending
  * on which component registered the hover value.
+ *
+ * @param componentId the component to scope updates to
+ * @param disableUpdates if true then return undefined, for performance reasons
+ * @param isTimestampScale override componentId scoping for timestamp based charts
  */
-export function useHoverValue(args?: {
+export function useHoverValue(args: {
   componentId: string;
+  disableUpdates?: boolean;
   isTimestampScale: boolean;
 }): HoverValue | undefined {
-  const hasArgs = !!args;
-  const componentId = args?.componentId;
-  const isTimestampScale = args?.isTimestampScale ?? false;
+  const componentId = args.componentId;
+  const isTimestampScale = args.isTimestampScale;
 
   const selector = useCallback(
     (store: TimelineInteractionStateStore) => {
-      if (!hasArgs) {
-        // Raw form -- user needs to check that the value should be shown.
-        return store.hoverValue;
-      }
       if (store.hoverValue == undefined) {
         return undefined;
       }
@@ -113,10 +115,10 @@ export function useHoverValue(args?: {
       // Otherwise just show hover bars when hovering over the panel itself.
       return store.hoverValue.componentId === componentId ? store.hoverValue : undefined;
     },
-    [hasArgs, componentId, isTimestampScale],
+    [componentId, isTimestampScale],
   );
 
-  return useTimelineInteractionState(selector);
+  return useTimelineInteractionState(args.disableUpdates === true ? undefinedSelector : selector);
 }
 
 /**

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -143,7 +143,7 @@ const useStyles = makeStyles<void, "container" | "toggleButton" | "toggleButtonF
   }),
 );
 
-export function PlotLegend(props: Props): JSX.Element {
+function PlotLegendComponent(props: Props): JSX.Element {
   const {
     currentTime,
     datasets,
@@ -294,3 +294,5 @@ export function PlotLegend(props: Props): JSX.Element {
     </div>
   );
 }
+
+export const PlotLegend = React.memo(PlotLegendComponent);

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -127,6 +127,7 @@ export function PlotLegendRow({
   const [hoverComponentId] = useState<string>(() => uuidv4());
   const hoverValue = useHoverValue({
     componentId: hoverComponentId,
+    disableUpdates: !showPlotValuesInLegend,
     isTimestampScale: true,
   });
 

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -37,6 +37,7 @@ import PanelToolbar, {
 } from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { ChartDefaultView } from "@foxglove/studio-base/components/TimeBasedChart";
+import { DataSet } from "@foxglove/studio-base/panels/Plot/internalTypes";
 import { usePlotPanelData } from "@foxglove/studio-base/panels/Plot/usePlotPanelData";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -52,6 +53,8 @@ export { plotableRosTypes } from "./types";
 export type { PlotConfig } from "./types";
 
 const defaultSidebarDimension = 240;
+
+const EmptyDatasets: DataSet[] = [];
 
 export function openSiblingPlotPanel(openSiblingPanel: OpenSiblingPanel, topicName: string): void {
   openSiblingPanel({
@@ -231,6 +234,8 @@ function Plot(props: Props) {
     return items;
   }, [datasets, xAxisVal]);
 
+  const onClickPath = useCallback((index: number) => setFocusedPath(["paths", String(index)]), []);
+
   return (
     <Stack
       flex="auto"
@@ -246,12 +251,13 @@ function Plot(props: Props) {
         fullWidth
         style={{ height: `calc(100% - ${PANEL_TOOLBAR_MIN_HEIGHT}px)` }}
       >
+        {/* Pass stable values here for properties when not showing values so that the legend memoization remains stable. */}
         {legendDisplay !== "none" && (
           <PlotLegend
-            currentTime={currentTimeSinceStart}
-            datasets={datasets}
+            currentTime={showPlotValuesInLegend ? currentTimeSinceStart : undefined}
+            datasets={showPlotValuesInLegend ? datasets : EmptyDatasets}
             legendDisplay={legendDisplay}
-            onClickPath={(index: number) => setFocusedPath(["paths", String(index)])}
+            onClickPath={onClickPath}
             paths={yAxisPaths}
             pathsWithMismatchedDataLengths={pathsWithMismatchedDataLengths}
             saveConfig={saveConfig}


### PR DESCRIPTION
**User-Facing Changes**
None (small increase in plot panel performance)

**Description**
The plot legend is an expensive component to rerender, partly because it uses complex dynamic styles. On a M1 Pro it seems to take ~5ms per legend. On a complex layout with many plots this can be a significant performance hit. When we're not displaying values there's no need to update the legend so this PR memoizes the legend component and stabilizes its properties and the hover values the legend rows receive to eliminate this overhead.

<img width="637" alt="Screenshot 2023-07-27 at 6 18 46 AM" src="https://github.com/foxglove/studio/assets/93935560/ce1371a5-c89d-4fdc-a546-d96e96acce45">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
