### PR TITLE
Allow custom layer URDFs to subscribe to a topic

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -373,8 +373,8 @@ function FieldInput({
           }
           MenuProps={{ MenuListProps: { dense: true } }}
         >
-          {field.options.map(({ label, value = UNDEFINED_SENTINEL_VALUE }) => (
-            <MenuItem key={value} value={value}>
+          {field.options.map(({ label, value = UNDEFINED_SENTINEL_VALUE, disabled }) => (
+            <MenuItem key={value} value={value} disabled={disabled}>
               {label}
             </MenuItem>
           ))}

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -427,6 +427,9 @@ export function ThreeDeeRender(props: {
     schemaHandlers,
     topicHandlers,
     config.imageMode.annotations,
+    // Need to update subscriptions when layers change as URDF layers might subscribe to topics
+    // shouldSubscribe values will be re-evaluated
+    config.layers,
   ]);
 
   // Notify the extension context when our subscription list changes

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -174,6 +174,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
   #transformsByInstanceId = new Map<string, TransformData[]>();
   #jointStates = new Map<string, JointPosition>();
   #textDecoder = new TextDecoder();
+  #urdfsByTopic = new Map<string, string>();
 
   public constructor(renderer: IRenderer) {
     super("foxglove.Urdfs", renderer);
@@ -306,7 +307,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
             value: config.sourceType ?? DEFAULT_CUSTOM_SETTINGS.sourceType,
             options: [
               {
-                label: "From URL",
+                label: "URL",
                 value: "url",
               },
               {
@@ -375,6 +376,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
             label: "Frame prefix",
             input: "string",
             help: "Prefix to apply to all frame names (also often called tfPrefix)",
+            placeholder: "Frame prefix",
             value: config.framePrefix ?? "",
           },
           displayMode: {
@@ -524,7 +526,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         });
 
         // Add the URDF renderable
-        this.#loadUrdf({ instanceId: newInstanceId, urdf: undefined });
+        const renderable = this.renderables.get(instanceId);
+        this.#loadUrdf({ instanceId: newInstanceId, urdf: renderable?.userData.urdf });
 
         // Update the settings tree
         this.updateSettingsTree();
@@ -581,11 +584,28 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         this.#debouncedLoadUrdf({ instanceId, urdf: undefined });
       } else if (field === "parameter") {
         urdf = this.renderer.parameters?.get(action.payload.value as string) as string | undefined;
-        this.#debouncedLoadUrdf({ instanceId, urdf });
+        this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
       } else if (field === "framePrefix") {
         this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
-      } else if (field === "displayMode") {
+      } else if (field === "displayMode" || field === "visible") {
         this.#loadUrdf({ instanceId, urdf, forceReload: true });
+      } else if (field === "sourceType") {
+        const sourceType = action.payload.value as LayerSettingsCustomUrdf["sourceType"];
+        if (sourceType === "topic") {
+          urdf = renderable?.userData.topic
+            ? this.#urdfsByTopic.get(renderable.userData.topic)
+            : undefined;
+        } else if (sourceType === "param") {
+          urdf = renderable?.userData.parameter
+            ? (this.renderer.parameters?.get(renderable.userData.parameter) as string | undefined)
+            : undefined;
+        } else {
+          urdf = undefined;
+        }
+        this.#loadUrdf({ instanceId, urdf, forceReload: true });
+      } else if (field === "topic") {
+        urdf = this.#urdfsByTopic.get(action.payload.value as string);
+        this.#loadUrdf({ instanceId, urdf });
       } else {
         this.#loadUrdf({ instanceId, urdf });
       }
@@ -598,6 +618,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     if (typeof robotDescription !== "string") {
       return;
     }
+    this.#urdfsByTopic.set(topic, robotDescription);
 
     if (topic === TOPIC_NAME) {
       this.#loadUrdf({ instanceId: TOPIC_NAME, urdf: robotDescription });
@@ -743,7 +764,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const forceReload = args.forceReload ?? false;
     let renderable = this.renderables.get(instanceId);
     const settings = this.#getCurrentSettings(instanceId);
-    if (renderable && urdf != undefined && !forceReload && renderable.userData.urdf === urdf) {
+    if (renderable && urdf && !forceReload && renderable.userData.urdf === urdf) {
       renderable.userData.settings = settings;
       return;
     }
@@ -817,6 +838,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
 
     if (!urdf) {
       const path = renderable.userData.settingsPath;
+      this.renderer.settings.errors.remove(path, PARSE_URDF_ERR);
+      this.renderer.settings.errors.remove(path, MISSING_TRANSFORM);
       if (sourceType === "url") {
         if (url != undefined) {
           this.#fetchUrdf(instanceId, url);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -8,6 +8,7 @@ import { debounce, maxBy } from "lodash";
 import * as THREE from "three";
 import { v4 as uuidv4 } from "uuid";
 
+import { filterMap } from "@foxglove/den/collection";
 import { UrdfGeometryMesh, UrdfRobot, UrdfVisual, parseRobot, UrdfJoint } from "@foxglove/den/urdf";
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
@@ -78,9 +79,9 @@ export type LayerSettingsUrdf = BaseSettings & {
 export type LayerSettingsCustomUrdf = CustomLayerSettings & {
   layerId: "foxglove.Urdf";
   sourceType: "url" | "param" | "topic";
-  url: string;
-  parameter: string;
-  topic: string;
+  url?: string;
+  parameter?: string;
+  topic?: string;
   framePrefix: string;
   displayMode: "auto" | "visual" | "collision";
 };
@@ -244,7 +245,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     if (topic != undefined) {
       const config = (this.renderer.config.topics[TOPIC_NAME] ?? {}) as Partial<LayerSettingsUrdf>;
       const fields: SettingsTreeFields = {
-        displayMode: { ...displayMode, value: config.displayMode ?? "auto" },
+        displayMode: { ...displayMode, value: config.displayMode ?? DEFAULT_SETTINGS.displayMode },
       };
       entries.push({
         path: ["topics", TOPIC_NAME],
@@ -269,7 +270,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       const config = (this.renderer.config.topics[PARAM_KEY] ?? {}) as Partial<LayerSettingsUrdf>;
 
       const fields: SettingsTreeFields = {
-        displayMode: { ...displayMode, value: config.displayMode ?? "auto" },
+        displayMode: { ...displayMode, value: config.displayMode ?? DEFAULT_SETTINGS.displayMode },
       };
 
       entries.push({
@@ -298,7 +299,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           sourceType: {
             label: "Source",
             input: "select",
-            value: config.sourceType ?? "url",
+            value: config.sourceType ?? DEFAULT_CUSTOM_SETTINGS.sourceType,
             options: [
               {
                 label: "From URL",
@@ -321,7 +322,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
                   input: "string",
                   placeholder: "package://",
                   help: "package:// URL or http(s) URL pointing to a Unified Robot Description Format (URDF) XML file",
-                  value: config.url ?? "",
+                  value: config.url ?? DEFAULT_CUSTOM_SETTINGS.url,
                 }
               : undefined,
           topic:
@@ -329,10 +330,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
               ? {
                   label: "Topic",
                   input: "autocomplete",
-                  value: config.topic ?? "",
-                  items: Array.from(this.renderer.topics ?? [])
-                    .filter((t) => URDF_TOPIC_SCHEMAS.has(t.schemaName))
-                    .map((t) => t.name),
+                  value: config.topic ?? DEFAULT_CUSTOM_SETTINGS.topic,
+                  items: filterMap(this.renderer.topics ?? [], (_topic) =>
+                    URDF_TOPIC_SCHEMAS.has(_topic.schemaName) ? _topic.name : undefined,
+                  ),
                 }
               : undefined,
           parameter:
@@ -340,20 +341,27 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
               ? {
                   label: "Parameter",
                   input: "autocomplete",
-                  value: config.parameter ?? "",
-                  items: Array.from(this.renderer.parameters ?? [])
-                    .filter(([_paramName, value]) => typeof value === "string")
-                    .map(([paramName, _value]) => paramName),
+                  value: config.parameter ?? DEFAULT_CUSTOM_SETTINGS.parameter,
+                  items: filterMap(this.renderer.parameters ?? [], ([paramName, value]) =>
+                    typeof value === "string" ? paramName : undefined,
+                  ),
                 }
               : undefined,
-          label: { label: "Label", input: "string", value: config.label ?? "URDF" },
+          label: {
+            label: "Label",
+            input: "string",
+            value: config.label ?? DEFAULT_CUSTOM_SETTINGS.label,
+          },
           framePrefix: {
             label: "Frame prefix",
             input: "string",
             help: "Prefix to apply to all frame names (also often called tfPrefix)",
             value: config.framePrefix ?? "",
           },
-          displayMode: { ...displayMode, value: config.displayMode ?? "auto" },
+          displayMode: {
+            ...displayMode,
+            value: config.displayMode ?? DEFAULT_CUSTOM_SETTINGS.displayMode,
+          },
         };
 
         entries.push({
@@ -577,11 +585,12 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
 
     // Update custom layer URDFs that subscribe to this topic.
-    const topicCustomLayers = Array.from(this.renderables.entries()).filter(
-      ([_instanceId, renderable]) =>
-        renderable.userData.sourceType === "topic" && renderable.userData.topic === topic,
+    const subscribedInstanceIds = filterMap(this.renderables, ([instanceId, renderable]) =>
+      renderable.userData.sourceType === "topic" && renderable.userData.topic === topic
+        ? instanceId
+        : undefined,
     );
-    for (const [instanceId] of topicCustomLayers) {
+    for (const instanceId of subscribedInstanceIds) {
       this.#loadUrdf({ instanceId, urdf: robotDescription });
     }
   };
@@ -733,7 +742,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const parameter = (settings as Partial<LayerSettingsCustomUrdf>).parameter;
     const topic = (settings as Partial<LayerSettingsCustomUrdf>).topic;
     const framePrefix = (settings as Partial<LayerSettingsCustomUrdf>).framePrefix;
-    const label = (settings as Partial<LayerSettingsCustomUrdf>).label ?? "URDF";
+    const label =
+      (settings as Partial<LayerSettingsCustomUrdf>).label ?? DEFAULT_CUSTOM_SETTINGS.label;
 
     if (label !== renderable?.userData.settings.label) {
       // Label has changed, update the config

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -310,7 +310,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
                 value: "url",
               },
               {
-                label: "File Path",
+                label: "File path",
                 value: "filePath",
                 disabled: !isDesktopApp(),
               },
@@ -337,7 +337,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
           filePath:
             config.sourceType === "filePath"
               ? {
-                  label: "File Path",
+                  label: "File path",
                   input: "string",
                   help: "Absolute file path (desktop app only)",
                   value: config.filePath ?? DEFAULT_CUSTOM_SETTINGS.filePath,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -310,7 +310,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
                 value: "url",
               },
               {
-                label: "File path",
+                label: "File path (Desktop only)",
                 value: "filePath",
                 disabled: !isDesktopApp(),
               },
@@ -816,24 +816,20 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
 
     if (!urdf) {
-      if (sourceType === "url" && url != undefined) {
-        // Fetch the URDF from the URL
-        this.#fetchUrdf(instanceId, url);
-        return;
-      } else if (sourceType === "filePath" && filePath != undefined) {
-        // Fetch the URDF from a local file
-        this.#fetchUrdf(instanceId, `file://${filePath}`);
-        return;
-      }
-    }
-
-    // At this point we have to have a URDF.
-    if (!urdf) {
       const path = renderable.userData.settingsPath;
       if (sourceType === "url") {
-        this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid URDF URL: "${url}"`);
+        if (url != undefined) {
+          this.#fetchUrdf(instanceId, url);
+        } else {
+          this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid URDF URL: "${url}"`);
+        }
       } else if (sourceType === "filePath") {
-        this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid File Path: "${filePath}"`);
+        if (filePath != undefined) {
+          this.#fetchUrdf(instanceId, `file://${filePath}`);
+        } else {
+          const errMsg = `Invalid File Path: "${filePath}"`;
+          this.renderer.settings.errors.add(path, VALID_SRC_ERR, errMsg);
+        }
       } else if (sourceType === "param") {
         this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid Parameter: "${parameter}"`);
       } else if (sourceType === "topic") {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -58,7 +58,7 @@ const PARAM_KEY = "param:/robot_description";
 const PARAM_NAME = "/robot_description";
 const PARAM_DISPLAY_NAME = "/robot_description (parameter)";
 
-const VALID_URL_ERR = "ValidUrl";
+const VALID_SRC_ERR = "ValidSrc";
 const FETCH_URDF_ERR = "FetchUrdf";
 const PARSE_URDF_ERR = "ParseUrdf";
 
@@ -77,7 +77,10 @@ export type LayerSettingsUrdf = BaseSettings & {
 
 export type LayerSettingsCustomUrdf = CustomLayerSettings & {
   layerId: "foxglove.Urdf";
+  sourceType: "url" | "param" | "topic";
   url: string;
+  parameter: string;
+  topic: string;
   framePrefix: string;
   displayMode: "auto" | "visual" | "collision";
 };
@@ -96,10 +99,14 @@ const DEFAULT_CUSTOM_SETTINGS: LayerSettingsCustomUrdf = {
   label: "URDF",
   instanceId: "invalid",
   layerId: LAYER_ID,
+  sourceType: "url",
   url: "",
+  parameter: "",
+  topic: "",
   framePrefix: "",
   displayMode: "auto",
 };
+const URDF_TOPIC_SCHEMAS = new Set<string>(["std_msgs/String", "std_msgs/msg/String"]);
 
 const tempVec3a = new THREE.Vector3();
 const tempVec3b = new THREE.Vector3();
@@ -112,6 +119,8 @@ export type UrdfUserData = BaseUserData & {
   fetching?: { url: string; control: AbortController };
   url: string | undefined;
   urdf: string | undefined;
+  sourceType: LayerSettingsCustomUrdf["sourceType"] | undefined;
+  parameter: string | undefined;
   renderables: Map<string, Renderable>;
 };
 
@@ -175,7 +184,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     // Load existing URDF layers from the config
     for (const [instanceId, entry] of Object.entries(renderer.config.layers)) {
       if (entry?.layerId === LAYER_ID) {
-        this.#loadUrdf(instanceId, undefined);
+        this.#loadUrdf({ instanceId, urdf: undefined });
       }
     }
   }
@@ -195,6 +204,15 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         type: "schema",
         schemaNames: JOINTSTATE_DATATYPES,
         subscription: { handler: this.#handleJointState },
+      },
+
+      {
+        type: "schema",
+        schemaNames: URDF_TOPIC_SCHEMAS,
+        subscription: {
+          shouldSubscribe: this.#shouldSubscribe,
+          handler: this.#handleRobotDescription,
+        },
       },
     ];
   }
@@ -275,12 +293,59 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     for (const [instanceId, layerConfig] of Object.entries(this.renderer.config.layers)) {
       if (layerConfig?.layerId === LAYER_ID) {
         const config = layerConfig as Partial<LayerSettingsCustomUrdf>;
-        const placeholder = "package://";
-        const help =
-          "package:// URL or http(s) URL pointing to a Unified Robot Description Format (URDF) XML file";
 
         const fields: SettingsTreeFields = {
-          url: { label: "URL", input: "string", placeholder, help, value: config.url ?? "" },
+          sourceType: {
+            label: "Source",
+            input: "select",
+            value: config.sourceType ?? "url",
+            options: [
+              {
+                label: "From URL",
+                value: "url",
+              },
+              {
+                label: "Parameter",
+                value: "param",
+              },
+              {
+                label: "Topic",
+                value: "topic",
+              },
+            ],
+          },
+          url:
+            config.sourceType === "url"
+              ? {
+                  label: "URL",
+                  input: "string",
+                  placeholder: "package://",
+                  help: "package:// URL or http(s) URL pointing to a Unified Robot Description Format (URDF) XML file",
+                  value: config.url ?? "",
+                }
+              : undefined,
+          topic:
+            config.sourceType === "topic"
+              ? {
+                  label: "Topic",
+                  input: "autocomplete",
+                  value: config.topic ?? "",
+                  items: Array.from(this.renderer.topics ?? [])
+                    .filter((t) => URDF_TOPIC_SCHEMAS.has(t.schemaName))
+                    .map((t) => t.name),
+                }
+              : undefined,
+          parameter:
+            config.sourceType === "param"
+              ? {
+                  label: "Parameter",
+                  input: "autocomplete",
+                  value: config.parameter ?? "",
+                  items: Array.from(this.renderer.parameters ?? [])
+                    .filter(([_paramName, value]) => typeof value === "string")
+                    .map(([paramName, _value]) => paramName),
+                }
+              : undefined,
           label: { label: "Label", input: "string", value: config.label ?? "URDF" },
           framePrefix: {
             label: "Frame prefix",
@@ -432,7 +497,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         });
 
         // Add the URDF renderable
-        this.#loadUrdf(newInstanceId, undefined);
+        this.#loadUrdf({ instanceId: newInstanceId, urdf: undefined });
 
         // Update the settings tree
         this.updateSettingsTree();
@@ -482,24 +547,50 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       // ["layers", instanceId, field]
       this.saveSetting(path, action.payload.value);
       const [_layers, instanceId, field] = path as [string, string, string];
-      if (instanceId === PARAM_KEY) {
-        this.#loadUrdf(instanceId, this.renderer.parameters?.get(PARAM_NAME) as string | undefined);
-      } else if (instanceId === TOPIC_NAME) {
-        this.#loadUrdf(instanceId, this.renderables.get(instanceId)?.userData.urdf);
+      const renderable = this.renderables.get(instanceId);
+      let urdf = renderable?.userData.urdf;
+
+      if (field === "url") {
+        this.#debouncedLoadUrdf({ instanceId, urdf: undefined });
+      } else if (field === "parameter") {
+        urdf = this.renderer.parameters?.get(action.payload.value as string) as string | undefined;
+        this.#debouncedLoadUrdf({ instanceId, urdf });
       } else if (field === "framePrefix") {
-        this.#debouncedLoadUrdf(instanceId, undefined);
+        this.#debouncedLoadUrdf({ instanceId, urdf, forceReload: true });
+      } else if (field === "displayMode") {
+        this.#loadUrdf({ instanceId, urdf, forceReload: true });
       } else {
-        this.#loadUrdf(instanceId, undefined);
+        this.#loadUrdf({ instanceId, urdf });
       }
     }
   };
 
   #handleRobotDescription = (messageEvent: PartialMessageEvent<{ data: string }>): void => {
+    const topic = messageEvent.topic;
     const robotDescription = messageEvent.message.data;
     if (typeof robotDescription !== "string") {
       return;
     }
-    this.#loadUrdf(TOPIC_NAME, robotDescription);
+
+    if (topic === TOPIC_NAME) {
+      this.#loadUrdf({ instanceId: TOPIC_NAME, urdf: robotDescription });
+    }
+
+    // Update custom layer URDFs that subscribe to this topic.
+    const topicCustomLayers = Array.from(this.renderables.entries()).filter(
+      ([_instanceId, renderable]) =>
+        renderable.userData.sourceType === "topic" && renderable.userData.topic === topic,
+    );
+    for (const [instanceId] of topicCustomLayers) {
+      this.#loadUrdf({ instanceId, urdf: robotDescription });
+    }
+  };
+
+  #shouldSubscribe = (topic: string): boolean => {
+    return Array.from(this.renderables.values()).some(
+      (renderable) =>
+        renderable.userData.sourceType === "topic" && renderable.userData.topic === topic,
+    );
   };
 
   #handleJointState = (messageEvent: PartialMessageEvent<JointState>): void => {
@@ -522,7 +613,21 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
   #handleParametersChange = (parameters: ReadonlyMap<string, unknown> | undefined): void => {
     const robotDescription = parameters?.get(PARAM_NAME);
     if (typeof robotDescription === "string") {
-      this.#loadUrdf(PARAM_KEY, robotDescription);
+      this.#loadUrdf({ instanceId: PARAM_KEY, urdf: robotDescription });
+    }
+
+    // Update custom layer URDFs that use parameters.
+    for (const [instanceId, renderable] of this.renderables.entries()) {
+      const sourceType = (renderable.userData.settings as Partial<LayerSettingsCustomUrdf>)
+        .sourceType;
+      const paramName = (renderable.userData.settings as Partial<LayerSettingsCustomUrdf>)
+        .parameter;
+      if (sourceType === "param" && paramName != undefined) {
+        const urdf = parameters?.get(paramName);
+        if (typeof urdf === "string") {
+          this.#loadUrdf({ instanceId, urdf });
+        }
+      }
     }
   };
 
@@ -539,7 +644,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     });
 
     // Add the URDF renderable
-    this.#loadUrdf(instanceId, undefined);
+    this.#loadUrdf({ instanceId, urdf: undefined });
 
     // Update the settings tree
     this.updateSettingsTree();
@@ -554,10 +659,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     // Check if a valid URL was provided
     if (!isValidUrl(url)) {
       const path = renderable.userData.settingsPath;
-      this.renderer.settings.errors.add(path, VALID_URL_ERR, `Invalid URDF URL: "${url}"`);
+      this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid URDF URL: "${url}"`);
       return;
     }
-    this.renderer.settings.errors.remove(renderable.userData.settingsPath, VALID_URL_ERR);
+    this.renderer.settings.errors.remove(renderable.userData.settingsPath, VALID_SRC_ERR);
 
     // Check if this URL has already been fetched
     if (renderable.userData.url === url) {
@@ -581,7 +686,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       .then((urdf) => {
         log.debug(`Fetched ${urdf.data.length} byte URDF from ${url}`);
         this.renderer.settings.errors.remove(["layers", instanceId], FETCH_URDF_ERR);
-        this.#loadUrdf(instanceId, this.#textDecoder.decode(urdf.data));
+        this.#loadUrdf({ instanceId, urdf: this.#textDecoder.decode(urdf.data) });
       })
       .catch((unknown) => {
         const err = unknown as Error;
@@ -601,15 +706,12 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     return settings;
   }
 
-  #loadUrdf(instanceId: string, urdf: string | undefined): void {
+  #loadUrdf(args: { instanceId: string; urdf?: string; forceReload?: boolean }): void {
+    const { instanceId, urdf } = args;
+    const forceReload = args.forceReload ?? false;
     let renderable = this.renderables.get(instanceId);
     const settings = this.#getCurrentSettings(instanceId);
-    if (
-      renderable &&
-      urdf != undefined &&
-      renderable.userData.urdf === urdf &&
-      renderable.userData.settings.displayMode === settings.displayMode
-    ) {
+    if (renderable && urdf != undefined && !forceReload && renderable.userData.urdf === urdf) {
       renderable.userData.settings = settings;
       return;
     }
@@ -626,7 +728,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const isTopicOrParam = instanceId === TOPIC_NAME || instanceId === PARAM_KEY;
     const frameId = this.renderer.fixedFrameId ?? ""; // Unused
     const settingsPath = isTopicOrParam ? ["topics", instanceId] : ["layers", instanceId];
+    const sourceType = (settings as Partial<LayerSettingsCustomUrdf>).sourceType;
     const url = (settings as Partial<LayerSettingsCustomUrdf>).url;
+    const parameter = (settings as Partial<LayerSettingsCustomUrdf>).parameter;
+    const topic = (settings as Partial<LayerSettingsCustomUrdf>).topic;
     const framePrefix = (settings as Partial<LayerSettingsCustomUrdf>).framePrefix;
     const label = (settings as Partial<LayerSettingsCustomUrdf>).label ?? "URDF";
 
@@ -653,24 +758,45 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
         pose: makePose(),
         settingsPath,
         settings,
+        sourceType,
+        topic,
+        parameter,
       });
       this.add(renderable);
       this.renderables.set(instanceId, renderable);
     }
 
     renderable.userData.urdf = urdf;
-    renderable.userData.url = urdf != undefined ? url : undefined;
+    renderable.userData.url = urdf != undefined && sourceType === "url" ? url : undefined;
+    renderable.userData.sourceType = sourceType;
+    renderable.userData.topic = topic;
+    renderable.userData.parameter = parameter;
     renderable.userData.settings = settings;
     renderable.userData.fetching = undefined;
 
-    if (!urdf) {
+    if (!urdf || forceReload) {
       renderable.removeChildren();
+    }
 
+    if (sourceType === "url" && !urdf && url != undefined) {
       // Fetch the URDF from the URL if we have one
-      if (url != undefined) {
-        this.#fetchUrdf(instanceId, url);
+      this.#fetchUrdf(instanceId, url);
+      return;
+    }
+
+    // At this point we have to have a URDF.
+    if (!urdf) {
+      const path = renderable.userData.settingsPath;
+      if (sourceType === "url") {
+        this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid URDF URL: "${url}"`);
+      } else if (sourceType === "param") {
+        this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid Parameter: "${parameter}"`);
+      } else if (sourceType === "topic") {
+        this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid Topic: "${topic}"`);
       }
       return;
+    } else {
+      this.renderer.settings.errors.remove(renderable.userData.settingsPath, VALID_SRC_ERR);
     }
 
     // Parse the URDF
@@ -678,6 +804,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     parseUrdf(urdf, async (uri) => await this.#getFileFetch(uri), framePrefix)
       .then((parsed) => {
         this.#loadRobot(loadedRenderable, parsed);
+        this.renderer.settings.errors.remove(
+          loadedRenderable.userData.settingsPath,
+          PARSE_URDF_ERR,
+        );
         // the frame from the settings update is called before the robot is loaded
         // need to queue another animation frame after robot has been loaded
         this.renderer.queueAnimationFrame();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -19,6 +19,7 @@ import {
   SettingsTreeFields,
 } from "@foxglove/studio";
 import { eulerToQuaternion } from "@foxglove/studio-base/util/geometry";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 import { RenderableCube } from "./markers/RenderableCube";
 import { RenderableCylinder } from "./markers/RenderableCylinder";
@@ -78,8 +79,9 @@ export type LayerSettingsUrdf = BaseSettings & {
 
 export type LayerSettingsCustomUrdf = CustomLayerSettings & {
   layerId: "foxglove.Urdf";
-  sourceType: "url" | "param" | "topic";
+  sourceType: "url" | "filePath" | "param" | "topic";
   url?: string;
+  filePath?: string;
   parameter?: string;
   topic?: string;
   framePrefix: string;
@@ -102,6 +104,7 @@ const DEFAULT_CUSTOM_SETTINGS: LayerSettingsCustomUrdf = {
   layerId: LAYER_ID,
   sourceType: "url",
   url: "",
+  filePath: "",
   parameter: "",
   topic: "",
   framePrefix: "",
@@ -119,6 +122,7 @@ export type UrdfUserData = BaseUserData & {
   settings: LayerSettingsUrdf | LayerSettingsCustomUrdf;
   fetching?: { url: string; control: AbortController };
   url: string | undefined;
+  filePath: string | undefined;
   urdf: string | undefined;
   sourceType: LayerSettingsCustomUrdf["sourceType"] | undefined;
   parameter: string | undefined;
@@ -306,6 +310,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
                 value: "url",
               },
               {
+                label: "File Path",
+                value: "filePath",
+                disabled: !isDesktopApp(),
+              },
+              {
                 label: "Parameter",
                 value: "param",
               },
@@ -323,6 +332,16 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
                   placeholder: "package://",
                   help: "package:// URL or http(s) URL pointing to a Unified Robot Description Format (URDF) XML file",
                   value: config.url ?? DEFAULT_CUSTOM_SETTINGS.url,
+                }
+              : undefined,
+          filePath:
+            config.sourceType === "filePath"
+              ? {
+                  label: "File Path",
+                  input: "string",
+                  help: "Absolute file path (desktop app only)",
+                  value: config.filePath ?? DEFAULT_CUSTOM_SETTINGS.filePath,
+                  disabled: !isDesktopApp(),
                 }
               : undefined,
           topic:
@@ -558,7 +577,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       const renderable = this.renderables.get(instanceId);
       let urdf = renderable?.userData.urdf;
 
-      if (field === "url") {
+      if (field === "url" || field === "filePath") {
         this.#debouncedLoadUrdf({ instanceId, urdf: undefined });
       } else if (field === "parameter") {
         urdf = this.renderer.parameters?.get(action.payload.value as string) as string | undefined;
@@ -674,7 +693,11 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     this.renderer.settings.errors.remove(renderable.userData.settingsPath, VALID_SRC_ERR);
 
     // Check if this URL has already been fetched
-    if (renderable.userData.url === url) {
+    if (
+      (renderable.userData.sourceType === "url" && renderable.userData.url === url) ||
+      (renderable.userData.sourceType === "filePath" &&
+        `file://${renderable.userData.filePath}` === url)
+    ) {
       return;
     }
 
@@ -739,6 +762,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     const settingsPath = isTopicOrParam ? ["topics", instanceId] : ["layers", instanceId];
     const sourceType = (settings as Partial<LayerSettingsCustomUrdf>).sourceType;
     const url = (settings as Partial<LayerSettingsCustomUrdf>).url;
+    const filePath = (settings as Partial<LayerSettingsCustomUrdf>).filePath;
     const parameter = (settings as Partial<LayerSettingsCustomUrdf>).parameter;
     const topic = (settings as Partial<LayerSettingsCustomUrdf>).topic;
     const framePrefix = (settings as Partial<LayerSettingsCustomUrdf>).framePrefix;
@@ -760,6 +784,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       renderable = new UrdfRenderable(instanceId, this.renderer, {
         urdf,
         url: urdf != undefined ? url : undefined,
+        filePath: urdf != undefined ? filePath : undefined,
         fetching: undefined,
         renderables: new Map(),
         receiveTime: 0n,
@@ -778,6 +803,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
 
     renderable.userData.urdf = urdf;
     renderable.userData.url = urdf != undefined && sourceType === "url" ? url : undefined;
+    renderable.userData.filePath =
+      urdf != undefined && sourceType === "filePath" ? filePath : undefined;
     renderable.userData.sourceType = sourceType;
     renderable.userData.topic = topic;
     renderable.userData.parameter = parameter;
@@ -788,10 +815,16 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       renderable.removeChildren();
     }
 
-    if (sourceType === "url" && !urdf && url != undefined) {
-      // Fetch the URDF from the URL if we have one
-      this.#fetchUrdf(instanceId, url);
-      return;
+    if (!urdf) {
+      if (sourceType === "url" && url != undefined) {
+        // Fetch the URDF from the URL
+        this.#fetchUrdf(instanceId, url);
+        return;
+      } else if (sourceType === "filePath" && filePath != undefined) {
+        // Fetch the URDF from a local file
+        this.#fetchUrdf(instanceId, `file://${filePath}`);
+        return;
+      }
     }
 
     // At this point we have to have a URDF.
@@ -799,6 +832,8 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
       const path = renderable.userData.settingsPath;
       if (sourceType === "url") {
         this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid URDF URL: "${url}"`);
+      } else if (sourceType === "filePath") {
+        this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid File Path: "${filePath}"`);
       } else if (sourceType === "param") {
         this.renderer.settings.errors.add(path, VALID_SRC_ERR, `Invalid Parameter: "${parameter}"`);
       } else if (sourceType === "topic") {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/UrdfDisplayMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/UrdfDisplayMode.stories.tsx
@@ -78,21 +78,24 @@ export const UrdfDisplayMode: StoryObj = {
     const urdfParamName = "/some_ns/robot_description";
     const urdfDisplays = {
       urdf1: {
-        url: encodeURI(`data:text/xml;utf8,${URDF}`),
+        sourceType: "param",
+        parameter: urdfParamName,
         layerId: "foxglove.Urdf",
         framePrefix: "display_auto/",
         displayMode: "auto",
         translation: { x: -2, y: 0, z: 0 },
       },
       urdf2: {
-        url: encodeURI(`data:text/xml;utf8,${URDF}`),
+        sourceType: "param",
+        parameter: urdfParamName,
         layerId: "foxglove.Urdf",
         framePrefix: "display_visual/",
         displayMode: "visual",
         translation: { x: 0, y: 0, z: 0 },
       },
       urdf3: {
-        url: encodeURI(`data:text/xml;utf8,${URDF}`),
+        sourceType: "param",
+        parameter: urdfParamName,
         layerId: "foxglove.Urdf",
         framePrefix: "display_collision/",
         displayMode: "collision",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
@@ -130,6 +130,7 @@ export const Urdfs: StoryObj = {
     const topics: Topic[] = [
       { name: "/robot_description", schemaName: "std_msgs/String" },
       { name: "/tf_static", schemaName: "tf2_msgs/TFMessage" },
+      { name: "/some/robot_description", schemaName: "std_msgs/String" },
     ];
     const robot_description: MessageEvent<{ data: string }> = {
       topic: "/robot_description",
@@ -184,6 +185,15 @@ export const Urdfs: StoryObj = {
               transforms: [mesh_T_robot_1, mesh_T_robot_2],
             },
           },
+          {
+            topic: "/some/robot_description",
+            schemaName: "std_msgs/String",
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 0,
+            message: {
+              data: URDF3,
+            },
+          },
         ],
       },
     });
@@ -202,18 +212,21 @@ export const Urdfs: StoryObj = {
                 layerId: "foxglove.Grid",
                 position: [0, 0, 0],
               },
-              urdf: {
+              urdfFromUrl: {
                 layerId: "foxglove.Urdf",
+                sourceType: "url",
                 url: encodeURI(`data:text/xml;utf8,${URDF2}`),
               },
-              paramUrdfRobot1: {
+              urdfFromParameter: {
                 layerId: "foxglove.Urdf",
-                url: encodeURI(`data:text/xml;utf8,${URDF3}`),
+                sourceType: "param",
+                parameter: urdfParamName,
                 framePrefix: `robot_1/`,
               },
-              paramUrdfRobot2: {
+              urdfFromTopic: {
                 layerId: "foxglove.Urdf",
-                url: encodeURI(`data:text/xml;utf8,${URDF3}`),
+                sourceType: "topic",
+                topic: "/some/robot_description",
                 framePrefix: `robot_2/`,
               },
             },

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -565,12 +565,12 @@ export type SettingsTreeFieldValue =
   | {
       input: "select";
       value?: number | number[];
-      options: Array<{ label: string; value: undefined | number }>;
+      options: Array<{ label: string; value: undefined | number; disabled?: boolean }>;
     }
   | {
       input: "select";
       value?: string | string[];
-      options: Array<{ label: string; value: undefined | string }>;
+      options: Array<{ label: string; value: undefined | string; disabled?: boolean }>;
     }
   | {
       input: "string";


### PR DESCRIPTION
**User-Facing Changes**
Allow custom layer URDFs to subscribe to a topic

**Description**
- Allows custom layer URDFs to subscribe to a topic. This was not possible so far, and only the `/robot_description` topic could be visualized.
- Adds a select box for selecting the custom layer source (`url`, `filePath`, `param`, `topic`)
  - The `filePath` option is only available on the desktop app

[Screencast from 27.07.2023 18:58:15.webm](https://github.com/foxglove/studio/assets/9250155/1ab285f2-0c8d-4162-a999-f627570a4595)



