### PR TITLE
foxglove websocket: Transfer arrayBuffer messages from worker

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
@@ -27,14 +27,7 @@ export default class WorkerSocketAdapter implements IWebSocket {
       }
     };
 
-    this.#worker.onmessage = (event: MessageEvent<FromWorkerMessage | ArrayBuffer>) => {
-      if (event.data instanceof ArrayBuffer) {
-        if (this.onmessage) {
-          this.onmessage(event);
-        }
-        return;
-      }
-
+    this.#worker.onmessage = (event: MessageEvent<FromWorkerMessage>) => {
       switch (event.data.type) {
         case "open":
           if (this.onopen) {
@@ -56,7 +49,7 @@ export default class WorkerSocketAdapter implements IWebSocket {
             this.onerror(event.data);
           }
           break;
-        case "textMessage":
+        case "message":
           if (this.onmessage) {
             this.onmessage(event.data);
           }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
@@ -27,7 +27,14 @@ export default class WorkerSocketAdapter implements IWebSocket {
       }
     };
 
-    this.#worker.onmessage = (event: MessageEvent<FromWorkerMessage>) => {
+    this.#worker.onmessage = (event: MessageEvent<FromWorkerMessage | ArrayBuffer>) => {
+      if (event.data instanceof ArrayBuffer) {
+        if (this.onmessage) {
+          this.onmessage(event);
+        }
+        return;
+      }
+
       switch (event.data.type) {
         case "open":
           if (this.onopen) {
@@ -49,7 +56,7 @@ export default class WorkerSocketAdapter implements IWebSocket {
             this.onerror(event.data);
           }
           break;
-        case "message":
+        case "textMessage":
           if (this.onmessage) {
             this.onmessage(event.data);
           }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
@@ -15,9 +15,9 @@ export type FromWorkerMessage =
 
 let ws: WebSocket | undefined = undefined;
 
-const send = (msg: FromWorkerMessage, transfer?: Transferable[]): void => {
-  self.postMessage(msg, transfer ?? []);
-};
+const send: (message: FromWorkerMessage) => void = self.postMessage;
+const sendWithTransfer: (message: FromWorkerMessage, transfer: Transferable[]) => void =
+  self.postMessage;
 
 self.onmessage = (event: MessageEvent<ToWorkerMessage>) => {
   const { type, data } = event.data;
@@ -42,13 +42,20 @@ self.onmessage = (event: MessageEvent<ToWorkerMessage>) => {
           send({ type: "close", data: JSON.parse(JSON.stringify(wsEvent) ?? "{}") });
         };
         ws.onmessage = (wsEvent: MessageEvent) => {
-          send(
-            {
+          if (wsEvent.data instanceof ArrayBuffer) {
+            sendWithTransfer(
+              {
+                type: "message",
+                data: wsEvent.data,
+              },
+              [wsEvent.data],
+            );
+          } else {
+            send({
               type: "message",
               data: wsEvent.data,
-            },
-            wsEvent.data instanceof ArrayBuffer ? [wsEvent.data] : [],
-          );
+            });
+          }
         };
       } catch (err) {
         // try-catch is needed to catch `Mixed Content` errors in Chrome, where the client

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
@@ -11,17 +11,12 @@ export type FromWorkerMessage =
   | { type: "open"; protocol: string }
   | { type: "close"; data: unknown }
   | { type: "error"; error: unknown }
-  | { type: "textMessage"; data: unknown }
-  | ArrayBuffer;
+  | { type: "message"; data: unknown };
 
 let ws: WebSocket | undefined = undefined;
 
-const send = (msg: FromWorkerMessage): void => {
-  if (msg instanceof ArrayBuffer) {
-    self.postMessage(msg, [msg]);
-  } else {
-    self.postMessage(msg);
-  }
+const send = (msg: FromWorkerMessage, transfer?: Transferable[]): void => {
+  self.postMessage(msg, transfer ?? []);
 };
 
 self.onmessage = (event: MessageEvent<ToWorkerMessage>) => {
@@ -47,10 +42,13 @@ self.onmessage = (event: MessageEvent<ToWorkerMessage>) => {
           send({ type: "close", data: JSON.parse(JSON.stringify(wsEvent) ?? "{}") });
         };
         ws.onmessage = (wsEvent: MessageEvent) => {
-          send({
-            type: "textMessage",
-            data: wsEvent.data,
-          });
+          send(
+            {
+              type: "message",
+              data: wsEvent.data,
+            },
+            wsEvent.data instanceof ArrayBuffer ? [wsEvent.data] : [],
+          );
         };
       } catch (err) {
         // try-catch is needed to catch `Mixed Content` errors in Chrome, where the client

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/worker.ts
@@ -11,12 +11,17 @@ export type FromWorkerMessage =
   | { type: "open"; protocol: string }
   | { type: "close"; data: unknown }
   | { type: "error"; error: unknown }
-  | { type: "message"; data: unknown };
+  | { type: "textMessage"; data: unknown }
+  | ArrayBuffer;
 
 let ws: WebSocket | undefined = undefined;
 
 const send = (msg: FromWorkerMessage): void => {
-  self.postMessage(msg);
+  if (msg instanceof ArrayBuffer) {
+    self.postMessage(msg, [msg]);
+  } else {
+    self.postMessage(msg);
+  }
 };
 
 self.onmessage = (event: MessageEvent<ToWorkerMessage>) => {
@@ -43,7 +48,7 @@ self.onmessage = (event: MessageEvent<ToWorkerMessage>) => {
         };
         ws.onmessage = (wsEvent: MessageEvent) => {
           send({
-            type: "message",
+            type: "textMessage",
             data: wsEvent.data,
           });
         };


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
From https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects

> For example, when an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) is transferred between threads, the memory resource that it points to is literally moved between contexts in a fast and efficient zero-copy operation



