### PR TITLE
Stop reading messages into cache when cache is full

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -175,8 +175,11 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
         // Indicate to the consumer that it can try reading again
         this.#readSignal.notifyAll();
 
-        // Keep reading while the messages we receive are <= the readUntil time.
-        if (receiveTime && compare(receiveTime, readUntil) <= 0) {
+        this.#source.updateCurrentReadHead(this.#readHead);
+
+        // Keep reading while the messages we receive are <= the readUntil time and while
+        // there is still space for reading new messages into the cache
+        if (receiveTime && compare(receiveTime, readUntil) <= 0 && this.#source.canReadMore()) {
           continue;
         }
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -175,7 +175,7 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
         // Indicate to the consumer that it can try reading again
         this.#readSignal.notifyAll();
 
-        this.#source.updateCurrentReadHead(this.#readHead);
+        this.#source.setCurrentReadHead(this.#readHead);
 
         // Keep reading while the messages we receive are <= the readUntil time and while
         // there is still space for reading new messages into the cache

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -737,7 +737,7 @@ describe("CachingIterableSource", () => {
 
     {
       const messageIterator = bufferedSource.messageIterator({
-        topics: ["a"],
+        topics: mockTopicSelection("a"),
       });
 
       // At the start the cache is empty and the source can read messages

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -709,6 +709,50 @@ describe("CachingIterableSource", () => {
     }
   });
 
+  it("should report full cache as cache fills up", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source, {
+      maxBlockSize: 102,
+      maxTotalSize: 202,
+    });
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < 8; ++i) {
+        yield {
+          type: "message-event",
+          msgEvent: {
+            topic: "a",
+            receiveTime: { sec: i, nsec: 0 },
+            message: undefined,
+            sizeInBytes: 101,
+            schemaName: "foo",
+          },
+        };
+      }
+    };
+
+    {
+      const messageIterator = bufferedSource.messageIterator({
+        topics: ["a"],
+      });
+
+      // At the start the cache is empty and the source can read messages
+      expect(bufferedSource.canReadMore()).toBeTruthy();
+
+      // The cache size after reading the first message should still allow reading a new message
+      await messageIterator.next();
+      expect(bufferedSource.canReadMore()).toBeTruthy();
+
+      // Next message fills up the cache and the source can not read more messages
+      await messageIterator.next();
+      expect(bufferedSource.canReadMore()).toBeFalsy();
+    }
+  });
+
   it("should clear the cache when topics change", async () => {
     const source = new TestSource();
     const bufferedSource = new CachingIterableSource(source, {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -357,19 +357,30 @@ describe("CachingIterableSource", () => {
       topics: mockTopicSelection("a"),
     });
 
-    await messageIterator.next();
+    // Reads the next message and updates the read head. The latter is done for the source to know
+    // which blocks it can evict.
+    const readNextMsgAndUpdateReadHead = async () => {
+      const { done, value } = await messageIterator.next();
+      if (done ?? false) {
+        return;
+      }
+      if (value.type === "message-event") {
+        bufferedSource.setCurrentReadHead(value.msgEvent.receiveTime);
+      }
+    };
 
+    await readNextMsgAndUpdateReadHead();
     // Nothing has been actually saved into the cache but we did emit the first item
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0 }]);
 
-    await messageIterator.next();
+    await readNextMsgAndUpdateReadHead();
     // We've read another message which let us setup a block for all the time we've read till now
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.5 }]);
 
-    await messageIterator.next();
+    await readNextMsgAndUpdateReadHead();
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.5000000001, end: 0.9999999999 }]);
 
-    await messageIterator.next();
+    await readNextMsgAndUpdateReadHead();
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.5000000001, end: 1 }]);
   });
 
@@ -687,8 +698,11 @@ describe("CachingIterableSource", () => {
       });
 
       // load all the messages into cache
-      for await (const _ of messageIterator) {
-        // no-op
+      for await (const result of messageIterator) {
+        // Update the current read head so the source knows which blocks it can evict.
+        if (result.type === "message-event") {
+          bufferedSource.setCurrentReadHead(result.msgEvent.receiveTime);
+        }
       }
 
       expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.6, end: 1 }]);

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -154,6 +154,9 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     };
 
     this.#currentReadHead = readHead;
