### PR TITLE
Include date in human-readable timestamp in playback controls

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.tsx
@@ -53,7 +53,7 @@ const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeD
 
 export function PlaybackControlsTooltipContent(params: { stamp: Time }): ReactNull | JSX.Element {
   const { stamp } = params;
-  const { formatTime, timeFormat } = useAppTimeFormat();
+  const { timeFormat, formatTime, formatDate } = useAppTimeFormat();
   const hoveredEvents = useTimelineInteractionState(selectHoveredEvents);
   const startTime = useMessagePipeline(selectStartTime);
   const { classes } = useStyles();
@@ -89,6 +89,7 @@ export function PlaybackControlsTooltipContent(params: { stamp: Time }): ReactNu
 
   switch (timeFormat) {
     case "TOD":
+      tooltipItems.push({ type: "item", title: "Date", value: formatDate(stamp) });
       tooltipItems.push({ type: "item", title: "Time", value: formatTime(stamp) });
       break;
     case "SEC":

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplay.tsx
@@ -17,9 +17,10 @@ import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 
-import PlaybackTimeDisplayMethod from "./PlaybackTimeDisplayMethod";
+import { UnconnectedPlaybackTimeDisplay } from "./UnconnectedPlaybackTimeDisplay";
 
 type Props = {
   onSeek: (seekTo: Time) => void;
@@ -38,9 +39,11 @@ export default function PlaybackTimeDisplay(props: Props): JSX.Element {
   const startTime = useMessagePipeline(selectStartTime);
   const endTime = useMessagePipeline(selectEndTime);
   const currentTime = useMessagePipeline(selectCurrentTime);
+  const appTimeFormat = useAppTimeFormat();
 
   return (
-    <PlaybackTimeDisplayMethod
+    <UnconnectedPlaybackTimeDisplay
+      appTimeFormat={appTimeFormat}
       currentTime={currentTime}
       startTime={startTime}
       endTime={endTime}

--- a/packages/studio-base/src/components/PlaybackControls/UnconnectedPlaybackTimeDisplay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/UnconnectedPlaybackTimeDisplay.tsx
@@ -301,7 +301,7 @@ export function UnconnectedPlaybackTimeDisplay({
           variant="filled"
           size="small"
           defaultValue={
-            appTimeFormat.timeFormat === "SEC" ? "0000000000.000000000" : "00:00:00.000"
+            appTimeFormat.timeFormat === "SEC" ? "0000000000.000000000" : "0000-00-00 00:00:00.000"
           }
           InputProps={{
             endAdornment: (

--- a/packages/studio-base/src/components/PlaybackControls/UnconnectedPlaybackTimeDisplay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/UnconnectedPlaybackTimeDisplay.tsx
@@ -21,7 +21,7 @@ import { makeStyles } from "tss-react/mui";
 
 import { Time, isTimeInRangeInclusive } from "@foxglove/rostime";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { IAppTimeFormat } from "@foxglove/studio-base/hooks/useAppTimeFormat";
 import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 import {
   formatDate,
@@ -31,6 +31,7 @@ import {
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
 type PlaybackTimeDisplayMethodProps = {
+  appTimeFormat: IAppTimeFormat;
   currentTime?: Time;
   startTime?: Time;
   endTime?: Time;
@@ -40,51 +41,53 @@ type PlaybackTimeDisplayMethodProps = {
   isPlaying: boolean;
 };
 
-const useStyles = makeStyles()((theme) => ({
-  textField: {
-    borderRadius: theme.shape.borderRadius,
+const useStyles = makeStyles<{ timeDisplayMethod: TimeDisplayMethod }>()(
+  (theme, { timeDisplayMethod }) => ({
+    textField: {
+      borderRadius: theme.shape.borderRadius,
 
-    "&.Mui-disabled": {
+      "&.Mui-disabled": {
+        [`.${filledInputClasses.root}`]: {
+          backgroundColor: "transparent",
+        },
+      },
+      "&:not(.Mui-disabled):hover": {
+        backgroundColor: theme.palette.action.hover,
+
+        [`.${iconButtonClasses.root}`]: {
+          visibility: "visible",
+        },
+      },
       [`.${filledInputClasses.root}`]: {
         backgroundColor: "transparent",
-      },
-    },
-    "&:not(.Mui-disabled):hover": {
-      backgroundColor: theme.palette.action.hover,
 
+        ":hover": {
+          backgroundColor: "transparent",
+        },
+      },
+      [`.${inputBaseClasses.input}`]: {
+        fontFeatureSettings: `${theme.typography.fontFeatureSettings}, 'zero' !important`,
+        minWidth: timeDisplayMethod === "TOD" ? "28ch" : "20ch",
+      },
       [`.${iconButtonClasses.root}`]: {
-        visibility: "visible",
+        borderTopLeftRadius: 0,
+        borderBottomLeftRadius: 0,
+        borderLeft: `1px solid ${theme.palette.background.paper}`,
+        visibility: "hidden",
+        marginRight: theme.spacing(-1),
       },
     },
-    [`.${filledInputClasses.root}`]: {
-      backgroundColor: "transparent",
+    textFieldError: {
+      outline: `1px solid ${theme.palette.error.main}`,
+      outlineOffset: -1,
 
-      ":hover": {
-        backgroundColor: "transparent",
+      [`.${inputBaseClasses.root}`]: {
+        color: theme.palette.error.main,
+        borderLeftColor: theme.palette.error.main,
       },
     },
-    [`.${inputBaseClasses.input}`]: {
-      fontFeatureSettings: `${theme.typography.fontFeatureSettings}, 'zero' !important`,
-      minWidth: "20ch",
-    },
-    [`.${iconButtonClasses.root}`]: {
-      borderTopLeftRadius: 0,
-      borderBottomLeftRadius: 0,
-      borderLeft: `1px solid ${theme.palette.background.paper}`,
-      visibility: "hidden",
-      marginRight: theme.spacing(-1),
-    },
-  },
-  textFieldError: {
-    outline: `1px solid ${theme.palette.error.main}`,
-    outlineOffset: -1,
-
-    [`.${inputBaseClasses.root}`]: {
-      color: theme.palette.error.main,
-      borderLeftColor: theme.palette.error.main,
-    },
-  },
-}));
+  }),
+);
 
 function PlaybackTimeMethodMenu({
   timeFormat,
@@ -144,7 +147,10 @@ function PlaybackTimeMethodMenu({
           <MenuItem
             key={option.key}
             selected={timeFormat === option.key}
-            onClick={async () => await setTimeFormat(option.key as TimeDisplayMethod)}
+            onClick={async () => {
+              await setTimeFormat(option.key as TimeDisplayMethod);
+              handleClose();
+            }}
           >
             {timeFormat === option.key && (
               <ListItemIcon>
@@ -163,7 +169,8 @@ function PlaybackTimeMethodMenu({
   );
 }
 
-export default function PlaybackTimeDisplayMethod({
+export function UnconnectedPlaybackTimeDisplay({
+  appTimeFormat,
   currentTime,
   startTime,
   endTime,
@@ -172,20 +179,23 @@ export default function PlaybackTimeDisplayMethod({
   onPause,
   isPlaying,
 }: PlaybackTimeDisplayMethodProps): JSX.Element {
-  const { classes, cx } = useStyles();
+  const { classes, cx } = useStyles({ timeDisplayMethod: appTimeFormat.timeFormat });
   const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const timeFormat = useAppTimeFormat();
+
   const timeRawString = useMemo(
     () => (currentTime ? formatTimeRaw(currentTime) : undefined),
     [currentTime],
   );
   const timeOfDayString = useMemo(
-    () => (currentTime ? formatTime(currentTime, timezone) : undefined),
+    () =>
+      currentTime
+        ? `${formatDate(currentTime, timezone)} ${formatTime(currentTime, timezone)}`
+        : undefined,
     [currentTime, timezone],
   );
   const currentTimeString = useMemo(
-    () => (timeFormat.timeFormat === "SEC" ? timeRawString : timeOfDayString),
-    [timeFormat.timeFormat, timeRawString, timeOfDayString],
+    () => (appTimeFormat.timeFormat === "SEC" ? timeRawString : timeOfDayString),
+    [appTimeFormat.timeFormat, timeRawString, timeOfDayString],
   );
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [inputText, setInputText] = useState<string | undefined>(currentTimeString ?? undefined);
@@ -204,7 +214,6 @@ export default function PlaybackTimeDisplayMethod({
 
       const validTimeAndMethod = getValidatedTimeAndMethodFromString({
         text: inputText,
-        date: formatDate(currentTime, timezone),
         timezone,
       });
 
@@ -221,12 +230,12 @@ export default function PlaybackTimeDisplayMethod({
         isTimeInRangeInclusive(validTimeAndMethod.time, startTime, endTime)
       ) {
         onSeek(validTimeAndMethod.time);
-        if (validTimeAndMethod.method !== timeFormat.timeFormat) {
-          void timeFormat.setTimeFormat(validTimeAndMethod.method);
+        if (validTimeAndMethod.method !== appTimeFormat.timeFormat) {
+          void appTimeFormat.setTimeFormat(validTimeAndMethod.method);
         }
       }
     },
-    [inputText, startTime, currentTime, endTime, timezone, onSeek, timeFormat],
+    [inputText, startTime, currentTime, endTime, timezone, onSeek, appTimeFormat],
   );
 
   useEffect(() => {
@@ -264,8 +273,8 @@ export default function PlaybackTimeDisplayMethod({
                     timezone,
                     timeOfDayString,
                     timeRawString,
-                    timeFormat: timeFormat.timeFormat,
-                    setTimeFormat: timeFormat.setTimeFormat,
+                    timeFormat: appTimeFormat.timeFormat,
+                    setTimeFormat: appTimeFormat.setTimeFormat,
                   }}
                 />
               ),
@@ -291,7 +300,9 @@ export default function PlaybackTimeDisplayMethod({
           disabled
           variant="filled"
           size="small"
-          defaultValue={timeFormat.timeFormat === "SEC" ? "0000000000.000000000" : "00:00:00.000"}
+          defaultValue={
+            appTimeFormat.timeFormat === "SEC" ? "0000000000.000000000" : "00:00:00.000"
+          }
           InputProps={{
             endAdornment: (
               <IconButton edge="end" disabled>

--- a/packages/studio-base/src/util/formatTime.test.ts
+++ b/packages/studio-base/src/util/formatTime.test.ts
@@ -114,7 +114,7 @@ describe("formatTime.parseTimeStr", () => {
 });
 
 describe("formatTime.getValidatedTimeAndMethodFromString", () => {
-  const commonArgs = { date: "2020-01-01", timezone: "America/Los_Angeles" };
+  const commonArgs = { timezone: "America/Los_Angeles" };
   it("takes a string and gets a validated ROS or TOD time", () => {
     expect(formatTime.getValidatedTimeAndMethodFromString({ ...commonArgs, text: "" })).toEqual(
       undefined,
@@ -128,6 +128,12 @@ describe("formatTime.getValidatedTimeAndMethodFromString", () => {
     expect(
       formatTime.getValidatedTimeAndMethodFromString({
         ...commonArgs,
+        text: "1:30:10.000 PM PST",
+      }),
+    ).toEqual(undefined);
+    expect(
+      formatTime.getValidatedTimeAndMethodFromString({
+        ...commonArgs,
         text: "1598635994.000000000",
       }),
     ).toEqual({
@@ -135,7 +141,10 @@ describe("formatTime.getValidatedTimeAndMethodFromString", () => {
       method: "SEC",
     });
     expect(
-      formatTime.getValidatedTimeAndMethodFromString({ ...commonArgs, text: "1:30:10.000 PM PST" }),
+      formatTime.getValidatedTimeAndMethodFromString({
+        ...commonArgs,
+        text: "2020-01-01 1:30:10.000 PM PST",
+      }),
     ).toEqual({
       time: { nsec: 0, sec: 1577914210 },
       method: "TOD",

--- a/packages/studio-base/src/util/formatTime.ts
+++ b/packages/studio-base/src/util/formatTime.ts
@@ -72,28 +72,26 @@ export function parseTimeStr(str: string, timezone?: string): Time | undefined {
   return result;
 }
 
-const todTimeRegex = /^\d+:\d+:\d+.\d+\s[PpAa][Mm]\s[A-Za-z$]+/;
+const todDateTimeRegex = /^\d+-\d+-\d+\s+\d+:\d+:\d+.\d+\s[PpAa][Mm]\s[A-Za-z$]+/;
 export const getValidatedTimeAndMethodFromString = ({
   text,
-  date,
   timezone,
 }: {
   text?: string;
-  date: string;
   timezone?: string;
 }): { time?: Time; method: TimeDisplayMethod } | undefined => {
   if (text == undefined || text === "") {
     return;
   }
   const isInvalidRawTime = isNaN(+text);
-  const isInvalidTodTime = !(todTimeRegex.test(text) && parseTimeStr(`${date} ${text}`, timezone));
+  const isInvalidTodTime = !(todDateTimeRegex.test(text) && parseTimeStr(text, timezone));
 
   if (isInvalidRawTime && isInvalidTodTime) {
     return;
   }
 
   return {
-    time: !isInvalidRawTime ? parseFuzzyRosTime(text) : parseTimeStr(`${date} ${text}`, timezone),
+    time: !isInvalidRawTime ? parseFuzzyRosTime(text) : parseTimeStr(text, timezone),
     method: isInvalidRawTime ? "TOD" : "SEC",
   };
 };


### PR DESCRIPTION
**User-Facing Changes**
The playback bar now includes the date alongside the current timestamp.

**Description**

Date is included in the tooltip and in the text field.

<img width="342" alt="image" src="https://github.com/foxglove/studio/assets/14237/11fa21aa-9b3e-4d5d-9c9d-13e1a1378e28">
