### PR TITLE
Fix handling of x axis indexed plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -12,10 +12,10 @@
 //   You may not use this file except in compliance with the License.
 
 import { StoryObj } from "@storybook/react";
-import { screen, userEvent } from "@storybook/testing-library";
+import { screen, userEvent, waitFor } from "@storybook/testing-library";
 import { produce } from "immer";
 import { shuffle } from "lodash";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { fromSec } from "@foxglove/rostime";
@@ -1149,7 +1149,12 @@ export const IndexBasedXAxisForArray: StoryObj = {
 export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   render: function Story() {
     const readySignal = useReadySignal({ count: 3 });
-    const pauseFrame = useCallback(() => {
+
+    const [ourFixture, setOurFixture] = useState(structuredClone(fixture));
+
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    useEffect(() => {
       setOurFixture((oldValue) => {
         return {
           ...oldValue,
@@ -1161,8 +1166,8 @@ export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
                 message: {
                   header: { stamp: { sec: 3, nsec: 0 } },
                   items: [
-                    { id: 10, speed: 4 },
-                    { id: 42, speed: 2 },
+                    { id: 10, speed: 1 },
+                    { id: 42, speed: 10 },
                   ],
                 },
                 schemaName: "msgs/State",
@@ -1172,10 +1177,7 @@ export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
           },
         };
       });
-
-      return readySignal;
-    }, [readySignal]);
-    const [ourFixture, setOurFixture] = useState(structuredClone(fixture));
+    }, []);
 
     return (
       <PlotWrapper
@@ -1203,7 +1205,7 @@ export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   },
 
   play: async (ctx) => {
-    await ctx.parameters.storyReady;
+    await waitFor(() => ctx.parameters.storyReady);
   },
 };
 

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -185,7 +185,9 @@ export function usePlotPanelData(params: Params): Immutable<{
 
   const allFramesByTopic = useAllFramesByTopic(subscribeTopics);
 
-  const allFrames = showSingleCurrentMessage ? EmptyAllFrames : allFramesByTopic;
+  // If showing a single message skip all messages coming from allFrames and use the messages from
+  // useMessageReducer only.
+  const allFramesToProcess = showSingleCurrentMessage ? EmptyAllFrames : allFramesByTopic;
 
   const messageDataPathGetter = useCachedGetMessagePathDataItems(validAllPathValues);
 
@@ -198,7 +200,7 @@ export function usePlotPanelData(params: Params): Immutable<{
     xAxisPathAsFullPlotPath !== state.xAxisPath ||
     globalVariables !== state.globalVariables;
 
-  if (allFrames !== state.allFrames || validAllPaths !== state.allPaths || resetDatasets) {
+  if (allFramesToProcess !== state.allFrames || validAllPaths !== state.allPaths || resetDatasets) {
     // Derive a new state based on the old state & new message data. Note that we maintain a
     // separate cursor into allFrames for each path. This is necessary because newly added series
     // might have the same path as previous series but will need to process all messages not from
@@ -221,7 +223,7 @@ export function usePlotPanelData(params: Params): Immutable<{
           continue;
         }
 
-        const newMessages = allFrames[topic]?.slice(newCursors.get(path) ?? 0);
+        const newMessages = allFramesToProcess[topic]?.slice(newCursors.get(path) ?? 0);
 
         if (newMessages == undefined || newMessages.length === 0) {
           continue;
@@ -255,7 +257,7 @@ export function usePlotPanelData(params: Params): Immutable<{
         : EmptyPlotData;
 
       return {
-        allFrames,
+        allFrames: allFramesToProcess,
         allPaths: validAllPaths,
         cursors: newCursors,
         data: appendPlotData(newState.data, newPlotData),
@@ -305,7 +307,7 @@ export function usePlotPanelData(params: Params): Immutable<{
   );
 
   // Access allFrames by reference to avoid invalidating the addMessages callback.
-  const latestAllFrames = useLatest(allFrames);
+  const latestAllFrames = useLatest(allFramesToProcess);
 
   const addMessages = useCallback(
     (accumulated: TaggedPlotData, msgEvents: Immutable<MessageEvent[]>) => {
@@ -431,7 +433,7 @@ export function usePlotPanelData(params: Params): Immutable<{
     const trimmed = filterMap(Object.values(accumulatedPathIntervals), (dataset) => {
       const trimmedDatasets = maps.mapValues(dataset.datasetsByPath, (ds, path) => {
         const topic = parseRosPath(path.value)?.topicName;
-        const end = topic ? allFrames[topic]?.at(-1)?.receiveTime : undefined;
+        const end = topic ? allFramesToProcess[topic]?.at(-1)?.receiveTime : undefined;
         if (end) {
           return {
             ...ds,
@@ -455,7 +457,7 @@ export function usePlotPanelData(params: Params): Immutable<{
     }
 
     return trimmed;
-  }, [accumulatedPathIntervals, allFrames]);
+  }, [accumulatedPathIntervals, allFramesToProcess]);
 
   // Combine allFrames & currentFrames datasets, optionally applying the @derivative
   // modifier and sorting by header stamp, which can only be calculated on a complete

--- a/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelData.ts
@@ -221,7 +221,8 @@ export function usePlotPanelData(params: Params): Immutable<{
           continue;
         }
 
-        const newMessages = allFramesByTopic[topic]?.slice(newCursors.get(path) ?? 0);
+        const newMessages = allFrames[topic]?.slice(newCursors.get(path) ?? 0);
+
         if (newMessages == undefined || newMessages.length === 0) {
           continue;
         }


### PR DESCRIPTION
**User-Facing Changes**
Fix issue with indexed x-axis plot rendering.

**Description**
When the x-axis of the plot is set to "Indexed" mode we should only use messages from currentFrame.

Fixes regression from #6577 

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
