### PR TITLE
Preserve distinctly labeled chart segments during downsampling

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -31,6 +31,30 @@ describe("downsampleTimeseries", () => {
     });
   });
 
+  it("preserves distinctly labeled segments", () => {
+    const result = downsampleTimeseries(
+      {
+        data: [
+          { x: 0, y: 0, value: 0, label: "1" },
+          { x: 10, y: 0, value: 0, label: "2" },
+          { x: 20, y: 0, value: 0 },
+          { x: 20, y: 1, value: 1 },
+          { x: 20, y: 10, value: 10 },
+          { x: 20, y: 20, value: 20 },
+        ],
+      },
+      bounds,
+    );
+    expect(result).toEqual({
+      data: [
+        { x: 0, y: 0, value: 0, label: "1" },
+        { x: 10, y: 0, value: 0, label: "2" },
+        { x: 20, y: 0, value: 0 },
+        { x: 20, y: 20, value: 20 },
+      ],
+    });
+  });
+
   it("should keep the min/max values within an interval", () => {
     const result = downsampleTimeseries(
       {

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -90,8 +90,12 @@ export function downsampleTimeseries(
     const x = Math.trunc(datum.x * pixelPerXValue);
     const y = Math.trunc(datum.y * pixelPerYValue);
 
-    // interval has ended, we determine whether to write additional points for min/max/last
-    if (intFirst?.xPixel !== x) {
+    // interval has ended, we determine whether to write additional points for min/max/last. Always
+    // create a new interval when encountering a new label.
+    if (
+      intFirst?.xPixel !== x ||
+      (intLast?.datum?.label != undefined && intLast.datum.label !== datum.label)
+    ) {
       // add the min value from previous interval if it doesn't match the first or last of that interval
       if (intMin && intMin.yPixel !== intFirst?.yPixel && intMin.yPixel !== intLast?.yPixel) {
         downsampled.push(intMin.datum);

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -91,7 +91,7 @@ export function downsampleTimeseries(
     const y = Math.trunc(datum.y * pixelPerYValue);
 
     // interval has ended, we determine whether to write additional points for min/max/last. Always
-    // create a new interval when encountering a new label.
+    // create a new interval when encountering a new label to preserve the transition from one label to another
     if (
       intFirst?.xPixel !== x ||
       (intLast?.datum?.label != undefined && intLast.datum.label !== datum.label)


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with ordering of state transitions when zooming out on the state transitions panel.

**Description**
We downsample the data in the state transitions panel but this can throw away points that represent state changes. This changes the downsampling logic to consider a point with a new label as a distinct segment in the downsampled data.

If we don't want to make this a universal change we could also pass it down as an option to the downsampler through TimeBasedChart.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
