### PR TITLE
Allow more flexible color entry for ColorPicker settings item

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.test.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.test.ts
@@ -1,0 +1,133 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import { useColorPickerControl } from "./ColorPickerControl";
+
+describe("useColorPickerControl", () => {
+  it("should emit expanded value for valid color entries for no-alpha", () => {
+    let lastOnChange: string | undefined;
+
+    const onChange = (val: string) => {
+      lastOnChange = val;
+    };
+
+    const { result, rerender } = renderHook<
+      Parameters<typeof useColorPickerControl>[0],
+      ReturnType<typeof useColorPickerControl>
+    >((props) => useColorPickerControl(props), {
+      initialProps: {
+        alphaType: "none",
+        value: undefined,
+        onChange,
+      },
+    });
+
+    // When there's no display value the swatch color defaults to black with some opacity
+    expect(result.current.swatchColor).toEqual("#00000044");
+
+    act(() => {
+      result.current.updateEditedValue("abc");
+    });
+
+    // After calling updateEditedValue, the edited value should be what the user entered
+    expect(result.current.editedValue).toEqual("abc");
+
+    // For an input of 'abc' we expect the last output value to be expanded to #aabbcc
+    expect(lastOnChange).toEqual("#aabbcc");
+
+    // Re-render with the new value
+    rerender({
+      alphaType: "none",
+      value: lastOnChange,
+      onChange,
+    });
+
+    // Edited value should remain unchanged
+    expect(result.current.editedValue).toEqual("abc");
+
+    // Switch color should be updated
+    expect(result.current.swatchColor).toEqual("#aabbcc");
+  });
+
+  it("should emit expanded value for valid color entries for alpha", () => {
+    let lastOnChange: string | undefined;
+
+    const onChange = (val: string) => {
+      lastOnChange = val;
+    };
+
+    const { result, rerender } = renderHook<
+      Parameters<typeof useColorPickerControl>[0],
+      ReturnType<typeof useColorPickerControl>
+    >((props) => useColorPickerControl(props), {
+      initialProps: {
+        alphaType: "alpha",
+        value: undefined,
+        onChange,
+      },
+    });
+
+    // When there's no display value the swatch color defaults to black with some opacity
+    expect(result.current.swatchColor).toEqual("#00000044");
+
+    act(() => {
+      result.current.updateEditedValue("abc");
+    });
+
+    // After calling updateEditedValue, the edited value should be what the user entered
+    expect(result.current.editedValue).toEqual("abc");
+
+    // For an input of 'abc' we expect the last output value to be expanded to #aabbcc
+    expect(lastOnChange).toEqual("#aabbccff");
+
+    // Re-render with the new value
+    rerender({
+      alphaType: "alpha",
+      value: lastOnChange,
+      onChange,
+    });
+
+    // Edited value should remain unchanged
+    expect(result.current.editedValue).toEqual("abc");
+
+    // Switch color should be updated
+    expect(result.current.swatchColor).toEqual("#aabbccff");
+  });
+
+  it("should update edited value with prop value", () => {
+    const onChange = () => {};
+
+    const { result, rerender } = renderHook<
+      Parameters<typeof useColorPickerControl>[0],
+      ReturnType<typeof useColorPickerControl>
+    >((props) => useColorPickerControl(props), {
+      initialProps: {
+        alphaType: "alpha",
+        value: "abc",
+        onChange,
+      },
+    });
+
+    act(() => {
+      result.current.updateEditedValue("abc");
+    });
+
+    // Re-render with the new expanded value prop
+    rerender({
+      alphaType: "alpha",
+      value: "aabbcc",
+      onChange,
+    });
+
+    act(() => {
+      result.current.onInputBlur();
+    });
+
+    // Edited value is updated to the input prop _value_ after the input blurs
+    expect(result.current.editedValue).toEqual("aabbccff");
+  });
+});

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -44,8 +44,59 @@ type ColorPickerInputProps = {
   onEnterKey?: () => void;
 };
 
-const hexMatcher = /^#?([0-9A-F]{3,8})$/i;
+export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
+  const { alphaType, onChange, value, onEnterKey } = props;
 