+
+    // Compute evictable block candiates such that canReadMore() returns a correct result as the
+    // callee may stop iterating when canReadMore() returns false.
     this.#evictableBlockCandidates = this.#findEvictableBlockCandidates(this.#currentReadHead);
 
     for (;;) {
@@ -528,7 +531,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
    * Update the current read head, such that the source can determine which blocks are evictable.
    * @param readHead current read head
    */
-  public updateCurrentReadHead(readHead: Time): void {
+  public setCurrentReadHead(readHead: Time): void {
     this.#currentReadHead = readHead;
   }
 
@@ -575,6 +578,8 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
 
     if (readHeadIdx === -1) {
       // No block contains current read head, return the oldest cache block.
+      // This can only happen when seeked to a new time and no message has been read yet, as
+      // reading a new message that does not fit in any block will always create a new cache block.
       const oldestBlockIdx = minIndexBy(this.#cache, (a, b) => a.lastAccess - b.lastAccess);
       return [this.#cache[oldestBlockIdx]!.id];
     }

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -584,7 +584,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
       return [this.#cache[oldestBlockIdx]!.id];
     }
 
-    // Blocks that are before the read head can be recycled.
+    // Blocks that are before the read head can be evicted.
     const blockIdsBeforeReadHead = mappedCache.splice(0, readHeadIdx).map((item) => item.id);
 
     // Iterate through remaining blocks until we find a gap in the block chain

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -581,7 +581,12 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
       // This can only happen when seeked to a new time and no message has been read yet, as
       // reading a new message that does not fit in any block will always create a new cache block.
       const oldestBlockIdx = minIndexBy(this.#cache, (a, b) => a.lastAccess - b.lastAccess);
-      return [this.#cache[oldestBlockIdx]!.id];
+      const oldestBlock = this.#cache[oldestBlockIdx];
+      if (!oldestBlock) {
+        // This should never happen as the cache is not empty and the index is valid.
+        throw new Error("Failed to retrieve oldest block from cache");
+      }
+      return [oldestBlock.id];
     }
 
     // Blocks that are before the read head can be evicted.

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -24,6 +24,9 @@ const log = Log.getLogger(__filename);
 
 // An individual cache item represents a continuous range of CacheIteratorItems
 type CacheBlock = {
+  // Unique id of the cache item.
+  id: bigint;
+
   // The start time of the cache item (inclusive).
   //
   // When reading a data source, the first message may come after the requested "start" time.
@@ -88,6 +91,12 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
   // Maximum size per block
   #maxBlockSizeBytes: number;
 
+  // The current read head, used for determining which blocks are evictable
+  #currentReadHead: Time = { sec: 0, nsec: 0 };
+
+  #nextBlockId: bigint = BigInt(0);
+  #evictableBlockCandidates: CacheBlock["id"][] = [];
+
   public constructor(source: IIterableSource, opt?: Options) {
     super();
 
@@ -143,6 +152,9 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
       // Find the first index where readHead is less than an existing start
       return compare(readHead, item.start) < 0;
     };
+
+    this.#currentReadHead = readHead;
+    this.#evictableBlockCandidates = this.#findEvictableBlockCandidates(this.#currentReadHead);
 
     for (;;) {
       if (compare(readHead, maxEnd) > 0) {
@@ -238,6 +250,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
         // if there is no block, we make a new block
         if (!block) {
           const newBlock: CacheBlock = {
+            id: this.#nextBlockId++,
             start: readHead,
             end: readHead,
             items: [],
@@ -298,7 +311,12 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
 
         const sizeInBytes =
           iterResult.type === "message-event" ? iterResult.msgEvent.sizeInBytes : 0;
-        if (this.#maybePurgeCache({ activeBlock: block, sizeInBytes })) {
+        if (
+          this.#maybePurgeCache({
+            activeBlock: block,
+            sizeInBytes,
+          })
+        ) {
           this.#recomputeLoadedRangeCache();
         }
 
@@ -335,6 +353,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
         // Since we never loop again we need to insert an empty block from the readHead
         // to sourceReadEnd because we know there's nothing else in that range.
         const newBlock: CacheBlock = {
+          id: this.#nextBlockId++,
           start: readHead,
           end: sourceReadEnd,
           items: pendingIterResults,
@@ -505,7 +524,88 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     this.emit("loadedRangesChange");
   }
 
-  // Purge the oldest cache block if adding sizeInBytes to the cache would exceed the maxTotalSizeBytes
+  /**
+   * Update the current read head, such that the source can determine which blocks are evictable.
+   * @param readHead current read head
+   */
+  public updateCurrentReadHead(readHead: Time): void {
+    this.#currentReadHead = readHead;
+  }
+
+  /**
+   * Checks if the current cache size allows reading more messages into the cache or if there are
+   * blocks that can be evicted.
+   * @returns True if more messages can be read, false otherwise.
+   */
+  public canReadMore(): boolean {
+    if (this.#totalSizeBytes < this.#maxTotalSizeBytes) {
+      // Still room for reading new messages from the source.
+      return true;
+    }
+
+    return this.#evictableBlockCandidates.length > 0;
+  }
+
+  /**
+   * Determines which cache blocks can be evicted. A cache block is evictable, if
+   * - its end time is before the given readHead
+   * - it is not part of the continuous block chain starting from the block that contains
+   *   the given readHead
+   * @param readHead current read head
+   * @returns A list of evictable blocks (ordered by most evictable first) or an empty list
+   * if there is no evictable block.
+   */
+  #findEvictableBlockCandidates(readHead: Time): CacheBlock["id"][] {
+    if (this.#cache.length === 0) {
+      return [];
+    }
+
+    // Create a light, mutable copy of the current cache.
+    const mappedCache = this.#cache.map((block) => ({
+      id: block.id,
+      start: block.start,
+      end: block.end,
+    }));
+    // Sort blocks by time (earlier blocks first).
+    mappedCache.sort((a, b) => compare(a.end, b.end));
+    // Find the index of the block that contains the current read head.
+    const readHeadIdx = mappedCache.findIndex(
+      (block) => compare(block.start, readHead) <= 0 && compare(block.end, readHead) >= 0,
+    );
+
+    if (readHeadIdx === -1) {
+      // No block contains current read head, return the oldest cache block.
+      const oldestBlockIdx = minIndexBy(this.#cache, (a, b) => a.lastAccess - b.lastAccess);
+      return [this.#cache[oldestBlockIdx]!.id];
+    }
+
+    // Blocks that are before the read head can be recycled.
+    const blockIdsBeforeReadHead = mappedCache.splice(0, readHeadIdx).map((item) => item.id);
+
+    // Iterate through remaining blocks until we find a gap in the block chain
+    let prevEnd: bigint | undefined;
+    let idx = 0;
+    for (idx = 0; idx < mappedCache.length; ++idx) {
+      const block = mappedCache[idx]!;
+      const start = toNanoSec(block.start);
+      const end = toNanoSec(block.end);
+      if (prevEnd == undefined || prevEnd + 1n === start) {
+        prevEnd = end;
+      } else {
+        break;
+      }
+    }
+
+    // All blocks that are not part of the first block chain can be considered evictable.
+    const blockIdsAfterGap = mappedCache.splice(idx).map((item) => item.id);
+
+    return [
+      ...blockIdsBeforeReadHead,
+      ...blockIdsAfterGap.reverse(), // Reverse order (furthest away from read head first)
+    ];
+  }
+
+  // Attempt to purge a cache block if adding sizeInBytes to the cache would exceed the maxTotalSizeBytes
   // @return true if a block was purged
   //
   // Throws if the cache block we want to purge is the active block.
@@ -517,16 +617,22 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
       return false;
     }
 
-    // Find the oldest cache item
-    const oldestIdx = minIndexBy(this.#cache, (a, b) => a.lastAccess - b.lastAccess);
+    // Find evictable block candidates
+    this.#evictableBlockCandidates = this.#findEvictableBlockCandidates(this.#currentReadHead);
+    if (this.#evictableBlockCandidates.length === 0) {
+      return false;
+    }
 
-    const oldestBlock = this.#cache[oldestIdx];
-    if (oldestBlock) {
-      if (oldestBlock === activeBlock) {
+    // Evict the first evictable candidate
+    const blockId = this.#evictableBlockCandidates.splice(0, 1)[0];
+    const idx = this.#cache.findIndex((item) => item.id === blockId);
+    const block = this.#cache[idx];
+    if (block) {
+      if (block === activeBlock) {
         throw new Error("Cannot evict the active cache block.");
       }
-      this.#totalSizeBytes -= oldestBlock.size;
-      this.#cache.splice(oldestIdx, 1);
+      this.#totalSizeBytes -= block.size;
+      this.#cache.splice(idx, 1);
       return true;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
Stop reading messages into cache when cache is full

**Description**
Currently, we only stop reading messages into the cache after having read a sufficient time ahead (10 seconds by default). The cache size limit is not taken into account, which is often not a problem when dealing with lightweight messages. However, when reading large messages (images / pointclouds), the cache may be full before having read the entire read-ahead duration. This PR changes the behavior to also take into account the cache size when determining if more messages should be read into the cache. A positive side effect of this implementation is a smarter strategy when choosing the most evictable cache block


**Current behavior**
Only stops when read-ahead duration has been reached
![current_buffering_behavior](https://github.com/foxglove/studio/assets/9250155/5da45e50-3f40-4dd6-b0e2-8016c217618a)

Always evicts oldest cache block which can cause unnecessary re-reads
![Peek 2023-08-11 19-31](https://github.com/foxglove/studio/assets/9250155/368d995b-2039-4288-a382-193de5bba767)


**New behavior**
Stops when either read-ahead duration has been read or when cache is full 
![new_buffering_behavior](https://github.com/foxglove/studio/assets/9250155/3453f1d5-5a5d-426c-97ef-6901c892d132)

uses a smart strategy for choosing the best evictable cache block
![Peek 2023-08-11 19-32](https://github.com/foxglove/studio/assets/9250155/e6d11dd8-a818-4511-9409-ab23da834fd4)

Fixes FG-4631






