### PR TITLE
Support `step` for raw images

### DIFF
--- a/packages/den/image/decodings.test.ts
+++ b/packages/den/image/decodings.test.ts
@@ -62,6 +62,9 @@ describe("decodeBGR8", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `"BGR8 image row step (11) must be at least 3*width (12)"`,
     );
+    expect(() =>
+      decodeBGR8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -97,6 +100,9 @@ describe("decodeBGRA8", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `"BGRA8 image row step (15) must be at least 4*width (16)"`,
     );
+    expect(() =>
+      decodeBGRA8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -132,6 +138,9 @@ describe("decodeRGB8", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `"RGB8 image row step (11) must be at least 3*width (12)"`,
     );
+    expect(() =>
+      decodeRGB8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -167,6 +176,9 @@ describe("decodeRGBA8", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `"RGBA8 image row step (15) must be at least 4*width (16)"`,
     );
+    expect(() =>
+      decodeRGBA8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -197,6 +209,9 @@ describe("decodeMono8", () => {
     expect(() =>
       decodeMono8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
     ).toThrowErrorMatchingInlineSnapshot(`"Uint8 image row step (3) must be at least width (4)"`);
+    expect(() =>
+      decodeMono8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -283,6 +298,16 @@ describe("decodeMono16", () => {
         new Uint8ClampedArray([]),
       ),
     ).toThrowErrorMatchingInlineSnapshot(`"RGBA8 image row step (7) must be at least 2*width (8)"`);
+    expect(() =>
+      decodeMono16(
+        new Uint8Array(width * height * 2),
+        width,
+        height,
+        step + 1,
+        /*is_bigendian=*/ false,
+        new Uint8ClampedArray([]),
+      ),
+    ).not.toThrow();
   });
 });
 
@@ -338,6 +363,16 @@ describe("decodeFloat1c", () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `"Float image row step (15) must be at least 4*width (16)"`,
     );
+    expect(() =>
+      decodeFloat1c(
+        new Uint8Array(width * height * 4),
+        width,
+        height,
+        step + 1,
+        /*is_bigendian=*/ false,
+        new Uint8ClampedArray([]),
+      ),
+    ).not.toThrow();
   });
 });
 
@@ -371,6 +406,10 @@ describe("decodeUYVY", () => {
     expect(() =>
       decodeUYVY(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
     ).toThrowErrorMatchingInlineSnapshot(`"UYVY image row step (7) must be at least 2*width (8)"`);
+
+    expect(() =>
+      decodeUYVY(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -404,6 +443,9 @@ describe("decodeYUYV", () => {
     expect(() =>
       decodeYUYV(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
     ).toThrowErrorMatchingInlineSnapshot(`"YUYV image row step (7) must be at least 2*width (8)"`);
+    expect(() =>
+      decodeYUYV(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+    ).not.toThrow();
   });
 });
 
@@ -443,6 +485,9 @@ describe("decodeBayer*()", () => {
       expect(() =>
         decodeBayerBGGR8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
       ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+      expect(() =>
+        decodeBayerBGGR8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+      ).not.toThrow();
     });
   });
 
@@ -473,6 +518,9 @@ describe("decodeBayer*()", () => {
       expect(() =>
         decodeBayerGBRG8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
       ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+      expect(() =>
+        decodeBayerGBRG8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+      ).not.toThrow();
     });
   });
 
@@ -503,6 +551,9 @@ describe("decodeBayer*()", () => {
       expect(() =>
         decodeBayerGRBG8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
       ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+      expect(() =>
+        decodeBayerGRBG8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+      ).not.toThrow();
     });
   });
 
@@ -533,6 +584,9 @@ describe("decodeBayer*()", () => {
       expect(() =>
         decodeBayerRGGB8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
       ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+      expect(() =>
+        decodeBayerRGGB8(new Uint8Array([]), width, height, step + 1, new Uint8ClampedArray([])),
+      ).not.toThrow();
     });
   });
 });

