### PR TITLE
Use @foxglove/schemas in user script templates and examples

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -58,8 +58,11 @@ import { Input, Message } from "./types";
 // Your script can output well-known message types, any of your custom message types, or
 // complete custom message types.
 //
-// Use \`Message\` to access your data source types or well-known types:
+// Use \`Message\` to access types from the schemas defined in your data source:
 // type Twist = Message<"geometry_msgs/Twist">;
+//
+// Import from the @foxglove/schemas package to use standard schema types:
+// import { Pose, LocationFix } from "@foxglove/schemas";
 //
 // Conventionally, it's common to make a _type alias_ for your script's output type
 // and use that type name as the return type for your script function.

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -61,7 +61,7 @@ import { Input, Message } from "./types";
 // Use \`Message\` to access types from the schemas defined in your data source:
 // type Twist = Message<"geometry_msgs/Twist">;
 //
-// Import from the @foxglove/schemas package to use standard schema types:
+// Import from the @foxglove/schemas package to use foxglove schema types:
 // import { Pose, LocationFix } from "@foxglove/schemas";
 //
 // Conventionally, it's common to make a _type alias_ for your script's output type

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/templates/locationFix.ts.template
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/templates/locationFix.ts.template
@@ -5,20 +5,20 @@
 // You can visualize this message with the Map panel
 // https://foxglove.dev/docs/studio/panels/map
 
-import { Input, Message } from "./types";
+import { Input } from "./types";
+import { LocationFix, PositionCovarianceType } from "@foxglove/schemas";
 
 export const inputs = ["/input/topic"];
 export const output = "/studio_script/my_gps";
 
-// Our node will output a LocationFix message
-type LocationFix = Message<"foxglove.LocationFix">;
-
 export default function script(event: Input<"/input/topic">): LocationFix {
   return {
+    timestamp: event.receiveTime,
+    frame_id: "frame",
     latitude: 51.477928,
     longitude: -0.001545,
     altitude: 0,
-    position_covariance_type: 0,
-    position_covariance: new Float64Array(),
+    position_covariance_type: PositionCovarianceType.APPROXIMATED,
+    position_covariance: [0, 0, 0, 0, 0, 0, 0, 0, 0],
   };
-};
+}


### PR DESCRIPTION
**User-Facing Changes**
Use @foxglove/schemas in user script templates and examples.

**Description**
Demonstrate use of the LocationFix type from @foxglove/schemas in our location fix template and update the comments in the standard template to differentiate between the `Message` types and @foxglove/schema types.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
