### PR TITLE
Support x axis min, max and range in state transitions panel

### DIFF
--- a/packages/studio-base/src/i18n/en/index.ts
+++ b/packages/studio-base/src/i18n/en/index.ts
@@ -15,4 +15,5 @@ export * from "./panels";
 export * from "./panelSettings";
 export * from "./plot";
 export * from "./settingsEditor";
+export * from "./stateTransitions";
 export * from "./threeDee";

--- a/packages/studio-base/src/i18n/en/stateTransitions.ts
+++ b/packages/studio-base/src/i18n/en/stateTransitions.ts
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const stateTransitions = {
+  maxXError: "X max must be greater than X min.",
+  min: "Min",
+  max: "Max",
+  xAxis: "X Axis",
+  secondsRange: "Range (seconds)",
+};

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -204,6 +204,57 @@ export const OnePath: StoryObj = {
   parameters: { useReadySignal: true },
 };
 
+export const WithXAxisMinMax: StoryObj = {
+  render: function Story() {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame} includeSettings>
+        <StateTransitions
+          overrideConfig={{
+            xAxisMinValue: 13,
+            xAxisMaxValue: 14,
+            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+  play: async ({ parameters }) => {
+    await parameters.storyReady;
+  },
+  parameters: { colorScheme: "light", useReadySignal: true },
+};
+
+export const WithXAxisRange: StoryObj = {
+  render: function Story() {
+    const readySignal = useReadySignal({ count: 3 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+    const ourFixture = produce(fixture, (draft) => {
+      draft.activeData!.endTime = systemStateMessages.at(-1)?.header.stamp;
+    });
+
+    return (
+      <PanelSetup fixture={ourFixture} pauseFrame={pauseFrame} includeSettings>
+        <StateTransitions
+          overrideConfig={{
+            xAxisRange: 3,
+            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+            isSynced: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+  play: async ({ parameters }) => {
+    await parameters.storyReady;
+  },
+  parameters: { colorScheme: "light", useReadySignal: true },
+};
+
 export const WithSettings: StoryObj = {
   render: function Story() {
     const readySignal = useReadySignal({ count: 3 });

--- a/packages/studio-base/src/panels/StateTransitions/types.ts
+++ b/packages/studio-base/src/panels/StateTransitions/types.ts
@@ -13,6 +13,9 @@ export type StateTransitionPath = {
 };
 
 export type StateTransitionConfig = {
-  paths: StateTransitionPath[];
   isSynced: boolean;
+  paths: StateTransitionPath[];
+  xAxisMaxValue?: number;
+  xAxisMinValue?: number;
+  xAxisRange?: number;
 };


### PR DESCRIPTION
**User-Facing Changes**
Support x axis min, max and range in state transitions

**Description**
The interface and implementation is analogous to the same feature in the plot panel.

<img width="1169" alt="Screenshot 2023-08-22 at 8 41 58 AM" src="https://github.com/foxglove/studio/assets/93935560/bea82613-437f-4bb0-846b-7ba2290529f1">


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
