### PR TITLE
Detect console errors during integration tests

### DIFF
--- a/benchmark/src/index.tsx
+++ b/benchmark/src/index.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect } from "react";
 import ReactDOM from "react-dom";
 
 import Logger from "@foxglove/log";
@@ -20,14 +19,6 @@ if (!rootEl) {
   throw new Error("missing #root element");
 }
 
-function LogAfterRender(props: React.PropsWithChildren<unknown>): JSX.Element {
-  useEffect(() => {
-    // Integration tests look for this console log to indicate the app has rendered once
-    log.debug("App rendered");
-  }, []);
-  return <>{props.children}</>;
-}
-
 async function main() {
   const { overwriteFetch, waitForFonts } = await import("@foxglove/studio-base");
   overwriteFetch();
@@ -38,12 +29,7 @@ async function main() {
 
   const { Root } = await import("./Root");
 
-  ReactDOM.render(
-    <LogAfterRender>
-      <Root />
-    </LogAfterRender>,
-    rootEl,
-  );
+  ReactDOM.render(<Root />, rootEl);
 }
 
 void main();

--- a/desktop/integration-test/startup.test.ts
+++ b/desktop/integration-test/startup.test.ts
@@ -24,21 +24,25 @@ describe("startup", () => {
     // Get the first window that the app opens, wait if necessary.
     const electronWindow = await electronApp.firstWindow();
 
-    // Direct Electron console to Node terminal.
-    await new Promise<void>((resolve, reject) => {
-      electronWindow.on("console", (message) => {
-        if (message.type() === "error") {
-          reject(new Error(message.text()));
-          return;
-        }
-        log.info(message.text());
+    try {
+      // Direct Electron console to Node terminal.
+      await new Promise<void>((resolve, reject) => {
+        electronWindow.on("console", (message) => {
+          if (message.type() === "error") {
+            reject(new Error(message.text()));
+            return;
+          }
+          log.info(message.text());
 
-        if (message.text().includes("App rendered")) {
-          resolve();
-        }
+          if (message.text().includes("App rendered")) {
+            // Wait for a few seconds for the app to render more components and detect if
+            // there are any errors after the initial app render
+            setTimeout(resolve, 2_000);
+          }
+        });
       });
-    });
-
-    await electronApp.close();
+    } finally {
+      await electronApp.close();
+    }
   }, 10_000);
 });

--- a/packages/studio-desktop/src/renderer/index.tsx
+++ b/packages/studio-desktop/src/renderer/index.tsx
@@ -26,8 +26,8 @@ const log = Logger.getLogger(__filename);
 function LogAfterRender(props: React.PropsWithChildren<unknown>): JSX.Element {
   useEffect(() => {
     // Integration tests look for this console log to indicate the app has rendered once
-    log.setLevel("debug");
-    log.debug("App rendered");
+    // We use console.debug to bypass our logging library which hides some log levels in prod builds
+    console.debug("App rendered");
   }, []);
   return <>{props.children}</>;
 }

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -17,10 +17,8 @@ const log = Logger.getLogger(__filename);
 function LogAfterRender(props: React.PropsWithChildren<unknown>): JSX.Element {
   useEffect(() => {
     // Integration tests look for this console log to indicate the app has rendered once
-    const level = log.getLevel();
-    log.setLevel("debug");
-    log.debug("App rendered");
-    log.setLevel(level);
+    // We use console.debug to bypass our logging library which hides some log levels in prod builds
+    console.debug("App rendered");
   }, []);
   return <>{props.children}</>;
 }

--- a/web/integration-test/startup.test.ts
+++ b/web/integration-test/startup.test.ts
@@ -37,23 +37,27 @@ describe("startup", () => {
     const page = await browser.newPage();
     await page.goto(url);
 
-    await new Promise<void>((resolve, reject) => {
-      page.on("console", (message) => {
-        if (message.type() === "error") {
-          reject(new Error(message.text()));
-          return;
-        }
-        log.info(message.text());
+    try {
+      await new Promise<void>((resolve, reject) => {
+        page.on("console", (message) => {
+          if (message.type() === "error") {
+            reject(new Error(message.text()));
+            return;
+          }
+          log.info(message.text());
 
-        if (message.text().includes("App rendered")) {
-          resolve();
-        }
+          if (message.text().includes("App rendered")) {
+            // Wait for a few seconds for the app to render more components and detect if
+            // there are any errors after the initial app render
+            setTimeout(resolve, 2_000);
+          }
+        });
       });
-    });
-
-    await browser.close();
-    await new Promise<void>((resolve) => {
-      server.close(() => resolve());
-    });
+    } finally {
+      await browser.close();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
   }, 15_000);
 });


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**

Add an exit delay to integration tests for web and desktop allowing for more rendering to happen and detect possible console errors that will fail the integration test.

Without this timeout, an integration test will succeed as soon as it sees the "App rendered" log which happens early in the rendering of the app. As the app continues rendering there might be other errors that happen so this change adds a 2 second timeout to allow those console errors to fail the integration test.
