### PR TITLE
Reset last received messages when player ID changed

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -38,17 +38,19 @@ export default class FakePlayer implements Player {
     activeData,
     presence,
     progress,
+    playerId,
   }: {
     activeData?: PlayerStateActiveData;
     presence?: PlayerPresence;
     progress?: PlayerState["progress"];
+    playerId?: string;
   } = {}): Promise<void> {
     if (!this.#listener) {
       return undefined;
     }
 
     return await this.#listener({
-      playerId: this.playerId,
+      playerId: playerId ?? this.playerId,
       presence: presence ?? PlayerPresence.PRESENT,
       capabilities: this.#capabilities,
       profile: this.#profile,

--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -252,11 +252,13 @@ export default function MockMessagePipelineProvider(
           });
         }
       };
+      const reset = () => {};
       const initialPublicState = getPublicState(undefined, props, dispatch);
       return {
         mockProps: omit(props, "children"),
         player: undefined,
         dispatch,
+        reset,
         publishersById: {},
         allPublishers: [],
         subscriptionsById: new Map(),

--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -252,7 +252,9 @@ export default function MockMessagePipelineProvider(
           });
         }
       };
-      const reset = () => {};
+      const reset = () => {
+        throw new Error("not implemented");
+      };
       const initialPublicState = getPublicState(undefined, props, dispatch);
       return {
         mockProps: omit(props, "children"),

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -23,7 +23,6 @@ import { pauseFrameForPromises, FramePromise } from "./pauseFrameForPromise";
 import {
   MessagePipelineInternalState,
   createMessagePipelineStore,
-  MessagePipelineStateAction,
   defaultPlayerState,
 } from "./store";
 import { MessagePipelineContext } from "./types";
@@ -124,8 +123,8 @@ export function MessagePipelineProvider({
   const msPerFrameRef = useRef<number>(16);
   msPerFrameRef.current = 1000 / (messageRate ?? 60);
 
-  const dispatch = store.getState().dispatch;
   useEffect(() => {
+    const dispatch = store.getState().dispatch;
     if (!player) {
       // When there is no player, set the player state to the default to go back to a state where we
       // indicate the player is not present.
@@ -140,7 +139,7 @@ export function MessagePipelineProvider({
     const { listener, cleanupListener } = createPlayerListener({
       msPerFrameRef,
       promisesToWaitForRef,
-      dispatch,
+      store,
     });
     player.setListener(listener);
     return () => {
@@ -152,7 +151,7 @@ export function MessagePipelineProvider({
         renderDone: undefined,
       });
     };
-  }, [player, dispatch]);
+  }, [player, store]);
 
   useEffect(() => {
     player?.setGlobalVariables(globalVariables);
@@ -199,14 +198,16 @@ function concatProblems(origState: PlayerState, problems: PlayerProblem[]): Play
 function createPlayerListener(args: {
   msPerFrameRef: React.MutableRefObject<number>;
   promisesToWaitForRef: React.MutableRefObject<FramePromise[]>;
-  dispatch: (action: MessagePipelineStateAction) => void;
+  store: StoreApi<MessagePipelineInternalState>;
 }): {
   listener: (state: PlayerState) => Promise<void>;
   cleanupListener: () => void;
 } {
-  const { msPerFrameRef, promisesToWaitForRef, dispatch: updateState } = args;
+  const { msPerFrameRef, promisesToWaitForRef, store } = args;
+  const updateState = store.getState().dispatch;
   const messageOrderTracker = new MessageOrderTracker();
   let closed = false;
+  let prevPlayerId: string | undefined;
   let resolveFn: undefined | (() => void);
   const listener = async (listenerPlayerState: PlayerState) => {
     if (closed) {
@@ -263,6 +264,11 @@ function createPlayerListener(args: {
         resolveFn();
       }, frameTime);
     }
+
+    if (prevPlayerId != undefined && listenerPlayerState.playerId !== prevPlayerId) {
+      store.getState().reset();
+    }
+    prevPlayerId = listenerPlayerState.playerId;
 
     updateState({
       type: "update-player-state",

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -239,7 +239,11 @@ function updatePlayerStateAction(
   const subsById = prevState.subscriptionsById;
   const subscriberIdsByTopic = prevState.subscriberIdsByTopic;
 
-  const lastMessageEventByTopic = prevState.lastMessageEventByTopic;
+  // Reset last received messages when player ID changed.
+  const lastMessageEventByTopic =
+    action.playerState.playerId === prevState.public.playerState.playerId
+      ? prevState.lastMessageEventByTopic
+      : new Map<string, MessageEvent>();
   const newTopicsBySubscriberId = new Map(prevState.newTopicsBySubscriberId);
 
   // Put messages into per-subscriber queues
@@ -334,6 +338,7 @@ function updatePlayerStateAction(
     renderDone: action.renderDone,
     public: newPublicState,
     lastCapabilities: capabilities,
+    lastMessageEventByTopic,
   };
 }
 

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -37,6 +37,9 @@ export function defaultPlayerState(): PlayerState {
 export type MessagePipelineInternalState = {
   dispatch: (action: MessagePipelineStateAction) => void;
 
+  /** Reset public and private state back to initial empty values */
+  reset: () => void;
+
   player?: Player;
 
   /** used to keep track of whether we need to update public.startPlayback/playUntil/etc. */
@@ -80,9 +83,6 @@ export function createMessagePipelineStore({
 }): StoreApi<MessagePipelineInternalState> {
   return createStore((set, get) => ({
     player: initialPlayer,
-    dispatch(action) {
-      set((state) => reducer(state, action));
-    },
     publishersById: {},
     allPublishers: [],
     subscriptionsById: new Map(),
@@ -90,6 +90,36 @@ export function createMessagePipelineStore({
     newTopicsBySubscriberId: new Map(),
     lastMessageEventByTopic: new Map(),
     lastCapabilities: [],
+
+    dispatch(action) {
+      set((state) => reducer(state, action));
+    },
+
+    reset() {
+      set((prev) => ({
+        ...prev,
+        publishersById: {},
+        allPublishers: [],
+        subscriptionsById: new Map(),
+        subscriberIdsByTopic: new Map(),
+        newTopicsBySubscriberId: new Map(),
+        lastMessageEventByTopic: new Map(),
+        lastCapabilities: [],
+        public: {
+          ...prev.public,
+          playerState: defaultPlayerState(),
+          messageEventsBySubscriberId: new Map(),
+          subscriptions: [],
+          sortedTopics: [],
+          datatypes: new Map(),
+          startPlayback: undefined,
+          playUntil: undefined,
+          pausePlayback: undefined,
+          setPlaybackSpeed: undefined,
+          seekPlayback: undefined,
+        },
+      }));
+    },
 
     public: {
       playerState: defaultPlayerState(),
@@ -239,11 +269,7 @@ function updatePlayerStateAction(
   const subsById = prevState.subscriptionsById;
   const subscriberIdsByTopic = prevState.subscriberIdsByTopic;
 
-  // Reset last received messages when player ID changed.
-  const lastMessageEventByTopic =
-    action.playerState.playerId === prevState.public.playerState.playerId
-      ? prevState.lastMessageEventByTopic
-      : new Map<string, MessageEvent>();
+  const lastMessageEventByTopic = prevState.lastMessageEventByTopic;
   const newTopicsBySubscriberId = new Map(prevState.newTopicsBySubscriberId);
 
   // Put messages into per-subscriber queues


### PR DESCRIPTION
**User-Facing Changes**
Fix messages from previous connection influencing visualizations

**Description**
Resets the last received messages when the player ID changes. 
For the foxglove-websocket player, the player instance remains the same during re-connections, but the ID changes. In that case, we also want to reset the last received messages which stem from a previous connection.
