### PR TITLE
Convert Log panel to an extension panel

### DIFF
--- a/packages/studio-base/src/panels/Log/FilterBar.tsx
+++ b/packages/studio-base/src/panels/Log/FilterBar.tsx
@@ -16,6 +16,7 @@ import { MenuItem, Select, Typography } from "@mui/material";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
 
+import { Immutable } from "@foxglove/studio";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { FilterTagInput } from "@foxglove/studio-base/panels/Log/FilterTagInput";
@@ -23,7 +24,7 @@ import useLogStyles from "@foxglove/studio-base/panels/Log/useLogStyles";
 import clipboard from "@foxglove/studio-base/util/clipboard";
 
 import LevelToString from "./LevelToString";
-import { LogMessageEvent, LogLevel } from "./types";
+import { LogLevel, NormalizedLogMessage } from "./types";
 
 // Create the log level options nodes once since they don't change per render.
 const LOG_LEVEL_OPTIONS = [
@@ -46,21 +47,21 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-type Filter = {
+export type Filter = {
   minLogLevel: number;
   searchTerms: string[];
 };
 
-export type FilterBarProps = {
+export type FilterBarProps = Immutable<{
   searchTerms: Set<string>;
   nodeNames: Set<string>;
   minLogLevel: number;
-  messages: readonly LogMessageEvent[];
+  messages: NormalizedLogMessage[];
 
   onFilterChange: (filter: Filter) => void;
-};
+}>;
 
-export default function FilterBar(props: FilterBarProps): JSX.Element {
+export function FilterBar(props: FilterBarProps): JSX.Element {
   const { classes: logStyles } = useLogStyles();
   const { classes, cx } = useStyles();
 

--- a/packages/studio-base/src/panels/Log/FilterBar.tsx
+++ b/packages/studio-base/src/panels/Log/FilterBar.tsx
@@ -11,17 +11,14 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import CopyAllIcon from "@mui/icons-material/CopyAll";
-import { MenuItem, Select, Typography } from "@mui/material";
+import { MenuItem, Paper, Select } from "@mui/material";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { Immutable } from "@foxglove/studio";
-import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
-import Stack from "@foxglove/studio-base/components/Stack";
+import CopyButton from "@foxglove/studio-base/components/CopyButton";
 import { FilterTagInput } from "@foxglove/studio-base/panels/Log/FilterTagInput";
 import useLogStyles from "@foxglove/studio-base/panels/Log/useLogStyles";
-import clipboard from "@foxglove/studio-base/util/clipboard";
 
 import LevelToString from "./LevelToString";
 import { LogLevel, NormalizedLogMessage } from "./types";
@@ -37,13 +34,16 @@ const LOG_LEVEL_OPTIONS = [
 
 const useStyles = makeStyles()((theme) => ({
   root: {
-    marginRight: theme.spacing(-1),
+    display: "flex",
+    padding: theme.spacing(0.75),
+    gap: theme.spacing(0.5),
+    alignItems: "flex-end",
   },
-  levelSelect: {
-    ".MuiSelect-select.MuiInputBase-inputSizeSmall": {
-      paddingBottom: `${theme.spacing(0.375)} !important`,
-      paddingTop: `${theme.spacing(0.375)} !important`,
-    },
+  button: {
+    flex: "none",
+  },
+  select: {
+    minWidth: 100,
   },
 }));
 
@@ -83,7 +83,7 @@ export function FilterBar(props: FilterBarProps): JSX.Element {
     const className = logLevelToClass(option.key);
     return (
       <MenuItem key={index} value={option.key} className={className}>
-        <Typography variant="body2">{option.text}</Typography>
+        {option.text}
       </MenuItem>
     );
   });
@@ -98,9 +98,9 @@ export function FilterBar(props: FilterBarProps): JSX.Element {
   );
 
   return (
-    <Stack className={classes.root} flex="auto" direction="row" gap={0.5} alignItems="center">
+    <Paper square className={classes.root}>
       <Select
-        className={classes.levelSelect}
+        className={classes.select}
         value={props.minLogLevel}
         size="small"
         renderValue={renderLogLevelValue}
@@ -123,16 +123,11 @@ export function FilterBar(props: FilterBarProps): JSX.Element {
           });
         }}
       />
-      <Stack direction="row" alignItems="center" gap={0.5}>
-        <ToolbarIconButton
-          onClick={() => {
-            void clipboard.copy(JSON.stringify(props.messages, undefined, 2) ?? "");
-          }}
-          title="Copy log to clipboard"
-        >
-          <CopyAllIcon />
-        </ToolbarIconButton>
-      </Stack>
-    </Stack>
+      <CopyButton
+        size="small"
+        getText={() => JSON.stringify(props.messages, undefined, 2) ?? ""}
+        className={classes.button}
+      />
+    </Paper>
   );
 }

--- a/packages/studio-base/src/panels/Log/FilterTagInput.tsx
+++ b/packages/studio-base/src/panels/Log/FilterTagInput.tsx
@@ -2,24 +2,32 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { TextField } from "@mui/material";
-import Autocomplete from "@mui/material/Autocomplete";
+import {
+  Autocomplete,
+  MenuItem,
+  MenuList,
+  MenuListProps,
+  TextField,
+  autocompleteClasses,
+  inputBaseClasses,
+} from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
 const useStyles = makeStyles()((theme) => ({
   input: {
-    ".MuiInputBase-root.MuiInputBase-sizeSmall .MuiAutocomplete-input.MuiInputBase-inputSizeSmall":
-      {
-        paddingBottom: theme.spacing(0.425),
-        paddingTop: theme.spacing(0.425),
-      },
-    ".MuiInputBase-root.MuiInputBase-sizeSmall": {
-      padding: theme.spacing(0.125),
-      gap: theme.spacing(0.25),
+    gap: theme.spacing(0.25),
+    flexWrap: "wrap",
+
+    [`&.${inputBaseClasses.root}.${autocompleteClasses.input}`]: {
+      width: "auto",
+    },
+    [`&.${inputBaseClasses.root}.${inputBaseClasses.sizeSmall}`]: {
+      paddingBlock: theme.spacing(0.275),
+      paddingLeft: theme.spacing(0.25),
     },
   },
   chip: {
-    "&.MuiAutocomplete-tag": {
+    [`&.${autocompleteClasses.tag}`]: {
       margin: 0,
     },
   },
@@ -50,8 +58,19 @@ export function FilterTagInput({
         variant: "filled",
         size: "small",
       }}
+      ListboxComponent={MenuList}
+      ListboxProps={{ dense: true } as MenuListProps}
+      renderOption={(props, option) => <MenuItem {...props}>{option}</MenuItem>}
       renderInput={(params) => (
-        <TextField {...params} size="small" className={classes.input} placeholder="Search filter" />
+        <TextField
+          {...params}
+          size="small"
+          InputProps={{
+            ...params.InputProps,
+            className: classes.input,
+          }}
+          placeholder="Search filter"
+        />
       )}
     />
   );

--- a/packages/studio-base/src/panels/Log/LogList.tsx
+++ b/packages/studio-base/src/panels/Log/LogList.tsx
@@ -20,10 +20,8 @@ import { AutoSizer } from "react-virtualized";
 import { VariableSizeList as List } from "react-window";
 import { makeStyles } from "tss-react/mui";
 
-import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
-import { NormalizedLogMessage } from "@foxglove/studio-base/panels/Log/types";
-
 import LogMessage from "./LogMessage";
+import { NormalizedLogMessage } from "./types";
 
 const useStyles = makeStyles()((theme) => ({
   floatingButton: {
@@ -44,7 +42,11 @@ type ListItemData = {
 };
 
 function Row(props: { data: ListItemData; index: number; style: CSSProperties }): JSX.Element {
-  const { timeFormat, timeZone } = useAppTimeFormat();
+  // fixme
+  //const { timeFormat, timeZone } = useAppTimeFormat();
+  const timeFormat = "SEC";
+  const timeZone = "UTC";
+
   const ref = useRef<HTMLDivElement>(ReactNull);
 
   useEffect(() => {

--- a/packages/studio-base/src/panels/Log/LogPanel.stories.tsx
+++ b/packages/studio-base/src/panels/Log/LogPanel.stories.tsx
@@ -15,8 +15,9 @@ import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { range } from "lodash";
 
-import Log from "@foxglove/studio-base/panels/Log";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
+
+import { LogPanel } from "./LogPanel";
 
 const fixture: Fixture = {
   topics: [{ name: "/rosout", schemaName: "rosgraph_msgs/Log" }],

--- a/packages/studio-base/src/panels/Log/LogPanel.stories.tsx
+++ b/packages/studio-base/src/panels/Log/LogPanel.stories.tsx
@@ -17,7 +17,7 @@ import { range } from "lodash";
 
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
-import { LogPanel } from "./LogPanel";
+import LogPanel from "./index";
 
 const fixture: Fixture = {
   topics: [{ name: "/rosout", schemaName: "rosgraph_msgs/Log" }],
@@ -215,13 +215,13 @@ const foxgloveLogFixture: Fixture = {
 
 export default {
   title: "panels/Log",
-  component: Log,
+  component: LogPanel,
 };
 
 export const Simple: StoryObj = {
   render: () => (
     <PanelSetup fixture={fixture}>
-      <Log />
+      <LogPanel />
     </PanelSetup>
   ),
 };
@@ -229,7 +229,7 @@ export const Simple: StoryObj = {
 export const Scrolled: StoryObj = {
   render: () => (
     <PanelSetup fixture={makeLongFixture()}>
-      <Log />
+      <LogPanel />
     </PanelSetup>
   ),
 };
@@ -237,7 +237,7 @@ export const Scrolled: StoryObj = {
 export const WithSettings: StoryObj = {
   render: () => (
     <PanelSetup fixture={fixture} includeSettings>
-      <Log />
+      <LogPanel />
     </PanelSetup>
   ),
 };
@@ -259,7 +259,9 @@ export const TopicToRenderWithSettings: StoryObj = {
       }}
       includeSettings
     >
-      <Log overrideConfig={{ topicToRender: "/foo/rosout", searchTerms: [], minLogLevel: 1 }} />
+      <LogPanel
+        overrideConfig={{ topicToRender: "/foo/rosout", searchTerms: [], minLogLevel: 1 }}
+      />
     </PanelSetup>
   ),
 };
@@ -267,7 +269,7 @@ export const TopicToRenderWithSettings: StoryObj = {
 export const FilteredTerms: StoryObj = {
   render: () => (
     <PanelSetup fixture={fixture}>
-      <Log
+      <LogPanel
         overrideConfig={{
           searchTerms: ["multiple", "/some_topic"],
           minLogLevel: 1,
@@ -282,7 +284,7 @@ export const FilteredTerms: StoryObj = {
 export const CaseInsensitiveFilter: StoryObj = {
   render: () => (
     <PanelSetup fixture={fixture}>
-      <Log
+      <LogPanel
         overrideConfig={{
           searchTerms: ["could", "Ipsum"],
           minLogLevel: 1,
@@ -297,7 +299,7 @@ export const CaseInsensitiveFilter: StoryObj = {
 export const AutoCompleteItems: StoryObj = {
   render: () => (
     <PanelSetup fixture={fixture}>
-      <Log
+      <LogPanel
         overrideConfig={{
           searchTerms: ["could", "Ipsum"],
           minLogLevel: 1,
@@ -316,7 +318,7 @@ export const AutoCompleteItems: StoryObj = {
 export const FoxgloveLog: StoryObj = {
   render: () => (
     <PanelSetup fixture={foxgloveLogFixture}>
-      <Log />
+      <LogPanel />
     </PanelSetup>
   ),
 };

--- a/packages/studio-base/src/panels/Log/LogPanel.tsx
+++ b/packages/studio-base/src/panels/Log/LogPanel.tsx
@@ -210,6 +210,9 @@ function LogPanel(props: Props): JSX.Element {
   return (
     <ThemeProvider isDark={isDarkTheme}>
       <Stack fullHeight>
+        <Stack fullHeight flexGrow={1}>
+          <LogList items={filteredMessages} />
+        </Stack>
         <FilterBar
           searchTerms={searchTermsSet}
           minLogLevel={minLogLevel}
@@ -217,9 +220,6 @@ function LogPanel(props: Props): JSX.Element {
           messages={filteredMessages}
           onFilterChange={setFilter}
         />
-        <Stack fullHeight flexGrow={1}>
-          <LogList items={filteredMessages} />
-        </Stack>
       </Stack>
     </ThemeProvider>
   );

--- a/packages/studio-base/src/panels/Log/LogPanel.tsx
+++ b/packages/studio-base/src/panels/Log/LogPanel.tsx
@@ -1,0 +1,228 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { produce } from "immer";
+import { set } from "lodash";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+
+import { filterMap } from "@foxglove/den/collection";
+import { useShallowMemo } from "@foxglove/hooks";
+import {
+  Immutable,
+  PanelExtensionContext,
+  SettingsTreeAction,
+  Subscription,
+  Topic,
+} from "@foxglove/studio";
+import Stack from "@foxglove/studio-base/components/Stack";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import concatAndTruncate from "@foxglove/studio-base/util/concatAndTruncate";
+
+import { Filter, FilterBar } from "./FilterBar";
+import LogList from "./LogList";
+import { normalizedLogMessage } from "./conversion";
+import { filterMessages } from "./filterMessages";
+import { buildSettingsTree } from "./settings";
+import { Config, LogMessageEvent, NormalizedLogMessage } from "./types";
+
+type Props = {
+  context: PanelExtensionContext;
+};
+
+const EMPTY_ARRAY: Immutable<Topic[]> = [];
+
+export function isSupportedSchema(schemaName: string): boolean {
+  switch (schemaName) {
+    case "foxglove_msgs/Log":
+    case "foxglove_msgs/msg/Log":
+    case "foxglove.Log":
+    case "foxglove::Log":
+    case "rcl_interfaces/msg/Log":
+    case "ros.rcl_interfaces.Log":
+    case "ros.rosgraph_msgs.Log":
+    case "rosgraph_msgs/Log":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Filter a list of Topics to those that are eligible for subscription either because their
+ * schemaName is supported or they can be converted to a supported schema.
+ */
+const computeElegibletopics = (topics: Immutable<Topic[]>) => {
+  return filterMap(topics, (topic) => {
+    if (isSupportedSchema(topic.schemaName)) {
+      return topic;
+    }
+
+    if (topic.convertibleTo) {
+      for (const schemaName of topic.convertibleTo) {
+        if (isSupportedSchema(schemaName)) {
+          return { name: topic.name, schemaName };
+        }
+      }
+    }
+    return undefined;
+  });
+};
+
+function LogPanel(props: Props): JSX.Element {
+  const { context } = props;
+
+  const [renderDone, setRenderDone] = useState<() => void>(() => () => {});
+  const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const [config, setConfig] = useState<Immutable<Config>>(context.initialState as Config);
+  const [allTopics, setAllTopics] = useState<Immutable<Topic[]>>([]);
+  const [allMessages, setAllMessages] = useState<Immutable<NormalizedLogMessage[]>>([]);
+  const [seenNodeNames, setSeenNodeNames] = useState<Immutable<Set<string>>>(new Set());
+
+  useLayoutEffect(() => {
+    context.watch("currentFrame");
+    context.watch("topics");
+    context.watch("didSeek");
+    context.watch("colorScheme");
+
+    context.onRender = (renderState, done) => {
+      setIsDarkTheme(renderState.colorScheme === "dark");
+      setRenderDone(() => done);
+      setAllTopics(renderState.topics ?? EMPTY_ARRAY);
+
+      if (renderState.didSeek === true) {
+        setAllMessages([]);
+      }
+
+      if (renderState.currentFrame) {
+        const logMessages = renderState.currentFrame as Immutable<LogMessageEvent[]>;
+        const normalized = logMessages.map((msgEvent) =>
+          normalizedLogMessage(msgEvent.schemaName, msgEvent.message),
+        );
+
+        setSeenNodeNames((oldSeenNames) => {
+          const newSeenNames = new Set<string>();
+
+          for (const message of normalized) {
+            const name = message.name;
+            if (name != undefined && !oldSeenNames.has(name)) {
+              newSeenNames.add(name);
+            }
+          }
+          if (newSeenNames.size === 0) {
+            return oldSeenNames;
+          }
+          return new Set([...oldSeenNames, ...newSeenNames]);
+        });
+
+        setAllMessages((oldMessages) => {
+          return concatAndTruncate(oldMessages, normalized, 100_000);
+        });
+      }
+    };
+  }, [context]);
+
+  const settingsTreeActionHandler = useCallback((action: Immutable<SettingsTreeAction>) => {
+    if (action.action !== "update") {
+      return;
+    }
+
+    const { path, value } = action.payload;
+    if (path[0] === "general" && path[1] === "topicToRender") {
+      setConfig(produce<Immutable<Config>>((draft) => set(draft, "topicToRender", value)));
+    }
+  }, []);
+
+  const eligibleTopics = useMemo(() => computeElegibletopics(allTopics), [allTopics]);
+
+  const firstEligible = eligibleTopics[0];
+  if (config.topicToRender == undefined && firstEligible != undefined) {
+    setConfig((oldConfig) => ({
+      ...oldConfig,
+      topicToRender: firstEligible.name,
+    }));
+  }
+
+  const { topicToRender } = config;
+
+  useEffect(() => {
+    context.setDefaultPanelTitle(topicToRender);
+  }, [context, topicToRender]);
+
+  // Memo the subscription topic separate from eligibleTopics so we don't re-subscribe when eligible topics changes
+  // but our subscriptionTopic has not
+  const subscriptionTopic = useMemo(() => {
+    return eligibleTopics.find((topic) => topic.name === topicToRender);
+  }, [eligibleTopics, topicToRender]);
+
+  useEffect(() => {
+    setAllMessages([]);
+
+    if (subscriptionTopic?.name == undefined) {
+      context.subscribe([] as Subscription[]);
+      return;
+    }
+
+    context.subscribe([{ topic: subscriptionTopic.name, convertTo: subscriptionTopic.schemaName }]);
+  }, [context, subscriptionTopic?.name, subscriptionTopic?.schemaName]);
+
+  // Use a shallow memo of the eligible topic names to avoid rebuilding the settings tree when the entire topics list changes
+  // but the eligible list of topics is unchanged
+  const eligibleTopicNames = useShallowMemo(
+    useMemo(() => eligibleTopics.map((topic) => topic.name), [eligibleTopics]),
+  );
+  useEffect(() => {
+    context.updatePanelSettingsEditor({
+      actionHandler: settingsTreeActionHandler,
+      nodes: buildSettingsTree(topicToRender, eligibleTopicNames),
+    });
+  }, [context, settingsTreeActionHandler, eligibleTopicNames, topicToRender]);
+
+  const setFilter = useCallback((filter: Filter) => {
+    setConfig({
+      minLogLevel: filter.minLogLevel,
+      searchTerms: filter.searchTerms,
+    });
+  }, []);
+
+  const searchTermsSet = useMemo(() => new Set(config.searchTerms), [config.searchTerms]);
+
+  const { minLogLevel, searchTerms } = config;
+  const filteredMessages = useMemo(
+    () => filterMessages(allMessages, { minLogLevel, searchTerms }),
+    [allMessages, minLogLevel, searchTerms],
+  );
+
+  // Indicate we finished the latest render after react finishes this render
+  useEffect(() => {
+    renderDone();
+  }, [renderDone]);
+
+  return (
+    <ThemeProvider isDark={isDarkTheme}>
+      <Stack fullHeight>
+        <FilterBar
+          searchTerms={searchTermsSet}
+          minLogLevel={minLogLevel}
+          nodeNames={seenNodeNames}
+          messages={filteredMessages}
+          onFilterChange={setFilter}
+        />
+        <Stack fullHeight flexGrow={1}>
+          <LogList items={filteredMessages} />
+        </Stack>
+      </Stack>
+    </ThemeProvider>
+  );
+}
+
+export { LogPanel };

--- a/packages/studio-base/src/panels/Log/filterMessages.test.ts
+++ b/packages/studio-base/src/panels/Log/filterMessages.test.ts
@@ -13,7 +13,7 @@
 
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 
-import filterMessages from "./filterMessages";
+import { filterMessages } from "./filterMessages";
 import { LogLevel, Ros1RosgraphMsgs$Log, Ros2RosgraphMsgs$Log } from "./types";
 
 describe("filter", () => {

--- a/packages/studio-base/src/panels/Log/filterMessages.ts
+++ b/packages/studio-base/src/panels/Log/filterMessages.ts
@@ -11,25 +11,25 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { getNormalizedMessage, getNormalizedLevel } from "./conversion";
-import { LogMessageEvent } from "./types";
+import { Immutable } from "@foxglove/studio";
 
-export default function filterMessages(
-  events: readonly LogMessageEvent[],
-  filter: { minLogLevel: number; searchTerms: string[] },
-): readonly LogMessageEvent[] {
+import { NormalizedLogMessage } from "./types";
+
+export function filterMessages(
+  messages: readonly NormalizedLogMessage[],
+  filter: Immutable<{ minLogLevel: number; searchTerms: string[] }>,
+): readonly NormalizedLogMessage[] {
   const { minLogLevel, searchTerms } = filter;
   const hasActiveFilters = minLogLevel > 1 || searchTerms.length > 0;
   // return all messages if we wouldn't filter anything
   if (!hasActiveFilters) {
-    return events;
+    return messages;
   }
 
   const searchTermsInLowerCase = searchTerms.map((term) => term.toLowerCase());
 
-  return events.filter((event) => {
-    const logMessage = event.message;
-    const effectiveLogLevel = getNormalizedLevel(event.schemaName, logMessage);
+  return messages.filter((message) => {
+    const effectiveLogLevel = message.level;
     if (effectiveLogLevel < minLogLevel) {
       return false;
     }
@@ -38,8 +38,8 @@ export default function filterMessages(
       return true;
     }
 
-    const lowerCaseName = logMessage.name?.toLowerCase() ?? "";
-    const lowerCaseMsg = getNormalizedMessage(logMessage).toLowerCase();
+    const lowerCaseName = message.name?.toLowerCase() ?? "";
+    const lowerCaseMsg = message.message.toLowerCase();
     return searchTermsInLowerCase.some(
       (term) => lowerCaseName.includes(term) || lowerCaseMsg.includes(term),
     );

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -1,153 +1,37 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
-import { produce } from "immer";
-import { set } from "lodash";
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useTranslation } from "react-i18next";
+import { useMemo } from "react";
 
-import { SettingsTreeAction } from "@foxglove/studio";
-import { useDataSourceInfo, useMessagesByTopic } from "@foxglove/studio-base/PanelAPI";
+import { useCrash } from "@foxglove/hooks";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import Stack from "@foxglove/studio-base/components/Stack";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
-import FilterBar, { FilterBarProps } from "./FilterBar";
-import LogList from "./LogList";
-import { normalizedLogMessage } from "./conversion";
-import filterMessages from "./filterMessages";
-import { buildSettingsTree } from "./settings";
-import { Config, LogMessageEvent } from "./types";
+import { initPanel } from "./initPanel";
+import { Config } from "./types";
 
 type Props = {
-  config: Config;
-  saveConfig: SaveConfig<Config>;
+  config: unknown;
+  saveConfig: SaveConfig<unknown>;
 };
 
-const SUPPORTED_DATATYPES = [
-  "foxglove_msgs/Log",
-  "foxglove_msgs/msg/Log",
-  "foxglove.Log",
-  "foxglove::Log",
-  "rcl_interfaces/msg/Log",
-  "ros.rcl_interfaces.Log",
-  "ros.rosgraph_msgs.Log",
-  "rosgraph_msgs/Log",
-];
-
-const LogPanel = React.memo(({ config, saveConfig }: Props) => {
-  const { topics } = useDataSourceInfo();
-  const { minLogLevel, searchTerms } = config;
-
-  const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
-  const { t } = useTranslation("log");
-
-  const onFilterChange = useCallback<FilterBarProps["onFilterChange"]>(
-    (filter) => {
-      saveConfig({ minLogLevel: filter.minLogLevel, searchTerms: filter.searchTerms });
-    },
-    [saveConfig],
-  );
-
-  const availableTopics = useMemo(
-    () =>
-      topics.filter(
-        (topic) => topic.schemaName != undefined && SUPPORTED_DATATYPES.includes(topic.schemaName),
-      ),
-    [topics],
-  );
-
-  const defaultTopicToRender = useMemo(() => availableTopics[0]?.name, [availableTopics]);
-
-  const topicToRender = config.topicToRender ?? defaultTopicToRender ?? "/rosout";
-
-  const { [topicToRender]: messages = [] } = useMessagesByTopic({
-    topics: [topicToRender],
-    historySize: 100000,
-  }) as { [key: string]: LogMessageEvent[] };
-
-  const actionHandler = useCallback(
-    (action: SettingsTreeAction) => {
-      if (action.action !== "update") {
-        return;
-      }
-
-      const { path, value } = action.payload;
-      saveConfig(produce<Config>((draft) => set(draft, path.slice(1), value)));
-    },
-    [saveConfig],
-  );
-
-  useEffect(() => {
-    updatePanelSettingsTree({
-      actionHandler,
-      nodes: buildSettingsTree(topicToRender, availableTopics, t),
-    });
-  }, [actionHandler, availableTopics, topicToRender, updatePanelSettingsTree, t]);
-
-  // avoid making new sets for node names
-  // the filter bar uess the node names during on-demand filtering
-  // the filter bar uses the node names during on-demand filtering
-  const seenNodeNamesCache = useRef(new Set<string>());
-
-  const seenNodeNames = useMemo(() => {
-    for (const msgEvent of messages) {
-      const name = msgEvent.message.name;
-      if (name != undefined) {
-        seenNodeNamesCache.current.add(name);
-      }
-    }
-
-    return seenNodeNamesCache.current;
-  }, [messages]);
-
-  const searchTermsSet = useMemo(() => new Set(searchTerms), [searchTerms]);
-
-  const filteredMessages = useMemo(
-    () => filterMessages(messages, { minLogLevel, searchTerms }),
-    [messages, minLogLevel, searchTerms],
-  );
-
-  const normalizedMessages = useMemo(
-    () => filteredMessages.map((msg) => normalizedLogMessage(msg.schemaName, msg["message"])),
-    [filteredMessages],
-  );
+function MapPanelAdapter(props: Props) {
+  const crash = useCrash();
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
-    <Stack fullHeight>
-      <PanelToolbar>
-        <FilterBar
-          searchTerms={searchTermsSet}
-          minLogLevel={minLogLevel}
-          nodeNames={seenNodeNames}
-          messages={filteredMessages}
-          onFilterChange={onFilterChange}
-        />
-      </PanelToolbar>
-      <Stack flexGrow={1}>
-        <LogList items={normalizedMessages} />
-      </Stack>
-    </Stack>
+    <PanelExtensionAdapter
+      config={props.config}
+      saveConfig={props.saveConfig}
+      initPanel={boundInitPanel}
+      highestSupportedConfigVersion={1}
+    />
   );
-});
+}
 
-LogPanel.displayName = "Log";
+MapPanelAdapter.panelType = "RosOut";
+MapPanelAdapter.defaultConfig = { searchTerms: [], minLogLevel: 1 } satisfies Config;
 
-export default Panel(
-  Object.assign(LogPanel, {
-    defaultConfig: { searchTerms: [], minLogLevel: 1 } as Config,
-    panelType: "RosOut", // The legacy RosOut name is used for backwards compatibility
-  }),
-);
+export default Panel(MapPanelAdapter);

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -17,7 +17,7 @@ type Props = {
   saveConfig: SaveConfig<unknown>;
 };
 
-function MapPanelAdapter(props: Props) {
+function LogPanelAdapter(props: Props) {
   const crash = useCrash();
   const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
@@ -31,7 +31,7 @@ function MapPanelAdapter(props: Props) {
   );
 }
 
-MapPanelAdapter.panelType = "RosOut";
-MapPanelAdapter.defaultConfig = { searchTerms: [], minLogLevel: 1 } satisfies Config;
+LogPanelAdapter.panelType = "RosOut";
+LogPanelAdapter.defaultConfig = { searchTerms: [], minLogLevel: 1 } satisfies Config;
 
-export default Panel(MapPanelAdapter);
+export default Panel(LogPanelAdapter);

--- a/packages/studio-base/src/panels/Log/initPanel.tsx
+++ b/packages/studio-base/src/panels/Log/initPanel.tsx
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StrictMode } from "react";
+import ReactDOM from "react-dom";
+
+import { useCrash } from "@foxglove/hooks";
+import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
+
+import { LogPanel } from "./LogPanel";
+
+export function initPanel(
+  crash: ReturnType<typeof useCrash>,
+  context: PanelExtensionContext,
+): () => void {
+  ReactDOM.render(
+    <StrictMode>
+      <CaptureErrorBoundary onError={crash}>
+        <LogPanel context={context} />
+      </CaptureErrorBoundary>
+    </StrictMode>,
+    context.panelElement,
+  );
+  return () => {
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+}

--- a/packages/studio-base/src/panels/Log/settings.ts
+++ b/packages/studio-base/src/panels/Log/settings.ts
@@ -2,29 +2,25 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { TFunction } from "i18next";
-
-import { SettingsTreeNodes } from "@foxglove/studio";
-import { Topic } from "@foxglove/studio-base/players/types";
+import { Immutable, SettingsTreeNodes } from "@foxglove/studio";
 
 export function buildSettingsTree(
-  topicToRender: string,
-  availableTopics: Topic[],
-  t: TFunction<"log">,
+  topicToRender: string | undefined,
+  availableTopics: Immutable<string[]>,
 ): SettingsTreeNodes {
-  const topicOptions = availableTopics.map((topic) => ({ label: topic.name, value: topic.name }));
-  const topicIsAvailable = availableTopics.some((topic) => topic.name === topicToRender);
-  if (!topicIsAvailable) {
+  const topicOptions = availableTopics.map((topic) => ({ label: topic, value: topic }));
+  const topicIsAvailable = availableTopics.some((topic) => topic === topicToRender);
+  if (!topicIsAvailable && topicToRender) {
     topicOptions.unshift({ value: topicToRender, label: topicToRender });
   }
-  const topicError = topicIsAvailable ? undefined : t("topicError", { topic: topicToRender });
+  const topicError = topicIsAvailable ? undefined : `Topic ${topicToRender} is not available.`;
 
   return {
     general: {
       fields: {
         topicToRender: {
           input: "select",
-          label: t("topic"),
+          label: "Topic",
           value: topicToRender,
           error: topicError,
           options: topicOptions,

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -104,6 +104,7 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
       },
       styleOverrides: {
         root: {
+          borderRadius: theme.shape.borderRadius,
           boxShadow: theme.shadows[2],
         },
         colorInherit: {


### PR DESCRIPTION
**User-Facing Changes**
Message Converter support for Log panel.

Visually:

The filter bar is moved under the panel toolbar. The toolbar shows the topic name.
<img width="493" alt="image" src="https://github.com/foxglove/studio/assets/84792/9b70a5a9-9c4f-4016-b70f-970010b6a85d">
**Description**
Resolves FG-4013

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
