### PR TITLE
Use fast fuzzy find algorithm on long item lists in autocomplete

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -32,6 +32,9 @@ import { ReactWindowListboxAdapter } from "@foxglove/studio-base/components/Reac
 
 const MAX_FZF_MATCHES = 200;
 
+// Above this number of items we fall back to the faster fuzzy find algorithm.
+const FAST_FIND_ITEM_CUTOFF = 1_000;
+
 type AutocompleteProps<T> = {
   autoSize?: boolean;
   disableAutoSelect?: boolean;
@@ -198,7 +201,8 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   const fzf = useMemo(() => {
     // @ts-expect-error Fzf selector TS type seems to be wrong?
     return new Fzf(items, {
-      fuzzy: "v2",
+      // v1 algorithm is significantly faster on long lists of items.
+      fuzzy: items.length > FAST_FIND_ITEM_CUTOFF ? "v1" : "v2",
       sort: sortWhenFiltering,
       limit: MAX_FZF_MATCHES,
       selector: getItemText,


### PR DESCRIPTION
**User-Facing Changes**
Performance improvement on message path editing with long autocomplete lists.

**Description**
There seems to be a very large performance difference on the fzf matching in the autocomplete on with long lists of items.

This is the performance of the slower v2 algorithm on a list of about 8k items:
<img width="637" alt="Screenshot 2023-08-03 at 12 46 55 PM" src="https://github.com/foxglove/studio/assets/93935560/ccc341e9-ba9c-4bc2-8312-14208d7f5a1f">

Switching to the v1 algorithm makes this much faster:
<img width="635" alt="Screenshot 2023-08-03 at 12 46 33 PM" src="https://github.com/foxglove/studio/assets/93935560/e94b4c07-8fbc-49f6-93a6-67f450c001b7">

This patch switches to the faster but less precise algorithm with more than 1,000 items.

https://github.com/junegunn/fzf/blob/4c9cab3f8ae7b55f7124d7c3cf7ac6b4cc3db210/src/algo/algo.go#L5

To quote:

```
FuzzyMatchV1 finds the first "fuzzy" occurrence of the pattern within the given
text in O(n) time where n is the length of the text. Once the position of the
last character is located, it traverses backwards to see if there's a shorter
substring that matches the pattern.

    a_____b___abc__  To find "abc"
    *-----*-----*>   1. Forward scan
             <***    2. Backward scan

The algorithm is simple and fast, but as it only sees the first occurrence,
it is not guaranteed to find the occurrence with the highest score.

    a_____b__c__abc
    *-----*--*  ***

FuzzyMatchV2 implements a modified version of Smith-Waterman algorithm to find
the optimal solution (highest score) according to the scoring criteria. Unlike
the original algorithm, omission or mismatch of a character in the pattern is
not allowed.

Performance
-----------

The new V2 algorithm is slower than V1 as it examines all occurrences of the
pattern instead of stopping immediately after finding the first one. The time
complexity of the algorithm is O(nm) if a match is found and O(n) otherwise
where n is the length of the item and m is the length of the pattern. Thus, the
performance overhead may not be noticeable for a query with high selectivity.
However, if the performance is more important than the quality of the result,
you can still choose v1 algorithm with --algo=v1.
```

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
