### PR TITLE
Fix imu chart in sample data

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
@@ -324,7 +324,7 @@
         {
           "value": "/imu.linear_accel.x",
           "enabled": true,
-          "timestampMethod": "headerStamp"
+          "timestampMethod": "receiveTime"
         },
         {
           "value": "/diagnostics.status[:].values[:]{key==\"throttle_sensor\"}.value",


### PR DESCRIPTION
**User-Facing Changes**
Fix imu diagnostics chart in the sample data layout.

**Description**
The imu series in the sample layout is set to order by header stamp, which results in an empty series:
<img width="1414" alt="Screenshot 2023-08-09 at 8 28 40 AM" src="https://github.com/foxglove/studio/assets/93935560/f5d42cf2-7aa9-40c7-ab4e-5e47492c7efb">

Changing it to receiveTime fixes it:
<img width="1412" alt="Screenshot 2023-08-09 at 8 29 01 AM" src="https://github.com/foxglove/studio/assets/93935560/445cc27c-9181-4443-b8b2-eca793440497">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
