### PR TITLE
Foxglove weboscket: Avoid emitting unnecessary parameter & topic stats changes

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -198,19 +198,20 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#channelsByTopic.clear();
       this.#servicesByName.clear();
       this.#serviceResponseCbs.clear();
-      this.#parameters = new Map();
-      this.#profile = undefined;
-      this.#publishedTopics = undefined;
-      this.#subscribedTopics = undefined;
-      this.#advertisedServices = undefined;
       this.#publicationsByTopic.clear();
-      this.#datatypes = new Map();
-
       for (const topic of this.#resolvedSubscriptionsByTopic.keys()) {
         this.#unresolvedSubscriptions.add(topic);
       }
       this.#resolvedSubscriptionsById.clear();
       this.#resolvedSubscriptionsByTopic.clear();
+
+      // Re-assign members that are emitted as player state
+      this.#profile = undefined;
+      this.#publishedTopics = undefined;
+      this.#subscribedTopics = undefined;
+      this.#advertisedServices = undefined;
+      this.#datatypes = new Map();
+      this.#parameters = new Map();
     });
 
     this.#client.on("error", (err) => {
@@ -532,7 +533,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           topicStats.set(topic, stats);
         }
         stats.numMessages++;
-        this.#topicsStats = new Map(topicStats);
+        this.#topicsStats = topicStats;
       } catch (error) {
         this.#problems.addProblem(`message:${chanInfo.channel.topic}`, {
           severity: "error",
@@ -577,7 +578,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         // Update params
         const updatedParameters = new Map(this.#parameters);
         mappedParameters.forEach((param) => updatedParameters.set(param.name, param.value));
-        this.#parameters = new Map(updatedParameters);
+        this.#parameters = updatedParameters;
       }
 
       this.#emitState();
@@ -728,7 +729,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
     }
 
-    this.#topicsStats = new Map(topicStats);
+    this.#topicsStats = topicStats;
     this.#topics = topics;
 
     // Update the _datatypes map;
@@ -853,7 +854,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         );
       }
     }
-    this.#topicsStats = new Map(topicStats);
+    this.#topicsStats = topicStats;
 
     for (const topic of this.#unresolvedSubscriptions) {
       if (!newTopics.has(topic)) {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -525,12 +525,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
         });
 
         // Update the message count for this topic
-        let stats = this.#topicsStats.get(topic);
+        const topicStats = new Map(this.#topicsStats);
+        let stats = topicStats.get(topic);
         if (!stats) {
           stats = { numMessages: 0 };
-          this.#topicsStats.set(topic, stats);
+          topicStats.set(topic, stats);
         }
         stats.numMessages++;
+        this.#topicsStats = new Map(topicStats);
       } catch (error) {
         this.#problems.addProblem(`message:${chanInfo.channel.topic}`, {
           severity: "error",
@@ -719,12 +721,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     // Remove stats entries for removed topics
     const topicsSet = new Set<string>(topics.map((topic) => topic.name));
-    for (const topic of this.#topicsStats.keys()) {
+    const topicStats = new Map(this.#topicsStats);
+    for (const topic of topicStats.keys()) {
       if (!topicsSet.has(topic)) {
-        this.#topicsStats.delete(topic);
+        topicStats.delete(topic);
       }
     }
 
+    this.#topicsStats = new Map(topicStats);
     this.#topics = topics;
 
     // Update the _datatypes map;
@@ -786,8 +790,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         speed: 1,
         lastSeekTime: this.#numTimeSeeks,
         topics: this.#topics,
-        // Always copy topic stats since message counts and timestamps are being updated
-        topicStats: new Map(this.#topicsStats),
+        topicStats: this.#topicsStats,
         datatypes: this.#datatypes,
         parameters: this.#parameters,
         publishedTopics: this.#publishedTopics,
@@ -833,6 +836,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
     }
 
+    const topicStats = new Map(this.#topicsStats);
     for (const [topic, subId] of this.#resolvedSubscriptionsByTopic) {
       if (!newTopics.has(topic)) {
         this.#client.unsubscribe(subId);
@@ -841,7 +845,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#recentlyCanceledSubscriptions.add(subId);
 
         // Reset the message count for this topic
-        this.#topicsStats.delete(topic);
+        topicStats.delete(topic);
 
         setTimeout(
           () => this.#recentlyCanceledSubscriptions.delete(subId),
@@ -849,6 +853,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
         );
       }
     }
+    this.#topicsStats = new Map(topicStats);
+
     for (const topic of this.#unresolvedSubscriptions) {
       if (!newTopics.has(topic)) {
         this.#unresolvedSubscriptions.delete(topic);

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -198,7 +198,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#channelsByTopic.clear();
       this.#servicesByName.clear();
       this.#serviceResponseCbs.clear();
-      this.#parameters.clear();
+      this.#parameters = new Map();
       this.#profile = undefined;
       this.#publishedTopics = undefined;
       this.#subscribedTopics = undefined;
@@ -573,7 +573,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#parameters = new Map(mappedParameters.map((param) => [param.name, param.value]));
       } else {
         // Update params
-        mappedParameters.forEach((param) => this.#parameters.set(param.name, param.value));
+        const updatedParameters = new Map(this.#parameters);
+        mappedParameters.forEach((param) => updatedParameters.set(param.name, param.value));
+        this.#parameters = new Map(updatedParameters);
       }
 
       this.#emitState();
@@ -787,7 +789,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         // Always copy topic stats since message counts and timestamps are being updated
         topicStats: new Map(this.#topicsStats),
         datatypes: this.#datatypes,
-        parameters: new Map(this.#parameters),
+        parameters: this.#parameters,
         publishedTopics: this.#publishedTopics,
         subscribedTopics: this.#subscribedTopics,
         services: this.#advertisedServices,
@@ -1180,7 +1182,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this.#receivedBytes = 0;
     this.#hasReceivedMessage = false;
     this.#problems.clear();
-    this.#parameters.clear();
+    this.#parameters = new Map();
     this.#fetchedAssets.clear();
     for (const [requestId, callback] of this.#fetchAssetRequests) {
       callback({


### PR DESCRIPTION
**User-Facing Changes**
Small performance improvement for Foxglove weboscket connections

**Description**
Avoids falsely flagging parameters & topic stats as changed even though they did not change at all. This was causing unnecessary function calls / re-rendering in e.g. components that were subscribing to parameter changes.