--- a/packages/den/image/decodings.test.ts
+++ b/packages/den/image/decodings.test.ts
@@ -1,24 +1,538 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
-import { decodeBayerRGGB8 } from "./decodings";
+import {
+  decodeBGR8,
+  decodeBGRA8,
+  decodeBayerBGGR8,
+  decodeBayerGBRG8,
+  decodeBayerGRBG8,
+  decodeBayerRGGB8,
+  decodeFloat1c,
+  decodeMono16,
+  decodeMono8,
+  decodeRGB8,
+  decodeRGBA8,
+  decodeUYVY,
+  decodeYUYV,
+} from "./decodings";
+
+function float32LE(num: number) {
+  const result = new Uint8Array(4);
+  new DataView(result.buffer).setFloat32(0, num, true);
+  return result;
+}
+
+function uint16LE(num: number) {
+  const result = new Uint8Array(2);
+  new DataView(result.buffer).setUint16(0, num, true);
+  return result;
+}
+
+describe("decodeBGR8", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 3 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeBGR8(
+      new Uint8Array([
+        ...[1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 88, 99],
+        ...[41, 42, 43, 51, 52, 53, 61, 62, 63, 71, 72, 73, 88, 99],
+      ]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        ...[3, 2, 1, 255, 13, 12, 11, 255, 23, 22, 21, 255, 33, 32, 31, 255],
+        ...[43, 42, 41, 255, 53, 52, 51, 255, 63, 62, 61, 255, 73, 72, 71, 255],
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 3 * width - 1;
+    expect(() =>
+      decodeBGR8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"BGR8 image row step (11) must be at least 3*width (12)"`,
+    );
+  });
+});
+
+describe("decodeBGRA8", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 4 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeBGRA8(
+      new Uint8Array([
+        ...[1, 2, 3, 4, 11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34, 88, 99],
+        ...[41, 42, 43, 44, 51, 52, 53, 54, 61, 62, 63, 64, 71, 72, 73, 74, 88, 99],
+      ]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        ...[3, 2, 1, 4, 13, 12, 11, 14, 23, 22, 21, 24, 33, 32, 31, 34],
+        ...[43, 42, 41, 44, 53, 52, 51, 54, 63, 62, 61, 64, 73, 72, 71, 74],
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 4 * width - 1;
+    expect(() =>
+      decodeBGRA8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"BGRA8 image row step (15) must be at least 4*width (16)"`,
+    );
+  });
+});
+
+describe("decodeRGB8", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 3 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeRGB8(
+      new Uint8Array([
+        ...[1, 2, 3, 11, 12, 13, 21, 22, 23, 31, 32, 33, 88, 99],
+        ...[41, 42, 43, 51, 52, 53, 61, 62, 63, 71, 72, 73, 88, 99],
+      ]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        ...[1, 2, 3, 255, 11, 12, 13, 255, 21, 22, 23, 255, 31, 32, 33, 255],
+        ...[41, 42, 43, 255, 51, 52, 53, 255, 61, 62, 63, 255, 71, 72, 73, 255],
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 3 * width - 1;
+    expect(() =>
+      decodeRGB8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"RGB8 image row step (11) must be at least 3*width (12)"`,
+    );
+  });
+});
+
+describe("decodeRGBA8", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 4 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeRGBA8(
+      new Uint8Array([
+        ...[1, 2, 3, 4, 11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34, 88, 99],
+        ...[41, 42, 43, 44, 51, 52, 53, 54, 61, 62, 63, 64, 71, 72, 73, 74, 88, 99],
+      ]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        ...[1, 2, 3, 4, 11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34],
+        ...[41, 42, 43, 44, 51, 52, 53, 54, 61, 62, 63, 64, 71, 72, 73, 74],
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 4 * width - 1;
+    expect(() =>
+      decodeRGBA8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"RGBA8 image row step (15) must be at least 4*width (16)"`,
+    );
+  });
+});
+
+describe("decodeMono8", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeMono8(
+      new Uint8Array([...[1, 2, 3, 4, 5, 6], ...[11, 12, 13, 14, 15, 16]]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        ...[1, 1, 1, 255, 2, 2, 2, 255, 3, 3, 3, 255, 4, 4, 4, 255],
+        ...[11, 11, 11, 255, 12, 12, 12, 255, 13, 13, 13, 255, 14, 14, 14, 255],
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = width - 1;
+    expect(() =>
+      decodeMono8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(`"Uint8 image row step (3) must be at least width (4)"`);
+  });
+});
+
+describe("decodeMono16", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 2 * width + 3;
+    const output = new Uint8ClampedArray(width * height * 4);
+    const defaultMax = 10_000;
+    decodeMono16(
+      new Uint8Array([
+        ...uint16LE(1000),
+        ...uint16LE(2000),
+        ...uint16LE(3000),
+        ...uint16LE(4000),
+        77,
+        88,
+        99,
+        ...uint16LE(1500),
+        ...uint16LE(2500),
+        ...uint16LE(3500),
+        ...uint16LE(4500),
+        77,
+        88,
+        99,
+      ]),
+      width,
+      height,
+      step,
+      /*is_bigendian=*/ false,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray(
+        [
+          1000,
+          1000,
+          1000,
+          defaultMax,
+          2000,
+          2000,
+          2000,
+          defaultMax,
+          3000,
+          3000,
+          3000,
+          defaultMax,
+          4000,
+          4000,
+          4000,
+          defaultMax,
+          1500,
+          1500,
+          1500,
+          defaultMax,
+          2500,
+          2500,
+          2500,
+          defaultMax,
+          3500,
+          3500,
+          3500,
+          defaultMax,
+          4500,
+          4500,
+          4500,
+          defaultMax,
+        ].map((x) => (x / defaultMax) * 255),
+      ),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 2 * width - 1;
+    expect(() =>
+      decodeMono16(
+        new Uint8Array([]),
+        width,
+        height,
+        step,
+        /*is_bigendian=*/ false,
+        new Uint8ClampedArray([]),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`"RGBA8 image row step (7) must be at least 2*width (8)"`);
+  });
+});
+
+describe("decodeFloat1c", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 4 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeFloat1c(
+      new Uint8Array([
+        ...float32LE(0.1),
+        ...float32LE(0.2),
+        ...float32LE(0.3),
+        ...float32LE(0.4),
+        88,
+        99,
+        ...float32LE(1.1),
+        ...float32LE(1.2),
+        ...float32LE(1.3),
+        ...float32LE(1.4),
+        88,
+        99,
+      ]),
+      width,
+      height,
+      step,
+      /*is_bigendian=*/ false,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray(
+        [
+          ...[0.1, 0.1, 0.1, 1, 0.2, 0.2, 0.2, 1, 0.3, 0.3, 0.3, 1, 0.4, 0.4, 0.4, 1],
+          ...[1.1, 1.1, 1.1, 1, 1.2, 1.2, 1.2, 1, 1.3, 1.3, 1.3, 1, 1.4, 1.4, 1.4, 1],
+        ].map((x) => new Float32Array([x])[0]! * 255),
+      ),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 4 * width - 1;
+    expect(() =>
+      decodeFloat1c(
+        new Uint8Array([]),
+        width,
+        height,
+        step,
+        /*is_bigendian=*/ false,
+        new Uint8ClampedArray([]),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Float image row step (15) must be at least 4*width (16)"`,
+    );
+  });
+});
+
+describe("decodeUYVY", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 2 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeUYVY(
+      new Uint8Array([
+        ...[0, 1, 0, 2, 0, 11, 0, 12, 88, 99],
+        ...[0, 21, 255, 22, 255, 31, 0, 32, 88, 99],
+      ]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        0, 136, 0, 255, 0, 137, 0, 255, 0, 146, 0, 255, 0, 147, 0, 255, 199, 0, 0, 255, 200, 0, 0,
+        255, 0, 79, 255, 255, 0, 80, 255, 255,
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 2 * width - 1;
+    expect(() =>
+      decodeUYVY(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(`"UYVY image row step (7) must be at least 2*width (8)"`);
+  });
+});
+
+describe("decodeYUYV", () => {
+  it("supports row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 2 * width + 2;
+    const output = new Uint8ClampedArray(width * height * 4);
+    decodeYUYV(
+      new Uint8Array([
+        ...[1, 0, 2, 0, 11, 0, 12, 0, 88, 99],
+        ...[21, 0, 22, 255, 31, 255, 32, 0, 88, 99],
+      ]),
+      width,
+      height,
+      step,
+      output,
+    );
+    expect(output).toEqual(
+      new Uint8ClampedArray([
+        ...[0, 136, 0, 255, 0, 137, 0, 255, 0, 146, 0, 255, 0, 147, 0, 255],
+        ...[199, 0, 0, 255, 200, 0, 0, 255, 0, 79, 255, 255, 0, 80, 255, 255],
+      ]),
+    );
+  });
+  it("rejects invalid row step", () => {
+    const width = 4;
+    const height = 2;
+    const step = 2 * width - 1;
+    expect(() =>
+      decodeYUYV(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+    ).toThrowErrorMatchingInlineSnapshot(`"YUYV image row step (7) must be at least 2*width (8)"`);
+  });
+});
 
 describe("decodeBayer*()", () => {
-  it("works for simple data", () => {
-    const output = new Uint8ClampedArray(2 * 2 * 4);
-    decodeBayerRGGB8(new Uint8Array([10, 20, 30, 40]), 2, 2, output);
-    expect(output).toStrictEqual(
-      new Uint8ClampedArray([10, 20, 40, 255, 10, 20, 40, 255, 10, 30, 40, 255, 10, 30, 40, 255]),
-    );
+  // All the tests below have the same expected output and just rearrange the input pixels accordingly
+  const decodeBayerExpectedOutput = new Uint8ClampedArray([
+    ...[12, 2, 1, 255, 12, 2, 1, 255, 14, 4, 3, 255, 14, 4, 3, 255],
+    ...[12, 11, 1, 255, 12, 11, 1, 255, 14, 13, 3, 255, 14, 13, 3, 255],
+    ...[32, 22, 21, 255, 32, 22, 21, 255, 34, 24, 23, 255, 34, 24, 23, 255],
+    ...[32, 31, 21, 255, 32, 31, 21, 255, 34, 33, 23, 255, 34, 33, 23, 255],
+  ]);
+
+  describe("decodeBayerBGGR8", () => {
+    it("supports row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width + 2;
+      const output = new Uint8ClampedArray(width * height * 4);
+      decodeBayerBGGR8(
+        new Uint8Array([
+          ...[1, 2, 3, 4, 88, 99],
+          ...[11, 12, 13, 14, 88, 99],
+          ...[21, 22, 23, 24, 88, 99],
+          ...[31, 32, 33, 34, 88, 99],
+        ]),
+        width,
+        height,
+        step,
+        output,
+      );
+      expect(output).toEqual(decodeBayerExpectedOutput);
+    });
+    it("rejects invalid row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width - 1;
+      expect(() =>
+        decodeBayerBGGR8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+      ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+    });
+  });
+
+  describe("decodeBayerGBRG8", () => {
+    it("supports row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width + 2;
+      const output = new Uint8ClampedArray(width * height * 4);
+      decodeBayerGBRG8(
+        new Uint8Array([
+          ...[2, 1, 4, 3, 88, 99],
+          ...[12, 11, 14, 13, 88, 99],
+          ...[22, 21, 24, 23, 88, 99],
+          ...[32, 31, 34, 33, 88, 99],
+        ]),
+        width,
+        height,
+        step,
+        output,
+      );
+      expect(output).toEqual(decodeBayerExpectedOutput);
+    });
+    it("rejects invalid row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width - 1;
+      expect(() =>
+        decodeBayerGBRG8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+      ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+    });
+  });
+
+  describe("decodeBayerGRBG8", () => {
+    it("supports row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width + 2;
+      const output = new Uint8ClampedArray(width * height * 4);
+      decodeBayerGRBG8(
+        new Uint8Array([
+          ...[2, 12, 4, 14, 88, 99],
+          ...[1, 11, 3, 13, 88, 99],
+          ...[22, 32, 24, 34, 88, 99],
+          ...[21, 31, 23, 33, 88, 99],
+        ]),
+        width,
+        height,
+        step,
+        output,
+      );
+      expect(output).toEqual(decodeBayerExpectedOutput);
+    });
+    it("rejects invalid row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width - 1;
+      expect(() =>
+        decodeBayerGRBG8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+      ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+    });
+  });
+
+  describe("decodeBayerRGGB8", () => {
+    it("supports row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width + 2;
+      const output = new Uint8ClampedArray(width * height * 4);
+      decodeBayerRGGB8(
+        new Uint8Array([
+          ...[12, 2, 14, 4, 88, 99],
+          ...[11, 1, 13, 3, 88, 99],
+          ...[32, 22, 34, 24, 88, 99],
+          ...[31, 21, 33, 23, 88, 99],
+        ]),
+        width,
+        height,
+        step,
+        output,
+      );
+      expect(output).toEqual(decodeBayerExpectedOutput);
+    });
+    it("rejects invalid row step", () => {
+      const width = 4;
+      const height = 4;
+      const step = width - 1;
+      expect(() =>
+        decodeBayerRGGB8(new Uint8Array([]), width, height, step, new Uint8ClampedArray([])),
+      ).toThrowErrorMatchingInlineSnapshot(`"Bayer image row step (3) must be at least width (4)"`);
+    });
   });
 });

