### PR TITLE
Table panel: Add support for displaying typed arrays

### DIFF
--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -37,6 +37,31 @@ import TableCell from "./TableCell";
 import { sanitizeAccessorPath } from "./sanitizeAccessorPath";
 import { CellValue } from "./types";
 
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array;
+
+function isTypedArray(value: unknown): value is TypedArray {
+  return (
+    value instanceof Uint8Array ||
+    value instanceof Uint8ClampedArray ||
+    value instanceof Int8Array ||
+    value instanceof Uint16Array ||
+    value instanceof Int16Array ||
+    value instanceof Uint32Array ||
+    value instanceof Int32Array ||
+    value instanceof Float32Array ||
+    value instanceof Float64Array
+  );
+}
+
 const useStyles = makeStyles<void, "tableData" | "tableHeader">()((theme, _params, classes) => ({
   table: {
     border: "none",
@@ -111,7 +136,7 @@ const columnHelper = createColumnHelper<CellValue>();
 
 function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonClasses: string) {
   const obj = val.toJSON?.() ?? val;
-  if (ArrayBuffer.isView(obj) && !(obj instanceof DataView)) {
+  if (isTypedArray(obj)) {
     return [
       columnHelper.display({
         id: "typedArray",
@@ -119,7 +144,7 @@ function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonCl
         enableSorting: false,
         enableColumnFilter: false,
         cell: ({ row }) => {
-          return <span>{`${(obj as Uint8Array)[row.index]}`}</span>;
+          return <span>{`${obj[row.index]}`}</span>;
         },
       }),
     ];
@@ -208,8 +233,7 @@ export default function Table({
   }, [accessorPath, classes.iconButton, value]);
 
   const data = React.useMemo(() => {
-    const isTypedArray = ArrayBuffer.isView(value) && !(value instanceof DataView);
-    return Array.isArray(value) ? value : isTypedArray ? Array.from(value as Uint8Array) : [value];
+    return Array.isArray(value) ? value : isTypedArray(value) ? Array.from(value) : [value];
   }, [value]);
 
   const [expanded, setExpanded] = React.useState<ExpandedState>({});

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -230,7 +230,7 @@ export default function Table({
 
   const [{ pageIndex, pageSize }, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
-    pageSize: 30,
+    pageSize: 10,
   });
 
   const pagination = React.useMemo(

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -20,11 +20,11 @@ import KeyboardDoubleArrowRightIcon from "@mui/icons-material/KeyboardDoubleArro
 import { Container, IconButton, MenuItem, Select, Typography } from "@mui/material";
 import {
   ExpandedState,
+  PaginationState,
   createColumnHelper,
   flexRender,
   getCoreRowModel,
   getExpandedRowModel,
-  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
@@ -138,14 +138,10 @@ function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonCl
   const obj = val.toJSON?.() ?? val;
   if (isTypedArray(obj)) {
     return [
-      columnHelper.display({
+      columnHelper.accessor((row) => row, {
         id: "typedArray",
         header: "",
-        enableSorting: false,
-        enableColumnFilter: false,
-        cell: ({ row }) => {
-          return <span>{`${obj[row.index]}`}</span>;
-        },
+        cell: (info) => info.getValue(),
       }),
     ];
   }
@@ -232,6 +228,19 @@ export default function Table({
     return getColumnsFromObject(maybeMessage as CellValue, accessorPath, classes.iconButton);
   }, [accessorPath, classes.iconButton, value]);
 
+  const [{ pageIndex, pageSize }, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 30,
+  });
+
+  const pagination = React.useMemo(
+    () => ({
+      pageIndex,
+      pageSize,
+    }),
+    [pageIndex, pageSize],
+  );
+
   const data = React.useMemo(() => {
     return Array.isArray(value) ? value : isTypedArray(value) ? Array.from(value) : [value];
   }, [value]);
@@ -241,15 +250,18 @@ export default function Table({
   const table = useReactTable({
     autoResetExpanded: false,
     columns,
-    data,
+    data: data.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getPaginationRowModel: isNested ? getPaginationRowModel() : undefined,
     getSortedRowModel: getSortedRowModel(),
-    initialState: { pagination: { pageSize: 30 } },
+    initialState: { pagination },
     onExpandedChange: setExpanded,
+    manualPagination: true,
+    pageCount: Math.ceil(data.length / pagination.pageSize),
+    onPaginationChange: setPagination,
     state: {
       expanded,
+      pagination,
     },
   });
 
@@ -265,10 +277,6 @@ export default function Table({
       </EmptyState>
     );
   }
-
-  const {
-    pagination: { pageIndex, pageSize },
-  } = table.getState();
 
   return (
     <>
@@ -299,22 +307,19 @@ export default function Table({
           })}
         </thead>
         <tbody>
-          {table
-            .getRowModel()
-            .rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize)
-            .map((row) => {
-              return (
-                <tr className={classes.tableRow} key={row.index}>
-                  {row.getVisibleCells().map((cell, i) => {
-                    return (
-                      <td className={classes.tableData} key={i}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
+          {table.getRowModel().rows.map((row) => {
+            return (
+              <tr className={classes.tableRow} key={row.id}>
+                {row.getVisibleCells().map((cell) => {
+                  return (
+                    <td className={classes.tableData} key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       {!isNested && (

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -111,6 +111,19 @@ const columnHelper = createColumnHelper<CellValue>();
 
 function getColumnsFromObject(val: CellValue, accessorPath: string, iconButtonClasses: string) {
   const obj = val.toJSON?.() ?? val;
+  if (ArrayBuffer.isView(obj) && !(obj instanceof DataView)) {
+    return [
+      columnHelper.display({
+        id: "typedArray",
+        header: "",
+        enableSorting: false,
+        enableColumnFilter: false,
+        cell: ({ row }) => {
+          return <span>{`${(obj as Uint8Array)[row.index]}`}</span>;
+        },
+      }),
+    ];
+  }
   const columns = Object.keys(obj).map((accessor) => {
     const id = accessorPath.length !== 0 ? `${accessorPath}.${accessor}` : accessor;
     return columnHelper.accessor(accessor, {
@@ -194,7 +207,10 @@ export default function Table({
     return getColumnsFromObject(maybeMessage as CellValue, accessorPath, classes.iconButton);
   }, [accessorPath, classes.iconButton, value]);
 
-  const data = React.useMemo(() => (Array.isArray(value) ? value : [value]), [value]);
+  const data = React.useMemo(() => {
+    const isTypedArray = ArrayBuffer.isView(value) && !(value instanceof DataView);
+    return Array.isArray(value) ? value : isTypedArray ? Array.from(value as Uint8Array) : [value];
+  }, [value]);
 
   const [expanded, setExpanded] = React.useState<ExpandedState>({});
 

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -25,6 +25,7 @@ const makeArrayData = ({
       },
       arr: nestArray ? makeArrayData({ length: 5, nestArray: false }) : [],
       primitiveArray: [1, 2, 3, 4, 5],
+      typedArray: new Uint32Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a]),
     };
   });
 };


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds support for displaying typed arrays as single paginated column in the table panel. Before, the table implementation created a column for every array element which would crash the app for large arrays (e.g. image data)

~Depending on the array size, expanding the row can take some time. This should ideally not depend on the array size since the values are paginated :thinking:~

[Screencast from 23.08.2023 13:59:42.webm](https://github.com/foxglove/studio/assets/9250155/bbce5e62-6849-4b5a-b632-796e2229afc5)


fixes FG-4575
