### PR TITLE
Improve state transition zoom behavior on closely overlapping states

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -31,6 +31,30 @@ describe("downsampleTimeseries", () => {
     });
   });
 
+  it("preserves distinctly labeled segments", () => {
+    const result = downsampleTimeseries(
+      {
+        data: [
+          { x: 0, y: 0, value: 0, label: "1" },
+          { x: 10, y: 0, value: 0, label: "2" },
+          { x: 20, y: 0, value: 0 },
+          { x: 20, y: 1, value: 1 },
+          { x: 20, y: 10, value: 10 },
+          { x: 20, y: 20, value: 20 },
+        ],
+      },
+      bounds,
+    );
+    expect(result).toEqual({
+      data: [
+        { x: 0, y: 0, value: 0, label: "1" },
+        { x: 10, y: 0, value: 0, label: "2" },
+        { x: 20, y: 0, value: 0 },
+        { x: 20, y: 20, value: 20 },
+      ],
+    });
+  });
+
   it("should keep the min/max values within an interval", () => {
     const result = downsampleTimeseries(
       {

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -90,8 +90,12 @@ export function downsampleTimeseries(
     const x = Math.trunc(datum.x * pixelPerXValue);
     const y = Math.trunc(datum.y * pixelPerYValue);
 
-    // interval has ended, we determine whether to write additional points for min/max/last
-    if (intFirst?.xPixel !== x) {
+    // interval has ended, we determine whether to write additional points for min/max/last. Always
+    // create a new interval when encountering a new label.
+    if (
+      intFirst?.xPixel !== x ||
+      (intLast?.datum?.label != undefined && intLast.datum.label !== datum.label)
+    ) {
       // add the min value from previous interval if it doesn't match the first or last of that interval
       if (intMin && intMin.yPixel !== intFirst?.yPixel && intMin.yPixel !== intLast?.yPixel) {
         downsampled.push(intMin.datum);

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { StoryObj } from "@storybook/react";
+import { produce } from "immer";
 import { useCallback } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -127,6 +128,59 @@ export const ColorPalette: StoryObj = {
       ))}
     </Stack>
   ),
+};
+
+export const CloseValues: StoryObj = {
+  render: function Story() {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    const closeMessages = [
+      { header: { stamp: { sec: 0, nsec: 0 } }, state: 0 },
+      { header: { stamp: { sec: 1, nsec: 0 } }, state: 1 },
+      { header: { stamp: { sec: 2, nsec: 0 } }, state: 2 },
+      { header: { stamp: { sec: 3, nsec: 0 } }, state: 3 },
+      { header: { stamp: { sec: 4, nsec: 0 } }, state: 4 },
+      { header: { stamp: { sec: 100, nsec: 0 } }, state: 4 },
+    ];
+
+    const closeFixture = produce(fixture, (draft) => {
+      draft.activeData = {
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 100, nsec: 0 },
+        isPlaying: false,
+        speed: 0.2,
+      };
+      draft.frame = {
+        "/some/topic/with/state": closeMessages.map((message, idx) => ({
+          topic: "/some/topic/with/state",
+          receiveTime: message.header.stamp,
+          message: { ...message, data: { value: idx } },
+          schemaName: "msgs/SystemState",
+
+          sizeInBytes: 0,
+        })),
+      };
+    });
+
+    return (
+      <PanelSetup fixture={closeFixture} pauseFrame={pauseFrame}>
+        <StateTransitions
+          overrideConfig={{
+            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+  play: async ({ parameters }) => {
+    await parameters.storyReady;
+  },
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
 };
 
 export const OnePath: StoryObj = {


### PR DESCRIPTION
**User-Facing Changes**
Improve behavior of state transition panel when zooming out on closely aligned segments.

**Description**
Improve the segment coloring logic to handle zooming out far enough that many segments overlap the same pixel.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
