### PR TITLE
Fix rerenders on PlaybackTimeDisplay

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplay.tsx
@@ -26,13 +26,18 @@ type Props = {
   onPause: () => void;
 };
 
-const selectActiveData = (ctx: MessagePipelineContext) => ctx.playerState.activeData;
+const selectIsPlaying = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.isPlaying;
+const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
+const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.endTime;
+const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 
 export default function PlaybackTimeDisplay(props: Props): JSX.Element {
   const [timezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
-  const activeData = useMessagePipeline(selectActiveData);
 
-  const { isPlaying, startTime, endTime, currentTime } = activeData ?? {};
+  const isPlaying = useMessagePipeline(selectIsPlaying);
+  const startTime = useMessagePipeline(selectStartTime);
+  const endTime = useMessagePipeline(selectEndTime);
+  const currentTime = useMessagePipeline(selectCurrentTime);
 
   return (
     <PlaybackTimeDisplayMethod


### PR DESCRIPTION
**User-Facing Changes**
None (minor performance enhancement)

**Description**
PlaybackTimeDisplay selects too much from the message pipeline, selecting all of `activeState`. This causes it to re-render more than necessary when the fields it needs aren't changing:

<img width="888" alt="Screenshot 2023-07-31 at 6 53 34 AM" src="https://github.com/foxglove/studio/assets/93935560/640e8c6d-e628-4166-b149-2ec8565a09bc">


Using more specific selectors for the fields it needs eliminates this.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
