### PR TITLE
Add "resetDeepLinks" to Desktop interface

### DIFF
--- a/packages/studio-base/src/components/AppBar/AppBarContainer.tsx
+++ b/packages/studio-base/src/components/AppBar/AppBarContainer.tsx
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { AppBar as MuiAppBar } from "@mui/material";
+import { CSSProperties, PropsWithChildren, useCallback, useMemo } from "react";
+import { makeStyles } from "tss-react/mui";
+
+import { APP_BAR_HEIGHT } from "./constants";
+
+type Props = PropsWithChildren<{
+  leftInset?: number;
+  onDoubleClick?: () => void;
+}>;
+
+const useStyles = makeStyles()((theme) => {
+  return {
+    root: {
+      gridArea: "appbar",
+      boxShadow: "none",
+      backgroundColor: theme.palette.appBar.main,
+      borderBottom: "none",
+      color: theme.palette.common.white,
+      height: APP_BAR_HEIGHT,
+
+      paddingRight: "calc(100% - env(titlebar-area-x) - env(titlebar-area-width))",
+      WebkitAppRegion: "drag", // make custom window title bar draggable for desktop app
+    },
+  };
+});
+
+export function AppBarContainer(props: Props): JSX.Element {
+  const { children, leftInset, onDoubleClick } = props;
+  const { classes } = useStyles();
+
+  // Leave space for system window controls on the right on Windows.
+  // Use hard-coded padding for Mac because it looks better than env(titlebar-area-x).
+  const extraStyle = useMemo<CSSProperties>(() => ({ paddingLeft: leftInset }), [leftInset]);
+
+  const handleDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      onDoubleClick?.();
+    },
+    [onDoubleClick],
+  );
+
+  return (
+    <MuiAppBar
+      className={classes.root}
+      style={extraStyle}
+      position="relative"
+      color="inherit"
+      elevation={0}
+      onDoubleClick={handleDoubleClick}
+      data-tourid="app-bar"
+    >
+      {children}
+    </MuiAppBar>
+  );
+}

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -10,8 +10,8 @@ import {
   PanelRight24Regular,
   SlideAdd24Regular,
 } from "@fluentui/react-icons";
-import { Avatar, Button, IconButton, AppBar as MuiAppBar, Tooltip } from "@mui/material";
-import { useCallback, useState } from "react";
+import { Avatar, Button, IconButton, Tooltip } from "@mui/material";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
@@ -43,33 +43,17 @@ import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { AddPanelMenu } from "./AddPanelMenu";
+import { AppBarContainer } from "./AppBarContainer";
 import { DataSource } from "./DataSource";
 import { UserMenu } from "./UserMenu";
-import { APP_BAR_HEIGHT } from "./constants";
 
