### PR TITLE
Pause playback until a fixed amount is buffered

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -23,10 +23,13 @@ import {
 const log = Log.getLogger(__filename);
 
 const DEFAULT_READ_AHEAD_DURATION = { sec: 10, nsec: 0 };
+const DEFAULT_MIN_READ_AHEAD_DURATION = { sec: 1, nsec: 0 };
 
 type Options = {
   // How far ahead to buffer
   readAheadDuration?: Time;
+  // The minimum duration to buffer before playback resumes
+  minReadAheadDuration?: Time;
 };
 
 interface EventTypes {
@@ -69,10 +72,14 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
   // How far ahead of the read head we should try to keep buffering
   #readAheadDuration: Time;
 
+  // The minimum duration to buffer before playback resumes
+  #minReadAheadDuration : Time;
+
   public constructor(source: IIterableSource, opt?: Options) {
     super();
 
     this.#readAheadDuration = opt?.readAheadDuration ?? DEFAULT_READ_AHEAD_DURATION;
+    this.#minReadAheadDuration = opt?.minReadAheadDuration ?? DEFAULT_MIN_READ_AHEAD_DURATION;
     this.#source = new CachingIterableSource(source);
 
     // pass-through the range change event
@@ -149,6 +156,12 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
         }
 
         this.#cache.enqueue(result);
+
+        // Make sure that we have buffered enough ahead before telling the consumer to try reading again.
+        const rangeEnd = addTime(this.#readHead, this.#minReadAheadDuration);
+        if (!this.#source.isRangeBuffered(this.#readHead, rangeEnd)) {
+          continue;
+        }
 
         // Indicate to the consumer that it can try reading again
         this.#readSignal.notifyAll();

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -7,7 +7,7 @@ import { isEqual, sortedIndexBy } from "lodash";
 
 import { minIndexBy, sortedIndexByTuple } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
-import { subtract, add, toNanoSec, compare } from "@foxglove/rostime";
+import { subtract, add, toNanoSec, compare, clampTime } from "@foxglove/rostime";
 import { Time, MessageEvent } from "@foxglove/studio";
 import { Range } from "@foxglove/studio-base/util/ranges";
 
@@ -449,6 +449,50 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     out.sort((a, b) => compare(a.receiveTime, b.receiveTime));
 
     return out;
+  }
+
+  /**
+   * Checks if the given time range is fully buffered.
+   *
+   * @param rangeStart Range start time
+   * @param rangeEnd Range end time
+   * @returns True if the entire range is buffered, false otherwise.
+   */
+  public isRangeBuffered(rangeStart: Time, rangeEnd: Time) : boolean {
+    if (compare(rangeStart, rangeEnd) > 0) {
+      throw new Error(`Invariant: rangeStart > rangeEnd`);
+    }
+
+    let currTime = rangeStart;
+    const findIndexContainingPredicate = (item: CacheBlock) => {
+      return compare(item.start, currTime) <= 0 && compare(item.end, currTime) >= 0;
+    };
+
+    for (;;) {
+      // Find the block that contains the current time
+      const cacheBlockIndex = this.#cache.findIndex(findIndexContainingPredicate);
+      const block = this.#cache[cacheBlockIndex];
+
+      if (!block || block.items.length === 0) {
+        // No block found or block is empty -> Range is not buffered
+        return false;
+      }
+
+      if (compare(block.end, rangeEnd) >= 0) {
+        // Block contains our range end time -> Entire range is buffered
+        return true;
+      }
+
+      // This block does not contain our range end time. Increase the time to move on to the
+      // next potential block.
+      const newTime = clampTime(add(block.end, { sec: 0, nsec: 1 }), rangeStart, rangeEnd);
+      if (compare(newTime, currTime) <= 0) {
+        // Time is not moving forward, abort to avoid an infinite loop
+        return false;
+      }
+
+      currTime = newTime;
+    }
   }
 
   #recomputeLoadedRangeCache(): void {


### PR DESCRIPTION
**User-Facing Changes**
Pause playback until a fixed amount is buffered

**Description**
Changes playback behavior to only resume playback when a fixed amount of time (1 second by default) is buffered. This results in a smoother, YouTube-like playback experience. So far when the read head reached the end of the buffered time range, we kept reading from the buffer which made visualizations appear jittery if buffering could not keep up with playback speed.


| Current behavior                                                                                       | This PR                                                                                                |
|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
| <video src="https://github.com/foxglove/studio/assets/9250155/2610247f-3ecf-474b-aaee-f0b716ced2e3" /> | <video src="https://github.com/foxglove/studio/assets/9250155/6e8ae2f9-145b-46df-b841-2bf98358c3fc" /> |