+  const { classes } = useStyles();
+
+  const {
+    swatchColor,
+    updatePrefixedColor,
+    editedValueIsInvalid,
+    editedValue,
+    updateEditedValue,
+    onInputBlur,
+  } = useColorPickerControl({
+    alphaType,
+    onChange,
+    value,
+  });
+
+  return (
+    <Stack className={classes.container} gap={1}>
+      {alphaType === "alpha" ? (
+        <HexAlphaColorPicker
+          className={classes.picker}
+          color={swatchColor}
+          onChange={updatePrefixedColor}
+        />
+      ) : (
+        <HexColorPicker
+          className={classes.picker}
+          color={swatchColor}
+          onChange={updatePrefixedColor}
+        />
+      )}
+      <TextField
+        size="small"
+        error={editedValueIsInvalid}
+        InputProps={{
+          onFocus: (event) => event.target.select(),
+          role: "input",
+          startAdornment: <TagIcon fontSize="small" />,
+          style: { fontFamily: fonts.MONOSPACE },
+        }}
+        placeholder={alphaType === "alpha" ? "RRGGBBAA" : "RRGGBB"}
+        value={editedValue}
+        onKeyDown={(event) => event.key === "Enter" && onEnterKey?.()}
+        onChange={(event) => updateEditedValue(event.target.value)}
+        onBlur={onInputBlur}
+      />
+    </Stack>
+  );
+}
+
+const hexMatcher = /^#?([0-9A-F]{3,8})$/i;
 function isValidHexColor(color: string, alphaType: "none" | "alpha") {
   const match = hexMatcher.exec(color);
   const length = match?.[1]?.length ?? 0;
@@ -55,10 +106,16 @@ function isValidHexColor(color: string, alphaType: "none" | "alpha") {
   return length === 3 || length === 6 || (alphaType === "alpha" && (length === 4 || length === 8));
 }
 
-export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
-  const { alphaType, onChange, value, onEnterKey } = props;
-
-  const { classes } = useStyles();
+// Internal business logic hook for ColorPickerControl
+//
+// Exported for tests and we disable the eslint requirement to specify a return value because this
+// hook is considered "internal" and we are ok inferring the return type
+//
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function useColorPickerControl(
+  props: Pick<ColorPickerInputProps, "alphaType" | "value" | "onChange">,
+) {
+  const { alphaType, onChange, value } = props;
 
   const parsedValue = useMemo(() => (value ? tinycolor(value) : undefined), [value]);
   const hex = alphaType === "alpha" ? parsedValue?.toHex8() : parsedValue?.toHex();
@@ -91,41 +148,26 @@ export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
 
       // if it is a valid color then we can emit the new value
       if (isValidHexColor(newValue, alphaType)) {
-        onChange(`#${newValue}`);
+        const parsed = tinycolor(newValue);
+        const settingValue = alphaType === "alpha" ? parsed.toHex8String() : parsed.toHexString();
+        onChange(settingValue);
       }
     },
     [alphaType, onChange],
   );
 
-  return (
-    <Stack className={classes.container} gap={1}>
-      {alphaType === "alpha" ? (
-        <HexAlphaColorPicker
-          className={classes.picker}
-          color={swatchColor}
-          onChange={updatePrefixedColor}
-        />
-      ) : (
-        <HexColorPicker
-          className={classes.picker}
-          color={swatchColor}
-          onChange={updatePrefixedColor}
-        />
-      )}
-      <TextField
-        size="small"
-        error={editedValueIsInvalid}
-        InputProps={{
-          onFocus: (event) => event.target.select(),
-          role: "input",
-          startAdornment: <TagIcon fontSize="small" />,
-          style: { fontFamily: fonts.MONOSPACE },
-        }}
-        placeholder={alphaType === "alpha" ? "RRGGBBAA" : "RRGGBB"}
-        value={editedValue}
-        onKeyDown={(event) => event.key === "Enter" && onEnterKey?.()}
-        onChange={(event) => updateEditedValue(event.target.value)}
-      />
-    </Stack>
-  );
+  // When the input blurs we update the edited value to the latest input value to show the user
+  // the expanded form that is the actual setting value.
+  const onInputBlur = useCallback(() => {
+    setEditedValue(hex ?? "");
+  }, [hex]);
+
+  return {
+    swatchColor,
+    updatePrefixedColor,
+    editedValueIsInvalid,
+    editedValue,
+    updateEditedValue,
+    onInputBlur,
+  };
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -4,7 +4,7 @@
 
 import TagIcon from "@mui/icons-material/Tag";
 import { TextField } from "@mui/material";
-import { useCallback, useState, useEffect, useMemo } from "react";
+import { useCallback, useState, useMemo } from "react";
 import { HexAlphaColorPicker, HexColorPicker } from "react-colorful";
 import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
