### PR TITLE
Reset the amount that is being read when seeking

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -234,6 +234,7 @@ export class IterablePlayer implements Player {
     this.#lastTickMillis = undefined;
     this.#isPlaying = false;
     this.#untilTime = undefined;
+    this.#lastRangeMillis = undefined;
     if (this.#state === "play") {
       this.#setState("idle");
     }
@@ -278,6 +279,8 @@ export class IterablePlayer implements Player {
     this.#metricsCollector.seek(targetTime);
     this.#seekTarget = targetTime;
     this.#untilTime = undefined;
+    this.#lastTickMillis = undefined;
+    this.#lastRangeMillis = undefined;
 
     this.#setState("seek-backfill");
   }
@@ -310,6 +313,8 @@ export class IterablePlayer implements Player {
       if (!this.#isPlaying && this.#currentTime) {
         this.#seekTarget ??= this.#currentTime;
         this.#untilTime = undefined;
+        this.#lastTickMillis = undefined;
+        this.#lastRangeMillis = undefined;
 
         // Trigger a seek backfill to load any missing messages and reset the forward iterator
         this.#setState("seek-backfill");


### PR DESCRIPTION
**User-Facing Changes**
Not worth being mentioned in release notes

**Description**
When seeking to a new time, we do want to reset the time range that is being read (as that one [depends on the previous history of time ranges](https://github.com/foxglove/studio/blob/362dc04143f5a15f535f8c5dec65b392c8189c36/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts#L792-L808)). For instance, when seeking to a buffered range, playback should continue as fast as possible and not be influenced by previous, potentially slow, ticks.