-const useStyles = makeStyles<{ leftInset?: number; debugDragRegion?: boolean }, "avatar">()(
-  (theme, { leftInset, debugDragRegion = false }, classes) => {
-    const DRAGGABLE_STYLE: Record<string, string> = { WebkitAppRegion: "drag" };
+const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()(
+  (theme, { debugDragRegion = false }, classes) => {
     const NOT_DRAGGABLE_STYLE: Record<string, string> = { WebkitAppRegion: "no-drag" };
     if (debugDragRegion) {
-      DRAGGABLE_STYLE.backgroundColor = "green";
       NOT_DRAGGABLE_STYLE.backgroundColor = "red";
     }
     return {
-      appBar: {
-        gridArea: "appbar",
-        boxShadow: "none",
-        backgroundColor: theme.palette.appBar.main,
-        borderBottom: "none",
-        color: theme.palette.common.white,
-        height: APP_BAR_HEIGHT,
-
-        // Leave space for system window controls on the right on Windows.
-        // Use hard-coded padding for Mac because it looks better than env(titlebar-area-x).
-        paddingLeft: leftInset,
-        paddingRight: "calc(100% - env(titlebar-area-x) - env(titlebar-area-width))",
-        ...DRAGGABLE_STYLE, // make custom window title bar draggable for desktop app
-      },
       toolbar: {
         display: "grid",
         width: "100%",
@@ -203,7 +187,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
     onUnmaximizeWindow,
     showCustomWindowControls = false,
   } = props;
-  const { classes, cx, theme } = useStyles({ leftInset, debugDragRegion });
+  const { classes, cx, theme } = useStyles({ debugDragRegion });
   const { currentUser, signIn } = useCurrentUser();
   const { t } = useTranslation("appBar");
 
@@ -232,25 +216,9 @@ export function AppBar(props: AppBarProps): JSX.Element {
   const userMenuOpen = Boolean(userAnchorEl);
   const panelMenuOpen = Boolean(panelAnchorEl);
 
-  const handleDoubleClick = useCallback(
-    (event: React.MouseEvent) => {
-      event.stopPropagation();
-      event.preventDefault();
-      onDoubleClick?.();
-    },
-    [onDoubleClick],
-  );
-
   return (
     <>
-      <MuiAppBar
-        className={classes.appBar}
-        position="relative"
-        color="inherit"
-        elevation={0}
-        onDoubleClick={handleDoubleClick}
-        data-tourid="app-bar"
-      >
+      <AppBarContainer onDoubleClick={onDoubleClick} leftInset={leftInset}>
         <div className={classes.toolbar}>
           <div className={classes.start}>
             <div className={classes.startInner}>
@@ -387,7 +355,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
             </div>
           </div>
         </div>
-      </MuiAppBar>
+      </AppBarContainer>
       <AddPanelMenu
         anchorEl={panelAnchorEl}
         open={panelMenuOpen}

--- a/packages/studio-desktop/src/common/types.ts
+++ b/packages/studio-desktop/src/common/types.ts
@@ -87,6 +87,9 @@ interface Desktop {
   // Get an array of deep links provided on app launch
   getDeepLinks: () => string[];
 
+  // Reset the deep links. After reset, `getDeepLinks` will return an empty array.
+  resetDeepLinks: () => void;
+
   // Get an array of available extensions and parsed package.json files
   getExtensions: () => Promise<DesktopExtension[]>;
 

--- a/packages/studio-desktop/src/preload/index.ts
+++ b/packages/studio-desktop/src/preload/index.ts
@@ -22,6 +22,14 @@ import {
 } from "../common/types";
 import { FOXGLOVE_PRODUCT_NAME, FOXGLOVE_PRODUCT_VERSION } from "../common/webpackDefines";
 
+// Since we have no way of modifying `window.process.argv` we use a sentinel cookie and reload
+// hack to reset the page without deep links. By setting a session cookie and reloading
+// we allow this preload script to read the cookie and ignore deep links in `getDeepLinks`
+const ignoreDeepLinks = document.cookie.includes("fox.ignoreDeepLinks=true");
+document.cookie = "";
+
+const deepLinks = ignoreDeepLinks ? [] : decodeRendererArg("deepLinks", window.process.argv) ?? [];
+
 export function main(): void {
   const log = Logger.getLogger(__filename);
 
@@ -106,7 +114,16 @@ export function main(): void {
       await ipcRenderer.invoke("updateNativeColorScheme");
     },
     getDeepLinks(): string[] {
-      return decodeRendererArg("deepLinks", window.process.argv) ?? [];
+      return deepLinks;
+    },
+    resetDeepLinks(): void {
+      // See `ignoreDeepLinks` comment above for why we do this hack to reset deep links
+
+      // set a session cookie called "fox.ignoreDeepLinks"
+      document.cookie = "fox.ignoreDeepLinks=true;";
+
+      // Reload the window so the new preloader script can read the cookie
+      window.location.reload();
     },
     async getExtensions() {
       const homePath = (await ipcRenderer.invoke("getHomePath")) as string;

--- a/packages/studio-desktop/src/preload/index.ts
+++ b/packages/studio-desktop/src/preload/index.ts
@@ -26,7 +26,7 @@ import { FOXGLOVE_PRODUCT_NAME, FOXGLOVE_PRODUCT_VERSION } from "../common/webpa
 // hack to reset the page without deep links. By setting a session cookie and reloading
 // we allow this preload script to read the cookie and ignore deep links in `getDeepLinks`
 const ignoreDeepLinks = document.cookie.includes("fox.ignoreDeepLinks=true");
-document.cookie = `fox.ignoreDeepLinks=;max-age=0;`;
+document.cookie = "fox.ignoreDeepLinks=;max-age=0;";
 
 const deepLinks = ignoreDeepLinks ? [] : decodeRendererArg("deepLinks", window.process.argv) ?? [];
 

--- a/packages/studio-desktop/src/preload/index.ts
+++ b/packages/studio-desktop/src/preload/index.ts
@@ -26,7 +26,7 @@ import { FOXGLOVE_PRODUCT_NAME, FOXGLOVE_PRODUCT_VERSION } from "../common/webpa
 // hack to reset the page without deep links. By setting a session cookie and reloading
 // we allow this preload script to read the cookie and ignore deep links in `getDeepLinks`
 const ignoreDeepLinks = document.cookie.includes("fox.ignoreDeepLinks=true");
-document.cookie = "";
+document.cookie = `fox.ignoreDeepLinks=;max-age=0;`;
 
 const deepLinks = ignoreDeepLinks ? [] : decodeRendererArg("deepLinks", window.process.argv) ?? [];
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**

The resetDeepLinks function resets the deep links for the desktop app by using a cookie + reload hack. Since deep links are only read on startup
we need to avoid reading them if we want to ignore them in App.

This change also extracts the root element of the AppBar into its own component so we can use it without using the entire AppBar. We need this since our desktop app disables system titlebar and we still want an AppBar background when we want to avoid rendering the workspace which renders the AppBar.