@@ -44,8 +44,15 @@ type ColorPickerInputProps = {
   onEnterKey?: () => void;
 };
 
+const hexMatcher = /^#?([0-9A-F]{3,8})$/i;
+
 function isValidHexColor(color: string, alphaType: "none" | "alpha") {
-  return alphaType === "alpha" ? /^[0-9a-f]{8}$/i.test(color) : /^[0-9a-f]{6}$/i.test(color);
+  const match = hexMatcher.exec(color);
+  const length = match?.[1]?.length ?? 0;
+
+  // 3 and 6 are always valid color values
+  // 4 and 8 are valid only if using alpha
+  return length === 3 || length === 6 || (alphaType === "alpha" && (length === 4 || length === 8));
 }
 
 export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
@@ -54,22 +61,35 @@ export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
   const { classes } = useStyles();
 
   const parsedValue = useMemo(() => (value ? tinycolor(value) : undefined), [value]);
+  const hex = alphaType === "alpha" ? parsedValue?.toHex8() : parsedValue?.toHex();
   const displayValue =
     alphaType === "alpha" ? parsedValue?.toHex8String() : parsedValue?.toHexString();
   const swatchColor = displayValue ?? "#00000044";
 
-  const [editedValue, setEditedValue] = useState("");
+  const [editedValue, setEditedValue] = useState(hex ?? "");
 
   const editedValueIsInvalid = editedValue.length > 0 && !isValidHexColor(editedValue, alphaType);
 
   const updateColor = useDebouncedCallback((newValue: string) => {
-    onChange(newValue);
+    onChange(`#${newValue}`);
+    setEditedValue(newValue);
   });
+
+  // HexColorPicker onChange provides a leading `#` for values and updateColor needs
+  // un-prefixed values so it can update the edited field
+  const updatePrefixedColor = useCallback(
+    (newValue: string) => {
+      const parsed = tinycolor(newValue);
+      updateColor(alphaType === "alpha" ? parsed.toHex8() : parsed.toHex());
+    },
+    [alphaType, updateColor],
+  );
 
   const updateEditedValue = useCallback(
     (newValue: string) => {
       setEditedValue(newValue);
 
+      // if it is a valid color then we can emit the new value
       if (isValidHexColor(newValue, alphaType)) {
         onChange(`#${newValue}`);
       }
@@ -77,23 +97,19 @@ export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
     [alphaType, onChange],
   );
 
-  useEffect(() => {
-    setEditedValue((alphaType === "alpha" ? parsedValue?.toHex8() : parsedValue?.toHex()) ?? "");
-  }, [alphaType, parsedValue]);
-
   return (
     <Stack className={classes.container} gap={1}>
       {alphaType === "alpha" ? (
         <HexAlphaColorPicker
           className={classes.picker}
           color={swatchColor}
-          onChange={(newValue) => updateColor(newValue)}
+          onChange={updatePrefixedColor}
         />
       ) : (
         <HexColorPicker
           className={classes.picker}
           color={swatchColor}
-          onChange={(newValue) => updateColor(newValue)}
+          onChange={updatePrefixedColor}
         />
       )}
       <TextField

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles<void, "iconButton">()((theme, _params, classes) => 
       padding: 0,
     },
     ".MuiInputBase-root": {
+      fontFamily: `${fonts.MONOSPACE}`,
       cursor: "pointer",
 
       [`:not(:hover) .${classes.iconButton}`]: {


### PR DESCRIPTION
**User-Facing Changes**
Allow more color string input variants for ColorPicker panel setting input type.

**Description**
Prior to this change, a user had to entry all of the hex digits into the color picker text input before the picker would accept their color. For RGB colors this meant entering all 6 hex characters for `rrggbb` and, for RGBA, 8 hex characters `rrggbbaa`.  When using RGBA it is common to want no opacity and default the last two characters to `ff`.

This change updates the hex text input to accept any of the following for RGB inputs: `rrggbb` and the common shorthand `rgb` which expands to repeat the characters -> `rrggbb`.

And for RGBA inputs this change updates the logic to accept any of the valid RGB inputs (defaulting alpha to `FF`) and also supports: `rrggbbaa` and the shorthand `rgba`.

As long as the user is editing the text input field they continue to see the string they input (if using the shorthand form) while the actual setting value is expanded to the long form. When the user exits the color picker popup and re-opens it they will see the long form of their color in the text field.

Updates the font style on the display field to use monospace. This makes the hex display visually match the input entry.

Fixes: #6275


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
