### PR TITLE
Fix transforms edits being cleared when seeking backwards

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -418,6 +418,10 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     for (const frameId of this.renderer.transformTree.frames().keys()) {
       this.#addFrameAxis(frameId);
     }
+    const config = this.renderer.config;
+    if (config.scene.transforms?.editable === true) {
+      this.#updateFrameAxes();
+    }
     this.updateSettingsTree();
   };
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix transforms edits being cleared when seeking backwards

**Description**
Seeking backwards in time clears the transform tree. When the transforms are added again, the offsets weren't being added back to the new, now-refreshed transforms. This PR adds the `#updateFrameAxes` to the `transformTreeUpdated` listener, so that it can apply these offsets when the frames are added back to the tree. 


<!-- link relevant GitHub issues -->
Fixes: FG-4553
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
