### PR TITLE
Improve performance of the state transitions panel on large messages

### DIFF
--- a/packages/studio-base/src/PanelAPI/index.ts
+++ b/packages/studio-base/src/PanelAPI/index.ts
@@ -20,6 +20,6 @@ export { useDataSourceInfo } from "./useDataSourceInfo";
 export { useMessageReducer } from "./useMessageReducer";
 
 export { useMessagesByTopic } from "./useMessagesByTopic";
-export { useBlocksByTopic } from "./useBlocksByTopic";
+export { useBlocksSubscriptions } from "./useBlocksSubscriptions";
 
 export { default as useConfigById } from "./useConfigById";

--- a/packages/studio-base/src/PanelAPI/useBlocksSubscriptions.test.tsx
+++ b/packages/studio-base/src/PanelAPI/useBlocksSubscriptions.test.tsx
@@ -16,13 +16,14 @@ import { renderHook } from "@testing-library/react-hooks";
 import { cloneDeep } from "lodash";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import { SubscribePayload } from "@foxglove/studio-base/players/types";
 
 import * as PanelAPI from ".";
 
-describe("useBlocksByTopic", () => {
+describe("useBlocksSubscriptions", () => {
   it("returns an empty structure when there are no blocks", async () => {
-    const { result } = renderHook(({ topics }) => PanelAPI.useBlocksByTopic(topics), {
-      initialProps: { topics: ["/foo"] },
+    const { result } = renderHook(({ topics }) => PanelAPI.useBlocksSubscriptions(topics), {
+      initialProps: { topics: [{ topic: "/foo" }] },
       wrapper: ({ children }) => (
         <MockMessagePipelineProvider>{children}</MockMessagePipelineProvider>
       ),
@@ -32,8 +33,8 @@ describe("useBlocksByTopic", () => {
   });
 
   it("returns no messagesByTopic when the player does not provide blocks", async () => {
-    const { result } = renderHook(({ topics }) => PanelAPI.useBlocksByTopic(topics), {
-      initialProps: { topics: ["/topic1"] },
+    const { result } = renderHook(({ topics }) => PanelAPI.useBlocksSubscriptions(topics), {
+      initialProps: { topics: [{ topic: "/topic1" }] },
       wrapper: ({ children }) => (
         <MockMessagePipelineProvider activeData={{}}>{children}</MockMessagePipelineProvider>
       ),
@@ -54,8 +55,8 @@ describe("useBlocksByTopic", () => {
         startTime: { sec: 0, nsec: 0 },
       },
     };
-    const { result } = renderHook(({ topics }) => PanelAPI.useBlocksByTopic(topics), {
-      initialProps: { topics: ["/topic1"] },
+    const { result } = renderHook(({ topics }) => PanelAPI.useBlocksSubscriptions(topics), {
+      initialProps: { topics: [{ topic: "/topic1" }] },
       wrapper: ({ children }) => (
         <MockMessagePipelineProvider activeData={activeData} progress={progress}>
           {children}
@@ -76,33 +77,39 @@ describe("useBlocksByTopic", () => {
         startTime: { sec: 0, nsec: 0 },
       },
     };
-    const { result, rerender } = renderHook(({ topics }) => PanelAPI.useBlocksByTopic(topics), {
-      initialProps: { topics: ["/topic"] },
-      wrapper: ({ children }) => (
-        <MockMessagePipelineProvider activeData={activeData} progress={progress}>
-          {children}
-        </MockMessagePipelineProvider>
-      ),
-    });
+
+    const stableSubscriptions: SubscribePayload[] = [{ topic: "/topic" }];
+
+    const { result, rerender } = renderHook(
+      ({ subscriptions }) => PanelAPI.useBlocksSubscriptions(subscriptions),
+      {
+        initialProps: { subscriptions: stableSubscriptions },
+        wrapper: ({ children }) => (
+          <MockMessagePipelineProvider activeData={activeData} progress={progress}>
+            {children}
+          </MockMessagePipelineProvider>
+        ),
+      },
+    );
 
     const c1 = result.current;
     expect(result.current).toEqual([{ "/topic": [] }]);
 
-    // Same identity on everything. useBlocksByTopic does not run again.
+    // Same identity on everything. useBlocksSubscriptions does not run again.
     progress = { messageCache: { ...progress.messageCache } };
-    rerender({ topics: ["/topic"] });
+    rerender({ subscriptions: stableSubscriptions });
     expect(result.current).toBe(c1);
 
     // Block identity is the same, but blocks array identity changes.
     progress = {
       messageCache: { ...progress.messageCache, blocks: progress.messageCache.blocks.slice() },
     };
-    rerender({ topics: ["/topic"] });
+    rerender({ subscriptions: stableSubscriptions });
     const c3 = result.current;
 
     // Both identities change.
     progress = { messageCache: cloneDeep(progress.messageCache) };
-    rerender({ topics: ["/topic"] });
+    rerender({ subscriptions: stableSubscriptions });
     const c4 = result.current;
 
     expect(c1).not.toBe(c3);

--- a/packages/studio-base/src/PanelAPI/useBlocksSubscriptions.test.tsx
+++ b/packages/studio-base/src/PanelAPI/useBlocksSubscriptions.test.tsx
@@ -17,6 +17,7 @@ import { cloneDeep } from "lodash";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { SubscribePayload } from "@foxglove/studio-base/players/types";
+import { mockMessage } from "@foxglove/studio-base/test/mocks/mockMessage";
 
 import * as PanelAPI from ".";
 
@@ -67,6 +68,39 @@ describe("useBlocksSubscriptions", () => {
     // No message readers, even though we have a definition and we try to subscribe to the topic.
     // This means the data will never be provided.
     expect(result.current).toEqual([undefined, undefined]);
+  });
+
+  it("handles sliced subscriptions", async () => {
+    const activeData = {};
+    const progress = {
+      messageCache: {
+        blocks: [
+          {
+            sizeInBytes: 0,
+            messagesByTopic: { "/topic": [mockMessage({ a: 1, b: 2 }, { topic: "/topic" })] },
+          },
+        ],
+        startTime: { sec: 0, nsec: 0 },
+      },
+    };
+
+    const stableSubscriptions: SubscribePayload[] = [{ topic: "/topic", fields: ["a"] }];
+
+    const { result } = renderHook(
+      ({ subscriptions }) => PanelAPI.useBlocksSubscriptions(subscriptions),
+      {
+        initialProps: { subscriptions: stableSubscriptions },
+        wrapper: ({ children }) => (
+          <MockMessagePipelineProvider activeData={activeData} progress={progress}>
+            {children}
+          </MockMessagePipelineProvider>
+        ),
+      },
+    );
+
+    expect(result.current).toEqual([
+      { "/topic": [expect.objectContaining({ topic: "/topic", message: { a: 1, b: 2 } })] },
+    ]);
   });
 
   it("maintains block identity across repeated renders", async () => {

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -20,11 +20,10 @@ import { useResizeDetector } from "react-resize-detector";
 import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
+import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
 import { add as addTimes, fromSec, subtract as subtractTimes, toSec } from "@foxglove/rostime";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
-import { useBlocksByTopic } from "@foxglove/studio-base/PanelAPI";
-import { getTopicsFromPaths } from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import {
   MessageDataItemsByPath,
   useDecodeMessagePathsForMessagesByTopic,
@@ -43,6 +42,8 @@ import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import { ChartData, ChartDatasets } from "@foxglove/studio-base/components/TimeBasedChart/types";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
+import { subscribePayloadFromMessagePath } from "@foxglove/studio-base/players/subscribePayloadFromMessagePath";
+import { SubscribePayload } from "@foxglove/studio-base/players/types";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -183,7 +184,6 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   const { classes } = useStyles();
 
   const pathStrings = useMemo(() => paths.map(({ value }) => value), [paths]);
-  const subscribeTopics = useMemo(() => getTopicsFromPaths(pathStrings), [pathStrings]);
 
   const { openPanelSettings } = useWorkspaceActions();
   const { id: panelId } = usePanelContext();
@@ -202,7 +202,12 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(pathStrings);
 
-  const blocks = useBlocksByTopic(subscribeTopics);
+  const subscriptions: SubscribePayload[] = useMemo(
+    () => filterMap(pathStrings, (path) => subscribePayloadFromMessagePath(path, "full")),
+    [pathStrings],
+  );
+
+  const blocks = PanelAPI.useBlocksSubscriptions(subscriptions);
   const decodedBlocks = useMemo(
     () => blocks.map(decodeMessagePathsForMessagesByTopic),
     [blocks, decodeMessagePathsForMessagesByTopic],

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -204,15 +204,15 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   const subscriptions: SubscribePayload[] = useMemo(
     () =>
-      filterMap(pathStrings, (path) => {
-        const payload = subscribePayloadFromMessagePath(path, "full");
+      filterMap(paths, (path) => {
+        const payload = subscribePayloadFromMessagePath(path.value, "full");
         // Include the header in case we are ordering by header stamp.
-        if (payload?.fields != undefined) {
+        if (path.timestampMethod === "headerStamp" && payload?.fields != undefined) {
           payload.fields.push("header");
         }
         return payload;
       }),
-    [pathStrings],
+    [paths],
   );
 
   const blocks = PanelAPI.useBlocksSubscriptions(subscriptions);

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -203,7 +203,15 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(pathStrings);
 
   const subscriptions: SubscribePayload[] = useMemo(
-    () => filterMap(pathStrings, (path) => subscribePayloadFromMessagePath(path, "full")),
+    () =>
+      filterMap(pathStrings, (path) => {
+        const payload = subscribePayloadFromMessagePath(path, "full");
+        // Include the header in case we are ordering by header stamp.
+        if (payload?.fields != undefined) {
+          payload.fields.push("header");
+        }
+        return payload;
+      }),
     [pathStrings],
   );
 


### PR DESCRIPTION
**User-Facing Changes**
Improve performance of the state transitions panel on large messages

**Description**
Improve performance of the state transitions panel on large messages by taking advantage of our new sliced topic subscriptions.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
