### PR TITLE
Update to latest @mcap/core and turn off crc checking

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -36,7 +36,7 @@
     "@foxglove/wasm-bz2": "0.1.1",
     "@foxglove/wasm-lz4": "1.0.2",
     "@foxglove/wasm-zstd": "1.0.1",
-    "@mcap/core": "1.2.1",
+    "@mcap/core": "1.3.0",
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "23.5.26",
     "flatbuffers_reflection": "0.0.7",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -47,7 +47,7 @@
     "@foxglove/wasm-lz4": "1.0.2",
     "@foxglove/ws-protocol": "0.7.0",
     "@foxglove/xmlrpc": "1.3.0",
-    "@mcap/core": "1.2.1",
+    "@mcap/core": "1.3.0",
     "@mui/icons-material": "5.14.1",
     "@mui/material": "5.14.2",
     "@popperjs/core": "2.11.8",

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -132,6 +132,7 @@ export class McapIndexedIterableSource implements IIterableSource {
       startTime: toNanoSec(start),
       endTime: toNanoSec(end),
       topics,
+      validateCrcs: false,
     })) {
       const channelInfo = this.#channelInfoById.get(message.channelId);
       if (!channelInfo) {
@@ -181,6 +182,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         endTime: toNanoSec(time),
         topics: [topic],
         reverse: true,
+        validateCrcs: false,
       })) {
         const channelInfo = this.#channelInfoById.get(message.channelId);
         if (!channelInfo) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2411,7 +2411,7 @@ __metadata:
     "@foxglove/wasm-bz2": 0.1.1
     "@foxglove/wasm-lz4": 1.0.2
     "@foxglove/wasm-zstd": 1.0.1
-    "@mcap/core": 1.2.1
+    "@mcap/core": 1.3.0
     "@protobufjs/base64": 1.1.2
     "@types/protobufjs": "workspace:*"
     flatbuffers: 23.5.26
@@ -2641,7 +2641,7 @@ __metadata:
     "@foxglove/wasm-lz4": 1.0.2
     "@foxglove/ws-protocol": 0.7.0
     "@foxglove/xmlrpc": 1.3.0
-    "@mcap/core": 1.2.1
+    "@mcap/core": 1.3.0
     "@mui/icons-material": 5.14.1
     "@mui/material": 5.14.2
     "@popperjs/core": 2.11.8
@@ -3407,6 +3407,17 @@ __metadata:
     heap-js: ^2.2.0
     tslib: ^2.5.0
   checksum: 6af8a9aa026577f6d61bd1cf2bdaa205b216741de4d8cc02953c43585a20fbca2672efa0cd9eaa7eeceeaa6b40242ac05dc09c70dab66c878090baf751f69220
+  languageName: node
+  linkType: hard
+
+"@mcap/core@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@mcap/core@npm:1.3.0"
+  dependencies:
+    "@foxglove/crc": ^0.0.3
+    heap-js: ^2.2.0
+    tslib: ^2.5.0
+  checksum: 339c783c57ac9538234f76a1986105fb441c7331805d3c3a1f135c79123980ba649f1b2ba4d7b5f43ed43371fd51af7660e268f96224c6bca55cebc750ab4fa3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None (performance improvements)

**Description**
CRC checking can amount to as much as 40% of CPU time in the message decoding worker. This turns it off for better performance.

![Screenshot 2023-07-26 at 8 28 22 AM](https://github.com/foxglove/studio/assets/93935560/8f36b6e3-2f76-4f8c-88a8-083df6eb36f5)

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
