### PR TITLE
Fix flaky plot with min and max Y values story

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -855,16 +855,14 @@ export const WithMinAndMaxYValues: StoryObj = {
   },
 
   parameters: {
-    chromatic: {
-      delay: 500,
-    },
     colorScheme: "light",
     useReadySignal: true,
   },
 
   name: "with min and max Y values",
 
-  play: async () => {
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
     const label = await screen.findByText("Y Axis");
     await userEvent.click(label);
   },


### PR DESCRIPTION
**User-Facing Changes**
None (fix flaky storybook story)

**Description**
Fix (hopefully) the plot with min & max Y values story by explicitly waiting for the ready signal instead of an arbitrary timeout period.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
