### PR TITLE
Smarter expansion logic in Raw Message panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -26,7 +26,8 @@ import {
   topicsWithIdsToDiffFixture,
   withMissingData,
 } from "./fixture";
-import { Constants, RawMessagesPanelConfig } from "./types";
+import type { RawMessagesPanelConfig } from "./types";
+import { Constants, NodeState } from "./types";
 
 const noDiffConfig = {
   diffMethod: "custom",
@@ -113,7 +114,7 @@ export const Overridden: StoryObj = {
         overrideConfig={{
           ...noDiffConfig,
           topicPath: "/msgs/big_topic",
-          expansion: { LotsOfStuff: "c", timestamp_array: "e" },
+          expansion: { LotsOfStuff: NodeState.Collapsed, timestamp_array: NodeState.Expanded },
         }}
       />
     </PanelSetup>

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -60,7 +60,7 @@ import {
   getValueActionForValue,
 } from "./getValueActionForValue";
 import { Constants, RawMessagesPanelConfig } from "./types";
-import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths } from "./utils";
+import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, toggleExpansion } from "./utils";
 
 type Props = {
   config: Immutable<RawMessagesPanelConfig>;
@@ -152,10 +152,10 @@ function RawMessages(props: Props) {
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
-  const autoExpandPaths = useMemo(() => {
+  const leaves = useMemo(() => {
     if (baseItem) {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
-      return generateDeepKeyPaths(maybeDeepParse(data), 5);
+      return generateDeepKeyPaths(maybeDeepParse(data), 5, 0);
     } else {
       return new Set<string>();
     }
@@ -200,24 +200,9 @@ function RawMessages(props: Props) {
 
   const onLabelClick = useCallback(
     (keypath: (string | number)[]) => {
-      const key = keypath.join("~");
-      setExpansion((old) => {
-        if (old === "all") {
-          return { [key]: "c" };
-        } else if (old === "none") {
-          return { [key]: "e" };
-        } else if (old == undefined) {
-          return { [key]: autoExpandPaths.has(key) ? "c" : "e" };
-        } else {
-          if (old[key]) {
-            return { ...old, [key]: old[key] === "c" ? "e" : "c" };
-          } else {
-            return { ...old, [key]: autoExpandPaths.has(key) ? "c" : "e" };
-          }
-        }
-      });
+      setExpansion((old) => toggleExpansion(old ?? "all", leaves, keypath.join("~")));
     },
-    [autoExpandPaths],
+    [leaves],
   );
 
   useEffect(() => {
@@ -372,7 +357,7 @@ function RawMessages(props: Props) {
         return true;
       }
 
-      return autoExpandPaths.has(joinedPath);
+      return leaves.has(joinedPath);
     };
 
     if (topicPath.length === 0) {
@@ -613,7 +598,7 @@ function RawMessages(props: Props) {
       </Stack>
     );
   }, [
-    autoExpandPaths,
+    leaves,
     baseItem,
     classes.big,
     classes.topic,

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -155,7 +155,7 @@ function RawMessages(props: Props) {
   const nodes = useMemo(() => {
     if (baseItem) {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
-      return generateDeepKeyPaths(maybeDeepParse(data), 5, 0);
+      return generateDeepKeyPaths(maybeDeepParse(data), 5);
     } else {
       return new Set<string>();
     }

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -152,7 +152,7 @@ function RawMessages(props: Props) {
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
-  const leaves = useMemo(() => {
+  const nodes = useMemo(() => {
     if (baseItem) {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
       return generateDeepKeyPaths(maybeDeepParse(data), 5, 0);
@@ -200,9 +200,9 @@ function RawMessages(props: Props) {
 
   const onLabelClick = useCallback(
     (keypath: (string | number)[]) => {
-      setExpansion((old) => toggleExpansion(old ?? "all", leaves, keypath.join("~")));
+      setExpansion((old) => toggleExpansion(old ?? "all", nodes, keypath.join("~")));
     },
-    [leaves],
+    [nodes],
   );
 
   useEffect(() => {
@@ -357,7 +357,7 @@ function RawMessages(props: Props) {
         return true;
       }
 
-      return leaves.has(joinedPath);
+      return true;
     };
 
     if (topicPath.length === 0) {
@@ -598,7 +598,6 @@ function RawMessages(props: Props) {
       </Stack>
     );
   }, [
-    leaves,
     baseItem,
     classes.big,
     classes.topic,

--- a/packages/studio-base/src/panels/RawMessages/types.ts
+++ b/packages/studio-base/src/panels/RawMessages/types.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 // Terse to save space in layout. c = collapsed, e = expanded.
-type NodeExpansion = "all" | "none" | Record<string, "e" | "c">;
+export type NodeExpansion = "all" | "none" | Record<string, "e" | "c">;
 
 export type RawMessagesPanelConfig = {
   diffEnabled: boolean;

--- a/packages/studio-base/src/panels/RawMessages/types.ts
+++ b/packages/studio-base/src/panels/RawMessages/types.ts
@@ -3,7 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 // Terse to save space in layout. c = collapsed, e = expanded.
-export type NodeExpansion = "all" | "none" | Record<string, "e" | "c">;
+export enum NodeState {
+  Collapsed = "c",
+  Expanded = "e",
+}
+
+export type NodeExpansion = "all" | "none" | Record<string, NodeState>;
 
 export type RawMessagesPanelConfig = {
   diffEnabled: boolean;

--- a/packages/studio-base/src/panels/RawMessages/utils.ts
+++ b/packages/studio-base/src/panels/RawMessages/utils.ts
@@ -69,11 +69,7 @@ export function toggleExpansion(
 /**
  * Recursively traverses all keypaths in obj, for use in JSON tree expansion.
  */
-export function generateDeepKeyPaths(
-  obj: unknown,
-  maxArrayLength: number,
-  minDepth: number,
-): Set<string> {
+export function generateDeepKeyPaths(obj: unknown, maxArrayLength: number): Set<string> {
   const keys = new Set<string>();
   const recurseMapKeys = (path: string[], nestedObj: unknown) => {
     if (nestedObj == undefined) {
@@ -92,7 +88,7 @@ export function generateDeepKeyPaths(
       return;
     }
 
-    if (path.length > minDepth) {
+    if (path.length > 0) {
       keys.add(path.join("~"));
     }
 

--- a/packages/studio-base/src/panels/RawMessages/utils.ts
+++ b/packages/studio-base/src/panels/RawMessages/utils.ts
@@ -18,6 +18,7 @@ import { foxgloveMessageSchemas } from "@foxglove/schemas/internal";
 import { diffLabels, DiffObject } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 
 import type { NodeExpansion } from "./types";
+import { NodeState } from "./types";
 
 export const DATA_ARRAY_PREVIEW_LIMIT = 20;
 const ROS1_COMMON_MSG_PACKAGES = new Set(Object.keys(ros1).map((key) => key.split("/")[0]!));
@@ -32,8 +33,8 @@ function isTypedArray(obj: unknown) {
   );
 }
 
-function invert(value: "e" | "c"): "e" | "c" {
-  return value === "e" ? "c" : "e";
+function invert(value: NodeState): NodeState {
+  return value === NodeState.Expanded ? NodeState.Collapsed : NodeState.Expanded;
 }
 
 /*
@@ -41,22 +42,27 @@ function invert(value: "e" | "c"): "e" | "c" {
  */
 export function toggleExpansion(
   state: NodeExpansion,
-  leaves: Set<string>,
+  paths: Set<string>,
   key: string,
 ): NodeExpansion {
   if (state === "all" || state === "none") {
-    const next = state === "all" ? "e" : "c";
+    const next = state === "all" ? NodeState.Expanded : NodeState.Collapsed;
     const nextState: NodeExpansion = {};
-    for (const leaf of leaves) {
+    for (const leaf of paths) {
+      // Implicitly expand all descendants when toggling collapsed root node
+      if (next === NodeState.Collapsed && leaf.endsWith(key)) {
+        continue;
+      }
       nextState[leaf] = leaf === key ? invert(next) : next;
     }
     return nextState;
   }
 
   const prev = state[key];
+  const next = prev != undefined ? invert(prev) : NodeState.Collapsed;
   return {
     ...state,
-    [key]: prev != undefined ? invert(prev) : "c",
+    [key]: next,
   };
 }
 


### PR DESCRIPTION
**User-Facing Changes**
[FG-4165] More intuitive node expansion in the Raw Message panel

**Description**
This one is tricky. The expansion logic in the Raw Message panel had some strange behavior. User actions would lead to unexpected results. Namely:

Scenario 1:
1. Collapse all nodes.
2. Expand one root node by clicking on it.
3. **Result:** All nodes expanded.

The inverse was also true.

Scenario 2:
1. Expand all nodes.
2. Collapse one root node by clicking on it.
3. **Result:** All nodes collapsed.

We fix this by cleaning up the transition from "all collapsed" and "all expanded" to the user-defined state by applying the previous state to all nodes when the user toggles a node when the tree is in one of those states.

This is much easier to understand visually:

https://github.com/foxglove/studio/assets/4588553/7ccfc156-089c-4d0e-82d1-f8b1a9deea54



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
