### PR TITLE
Show alert when marketplace extension fetch fails

### DIFF
--- a/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.stories.tsx
@@ -103,3 +103,26 @@ export const Sidebar: StoryObj = {
     );
   },
 };
+
+export const WithoutNetwork: StoryObj = {
+  render: function Story() {
+    const [config] = useState(() => makeMockAppConfiguration());
+
+    const marketPlace = {
+      ...MockExtensionMarketplace,
+      getAvailableExtensions: () => {
+        throw new Error("offline");
+      },
+    };
+
+    return (
+      <AppConfigurationContext.Provider value={config}>
+        <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
+          <ExtensionMarketplaceContext.Provider value={marketPlace}>
+            <ExtensionsSettings />
+          </ExtensionMarketplaceContext.Provider>
+        </ExtensionCatalogProvider>
+      </AppConfigurationContext.Provider>
+    );
+  },
+};

--- a/packages/studio-base/src/components/ExtensionsSettings/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.tsx
@@ -2,7 +2,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Button, List, ListItem, ListItemButton, ListItemText, Typography } from "@mui/material";
+import {
+  Alert,
+  Button,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from "@mui/material";
 import { differenceWith, groupBy, isEmpty, keyBy } from "lodash";
 import { useEffect, useMemo, useState } from "react";
 import { useAsyncFn } from "react-use";
@@ -152,22 +160,21 @@ export default function ExtensionsSettings(): React.ReactElement {
     );
   }
 
-  if (marketplaceEntries.error) {
-    return (
-      <Stack gap={1} alignItems="center" justifyContent="center" fullHeight>
-        <Typography align="center" variant="body2" color="text.secondary">
-          Failed to fetch the list of available extensions. Check your Internet connection and try
-          again.
-        </Typography>
-        <Button onClick={async () => await refreshMarketplaceEntries()}>
-          Retry Fetching Extensions
-        </Button>
-      </Stack>
-    );
-  }
-
   return (
     <Stack gap={1}>
+      {marketplaceEntries.error && (
+        <Alert severity="error">
+          <Stack gap={1} alignItems="center" justifyContent="center" fullHeight>
+            <Typography align="center" variant="body2" color="text.secondary">
+              Failed to fetch the list of available marketplace extensions. Check your Internet
+              connection and try again.
+            </Typography>
+            <Button onClick={async () => await refreshMarketplaceEntries()}>
+              Retry Fetching Extensions
+            </Button>
+          </Stack>
+        </Alert>
+      )}
       {!isEmpty(namespacedEntries) ? (
         Object.entries(namespacedEntries).map(([namespace, entries]) => (
           <List key={namespace}>

--- a/packages/studio-base/src/components/ExtensionsSettings/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.tsx
@@ -4,6 +4,7 @@
 
 import {
   Alert,
+  AlertTitle,
   Button,
   List,
   ListItem,

--- a/packages/studio-base/src/components/ExtensionsSettings/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.tsx
@@ -164,14 +164,16 @@ export default function ExtensionsSettings(): React.ReactElement {
   return (
     <Stack gap={1}>
       {marketplaceEntries.error && (
-        <Alert severity="error">
-          <Stack gap={1} alignItems="center" justifyContent="center" fullHeight>
-            <AlertTitle>Failed to fetch the list of available marketplace extensions,</AlertTitle>
-            Check your Internet connection and try again.
-            <Button onClick={async () => await refreshMarketplaceEntries()}>
-              Retry Fetching Extensions
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" onClick={async () => await refreshMarketplaceEntries()}>
+              Retry
             </Button>
-          </Stack>
+          }
+        >
+          <AlertTitle>Failed to retrieve the list of available marketplace extensions</AlertTitle>
+          Check your internet connection and try again.
         </Alert>
       )}
       {!isEmpty(namespacedEntries) ? (

--- a/packages/studio-base/src/components/ExtensionsSettings/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSettings/index.tsx
@@ -165,10 +165,8 @@ export default function ExtensionsSettings(): React.ReactElement {
       {marketplaceEntries.error && (
         <Alert severity="error">
           <Stack gap={1} alignItems="center" justifyContent="center" fullHeight>
-            <Typography align="center" variant="body2" color="text.secondary">
-              Failed to fetch the list of available marketplace extensions. Check your Internet
-              connection and try again.
-            </Typography>
+            <AlertTitle>Failed to fetch the list of available marketplace extensions,</AlertTitle>
+            Check your Internet connection and try again.
             <Button onClick={async () => await refreshMarketplaceEntries()}>
               Retry Fetching Extensions
             </Button>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When the marketplace extension fetch fails show an error alert and render the local extensions instead of rendering only the error message and leaving the rest of the view unusable.

<img width="726" alt="Screenshot 2023-08-14 at 11 59 05 AM" src="https://github.com/foxglove/studio/assets/93935560/3f1ae560-a137-4313-8514-d15bba5ca25c">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
