### PR TITLE
Upgrade to zustand 4.4.0 and fix uses of shallow selector

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -86,6 +86,7 @@
     "@types/three": "^0.149.0",
     "@types/tinycolor2": "1.4.3",
     "@types/url-search-params": "1.1.0",
+    "@types/use-sync-external-store": "0.0.3",
     "@types/uuid": "9.0.2",
     "@types/wicg-file-system-access": "2020.9.6",
     "@uiw/react-textarea-code-editor": "2.1.7",
@@ -175,8 +176,9 @@
     "url-search-params": "1.1.0",
     "use-debounce": "9.0.4",
     "use-immer": "0.9.0",
+    "use-sync-external-store": "1.2.0",
     "uuid": "9.0.0",
     "webpack": "5.88.2",
-    "zustand": "4.3.9"
+    "zustand": "4.4.0"
   }
 }

--- a/packages/studio-base/src/components/AppBar/AppMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/AppMenu.tsx
@@ -13,7 +13,6 @@ import {
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
-import { shallow } from "zustand/shallow";
 
 import { AppBarMenuItem } from "@foxglove/studio-base/components/AppBar/types";
 import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
@@ -23,7 +22,7 @@ import { useCurrentUserType } from "@foxglove/studio-base/context/CurrentUserCon
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import {
   WorkspaceContextStore,
-  useWorkspaceStore,
+  useWorkspaceStoreWithShallowSelector,
 } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
@@ -69,7 +68,7 @@ export function AppMenu(props: AppMenuProps): JSX.Element {
       left: { open: leftSidebarOpen },
       right: { open: rightSidebarOpen },
     },
-  } = useWorkspaceStore(selectWorkspace, shallow);
+  } = useWorkspaceStoreWithShallowSelector(selectWorkspace);
   const { sidebarActions, dialogActions, layoutActions } = useWorkspaceActions();
 
   const handleNestedMenuClose = useCallback(() => {

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -10,12 +10,11 @@ import {
   PanelRight24Regular,
   SlideAdd24Regular,
 } from "@fluentui/react-icons";
-import { Avatar, Button, IconButton, Tooltip, AppBar as MuiAppBar } from "@mui/material";
+import { Avatar, Button, IconButton, AppBar as MuiAppBar, Tooltip } from "@mui/material";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
-import { shallow } from "zustand/shallow";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { AppBarIconButton } from "@foxglove/studio-base/components/AppBar/AppBarIconButton";
@@ -35,8 +34,8 @@ import {
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import {
-  useWorkspaceStore,
   WorkspaceContextStore,
+  useWorkspaceStoreWithShallowSelector,
 } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
@@ -222,7 +221,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
       left: { open: leftSidebarOpen },
       right: { open: rightSidebarOpen },
     },
-  } = useWorkspaceStore(selectWorkspace, shallow);
+  } = useWorkspaceStoreWithShallowSelector(selectWorkspace);
   const { sidebarActions } = useWorkspaceActions();
 
   const [appMenuEl, setAppMenuEl] = useState<undefined | HTMLElement>(undefined);

