### PR TITLE
Improve interactivity of plot series path editing

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -58,7 +58,7 @@ export type { PlotConfig } from "./types";
 const defaultSidebarDimension = 240;
 
 const EmptyDataSets: Immutable<DataSet[]> = Object.freeze([]);
-const EmtpyDataSet: Immutable<DataSet> = Object.freeze({ data: [] });
+const EmtpyDataSet: Immutable<DataSet> = Object.freeze({ data: [], label: "" });
 
 export function openSiblingPlotPanel(openSiblingPanel: OpenSiblingPanel, topicName: string): void {
   openSiblingPanel({

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -16,6 +16,7 @@ import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react
 import { useLatest } from "react-use";
 import { DeepWritable } from "ts-essentials";
 
+import { useShallowMemo } from "@foxglove/hooks";
 import {
   Time,
   add as addTimes,
@@ -23,6 +24,7 @@ import {
   subtract as subtractTimes,
   toSec,
 } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
 import {
   MessagePipelineContext,
   useMessagePipeline,
@@ -55,7 +57,8 @@ export type { PlotConfig } from "./types";
 
 const defaultSidebarDimension = 240;
 
-const EmptyDatasets: DataSet[] = [];
+const EmptyDataSets: Immutable<DataSet[]> = Object.freeze([]);
+const EmtpyDataSet: Immutable<DataSet> = Object.freeze({ data: [] });
 
 export function openSiblingPlotPanel(openSiblingPanel: OpenSiblingPanel, topicName: string): void {
   openSiblingPanel({
@@ -240,6 +243,13 @@ function Plot(props: Props) {
 
   const onClickPath = useCallback((index: number) => setFocusedPath(["paths", String(index)]), []);
 
+  // Stabilize datasets we send to the chart by first replacing empty datasets with a constant value
+  // and then shallow memoizing the whole set. This prevents a lot of unnecessary and expensive
+  // rendering while the user is interactively editing paths that don't result in any messages.
+  const stableDatasets = useShallowMemo(
+    datasets.map((ds) => (ds.data.length === 0 ? EmtpyDataSet : ds)),
+  );
+
   return (
     <Stack
       flex="auto"
@@ -259,7 +269,7 @@ function Plot(props: Props) {
         {legendDisplay !== "none" && (
           <PlotLegend
             currentTime={showPlotValuesInLegend ? currentTimeSinceStart : undefined}
-            datasets={showPlotValuesInLegend ? datasets : EmptyDatasets}
+            datasets={showPlotValuesInLegend ? datasets : EmptyDataSets}
             legendDisplay={legendDisplay}
             onClickPath={onClickPath}
             paths={yAxisPaths}
@@ -274,7 +284,7 @@ function Plot(props: Props) {
           <PlotChart
             currentTime={currentTimeSinceStart}
             datasetBounds={datasetBounds}
-            datasets={castWritable(datasets)}
+            datasets={castWritable(stableDatasets)}
             defaultView={defaultView}
             isSynced={xAxisVal === "timestamp" && isSynced}
             maxYValue={parseFloat((maxYValue ?? "").toString())}

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { compact, isNumber, uniq } from "lodash";
+import { isNumber, uniq } from "lodash";
 import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 import { DeepWritable } from "ts-essentials";
@@ -182,16 +182,11 @@ function Plot(props: Props) {
     return followingView ?? fixedView ?? undefined;
   }, [fixedView, followingView]);
 
-  const allPaths = useMemo(() => {
-    return yAxisPaths.map(({ value }) => value).concat(compact([xAxisPath?.value]));
-  }, [xAxisPath?.value, yAxisPaths]);
-
   const {
     bounds: datasetBounds,
     datasets,
     pathsWithMismatchedDataLengths,
   } = usePlotPanelData({
-    allPaths,
     followingView,
     showSingleCurrentMessage,
     startTime,

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -56,8 +56,6 @@ export type PlotDataItem = {
   headerStamp?: Time;
 };
 
-export type PlotDataByPath = Record<string, PlotDataItem[]>;
-
 // A "reference line" plot path is a numeric value. It creates a horizontal line on the plot at the specified value.
 export function isReferenceLinePlotPathType(path: BasePlotPath): boolean {
   return !isNaN(Number.parseFloat(path.value));

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -14,10 +14,8 @@ import { Range } from "@foxglove/studio-base/util/ranges";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import {
-  BasePlotPath,
   DatasetsByPath,
   Datum,
-  PlotDataByPath,
   PlotDataItem,
   PlotPath,
   PlotXAxisVal,
@@ -171,10 +169,10 @@ export function reducePlotData(data: Im<PlotData[]>): Im<PlotData> {
 export function buildPlotData(
   args: Im<{
     invertedTheme?: boolean;
-    itemsByPath: PlotDataByPath;
+    itemsByPath: Map<PlotPath, PlotDataItem[]>;
     paths: PlotPath[];
     startTime: Time;
-    xAxisPath?: BasePlotPath;
+    xAxisPath?: PlotPath;
     xAxisVal: PlotXAxisVal;
   }>,
 ): PlotData {
@@ -183,8 +181,8 @@ export function buildPlotData(
   const pathsWithMismatchedDataLengths: string[] = [];
   const datasets: DatasetsByPath = new Map();
   for (const [index, path] of paths.entries()) {
-    const yRanges = itemsByPath[path.value] ?? [];
-    const xRanges = xAxisPath && itemsByPath[xAxisPath.value];
+    const yRanges = itemsByPath.get(path) ?? [];
+    const xRanges = xAxisPath && itemsByPath.get(xAxisPath);
     if (!path.enabled) {
       continue;
     } else if (!isReferenceLinePlotPathType(path)) {

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -7,10 +7,7 @@ import memoizeWeak from "memoize-weak";
 
 import { Time } from "@foxglove/rostime";
 import { Immutable as Im } from "@foxglove/studio";
-import {
-  MessageAndData,
-  MessageDataItemsByPath,
-} from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { MessageAndData } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { getDatasetsFromMessagePlotPath } from "@foxglove/studio-base/panels/Plot/datasets";
 import { Bounds, makeInvertedBounds, unionBounds } from "@foxglove/studio-base/types/Bounds";
 import { Range } from "@foxglove/studio-base/util/ranges";
@@ -21,6 +18,7 @@ import {
   DatasetsByPath,
   Datum,
   PlotDataByPath,
+  PlotDataItem,
   PlotPath,
   PlotXAxisVal,
   isReferenceLinePlotPathType,
@@ -144,7 +142,7 @@ function compare(a: Im<PlotData>, b: Im<PlotData>): number {
  * Note: this is a free function so we are not making it for every loop iteration
  * in `getByPath` below.
  */
-function messageAndDataToPathItem(messageAndData: MessageAndData) {
+export function messageAndDataToPathItem(messageAndData: MessageAndData): PlotDataItem {
   const headerStamp = getTimestampForMessage(messageAndData.messageEvent.message);
   return {
     queriedData: messageAndData.queriedData,
@@ -152,18 +150,6 @@ function messageAndDataToPathItem(messageAndData: MessageAndData) {
     headerStamp,
   };
 }
-
-/**
- * Fetch the data we need from each item in itemsByPath and discard the rest of
- * the message to save memory.
- */
-export const getByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath => {
-  const ret: PlotDataByPath = {};
-  for (const [path, items] of Object.entries(itemsByPath)) {
-    ret[path] = items.map(messageAndDataToPathItem);
-  }
-  return ret;
-};
 
 /**
  * Reduce multiple PlotData objects into a single PlotData object, concatenating messages

--- a/packages/studio-base/src/panels/Plot/useAllFramesByTopic.test.tsx
+++ b/packages/studio-base/src/panels/Plot/useAllFramesByTopic.test.tsx
@@ -38,7 +38,6 @@ describe("useAllFramesByTopic", () => {
 
     expect(result.current).toEqual({
       topic_a: [expect.objectContaining({ topic: "topic_a" })],
-      topic_b: [],
     });
 
     const updatedProgress: Progress = {

--- a/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
+++ b/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
@@ -132,7 +132,7 @@ export function useAllFramesByTopic(
   }
 
   // Stablize the flattened messages by shallow memoing the whole set after excluding empty topics.
-  const stableMessagesWithData = useShallowMemo(pickBy(state.messages, (v) => v.length > 0));
+  const stableMessagesWithData = useShallowMemo(pickBy(state.messages, (msgs) => msgs.length > 0));
 
   return stableMessagesWithData;
 }

--- a/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
+++ b/packages/studio-base/src/panels/Plot/useAllFramesByTopic.ts
@@ -2,10 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { sumBy, transform } from "lodash";
+import { pickBy, sumBy, transform } from "lodash";
 import { useEffect, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
+import { useShallowMemo } from "@foxglove/hooks";
 import { Immutable } from "@foxglove/studio";
 import {
   MessagePipelineContext,
@@ -118,7 +119,9 @@ export function useAllFramesByTopic(
         // here.
         for (const [topic, blockMessages] of Object.entries(block.messagesByTopic)) {
           if (idx > (newState.cursors[topic] ?? -1)) {
-            newState.messages[topic] = (newState.messages[topic] ?? []).concat(blockMessages);
+            if (blockMessages.length > 0) {
+              newState.messages[topic] = (newState.messages[topic] ?? []).concat(blockMessages);
+            }
             newState.cursors[topic] = idx;
           }
         }
@@ -128,5 +131,8 @@ export function useAllFramesByTopic(
     });
   }
 
-  return state.messages;
+  // Stablize the flattened messages by shallow memoing the whole set after excluding empty topics.
+  const stableMessagesWithData = useShallowMemo(pickBy(state.messages, (v) => v.length > 0));
+
+  return stableMessagesWithData;
 }

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
@@ -24,7 +24,7 @@ jest.mock("@foxglove/studio-base/hooks/useGlobalVariables");
 const topics: Topic[] = [{ name: "topic", schemaName: "schema" }];
 const datatypes: RosDatatypes = new Map(
   Object.entries({
-    datatype: {
+    schema: {
       definitions: [{ name: "value", type: "uint32", isArray: false, isComplex: false }],
     },
   }),
@@ -139,6 +139,7 @@ describe("usePlotPanelData", () => {
           return (
             <MockCurrentLayoutProvider>
               <MockMessagePipelineProvider
+                datatypes={datatypes}
                 topics={topics}
                 activeData={activeData}
                 progress={progress}

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
@@ -4,8 +4,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { renderHook } from "@testing-library/react-hooks";
+import { produce } from "immer";
+import { PropsWithChildren } from "react";
+import { DeepWritable } from "ts-essentials";
 
-import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import MockMessagePipelineProvider, {
+  MockMessagePipelineProps,
+} from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   MessageEvent,
@@ -21,8 +26,8 @@ import { usePlotPanelData } from "./usePlotPanelData";
 
 jest.mock("@foxglove/studio-base/hooks/useGlobalVariables");
 
-const topics: Topic[] = [{ name: "topic", schemaName: "schema" }];
-const datatypes: RosDatatypes = new Map(
+const testTopics: Topic[] = [{ name: "topic", schemaName: "schema" }];
+const testDataTypes: RosDatatypes = new Map(
   Object.entries({
     schema: {
       definitions: [{ name: "value", type: "uint32", isArray: false, isComplex: false }],
@@ -35,22 +40,22 @@ const fixtureMessages1: MessageEvent[] = [mockMessage({ value: 1 })];
 const fixtureMessages2: MessageEvent[] = [mockMessage({ value: 2 })];
 
 const fixtureActiveData: PlayerStateActiveData = {
-  messages: [],
-  totalBytesReceived: 0,
   currentTime: { sec: 0, nsec: 0 },
-  startTime: { sec: 0, nsec: 0 },
+  datatypes: testDataTypes,
   endTime: { sec: 3, nsec: 0 },
   isPlaying: false,
-  speed: 1,
   lastSeekTime: 0,
-  topics,
+  messages: [],
+  speed: 1,
+  startTime: { sec: 0, nsec: 0 },
+  topics: testTopics,
   topicStats: new Map(),
-  datatypes,
+  totalBytesReceived: 0,
 };
 
-const fixtureInitialProps = {
-  activeData: fixtureActiveData,
-  allPaths: ["topic.values[0]"],
+type UsePlotPanelDataArgs = Parameters<typeof usePlotPanelData>[0];
+
+const fixtureInitialProps: UsePlotPanelDataArgs = {
   followingView: undefined,
   showSingleCurrentMessage: false,
   startTime: { sec: 0, nsec: 0 },
@@ -58,98 +63,101 @@ const fixtureInitialProps = {
   yAxisPaths: [{ value: "topic.value", enabled: true, timestampMethod: "receiveTime" }],
 } as const;
 
+const testProgress: DeepWritable<Progress> = {
+  fullyLoadedFractionRanges: [],
+  messageCache: {
+    startTime: { sec: 0, nsec: 0 },
+    blocks: [
+      {
+        messagesByTopic: { topic: fixtureMessages1 },
+        sizeInBytes: 1,
+      },
+    ],
+  },
+};
+
+type WrapperProps = PropsWithChildren<{
+  messagePipeline: MockMessagePipelineProps;
+  plotPanelData: UsePlotPanelDataArgs;
+}>;
+
+const wrapperInitialProps: WrapperProps = {
+  messagePipeline: { activeData: fixtureActiveData, datatypes: testDataTypes, topics: testTopics },
+  plotPanelData: fixtureInitialProps,
+};
+
+function Wrapper(props: WrapperProps) {
+  return (
+    <MockCurrentLayoutProvider>
+      <MockMessagePipelineProvider {...props.messagePipeline}>
+        {props.children}
+      </MockMessagePipelineProvider>
+    </MockCurrentLayoutProvider>
+  );
+}
+
 describe("usePlotPanelData", () => {
   it("doesn't accumulate frames when showing single messages", () => {
-    const initialProps = { ...fixtureInitialProps, showSingleCurrentMessage: true };
+    const initialProps = produce(wrapperInitialProps, (draft) => {
+      draft.plotPanelData.showSingleCurrentMessage = true;
+    });
 
     (useGlobalVariables as jest.Mock).mockReturnValue({ globalVariables: { var: 1 } });
 
     const { result, rerender } = renderHook(
-      ({ activeData: _, ...props }) => usePlotPanelData(props),
-      {
-        initialProps,
-        wrapper: ({ children, activeData }) => {
-          return (
-            <MockCurrentLayoutProvider>
-              <MockMessagePipelineProvider topics={topics} activeData={activeData}>
-                {children}
-              </MockMessagePipelineProvider>
-            </MockCurrentLayoutProvider>
-          );
-        },
-      },
+      ({ plotPanelData }) => usePlotPanelData(plotPanelData),
+      { initialProps, wrapper: Wrapper },
     );
 
-    rerender({
-      ...initialProps,
-      activeData: {
-        ...initialProps.activeData,
-        currentTime: { sec: 1, nsec: 0 },
-        lastSeekTime: 1,
-        messages: fixtureMessages1,
-      },
-    });
-
-    rerender({
-      ...initialProps,
-      activeData: {
-        ...initialProps.activeData,
-        currentTime: { sec: 2, nsec: 0 },
-        lastSeekTime: 2,
-        messages: fixtureMessages2,
-      },
-    });
+    rerender(
+      produce(initialProps, (draft) => {
+        draft.messagePipeline.activeData!.currentTime = { sec: 1, nsec: 0 };
+        draft.messagePipeline.activeData!.lastSeekTime = 1;
+        draft.messagePipeline.activeData!.messages = fixtureMessages1;
+      }),
+    );
 
     expect(result.current).toEqual({
       bounds: expect.any(Object),
       datasets: [
-        {
-          data: [],
+        expect.objectContaining({
+          data: [expect.objectContaining({ value: 1, x: 0, y: 1 })],
           label: "topic.value",
-        },
+        }),
+      ],
+      pathsWithMismatchedDataLengths: [],
+    });
+
+    rerender(
+      produce(initialProps, (draft) => {
+        draft.messagePipeline.activeData!.currentTime = { sec: 2, nsec: 0 };
+        draft.messagePipeline.activeData!.lastSeekTime = 2;
+        draft.messagePipeline.activeData!.messages = fixtureMessages2;
+      }),
+    );
+
+    expect(result.current).toEqual({
+      bounds: expect.any(Object),
+      datasets: [
+        expect.objectContaining({
+          data: [expect.objectContaining({ value: 2, x: 0, y: 2 })],
+          label: "topic.value",
+        }),
       ],
       pathsWithMismatchedDataLengths: [],
     });
   });
 
   it("updates data when global variables change", () => {
-    const initialProps = { ...fixtureInitialProps };
-    const progress: Progress = {
-      fullyLoadedFractionRanges: [],
-      messageCache: {
-        startTime: { sec: 0, nsec: 0 },
-        blocks: [
-          {
-            messagesByTopic: {
-              topic: fixtureMessages1,
-            },
-            sizeInBytes: 1,
-          },
-        ],
-      },
-    };
+    const initialProps = produce(wrapperInitialProps, (draft) => {
+      draft.messagePipeline.progress = testProgress;
+    });
 
     (useGlobalVariables as jest.Mock).mockReturnValue({ globalVariables: { var: 1 } });
 
     const { result, rerender } = renderHook(
-      ({ activeData: _, ...props }) => usePlotPanelData(props),
-      {
-        initialProps,
-        wrapper: ({ children, activeData }) => {
-          return (
-            <MockCurrentLayoutProvider>
-              <MockMessagePipelineProvider
-                datatypes={datatypes}
-                topics={topics}
-                activeData={activeData}
-                progress={progress}
-              >
-                {children}
-              </MockMessagePipelineProvider>
-            </MockCurrentLayoutProvider>
-          );
-        },
-      },
+      ({ plotPanelData }) => usePlotPanelData(plotPanelData),
+      { initialProps, wrapper: Wrapper },
     );
 
     const initialOutput = result.current;
@@ -163,5 +171,67 @@ describe("usePlotPanelData", () => {
     rerender();
 
     expect(result.current).not.toBe(initialOutput);
+  });
+
+  it("updates data when a new valid series path is added", () => {
+    const initialProps = produce(wrapperInitialProps, (draft) => {
+      draft.messagePipeline.progress = testProgress;
+    });
+
+    (useGlobalVariables as jest.Mock).mockReturnValue({ globalVariables: { var: 1 } });
+
+    const { result, rerender } = renderHook(
+      ({ plotPanelData }) => usePlotPanelData(plotPanelData),
+      { initialProps, wrapper: Wrapper },
+    );
+
+    const initialOutput = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialOutput);
+
+    const secondProps = produce(initialProps, (draft) => {
+      draft.plotPanelData.yAxisPaths.push({
+        value: "topic.value",
+        enabled: true,
+        timestampMethod: "receiveTime",
+      });
+    });
+
+    rerender(secondProps);
+
+    expect(result.current).not.toBe(initialOutput);
+  });
+
+  it("doesn't update data when an invalid series path is added", () => {
+    const initialProps = produce(wrapperInitialProps, (draft) => {
+      draft.messagePipeline.progress = testProgress;
+    });
+
+    (useGlobalVariables as jest.Mock).mockReturnValue({ globalVariables: { var: 1 } });
+
+    const { result, rerender } = renderHook(
+      ({ plotPanelData }) => usePlotPanelData(plotPanelData),
+      { initialProps, wrapper: Wrapper },
+    );
+
+    const initialOutput = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialOutput);
+
+    const secondProps = produce(initialProps, (draft) => {
+      draft.plotPanelData.yAxisPaths.push({
+        value: "nonsense",
+        enabled: true,
+        timestampMethod: "receiveTime",
+      });
+    });
+
+    rerender(secondProps);
+
+    expect(result.current).toBe(initialOutput);
   });
 });

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.test.tsx
@@ -12,12 +12,7 @@ import MockMessagePipelineProvider, {
   MockMessagePipelineProps,
 } from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
-import {
-  MessageEvent,
-  PlayerStateActiveData,
-  Progress,
-  Topic,
-} from "@foxglove/studio-base/players/types";
+import { PlayerStateActiveData, Progress, Topic } from "@foxglove/studio-base/players/types";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { mockMessage } from "@foxglove/studio-base/test/mocks/mockMessage";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
@@ -26,7 +21,10 @@ import { usePlotPanelData } from "./usePlotPanelData";
 
 jest.mock("@foxglove/studio-base/hooks/useGlobalVariables");
 
-const testTopics: Topic[] = [{ name: "topic", schemaName: "schema" }];
+const testTopics: Topic[] = [
+  { name: "topic_a", schemaName: "schema" },
+  { name: "topic_b", schemaName: "schema" },
+];
 const testDataTypes: RosDatatypes = new Map(
   Object.entries({
     schema: {
@@ -34,10 +32,6 @@ const testDataTypes: RosDatatypes = new Map(
     },
   }),
 );
-
-const fixtureMessages1: MessageEvent[] = [mockMessage({ value: 1 })];
-
-const fixtureMessages2: MessageEvent[] = [mockMessage({ value: 2 })];
 
 const fixtureActiveData: PlayerStateActiveData = {
   currentTime: { sec: 0, nsec: 0 },
@@ -60,7 +54,7 @@ const fixtureInitialProps: UsePlotPanelDataArgs = {
   showSingleCurrentMessage: false,
   startTime: { sec: 0, nsec: 0 },
   xAxisVal: "timestamp",
-  yAxisPaths: [{ value: "topic.value", enabled: true, timestampMethod: "receiveTime" }],
+  yAxisPaths: [{ value: "topic_a.value", enabled: true, timestampMethod: "receiveTime" }],
 } as const;
 
 const testProgress: DeepWritable<Progress> = {
@@ -69,7 +63,9 @@ const testProgress: DeepWritable<Progress> = {
     startTime: { sec: 0, nsec: 0 },
     blocks: [
       {
-        messagesByTopic: { topic: fixtureMessages1 },
+        messagesByTopic: {
+          topic_a: [mockMessage({ value: 1 }, { topic: "topic_a" })],
+        },
         sizeInBytes: 1,
       },
     ],
@@ -97,6 +93,77 @@ function Wrapper(props: WrapperProps) {
 }
 
 describe("usePlotPanelData", () => {
+  it("accumulates frames and preserves empty datasets", () => {
+    const initialProps = produce(wrapperInitialProps, (draft) => {
+      draft.plotPanelData.yAxisPaths.push({
+        value: "topic_b.value",
+        enabled: true,
+        timestampMethod: "receiveTime",
+      });
+    });
+
+    (useGlobalVariables as jest.Mock).mockReturnValue({ globalVariables: { var: 1 } });
+
+    const { result, rerender } = renderHook(
+      ({ plotPanelData }) => usePlotPanelData(plotPanelData),
+      { initialProps, wrapper: Wrapper },
+    );
+
+    rerender(
+      produce(initialProps, (draft) => {
+        draft.messagePipeline.activeData!.currentTime = { sec: 1, nsec: 0 };
+        draft.messagePipeline.activeData!.lastSeekTime = 1;
+        draft.messagePipeline.activeData!.messages = [
+          mockMessage({ value: 1 }, { topic: "topic_a" }),
+        ];
+      }),
+    );
+
+    expect(result.current).toEqual({
+      bounds: expect.any(Object),
+      datasets: [
+        expect.objectContaining({
+          data: [expect.objectContaining({ value: 1, x: 0, y: 1 })],
+          label: "topic_a.value",
+        }),
+        expect.objectContaining({
+          data: [],
+          label: "topic_b.value",
+        }),
+      ],
+      pathsWithMismatchedDataLengths: [],
+    });
+
+    rerender(
+      produce(initialProps, (draft) => {
+        draft.messagePipeline.activeData!.currentTime = { sec: 2, nsec: 0 };
+        draft.messagePipeline.activeData!.lastSeekTime = 2;
+        draft.messagePipeline.activeData!.messages = [
+          mockMessage({ value: 2 }, { topic: "topic_a", receiveTime: { sec: 1, nsec: 0 } }),
+        ];
+      }),
+    );
+
+    expect(result.current).toEqual({
+      bounds: expect.any(Object),
+      datasets: [
+        expect.objectContaining({
+          data: [
+            expect.objectContaining({ value: 1, x: 0, y: 1 }),
+            expect.objectContaining({ x: NaN, y: NaN }),
+            expect.objectContaining({ value: 2, x: 1, y: 2 }),
+          ],
+          label: "topic_a.value",
+        }),
+        expect.objectContaining({
+          data: [],
+          label: "topic_b.value",
+        }),
+      ],
+      pathsWithMismatchedDataLengths: [],
+    });
+  });
+
   it("doesn't accumulate frames when showing single messages", () => {
     const initialProps = produce(wrapperInitialProps, (draft) => {
       draft.plotPanelData.showSingleCurrentMessage = true;
@@ -113,7 +180,9 @@ describe("usePlotPanelData", () => {
       produce(initialProps, (draft) => {
         draft.messagePipeline.activeData!.currentTime = { sec: 1, nsec: 0 };
         draft.messagePipeline.activeData!.lastSeekTime = 1;
-        draft.messagePipeline.activeData!.messages = fixtureMessages1;
+        draft.messagePipeline.activeData!.messages = [
+          mockMessage({ value: 1 }, { topic: "topic_a" }),
+        ];
       }),
     );
 
@@ -122,7 +191,7 @@ describe("usePlotPanelData", () => {
       datasets: [
         expect.objectContaining({
           data: [expect.objectContaining({ value: 1, x: 0, y: 1 })],
-          label: "topic.value",
+          label: "topic_a.value",
         }),
       ],
       pathsWithMismatchedDataLengths: [],
@@ -132,7 +201,9 @@ describe("usePlotPanelData", () => {
       produce(initialProps, (draft) => {
         draft.messagePipeline.activeData!.currentTime = { sec: 2, nsec: 0 };
         draft.messagePipeline.activeData!.lastSeekTime = 2;
-        draft.messagePipeline.activeData!.messages = fixtureMessages2;
+        draft.messagePipeline.activeData!.messages = [
+          mockMessage({ value: 2 }, { topic: "topic_a", receiveTime: { sec: 1, nsec: 0 } }),
+        ];
       }),
     );
 
@@ -140,8 +211,8 @@ describe("usePlotPanelData", () => {
       bounds: expect.any(Object),
       datasets: [
         expect.objectContaining({
-          data: [expect.objectContaining({ value: 2, x: 0, y: 2 })],
-          label: "topic.value",
+          data: [expect.objectContaining({ value: 2, x: 1, y: 2 })],
+          label: "topic_a.value",
         }),
       ],
       pathsWithMismatchedDataLengths: [],
@@ -193,7 +264,7 @@ describe("usePlotPanelData", () => {
 
     const secondProps = produce(initialProps, (draft) => {
       draft.plotPanelData.yAxisPaths.push({
-        value: "topic.value",
+        value: "topic_a.value",
         enabled: true,
         timestampMethod: "receiveTime",
       });

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@mui/material";
-import { groupBy, intersection, isEmpty, mapValues } from "lodash";
+import { groupBy, intersection, isEmpty } from "lodash";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLatest } from "react-use";
 
@@ -15,29 +15,34 @@ import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import parseRosPath, {
   getTopicsFromPaths,
 } from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
-import {
-  useCachedGetMessagePathDataItems,
-  useDecodeMessagePathsForMessagesByTopic,
-} from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { useCachedGetMessagePathDataItems } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { ChartDefaultView } from "@foxglove/studio-base/components/TimeBasedChart";
 import useGlobalVariables, {
   GlobalVariables,
 } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { derivative } from "@foxglove/studio-base/panels/Plot/transformPlotRange";
+import { useStableValidPathsForDatasourceTopics } from "@foxglove/studio-base/panels/Plot/useStableValidPathsForDatasourceTopics";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { Bounds, makeInvertedBounds, unionBounds } from "@foxglove/studio-base/types/Bounds";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import { calculateDatasetBounds } from "./datasets";
-import { BasePlotPath, DataSet, PlotDataByPath, PlotPath, PlotXAxisVal } from "./internalTypes";
+import {
+  BasePlotPath,
+  DataSet,
+  PlotDataByPath,
+  PlotDataItem,
+  PlotPath,
+  PlotXAxisVal,
+} from "./internalTypes";
 import * as maps from "./maps";
 import {
   EmptyPlotData,
   PlotData,
   appendPlotData,
   buildPlotData,
+  messageAndDataToPathItem,
   reducePlotData,
-  getByPath,
 } from "./plotData";
 import { useAllFramesByTopic } from "./useAllFramesByTopic";
 
@@ -62,6 +67,7 @@ type Params = Immutable<{
 type State = Immutable<{
   allFrames: Record<string, Immutable<MessageEvent[]>>;
   allPaths: readonly string[];
+  // These cursors are per-path pointers into the per-topic messages corresponding to the path.
   cursors: Record<string, number>;
   data: PlotData;
   globalVariables: GlobalVariables;
@@ -145,16 +151,23 @@ export function usePlotPanelData(params: Params): Immutable<{
     yAxisPaths,
   } = params;
 
+  // Filter allPaths down to paths that parse as a valid path and point to a topic that exists in
+  // our datasource to prevent a lot of wasted work while the user is inteeractively editing paths.
+  const validAllPaths = useStableValidPathsForDatasourceTopics(allPaths);
+  const validYAxisPaths = useShallowMemo(
+    yAxisPaths.filter((path) => validAllPaths.some((vp) => path.value === vp)),
+  );
+
+  const subscribeTopics = useMemo(() => getTopicsFromPaths(validAllPaths), [validAllPaths]);
+
   const theme = useTheme();
 
   // When iterating message events, we need a reverse lookup from topic to the
   // paths that requested the topic.
   const topicToPaths = useMemo(
-    () => groupBy(allPaths, (path) => parseRosPath(path)?.topicName),
-    [allPaths],
+    () => groupBy(validAllPaths, (path) => parseRosPath(path)?.topicName),
+    [validAllPaths],
   );
-
-  const subscribeTopics = useShallowMemo(getTopicsFromPaths(allPaths));
 
   const subscriptions: Subscription[] = useMemo(() => {
     return subscribeTopics.map((topic) => ({ topic, preload: true }));
@@ -166,37 +179,58 @@ export function usePlotPanelData(params: Params): Immutable<{
 
   const allFrames = showSingleCurrentMessage ? EmptyAllFrames : allFramesByTopic;
 
-  const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(allPaths);
+  const messageDataPathGetter = useCachedGetMessagePathDataItems(validAllPaths);
 
   const { globalVariables } = useGlobalVariables();
 
   // Resets all data when global variables change. This could be more fine grained and parse the
   // paths to only rebuild when variables change that are referenced in plot paths.
   const resetDatasets =
-    allPaths !== state.allPaths ||
     xAxisVal !== state.xAxisVal ||
     xAxisPath !== state.xAxisPath ||
     globalVariables !== state.globalVariables;
 
-  if (allFrames !== state.allFrames || resetDatasets) {
+  if (allFrames !== state.allFrames || validAllPaths !== state.allPaths || resetDatasets) {
     // use setState directly instead of useEffect to skip an extra render.
     setState((oldState) => {
       const newState = resetDatasets ? makeInitialState() : oldState;
 
-      const newFramesByTopic = mapValues(allFrames, (messages, topic) =>
-        messages.slice(newState.cursors[topic] ?? 0),
-      );
+      const newDataItems: Record<string, PlotDataItem[]> = {};
+      const newCursors: Record<string, number> = {};
+      let haveNewMessages = false;
+      for (const path of validAllPaths) {
+        newCursors[path] = newState.cursors[path] ?? 0;
 
-      const newCursors = mapValues(allFrames, (messages) => messages.length);
+        const topic = parseRosPath(path)?.topicName;
+        if (topic == undefined) {
+          continue;
+        }
 
-      const newBlockItems = getByPath(decodeMessagePathsForMessagesByTopic(newFramesByTopic));
+        const newMessages = allFramesByTopic[topic]?.slice(newCursors[path] ?? 0);
+        if (newMessages == undefined || newMessages.length === 0) {
+          continue;
+        }
 
-      const anyNewFrames = Object.values(newFramesByTopic).some((msgs) => msgs.length > 0);
+        newCursors[path] = (newCursors[path] ?? 0) + newMessages.length;
 
-      const newPlotData = anyNewFrames
+        const dataItems: PlotDataItem[] = filterMap(newMessages, (msg) => {
+          const queriedData = messageDataPathGetter(path, msg);
+
+          return queriedData && queriedData.length > 0
+            ? messageAndDataToPathItem({ queriedData, messageEvent: msg })
+            : undefined;
+        });
+
+        if (dataItems.length > 0) {
+          haveNewMessages = true;
+          newDataItems[path] = dataItems;
+        }
+      }
+
+      const newPlotData = haveNewMessages
         ? buildPlotData({
-            paths: yAxisPaths,
-            itemsByPath: newBlockItems,
+            paths: validYAxisPaths,
+            itemsByPath: newDataItems,
             startTime: startTime ?? ZERO_TIME,
             xAxisVal,
             xAxisPath,
@@ -206,7 +240,7 @@ export function usePlotPanelData(params: Params): Immutable<{
 
       return {
         allFrames,
-        allPaths,
+        allPaths: validAllPaths,
         cursors: newCursors,
         data: appendPlotData(newState.data, newPlotData),
         globalVariables,
@@ -217,7 +251,7 @@ export function usePlotPanelData(params: Params): Immutable<{
     });
   }
 
-  const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(allPaths);
+  const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(validAllPaths);
 
   const restore = useCallback(
     (previous?: TaggedPlotData): TaggedPlotData => {
@@ -231,8 +265,8 @@ export function usePlotPanelData(params: Params): Immutable<{
 
       // Discard datasets no longer in current y paths and recompute bounds and mismatched
       // paths so we don't hang onto data we no longer need.
-      const newYPathValues = yAxisPaths.map((path) => path.value);
-      const retainedDataSets = maps.pick(previous.data.datasetsByPath, yAxisPaths);
+      const newYPathValues = validYAxisPaths.map((path) => path.value);
+      const retainedDataSets = maps.pick(previous.data.datasetsByPath, validYAxisPaths);
       const newMismatchedPaths = intersection(
         previous.data.pathsWithMismatchedDataLengths,
         newYPathValues,
@@ -251,7 +285,7 @@ export function usePlotPanelData(params: Params): Immutable<{
         },
       };
     },
-    [showSingleCurrentMessage, yAxisPaths],
+    [showSingleCurrentMessage, validYAxisPaths],
   );
 
   // Access allFrames by reference to avoid invalidating the addMessages callback.
@@ -324,7 +358,7 @@ export function usePlotPanelData(params: Params): Immutable<{
       }
 
       const newPlotData = buildPlotData({
-        paths: yAxisPaths,
+        paths: validYAxisPaths,
         itemsByPath: newMessages,
         startTime: startTime ?? ZERO_TIME,
         xAxisVal,
@@ -349,7 +383,7 @@ export function usePlotPanelData(params: Params): Immutable<{
       topicToPaths,
       xAxisPath,
       xAxisVal,
-      yAxisPaths,
+      validYAxisPaths,
     ],
   );
 
@@ -422,13 +456,13 @@ export function usePlotPanelData(params: Params): Immutable<{
       //
       // Label is needed so that TimeBasedChart doesn't discard the empty dataset and mess
       // up the ordering.
-      datasets: yAxisPaths.map(
+      datasets: validYAxisPaths.map(
         (path) =>
           sortedData.datasetsByPath.get(path) ?? { label: path.label ?? path.value, data: [] },
       ),
       pathsWithMismatchedDataLengths: sortedData.pathsWithMismatchedDataLengths,
     };
-  }, [state.data, trimmedCurrentFrameData, yAxisPaths]);
+  }, [state.data, trimmedCurrentFrameData, validYAxisPaths]);
 
   return allData;
 }

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -200,12 +200,12 @@ export function usePlotPanelData(params: Params): Immutable<{
 
   if (allFrames !== state.allFrames || validAllPaths !== state.allPaths || resetDatasets) {
     // Derive a new state based on the old state & new message data. Note that we maintain a
-    // separate cursor into allFrames for each path. This is necessary because as new series are
-    // added we need to read all available messages even if the new series matches the path of an
-    // existing series.
+    // separate cursor into allFrames for each path. This is necessary because newly added series
+    // might have the same path as previous series but will need to process all messages not from
+    // the beginning instead of reusing the cursor from the previous series with the same path.
     //
-    // We try here to provide a minimal update for downstream referential integrity purposes.
-    // Paths that recieve no new messages should be represented unchanged in the new state.
+    // We try here to provide a minimal update for downstream referential integrity purposes. Paths
+    // that recieve no new messages should be represented unchanged in the new state.
     //
     // Uses setState directly instead of useEffect to skip an extra render.
     setState((oldState) => {

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -27,14 +27,7 @@ import { Bounds, makeInvertedBounds, unionBounds } from "@foxglove/studio-base/t
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import { calculateDatasetBounds } from "./datasets";
-import {
-  BasePlotPath,
-  DataSet,
-  PlotDataByPath,
-  PlotDataItem,
-  PlotPath,
-  PlotXAxisVal,
-} from "./internalTypes";
+import { BasePlotPath, DataSet, PlotDataItem, PlotPath, PlotXAxisVal } from "./internalTypes";
 import * as maps from "./maps";
 import {
   EmptyPlotData,
@@ -55,7 +48,6 @@ const EMPTY_ARR = Object.freeze(new Array<PlotData>());
 type TaggedPlotData = { tag: string; data: Immutable<PlotData> };
 
 type Params = Immutable<{
-  allPaths: string[];
   followingView: undefined | ChartDefaultView;
   showSingleCurrentMessage: boolean;
   startTime: undefined | Time;
@@ -66,14 +58,13 @@ type Params = Immutable<{
 
 type State = Immutable<{
   allFrames: Record<string, Immutable<MessageEvent[]>>;
-  allPaths: readonly string[];
-  // These cursors are per-path pointers into the per-topic messages corresponding to the path.
-  cursors: Record<string, number>;
+  allPaths: PlotPath[];
+  cursors: Map<PlotPath, number>;
   data: PlotData;
   globalVariables: GlobalVariables;
   subscriptions: Subscription[];
   xAxisVal: PlotXAxisVal;
-  xAxisPath: undefined | BasePlotPath;
+  xAxisPath: undefined | PlotPath;
 }>;
 
 /**
@@ -124,7 +115,7 @@ function makeInitialState(): State {
   return {
     allFrames: {},
     allPaths: [],
-    cursors: {},
+    cursors: new Map(),
     data: EmptyPlotData,
     globalVariables: {},
     subscriptions: [],
@@ -135,37 +126,54 @@ function makeInitialState(): State {
 
 /**
  * Collates and combines data from alLFrames and currentFrame messages.
+ *
+ * Note that this expects xAxisPath & yAxisPaths to be referentially stable if their properties
+ * haven't changed.
  */
 export function usePlotPanelData(params: Params): Immutable<{
   bounds: Bounds;
   datasets: DataSet[];
   pathsWithMismatchedDataLengths: string[];
 }> {
-  const {
-    allPaths,
-    followingView,
-    showSingleCurrentMessage,
-    startTime,
-    xAxisPath,
-    xAxisVal,
-    yAxisPaths,
-  } = params;
+  const { followingView, showSingleCurrentMessage, startTime, xAxisPath, xAxisVal, yAxisPaths } =
+    params;
+
+  // Because we have to track our new message cursors separately for each path we have to index
+  // into our accumulated messages by the exact path object. This means the xAxis path has to be
+  // representable as another PlotPath.
+  const xAxisPathAsFullPlotPath: undefined | PlotPath = useMemo(
+    () => (xAxisPath ? { ...xAxisPath, timestampMethod: "receiveTime" } : undefined),
+    [xAxisPath],
+  );
+
+  const allPaths = useMemo(
+    () => (xAxisPathAsFullPlotPath ? [...yAxisPaths, xAxisPathAsFullPlotPath] : yAxisPaths),
+    [xAxisPathAsFullPlotPath, yAxisPaths],
+  );
 
   // Filter allPaths down to paths that parse as a valid path and point to a topic that exists in
   // our datasource to prevent a lot of wasted work while the user is inteeractively editing paths.
   const validAllPaths = useStableValidPathsForDatasourceTopics(allPaths);
   const validYAxisPaths = useShallowMemo(
-    yAxisPaths.filter((path) => validAllPaths.some((vp) => path.value === vp)),
+    yAxisPaths.filter((path) => validAllPaths.some((vp) => path.value === vp.value)),
   );
 
-  const subscribeTopics = useMemo(() => getTopicsFromPaths(validAllPaths), [validAllPaths]);
+  const validAllPathValues = useMemo(
+    () => validAllPaths.map((path) => path.value),
+    [validAllPaths],
+  );
+
+  const subscribeTopics = useMemo(
+    () => getTopicsFromPaths(validAllPathValues),
+    [validAllPathValues],
+  );
 
   const theme = useTheme();
 
   // When iterating message events, we need a reverse lookup from topic to the
   // paths that requested the topic.
   const topicToPaths = useMemo(
-    () => groupBy(validAllPaths, (path) => parseRosPath(path)?.topicName),
+    () => groupBy(validAllPaths, (path) => parseRosPath(path.value)?.topicName),
     [validAllPaths],
   );
 
@@ -179,7 +187,7 @@ export function usePlotPanelData(params: Params): Immutable<{
 
   const allFrames = showSingleCurrentMessage ? EmptyAllFrames : allFramesByTopic;
 
-  const messageDataPathGetter = useCachedGetMessagePathDataItems(validAllPaths);
+  const messageDataPathGetter = useCachedGetMessagePathDataItems(validAllPathValues);
 
   const { globalVariables } = useGlobalVariables();
 
@@ -187,34 +195,41 @@ export function usePlotPanelData(params: Params): Immutable<{
   // paths to only rebuild when variables change that are referenced in plot paths.
   const resetDatasets =
     xAxisVal !== state.xAxisVal ||
-    xAxisPath !== state.xAxisPath ||
+    xAxisPathAsFullPlotPath !== state.xAxisPath ||
     globalVariables !== state.globalVariables;
 
   if (allFrames !== state.allFrames || validAllPaths !== state.allPaths || resetDatasets) {
-    // use setState directly instead of useEffect to skip an extra render.
+    // Derive a new state based on the old state & new message data. Note that we maintain a
+    // separate cursor into allFrames for each path. This is necessary because as new series are
+    // added we need to read all available messages even if the new series matches the path of an
+    // existing series.
+    //
+    // We try here to provide a minimal update for downstream referential integrity purposes.
+    // Paths that recieve no new messages should be represented unchanged in the new state.
+    //
+    // Uses setState directly instead of useEffect to skip an extra render.
     setState((oldState) => {
       const newState = resetDatasets ? makeInitialState() : oldState;
-
-      const newDataItems: Record<string, PlotDataItem[]> = {};
-      const newCursors: Record<string, number> = {};
+      const newDataItems: Map<PlotPath, PlotDataItem[]> = new Map();
+      const newCursors: Map<PlotPath, number> = new Map();
       let haveNewMessages = false;
       for (const path of validAllPaths) {
-        newCursors[path] = newState.cursors[path] ?? 0;
+        newCursors.set(path, newState.cursors.get(path) ?? 0);
 
-        const topic = parseRosPath(path)?.topicName;
+        const topic = parseRosPath(path.value)?.topicName;
         if (topic == undefined) {
           continue;
         }
 
-        const newMessages = allFramesByTopic[topic]?.slice(newCursors[path] ?? 0);
+        const newMessages = allFramesByTopic[topic]?.slice(newCursors.get(path) ?? 0);
         if (newMessages == undefined || newMessages.length === 0) {
           continue;
         }
 
-        newCursors[path] = (newCursors[path] ?? 0) + newMessages.length;
+        newCursors.set(path, (newCursors.get(path) ?? 0) + newMessages.length);
 
         const dataItems: PlotDataItem[] = filterMap(newMessages, (msg) => {
-          const queriedData = messageDataPathGetter(path, msg);
+          const queriedData = messageDataPathGetter(path.value, msg);
 
           return queriedData && queriedData.length > 0
             ? messageAndDataToPathItem({ queriedData, messageEvent: msg })
@@ -223,7 +238,7 @@ export function usePlotPanelData(params: Params): Immutable<{
 
         if (dataItems.length > 0) {
           haveNewMessages = true;
-          newDataItems[path] = dataItems;
+          newDataItems.set(path, dataItems);
         }
       }
 
@@ -233,7 +248,7 @@ export function usePlotPanelData(params: Params): Immutable<{
             itemsByPath: newDataItems,
             startTime: startTime ?? ZERO_TIME,
             xAxisVal,
-            xAxisPath,
+            xAxisPath: xAxisPathAsFullPlotPath,
             invertedTheme: theme.palette.mode === "dark",
           })
         : EmptyPlotData;
@@ -245,13 +260,13 @@ export function usePlotPanelData(params: Params): Immutable<{
         data: appendPlotData(newState.data, newPlotData),
         globalVariables,
         subscriptions,
-        xAxisPath,
+        xAxisPath: xAxisPathAsFullPlotPath,
         xAxisVal,
       };
     });
   }
 
-  const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(validAllPaths);
+  const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(validAllPathValues);
 
   const restore = useCallback(
     (previous?: TaggedPlotData): TaggedPlotData => {
@@ -295,7 +310,7 @@ export function usePlotPanelData(params: Params): Immutable<{
     (accumulated: TaggedPlotData, msgEvents: Immutable<MessageEvent[]>) => {
       const lastEventTime = msgEvents.at(-1)?.receiveTime;
       const isFollowing = followingView?.type === "following";
-      const newMessages: PlotDataByPath = {};
+      const newMessages: Map<PlotPath, PlotDataItem[]> = new Map();
 
       for (const msgEvent of msgEvents) {
         const paths = topicToPaths[msgEvent.topic];
@@ -304,15 +319,15 @@ export function usePlotPanelData(params: Params): Immutable<{
         }
 
         for (const path of paths) {
-          const dataItem = cachedGetMessagePathDataItems(path, msgEvent);
+          const dataItem = cachedGetMessagePathDataItems(path.value, msgEvent);
           if (!dataItem) {
             continue;
           }
 
           const headerStamp = getTimestampForMessage(msgEvent.message);
 
-          const allFramesForPathStart = latestAllFrames.current[path]?.at(0)?.receiveTime;
-          const allFramesForPathEnd = latestAllFrames.current[path]?.at(-1)?.receiveTime;
+          const allFramesForPathStart = latestAllFrames.current[path.value]?.at(0)?.receiveTime;
+          const allFramesForPathEnd = latestAllFrames.current[path.value]?.at(-1)?.receiveTime;
           if (
             allFramesForPathStart &&
             allFramesForPathEnd &&
@@ -331,9 +346,9 @@ export function usePlotPanelData(params: Params): Immutable<{
           };
 
           if (showSingleCurrentMessage) {
-            newMessages[path] = [plotDataItem];
+            newMessages.set(path, [plotDataItem]);
           } else {
-            let plotDataPath = newMessages[path]?.slice() ?? [];
+            let plotDataPath = newMessages.get(path)?.slice() ?? [];
             const plotDataItems = plotDataPath;
             // If we are using the _following_ view mode, truncate away any
             // items older than the view window.
@@ -348,7 +363,7 @@ export function usePlotPanelData(params: Params): Immutable<{
               plotDataPath = plotDataItems.concat(plotDataItem);
             }
 
-            newMessages[path] = plotDataPath;
+            newMessages.set(path, plotDataPath);
           }
         }
       }
@@ -362,7 +377,7 @@ export function usePlotPanelData(params: Params): Immutable<{
         itemsByPath: newMessages,
         startTime: startTime ?? ZERO_TIME,
         xAxisVal,
-        xAxisPath,
+        xAxisPath: xAxisPathAsFullPlotPath,
         invertedTheme: theme.palette.mode === "dark",
       });
 
@@ -374,16 +389,16 @@ export function usePlotPanelData(params: Params): Immutable<{
       };
     },
     [
-      cachedGetMessagePathDataItems,
       followingView,
-      latestAllFrames,
-      showSingleCurrentMessage,
-      startTime,
-      theme.palette.mode,
-      topicToPaths,
-      xAxisPath,
-      xAxisVal,
       validYAxisPaths,
+      startTime,
+      xAxisVal,
+      xAxisPathAsFullPlotPath,
+      theme.palette.mode,
+      showSingleCurrentMessage,
+      topicToPaths,
+      cachedGetMessagePathDataItems,
+      latestAllFrames,
     ],
   );
 

--- a/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
+++ b/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createSelector } from "reselect";
+
+import { filterMap } from "@foxglove/den/collection";
+import { useShallowMemo } from "@foxglove/hooks";
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+
+export const selectKeyedTopics = createSelector(
+  (ctx: MessagePipelineContext) => ctx.sortedTopics,
+  (topics) => new Set(topics.map((topic) => topic.name)),
+);
+
+/**
+ * Returns a list of paths that parse as a valid path and reference a topic that exists in
+ * datasource.
+ */
+export function useStableValidPathsForDatasourceTopics(
+  paths: readonly string[],
+): readonly string[] {
+  const keyedTopics = useMessagePipeline(selectKeyedTopics);
+
+  const stableValidPaths = useShallowMemo(
+    filterMap(paths, (path) => {
+      const parsedTopic = parseRosPath(path)?.topicName;
+      const pathIsBareTopic = path === parsedTopic;
+      return !pathIsBareTopic && parsedTopic && keyedTopics.has(parsedTopic) ? path : undefined;
+    }),
+  );
+
+  return stableValidPaths;
+}

--- a/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
+++ b/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
@@ -16,7 +16,9 @@ import {
 import { PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
 
 const selectKeyedTopics = createSelector(
-  (ctx: MessagePipelineContext) => ctx.sortedTopics,
+  (ctx: MessagePipelineContext) => {
+    return ctx.sortedTopics;
+  },
   (topics) => new Set(topics.map((topic) => topic.name)),
 );
 

--- a/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
+++ b/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { useMemo } from "react";
 import { createSelector } from "reselect";
 
 import { filterMap } from "@foxglove/den/collection";
@@ -14,7 +15,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
 
-export const selectKeyedTopics = createSelector(
+const selectKeyedTopics = createSelector(
   (ctx: MessagePipelineContext) => ctx.sortedTopics,
   (topics) => new Set(topics.map((topic) => topic.name)),
 );
@@ -28,13 +29,17 @@ export function useStableValidPathsForDatasourceTopics(
 ): Immutable<PlotPath[]> {
   const keyedTopics = useMessagePipeline(selectKeyedTopics);
 
-  const stableValidPaths = useShallowMemo(
-    filterMap(paths, (path) => {
-      const parsedTopic = parseRosPath(path.value)?.topicName;
-      const pathIsBareTopic = path.value === parsedTopic;
-      return !pathIsBareTopic && parsedTopic && keyedTopics.has(parsedTopic) ? path : undefined;
-    }),
+  const validPaths = useMemo(
+    () =>
+      filterMap(paths, (path) => {
+        const parsedTopic = parseRosPath(path.value)?.topicName;
+        const pathIsBareTopic = path.value === parsedTopic;
+        return !pathIsBareTopic && parsedTopic && keyedTopics.has(parsedTopic) ? path : undefined;
+      }),
+    [keyedTopics, paths],
   );
+
+  const stableValidPaths = useShallowMemo(validPaths);
 
   return stableValidPaths;
 }

--- a/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
+++ b/packages/studio-base/src/panels/Plot/useStableValidPathsForDatasourceTopics.ts
@@ -6,11 +6,13 @@ import { createSelector } from "reselect";
 
 import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
+import { Immutable } from "@foxglove/studio";
 import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
 
 export const selectKeyedTopics = createSelector(
   (ctx: MessagePipelineContext) => ctx.sortedTopics,
@@ -18,18 +20,18 @@ export const selectKeyedTopics = createSelector(
 );
 
 /**
- * Returns a list of paths that parse as a valid path and reference a topic that exists in
- * datasource.
+ * Returns a referentially stable list of paths that parse as a valid path and reference a topic
+ * that exists in our datasource.
  */
 export function useStableValidPathsForDatasourceTopics(
-  paths: readonly string[],
-): readonly string[] {
+  paths: Immutable<PlotPath[]>,
+): Immutable<PlotPath[]> {
   const keyedTopics = useMessagePipeline(selectKeyedTopics);
 
   const stableValidPaths = useShallowMemo(
     filterMap(paths, (path) => {
-      const parsedTopic = parseRosPath(path)?.topicName;
-      const pathIsBareTopic = path === parsedTopic;
+      const parsedTopic = parseRosPath(path.value)?.topicName;
+      const pathIsBareTopic = path.value === parsedTopic;
       return !pathIsBareTopic && parsedTopic && keyedTopics.has(parsedTopic) ? path : undefined;
     }),
   );


### PR DESCRIPTION
**User-Facing Changes**
Improve interactivity of plot series path editing.

**Description**
Currently when a user is actively editing a series path in the plot panel the paths that are inputs to `usePlotPanelData` are rapidly changing and this causes a complete rebuild of the datasets on each keystroke which can be very slow on larger datasets. This patch tries to eliminate most of that work in the cases where it's not useful by filtering out changes to series paths that will not result in any new messages being processed and included in the dataset.

This involves pre-filtering paths that either are not valid ros paths or that parse to a topic that is not present in our dataset. And the logic that builds datasets from these filtered paths tries to eliminate any changes that wouldn't result in any new messages.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
