### PR TITLE
foxglove websocket: Remember parameter types

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -45,7 +45,7 @@
     "@foxglove/velodyne-cloud": "1.0.1",
     "@foxglove/wasm-bz2": "0.1.1",
     "@foxglove/wasm-lz4": "1.0.2",
-    "@foxglove/ws-protocol": "0.7.0",
+    "@foxglove/ws-protocol": "0.7.1",
     "@foxglove/xmlrpc": "1.3.0",
     "@mcap/core": "1.3.0",
     "@mui/icons-material": "5.14.3",

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -139,6 +139,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   #nextAssetRequestId = 0;
   #fetchAssetRequests = new Map<number, (response: FetchAssetResponse) => void>();
   #fetchedAssets = new Map<string, Promise<Asset>>();
+  #parameterTypeByName = new Map<string, Parameter["type"]>();
 
   public constructor({
     url,
@@ -568,17 +569,23 @@ export default class FoxgloveWebSocketPlayer implements Player {
             }
           : param;
       });
+      const parameterTypes = parameters.map((p) => [p.name, p.type] as [string, Parameter["type"]]);
+      const parameterTypesMap = new Map<string, Parameter["type"]>(parameterTypes);
 
       const newParameters = mappedParameters.filter((param) => !this.#parameters.has(param.name));
 
       if (id === GET_ALL_PARAMS_REQUEST_ID) {
         // Reset params
         this.#parameters = new Map(mappedParameters.map((param) => [param.name, param.value]));
+        this.#parameterTypeByName = parameterTypesMap;
       } else {
         // Update params
         const updatedParameters = new Map(this.#parameters);
         mappedParameters.forEach((param) => updatedParameters.set(param.name, param.value));
         this.#parameters = updatedParameters;
+        for (const [paramName, paramType] of parameterTypesMap) {
+          this.#parameterTypeByName.set(paramName, paramType);
+        }
       }
 
       this.#emitState();
@@ -940,7 +947,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         {
           name: key,
           value: paramValueToSent as Parameter["value"],
-          type: isByteArray ? "byte_array" : undefined,
+          type: isByteArray ? "byte_array" : this.#parameterTypeByName.get(key),
         },
       ],
       uuidv4(),
@@ -1200,6 +1207,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       });
     }
     this.#fetchAssetRequests.clear();
+    this.#parameterTypeByName.clear();
   }
 
   #updateDataTypes(datatypes: MessageDefinitionMap): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,7 +2639,7 @@ __metadata:
     "@foxglove/velodyne-cloud": 1.0.1
     "@foxglove/wasm-bz2": 0.1.1
     "@foxglove/wasm-lz4": 1.0.2
-    "@foxglove/ws-protocol": 0.7.0
+    "@foxglove/ws-protocol": 0.7.1
     "@foxglove/xmlrpc": 1.3.0
     "@mcap/core": 1.3.0
     "@mui/icons-material": 5.14.3
@@ -2923,14 +2923,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ws-protocol@npm:0.7.0":
-  version: 0.7.0
-  resolution: "@foxglove/ws-protocol@npm:0.7.0"
+"@foxglove/ws-protocol@npm:0.7.1":
+  version: 0.7.1
+  resolution: "@foxglove/ws-protocol@npm:0.7.1"
   dependencies:
     debug: ^4
     eventemitter3: ^5.0.1
-    tslib: ^2.5.3
-  checksum: e0850fd9b034526027e450d48c60f1d447d519da01d882ca342f8dcbf935611c217c6eac996b2ed486749a394ba006f80fd7f39b4393cf7be3a65003fecca700
+    tslib: ^2.6.0
+  checksum: 913681bf45109f9989d60329270727381192e5fc278de1df50bb5c88f2376c7c97570e9a8c79c5761c3a6af0277e88b9a455c3973205c7d6bbdcf8f8a9dd3567
   languageName: node
   linkType: hard
 
@@ -19970,7 +19970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.6.1, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.5.3":
+"tslib@npm:2.6.1, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.0":
   version: 2.6.1
   resolution: "tslib@npm:2.6.1"
   checksum: b0d176d176487905b66ae4d5856647df50e37beea7571c53b8d10ba9222c074b81f1410fb91da13debaf2cbc970663609068bdebafa844ea9d69b146527c38fe


### PR DESCRIPTION
**User-Facing Changes**
Not worth being mentioned in release notes

**Description**
When setting a float parameter to e.g. `1.0`, Javascript automatically makes it to `1` and the server would deduce this as a integer parameter. Remembering the parameter type that is communicated by the server, and sending it along with a `setParameter` request fixes this.

See also https://github.com/foxglove/ws-protocol/pull/519 and https://github.com/foxglove/ros-foxglove-bridge/pull/256

Fixes https://github.com/foxglove/studio/issues/6559