--- a/packages/studio-base/src/context/EventsContext.ts
+++ b/packages/studio-base/src/context/EventsContext.ts
@@ -85,10 +85,7 @@ export type EventsStore = Immutable<{
 
 export const EventsContext = createContext<undefined | StoreApi<EventsStore>>(undefined);
 
-export function useEvents<T>(
-  selector: (store: EventsStore) => T,
-  equalityFn?: (a: T, b: T) => boolean,
-): T {
+export function useEvents<T>(selector: (store: EventsStore) => T): T {
   const context = useGuaranteedContext(EventsContext);
-  return useStore(context, selector, equalityFn);
+  return useStore(context, selector);
 }

--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -39,10 +39,7 @@ export const ExtensionCatalogContext = createContext<undefined | StoreApi<Extens
   undefined,
 );
 
-export function useExtensionCatalog<T>(
-  selector: (registry: ExtensionCatalog) => T,
-  equalityFn?: (a: T, b: T) => boolean,
-): T {
+export function useExtensionCatalog<T>(selector: (registry: ExtensionCatalog) => T): T {
   const context = useGuaranteedContext(ExtensionCatalogContext);
-  return useStore(context, selector, equalityFn);
+  return useStore(context, selector);
 }

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -42,10 +42,7 @@ export type PanelStateStore = {
 
 export const PanelStateContext = createContext<undefined | StoreApi<PanelStateStore>>(undefined);
 
-export function usePanelStateStore<T>(
-  selector: (store: PanelStateStore) => T,
-  equalityFn?: (a: T, b: T) => boolean,
-): T {
+export function usePanelStateStore<T>(selector: (store: PanelStateStore) => T): T {
   const context = useGuaranteedContext(PanelStateContext);
-  return useStore(context, selector, equalityFn);
+  return useStore(context, selector);
 }

--- a/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
+++ b/packages/studio-base/src/context/TimelineInteractionStateContext.tsx
@@ -132,8 +132,7 @@ export function useHoverValue(opt?: {
  */
 export function useTimelineInteractionState<T>(
   selector: (store: TimelineInteractionStateStore) => T,
-  equalityFn?: (a: T, b: T) => boolean,
 ): T {
   const context = useGuaranteedContext(TimelineInteractionStateContext);
-  return useStore(context, selector, equalityFn);
+  return useStore(context, selector);
 }

--- a/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { createContext } from "react";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector";
 import { StoreApi, useStore } from "zustand";
+import { shallow } from "zustand/shallow";
 
 import { useGuaranteedContext } from "@foxglove/hooks";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
@@ -64,10 +66,26 @@ export const WorkspaceStoreSelectors = {
 /**
  * Fetches values from the workspace store.
  */
-export function useWorkspaceStore<T>(
-  selector: (store: WorkspaceContextStore) => T,
-  equalityFn?: (a: T, b: T) => boolean,
-): T {
+export function useWorkspaceStore<T>(selector: (store: WorkspaceContextStore) => T): T {
   const context = useGuaranteedContext(WorkspaceContext);
-  return useStore(context, selector, equalityFn);
+  return useStore(context, selector);
+}
+
+/**
+ * Fetches values from the workspace store.
+ *
+ * Uses a shallow comparison on the value returned from the selector to decide if the selected value
+ * should be considered a new value and result in a re-render.
+ */
+export function useWorkspaceStoreWithShallowSelector<T>(
+  selector: (store: WorkspaceContextStore) => T,
+): T {
+  const store = useGuaranteedContext(WorkspaceContext);
+  return useSyncExternalStoreWithSelector(
+    store.subscribe,
+    store.getState,
+    store.getState,
+    selector,
+    shallow,
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,6 +2680,7 @@ __metadata:
     "@types/three": ^0.149.0
     "@types/tinycolor2": 1.4.3
     "@types/url-search-params": 1.1.0
+    "@types/use-sync-external-store": 0.0.3
     "@types/uuid": 9.0.2
     "@types/wicg-file-system-access": 2020.9.6
     "@uiw/react-textarea-code-editor": 2.1.7
@@ -2769,9 +2770,10 @@ __metadata:
     url-search-params: 1.1.0
     use-debounce: 9.0.4
     use-immer: 0.9.0
+    use-sync-external-store: 1.2.0
     uuid: 9.0.0
     webpack: 5.88.2
-    zustand: 4.3.9
+    zustand: 4.4.0
   languageName: unknown
   linkType: soft
 
@@ -6387,6 +6389,13 @@ __metadata:
   version: 1.1.0
   resolution: "@types/url-search-params@npm:1.1.0"
   checksum: d279350351451a0469aaf8984e455e7480a6a64d3377e9fac7aca25c3f65014cc9792c567a7a91d8ce63f9c94b9b255e09763417a269256d40115c3803245fb1
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:0.0.3":
+  version: 0.0.3
+  resolution: "@types/use-sync-external-store@npm:0.0.3"
+  checksum: 161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
   languageName: node
   linkType: hard
 
@@ -21472,20 +21481,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:4.3.9":
-  version: 4.3.9
-  resolution: "zustand@npm:4.3.9"
+"zustand@npm:4.4.0":
+  version: 4.4.0
+  resolution: "zustand@npm:4.4.0"
   dependencies:
     use-sync-external-store: 1.2.0
   peerDependencies:
+    "@types/react": ">=16.8"
     immer: ">=9.0"
     react: ">=16.8"
   peerDependenciesMeta:
+    "@types/react":
+      optional: true
     immer:
       optional: true
     react:
       optional: true
-  checksum: fc83d653913fa537c354ba8b95d3a4fdebe62d2ebd3d9f5aeff2edf062811c0f5af48e02ab4da32b666752fd4f3e78c2b44624e445254f48503595435d4a7d70
+  checksum: 37e69eec1b56677a93712e5aa6d0048b55997379919dc0f78f61181f8a58994a6cae064f816f8101f5b1039008d3c1c9d136432a62e0edeb796807cc84cf45ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The most recent zustand update removed support for passing a custom comparison function along with `useStore` selectors:

https://github.com/pmndrs/zustand/discussions/1937

This updates to the latest zustand and works around this change by adding a separate `useWorkspaceStoreWithShallowSelector` hook for those few places where we were previously taking advantage of this feature.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
