### PR TITLE
Improve memory usage on large messages in the state transitions panel.

### DIFF
--- a/packages/studio-base/src/PanelAPI/useMessagesByTopic.test.tsx
+++ b/packages/studio-base/src/PanelAPI/useMessagesByTopic.test.tsx
@@ -34,6 +34,20 @@ describe("useMessagesByTopic", () => {
     expect(result.current).toEqual({ "/foo": [] });
   });
 
+  it("accepts SubscribePayloads", async () => {
+    const { result } = renderHook(
+      ({ topics, historySize }) => PanelAPI.useMessagesByTopic({ topics, historySize }),
+      {
+        initialProps: { topics: [{ topic: "/foo", fields: ["a"] }], historySize: 1 },
+        wrapper: ({ children }) => (
+          <MockMessagePipelineProvider>{children}</MockMessagePipelineProvider>
+        ),
+      },
+    );
+
+    expect(result.current).toEqual({ "/foo": [] });
+  });
+
   it("add messages to their respective arrays", () => {
     const message1: MessageEvent = {
       topic: "/foo",

--- a/packages/studio-base/src/PanelAPI/useMessagesByTopic.ts
+++ b/packages/studio-base/src/PanelAPI/useMessagesByTopic.ts
@@ -15,7 +15,7 @@ import { groupBy } from "lodash";
 import { useCallback } from "react";
 
 import { useDeepMemo } from "@foxglove/hooks";
-import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { MessageEvent, SubscribePayload } from "@foxglove/studio-base/players/types";
 import concatAndTruncate from "@foxglove/studio-base/util/concatAndTruncate";
 
 import { useMessageReducer } from "./useMessageReducer";
@@ -31,7 +31,7 @@ type UnknownMessageEventsByTopic = Record<string, readonly MessageEvent[]>;
  * - During live playback the panel will re-render when new messages arrive.
  */
 export function useMessagesByTopic(params: {
-  topics: readonly string[];
+  topics: readonly string[] | SubscribePayload[];
   historySize: number;
 }): Record<string, readonly MessageEvent[]> {
   const { historySize, topics } = params;
@@ -58,8 +58,9 @@ export function useMessagesByTopic(params: {
       // When changing topics, we try to keep as many messages around from the previous set of
       // topics as possible.
       for (const topic of requestedTopics) {
-        const prevMessages = prevMessagesByTopic?.[topic];
-        newMessagesByTopic[topic] = prevMessages?.slice(-historySize) ?? [];
+        const topicName = typeof topic === "string" ? topic : topic.topic;
+        const prevMessages = prevMessagesByTopic?.[topicName];
+        newMessagesByTopic[topicName] = prevMessages?.slice(-historySize) ?? [];
       }
       return newMessagesByTopic;
     },

--- a/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.ts
@@ -11,10 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { memoize, uniq } from "lodash";
-import { Parser, Grammar } from "nearley";
-
-import { filterMap } from "@foxglove/den/collection";
+import { memoize } from "lodash";
+import { Grammar, Parser } from "nearley";
 
 import { RosPath } from "./constants";
 import grammar from "./grammar.ne";
@@ -48,13 +46,5 @@ const parseRosPath = memoize((path: string): RosPath | undefined => {
     return undefined;
   }
 });
-export default parseRosPath;
 
-export function getTopicsFromPaths(paths: readonly string[]): string[] {
-  return uniq(
-    filterMap(paths, (path) => {
-      const rosPath = parseRosPath(path);
-      return rosPath ? rosPath.topicName : undefined;
-    }),
-  );
-}
+export default parseRosPath;

--- a/packages/studio-base/src/components/MessagePathSyntax/useMessagesByPath.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessagesByPath.test.tsx
@@ -100,10 +100,11 @@ describe("useMessagesByPath", () => {
     const { unmount, rerender } = renderHook(Hooks, {
       wrapper,
       initialProps: {
-        paths: ["/some/topic", "/some/other/topic"],
+        paths: ["/some/topic", "/some/other/topic", "/sliced_topic.field"],
         topics: [
           { name: "/some/topic", schemaName: "dummy" },
           { name: "/some/other/topic", schemaName: "dummy" },
+          { name: "/sliced_topic", schemaName: "dummy" },
         ],
       },
     });
@@ -117,6 +118,12 @@ describe("useMessagesByPath", () => {
         [
           { topic: "/some/topic", preloadType: "partial", requestor: undefined },
           { topic: "/some/other/topic", preloadType: "partial", requestor: undefined },
+          {
+            topic: "/sliced_topic",
+            preloadType: "partial",
+            fields: ["field"],
+            requestor: undefined,
+          },
         ],
       ],
       [

--- a/packages/studio-base/src/components/MessagePathSyntax/useMessagesByPath.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessagesByPath.ts
@@ -13,13 +13,14 @@
 
 import { useMemo } from "react";
 
+import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
-import { getTopicsFromPaths } from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import {
   MessageDataItemsByPath,
   useDecodeMessagePathsForMessagesByTopic,
 } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { subscribePayloadFromMessagePath } from "@foxglove/studio-base/players/subscribePayloadFromMessagePath";
 
 // Given a set of message paths, subscribe to the appropriate topics and return
 // messages with their queried data decoded for each path.
@@ -28,7 +29,10 @@ export default function useMessagesByPath(
   historySize: number = Infinity,
 ): MessageDataItemsByPath {
   const memoizedPaths: string[] = useShallowMemo(paths);
-  const subscribeTopics = useMemo(() => getTopicsFromPaths(memoizedPaths), [memoizedPaths]);
+  const subscribeTopics = useMemo(
+    () => filterMap(memoizedPaths, (path) => subscribePayloadFromMessagePath(path)),
+    [memoizedPaths],
+  );
 
   const messagesByTopic = PanelAPI.useMessagesByTopic({
     topics: subscribeTopics,

--- a/packages/studio-base/src/players/subscribePayloadFromMessagePath.test.ts
+++ b/packages/studio-base/src/players/subscribePayloadFromMessagePath.test.ts
@@ -12,16 +12,16 @@ describe("subscribePayloadFromMessagePath", () => {
 
   it("handles specific field paths", () => {
     const result = subscribePayloadFromMessagePath("topic.field");
-    expect(result).toEqual({ topic: "topic", fields: ["field"] });
+    expect(result).toEqual({ topic: "topic", fields: ["field"], preloadType: "partial" });
   });
 
   it("handles nested field paths", () => {
     const result = subscribePayloadFromMessagePath("topic.field.subfield");
-    expect(result).toEqual({ topic: "topic", fields: ["field"] });
+    expect(result).toEqual({ topic: "topic", fields: ["field"], preloadType: "partial" });
   });
 
   it("handles complex paths", () => {
     const result = subscribePayloadFromMessagePath("topic{x==1}.field[:].subfield");
-    expect(result).toEqual({ topic: "topic", fields: ["field"] });
+    expect(result).toEqual({ topic: "topic", fields: ["field"], preloadType: "partial" });
   });
 });

--- a/packages/studio-base/src/players/subscribePayloadFromMessagePath.ts
+++ b/packages/studio-base/src/players/subscribePayloadFromMessagePath.ts
@@ -28,12 +28,12 @@ export function subscribePayloadFromMessagePath(
   );
 
   if (!firstField) {
-    return { topic: parsedPath.topicName, preloadType };
+    return { topic: parsedPath.topicName, preloadType: preloadType ?? "partial" };
   }
 
   return {
     topic: parsedPath.topicName,
-    preloadType,
+    preloadType: preloadType ?? "partial",
     fields: [firstField.name],
   };
 }


### PR DESCRIPTION
**User-Facing Changes**
Improve memory usage on large messages in the state transitions panel.

**Description**
During playback the StateTransition panel accumulates currentFrame messages via the useMessagesByPath hook. This PR expands topic slicing to that hook so that we only accumulate the portions of messages we actually need.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