--- a/packages/den/image/decodings.ts
+++ b/packages/den/image/decodings.ts
@@ -50,8 +50,9 @@ export function decodeUYVY(
 
   // populate 2 pixels at a time
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col += 2) {
-      const off = row * step + col * 2;
+      const off = rowStart + col * 2;
       const u = uyvy[off]! - 128;
       const y1 = uyvy[off + 1]!;
       const v = uyvy[off + 2]! - 128;
@@ -76,8 +77,9 @@ export function decodeYUYV(
 
   // populate 2 pixels at a time
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col += 2) {
-      const off = row * step + col * 2;
+      const off = rowStart + col * 2;
       const y1 = yuyv[off]!;
       const u = yuyv[off + 1]! - 128;
       const y2 = yuyv[off + 2]!;
@@ -101,8 +103,9 @@ export function decodeRGB8(
   let outIdx = 0;
 
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      const inIdx = row * step + col * 3;
+      const inIdx = rowStart + col * 3;
       const r = rgb[inIdx]!;
       const g = rgb[inIdx + 1]!;
       const b = rgb[inIdx + 2]!;
@@ -128,8 +131,9 @@ export function decodeRGBA8(
   let outIdx = 0;
 
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      const inIdx = row * step + col * 4;
+      const inIdx = rowStart + col * 4;
       const r = rgba[inIdx]!;
       const g = rgba[inIdx + 1]!;
       const b = rgba[inIdx + 2]!;
@@ -156,8 +160,9 @@ export function decodeBGRA8(
   let outIdx = 0;
 
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      const inIdx = row * step + col * 4;
+      const inIdx = rowStart + col * 4;
       const b = rgba[inIdx]!;
       const g = rgba[inIdx + 1]!;
       const r = rgba[inIdx + 2]!;
@@ -184,8 +189,9 @@ export function decodeBGR8(
   let outIdx = 0;
 
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      const inIdx = row * step + col * 3;
+      const inIdx = rowStart + col * 3;
       const b = bgr[inIdx]!;
       const g = bgr[inIdx + 1]!;
       const r = bgr[inIdx + 2]!;
@@ -214,8 +220,9 @@ export function decodeFloat1c(
 
   let outIdx = 0;
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      const val = view.getFloat32(row * step + col * 4, !is_bigendian) * 255;
+      const val = view.getFloat32(rowStart + col * 4, !is_bigendian) * 255;
       output[outIdx++] = val;
       output[outIdx++] = val;
       output[outIdx++] = val;
@@ -237,8 +244,9 @@ export function decodeMono8(
   let outIdx = 0;
 
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      const ch = mono8[row * step + col]!;
+      const ch = mono8[rowStart + col]!;
       output[outIdx++] = ch;
       output[outIdx++] = ch;
       output[outIdx++] = ch;
@@ -280,8 +288,9 @@ export function decodeMono16(
 
   let outIdx = 0;
   for (let row = 0; row < height; row++) {
+    const rowStart = row * step;
     for (let col = 0; col < width; col++) {
-      let val = view.getUint16(row * step + col * 2, !is_bigendian);
+      let val = view.getUint16(rowStart + col * 2, !is_bigendian);
 
       if (converter) {
         const { r, g, b } = converter(val);

--- a/packages/den/image/decodings.ts
+++ b/packages/den/image/decodings.ts
@@ -37,24 +37,28 @@ function yuvToRGBA8(
 }
 
 export function decodeUYVY(
-  yuv: Uint8Array,
+  uyvy: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let c = 0;
-  let off = 0;
+  if (step < width * 2) {
+    throw new Error(`UYVY image row step (${step}) must be at least 2*width (${width * 2})`);
+  }
+  let outIdx = 0;
 
   // populate 2 pixels at a time
-  const max = height * width;
-  for (let r = 0; r <= max; r += 2) {
-    const u = yuv[off]! - 128;
-    const y1 = yuv[off + 1]!;
-    const v = yuv[off + 2]! - 128;
-    const y2 = yuv[off + 3]!;
-    yuvToRGBA8(y1, u, y2, v, c, output);
-    c += 8;
-    off += 4;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col += 2) {
+      const off = row * step + col * 2;
+      const u = uyvy[off]! - 128;
+      const y1 = uyvy[off + 1]!;
+      const v = uyvy[off + 2]! - 128;
+      const y2 = uyvy[off + 3]!;
+      yuvToRGBA8(y1, u, y2, v, outIdx, output);
+      outIdx += 8;
+    }
   }
 }
 
@@ -62,21 +66,25 @@ export function decodeYUYV(
   yuyv: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let c = 0;
-  let off = 0;
+  if (step < width * 2) {
+    throw new Error(`YUYV image row step (${step}) must be at least 2*width (${width * 2})`);
+  }
+  let outIdx = 0;
 
   // populate 2 pixels at a time
-  const max = height * width;
-  for (let r = 0; r <= max; r += 2) {
-    const y1 = yuyv[off]!;
-    const u = yuyv[off + 1]! - 128;
-    const y2 = yuyv[off + 2]!;
-    const v = yuyv[off + 3]! - 128;
-    yuvToRGBA8(y1, u, y2, v, c, output);
-    c += 8;
-    off += 4;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col += 2) {
+      const off = row * step + col * 2;
+      const y1 = yuyv[off]!;
+      const u = yuyv[off + 1]! - 128;
+      const y2 = yuyv[off + 2]!;
+      const v = yuyv[off + 3]! - 128;
+      yuvToRGBA8(y1, u, y2, v, outIdx, output);
+      outIdx += 8;
+    }
   }
 }
 
@@ -84,20 +92,26 @@ export function decodeRGB8(
   rgb: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let inIdx = 0;
+  if (step < width * 3) {
+    throw new Error(`RGB8 image row step (${step}) must be at least 3*width (${width * 3})`);
+  }
   let outIdx = 0;
 
-  for (let i = 0; i < width * height; i++) {
-    const r = rgb[inIdx++]!;
-    const g = rgb[inIdx++]!;
-    const b = rgb[inIdx++]!;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const inIdx = row * step + col * 3;
+      const r = rgb[inIdx]!;
+      const g = rgb[inIdx + 1]!;
+      const b = rgb[inIdx + 2]!;
 
-    output[outIdx++] = r;
-    output[outIdx++] = g;
-    output[outIdx++] = b;
-    output[outIdx++] = 255;
+      output[outIdx++] = r;
+      output[outIdx++] = g;
+      output[outIdx++] = b;
+      output[outIdx++] = 255;
+    }
   }
 }
 
@@ -105,21 +119,27 @@ export function decodeRGBA8(
   rgba: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let inIdx = 0;
+  if (step < width * 4) {
+    throw new Error(`RGBA8 image row step (${step}) must be at least 4*width (${width * 4})`);
+  }
   let outIdx = 0;
 
-  for (let i = 0; i < width * height; i++) {
-    const r = rgba[inIdx++]!;
-    const g = rgba[inIdx++]!;
-    const b = rgba[inIdx++]!;
-    const a = rgba[inIdx++]!;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const inIdx = row * step + col * 4;
+      const r = rgba[inIdx]!;
+      const g = rgba[inIdx + 1]!;
+      const b = rgba[inIdx + 2]!;
+      const a = rgba[inIdx + 3]!;
 
-    output[outIdx++] = r;
-    output[outIdx++] = g;
-    output[outIdx++] = b;
-    output[outIdx++] = a;
+      output[outIdx++] = r;
+      output[outIdx++] = g;
+      output[outIdx++] = b;
+      output[outIdx++] = a;
+    }
   }
 }
 
@@ -127,21 +147,27 @@ export function decodeBGRA8(
   rgba: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let inIdx = 0;
+  if (step < width * 4) {
+    throw new Error(`BGRA8 image row step (${step}) must be at least 4*width (${width * 4})`);
+  }
   let outIdx = 0;
 
-  for (let i = 0; i < width * height; i++) {
-    const b = rgba[inIdx++]!;
-    const g = rgba[inIdx++]!;
-    const r = rgba[inIdx++]!;
-    const a = rgba[inIdx++]!;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const inIdx = row * step + col * 4;
+      const b = rgba[inIdx]!;
+      const g = rgba[inIdx + 1]!;
+      const r = rgba[inIdx + 2]!;
+      const a = rgba[inIdx + 3]!;
 
-    output[outIdx++] = r;
-    output[outIdx++] = g;
-    output[outIdx++] = b;
-    output[outIdx++] = a;
+      output[outIdx++] = r;
+      output[outIdx++] = g;
+      output[outIdx++] = b;
+      output[outIdx++] = a;
+    }
   }
 }
 
@@ -149,20 +175,26 @@ export function decodeBGR8(
   bgr: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let inIdx = 0;
+  if (step < width * 3) {
+    throw new Error(`BGR8 image row step (${step}) must be at least 3*width (${width * 3})`);
+  }
   let outIdx = 0;
 
-  for (let i = 0; i < width * height; i++) {
-    const b = bgr[inIdx++]!;
-    const g = bgr[inIdx++]!;
-    const r = bgr[inIdx++]!;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const inIdx = row * step + col * 3;
+      const b = bgr[inIdx]!;
+      const g = bgr[inIdx + 1]!;
+      const r = bgr[inIdx + 2]!;
 
-    output[outIdx++] = r;
-    output[outIdx++] = g;
-    output[outIdx++] = b;
-    output[outIdx++] = 255;
+      output[outIdx++] = r;
+      output[outIdx++] = g;
+      output[outIdx++] = b;
+      output[outIdx++] = 255;
+    }
   }
 }
 
@@ -170,19 +202,25 @@ export function decodeFloat1c(
   gray: Uint8Array,
   width: number,
   height: number,
+  step: number,
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   is_bigendian: boolean,
   output: Uint8ClampedArray,
 ): void {
+  if (step < width * 4) {
+    throw new Error(`Float image row step (${step}) must be at least 4*width (${width * 4})`);
+  }
   const view = new DataView(gray.buffer, gray.byteOffset);
 
   let outIdx = 0;
-  for (let i = 0; i < width * height * 4; i += 4) {
-    const val = view.getFloat32(i, !is_bigendian) * 255;
-    output[outIdx++] = val;
-    output[outIdx++] = val;
-    output[outIdx++] = val;
-    output[outIdx++] = 255;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const val = view.getFloat32(row * step + col * 4, !is_bigendian) * 255;
+      output[outIdx++] = val;
+      output[outIdx++] = val;
+      output[outIdx++] = val;
+      output[outIdx++] = 255;
+    }
   }
 }
 
@@ -190,17 +228,22 @@ export function decodeMono8(
   mono8: Uint8Array,
   width: number,
   height: number,
+  step: number,
   output: Uint8ClampedArray,
 ): void {
-  let inIdx = 0;
+  if (step < width) {
+    throw new Error(`Uint8 image row step (${step}) must be at least width (${width})`);
+  }
   let outIdx = 0;
 
-  for (let i = 0; i < width * height; i++) {
-    const ch = mono8[inIdx++]!;
-    output[outIdx++] = ch;
-    output[outIdx++] = ch;
-    output[outIdx++] = ch;
-    output[outIdx++] = 255;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const ch = mono8[row * step + col]!;
+      output[outIdx++] = ch;
+      output[outIdx++] = ch;
+      output[outIdx++] = ch;
+      output[outIdx++] = 255;
+    }
   }
 }
 
@@ -208,6 +251,7 @@ export function decodeMono16(
   mono16: Uint8Array,
   width: number,
   height: number,
+  step: number,
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   is_bigendian: boolean,
   output: Uint8ClampedArray,
@@ -217,6 +261,9 @@ export function decodeMono16(
     colorConverter?: (value: number) => { r: number; g: number; b: number; a: number };
   },
 ): void {
+  if (step < width * 2) {
+    throw new Error(`RGBA8 image row step (${step}) must be at least 2*width (${width * 2})`);
+  }
   const view = new DataView(mono16.buffer, mono16.byteOffset);
 
   // Use user-provided max/min values, or default to 0-10000, consistent with image_view's default.
@@ -232,25 +279,27 @@ export function decodeMono16(
   const converter = options?.colorConverter;
 
   let outIdx = 0;
-  for (let i = 0; i < width * height * 2; i += 2) {
-    let val = view.getUint16(i, !is_bigendian);
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      let val = view.getUint16(row * step + col * 2, !is_bigendian);
 
-    if (converter) {
-      const { r, g, b } = converter(val);
+      if (converter) {
+        const { r, g, b } = converter(val);
 
-      output[outIdx++] = r * 255;
-      output[outIdx++] = g * 255;
-      output[outIdx++] = b * 255;
-    } else {
-      // 0 - 1.0
-      val = (val - minValue) / (maxValue - minValue);
-      val *= 255;
+        output[outIdx++] = r * 255;
+        output[outIdx++] = g * 255;
+        output[outIdx++] = b * 255;
+      } else {
+        // 0 - 1.0
+        val = (val - minValue) / (maxValue - minValue);
+        val *= 255;
 
-      output[outIdx++] = val;
-      output[outIdx++] = val;
-      output[outIdx++] = val;
+        output[outIdx++] = val;
+        output[outIdx++] = val;
+        output[outIdx++] = val;
+      }
+      output[outIdx++] = 255;
     }
-    output[outIdx++] = 255;
   }
 }
 
@@ -261,7 +310,13 @@ function makeSpecializedDecodeBayer(
   tr: string,
   bl: string,
   br: string,
-): (data: Uint8Array, width: number, height: number, output: Uint8ClampedArray) => void {
+): (
+  data: Uint8Array,
+  width: number,
+  height: number,
+  step: number,
+  output: Uint8ClampedArray,
+) => void {
   // We probably can't afford real debayering/demosaicking, so do something simpler
   // The input array look like a single-plane array of pixels.  However, each pixel represents a one particular color
   // for a group of pixels in the 2x2 region.  For 'rggb', there color representatio for the 2x2 region looks like:
@@ -281,17 +336,21 @@ function makeSpecializedDecodeBayer(
     "data",
     "width",
     "height",
+    "step",
     "output",
-    `
+    /* js */ `
+  if (step < width) {
+    throw new Error(\`Bayer image row step (\${step}) must be at least width (\${width})\`);
+  }
   for (let i = 0; i < height / 2; i++) {
-    let inIdx = i * 2 * width;
+    let inIdx = i * 2 * step;
     let outTopIdx = i * 2 * width * 4; // Addresses top row
     let outBottomIdx = (i * 2 + 1) * width * 4; // Addresses bottom row
     for (let j = 0; j < width / 2; j++) {
       const tl = data[inIdx++];
       const tr = data[inIdx++];
-      const bl = data[inIdx + width - 2];
-      const br = data[inIdx + width - 1];
+      const bl = data[inIdx + step - 2];
+      const br = data[inIdx + step - 1];
 
       const ${tl} = tl;
       const ${tr} = tr;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/decodeImage.ts
@@ -55,49 +55,49 @@ export function decodeRawImage(
   options: Partial<RawImageOptions>,
   output: Uint8ClampedArray,
 ): void {
-  const { encoding, width, height } = image;
+  const { encoding, width, height, step } = image;
   const is_bigendian = "is_bigendian" in image ? image.is_bigendian : false;
   const rawData = image.data as Uint8Array;
   switch (encoding) {
     case "yuv422":
     case "uyvy":
-      decodeUYVY(rawData, width, height, output);
+      decodeUYVY(rawData, width, height, step, output);
       break;
     case "yuv422_yuy2":
     case "yuyv":
-      decodeYUYV(rawData, width, height, output);
+      decodeYUYV(rawData, width, height, step, output);
       break;
     case "rgb8":
-      decodeRGB8(rawData, width, height, output);
+      decodeRGB8(rawData, width, height, step, output);
       break;
     case "rgba8":
-      decodeRGBA8(rawData, width, height, output);
+      decodeRGBA8(rawData, width, height, step, output);
       break;
     case "bgra8":
-      decodeBGRA8(rawData, width, height, output);
+      decodeBGRA8(rawData, width, height, step, output);
       break;
     case "bgr8":
     case "8UC3":
-      decodeBGR8(rawData, width, height, output);
+      decodeBGR8(rawData, width, height, step, output);
       break;
     case "32FC1":
-      decodeFloat1c(rawData, width, height, is_bigendian, output);
+      decodeFloat1c(rawData, width, height, step, is_bigendian, output);
       break;
     case "bayer_rggb8":
-      decodeBayerRGGB8(rawData, width, height, output);
+      decodeBayerRGGB8(rawData, width, height, step, output);
       break;
     case "bayer_bggr8":
-      decodeBayerBGGR8(rawData, width, height, output);
+      decodeBayerBGGR8(rawData, width, height, step, output);
       break;
     case "bayer_gbrg8":
-      decodeBayerGBRG8(rawData, width, height, output);
+      decodeBayerGBRG8(rawData, width, height, step, output);
       break;
     case "bayer_grbg8":
-      decodeBayerGRBG8(rawData, width, height, output);
+      decodeBayerGRBG8(rawData, width, height, step, output);
       break;
     case "mono8":
     case "8UC1":
-      decodeMono8(rawData, width, height, output);
+      decodeMono8(rawData, width, height, step, output);
       break;
     case "mono16":
     case "16UC1": {
@@ -117,7 +117,7 @@ export function decodeRawImage(
         min,
         max,
       );
-      decodeMono16(rawData, width, height, is_bigendian, output, {
+      decodeMono16(rawData, width, height, step, is_bigendian, output, {
         minValue: options.minValue,
         maxValue: options.maxValue,
         colorConverter: (value: number) => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/imageCommon.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/imageCommon.ts
@@ -72,6 +72,7 @@ export function makeRawImageAndCalibration(args: MakeImageArgs): {
       frame_id: frameId,
       width,
       height,
+      step: 3 * width,
       encoding: "rgb8",
       data: imageData,
     },


### PR DESCRIPTION
**User-Facing Changes**
The `step` field of `foxglove.RawImage` and `sensor_msgs/Image` is now respected.

**Description**
Adds support for `step` to all the decoder functions and adds unit tests.

Also adds sanity checks for the `step` value to ensure that it is large enough.