### PR TITLE
Improve performance of plot panel menus

### DIFF
--- a/packages/studio-base/src/components/PanelContextMenu.tsx
+++ b/packages/studio-base/src/components/PanelContextMenu.tsx
@@ -40,7 +40,7 @@ type PanelContextMenuProps = {
  * This is a convenience component for attaching a context menu to a panel. It
  * must be a child of a Panel component to work.
  */
-export function PanelContextMenu(props: PanelContextMenuProps): JSX.Element {
+function PanelContextMenuComponent(props: PanelContextMenuProps): JSX.Element {
   const { getItems } = props;
 
   const rootRef = useRef<HTMLDivElement>(ReactNull);
@@ -124,3 +124,5 @@ export function PanelContextMenu(props: PanelContextMenuProps): JSX.Element {
     </div>
   );
 }
+
+export const PanelContextMenu = React.memo(PanelContextMenuComponent);

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export function PanelActionsDropdown({ isUnknownPanel }: Props): JSX.Element {
+function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
   const { classes, cx } = useStyles();
   const [menuAnchorEl, setMenuAnchorEl] = useState<undefined | HTMLElement>(undefined);
   const [subMenuAnchorEl, setSubmenuAnchorEl] = useState<undefined | HTMLElement>(undefined);
@@ -263,3 +263,5 @@ export function PanelActionsDropdown({ isUnknownPanel }: Props): JSX.Element {
     </div>
   );
 }
+
+export const PanelActionsDropdown = React.memo(PanelActionsDropdownComponent);

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -13,6 +13,7 @@
 
 import { compact, isNumber, uniq } from "lodash";
 import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
+import { useLatest } from "react-use";
 import { DeepWritable } from "ts-essentials";
 
 import {
@@ -220,16 +221,19 @@ function Plot(props: Props) {
     [legendDisplay],
   );
 
+  // Access datasets by latest reference to stabilize our getPanelContextMenuItems callback.
+  const latestDatasets = useLatest(datasets);
+
   const getPanelContextMenuItems = useCallback(() => {
     const items: PanelContextMenuItem[] = [
       {
         type: "item",
         label: "Download plot data as CSV",
-        onclick: () => downloadCSV(datasets, xAxisVal),
+        onclick: () => downloadCSV(latestDatasets.current, xAxisVal),
       },
     ];
     return items;
-  }, [datasets, xAxisVal]);
+  }, [latestDatasets, xAxisVal]);
 
   return (
     <Stack


### PR DESCRIPTION
**User-Facing Changes**
None (minor performance improvements)

**Description**
The panel context menu and actions dropdown are both somewhat expensive to render. We can improve this with memoization and stabilizing properties.

<img width="642" alt="Screenshot 2023-07-27 at 7 37 07 AM" src="https://github.com/foxglove/studio/assets/93935560/4f3fe2b5-7f34-440e-bc12-591e15669664">
<img width="638" alt="Screenshot 2023-07-27 at 7 43 58 AM" src="https://github.com/foxglove/studio/assets/93935560/0505bb8c-45c0-4206-bbec-4fc47a76325d">


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
