### PR TITLE
Fix memoization of enumValuesByDatatypeAndField

### DIFF
--- a/packages/studio-base/src/util/selectors.ts
+++ b/packages/studio-base/src/util/selectors.ts
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { keyBy } from "lodash";
+import memoizeWeak from "memoize-weak";
 import { createSelector } from "reselect";
 
 import { Immutable } from "@foxglove/studio";
@@ -71,9 +72,12 @@ export function extractTypeFromStudioEnumAnnotation(name: string): string | unde
   return undefined;
 }
 
-// returns a map of the form {datatype -> {field -> {value -> name}}}
-export const enumValuesByDatatypeAndField = createSelector(
-  (datatypes: Immutable<RosDatatypes>) => datatypes,
+// Returns a nested record of the form {datatype -> {field -> {value -> name}}}.
+//
+// We need memoizeWeak here because this function is called by multiple callers, each with their own
+// stable version of datatypes, so memoizing on a single datatypes via a memo that depends on a
+// single global stable value like createSelector won't work.
+export const enumValuesByDatatypeAndField = memoizeWeak(
   (
     datatypes: Immutable<RosDatatypes>,
   ): { [datatype: string]: { [field: string]: { [value: string]: string } } } => {


### PR DESCRIPTION
**User-Facing Changes**
None (performance improvement on some datasets)

**Description**
`enumValuesByDatatypeAndField` is used by `useCachedGetMessagePathDataItems` to preprocess datatypes for extracting values from messages. Each user of `useCachedGetMessagePathDataItems` will provide a stable, memoized version of datatypes, but these will be distinct for each caller of `useCachedGetMessagePathDataItems`. So `createSelector` is the wrong memoization tool because it depends on a single, globally stable input. For data sources with messages with a large number of fields this can result in considerable overhead because this function is not stable.

In a layout with multiple plot panels, for example, the current `createSelector` based implementation is constantly being invalidated. Switching this to `memoizeWeak` eliminates this overhead.

_Before_:
<img width="754" alt="Screenshot 2023-07-28 at 5 55 20 AM" src="https://github.com/foxglove/studio/assets/93935560/ea0c628f-6af4-46ac-affd-5983e30774dd">

_After_:
<img width="752" alt="Screenshot 2023-07-28 at 6 55 35 AM" src="https://github.com/foxglove/studio/assets/93935560/9175390a-f243-4165-b56a-d26c37aed2b4">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
