### PR TITLE
Fix block loader loading index logic

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -345,7 +345,7 @@ export class BlockLoader {
       }
 
       await cursor.end();
-      blockId = endBlockId + 1;
+      blockId = endBlockId;
     }
   }
 


### PR DESCRIPTION
**User-Facing Changes**
Fixes a bug causing incomplete plot loading on large datasets.

**Description**
Fix an off-by-one error in the block loader loading algorithm. When it completes an iteration of the load loop it sets the new start index to the end index + 1:

https://github.com/foxglove/studio/blob/61afaf699cfb95783332e468315f3b088013d264/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts#L348

This is incorrect because the outer loop also increments this index:
https://github.com/foxglove/studio/blob/61afaf699cfb95783332e468315f3b088013d264/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts#L199

This results in an `undefined` block in the block list, which stalls downstream loading of blocks that interprets an undefined block as a block waiting to load.

This issue only manifests on larger datasets and more complex layouts where the topics requested change during iterations of this loop. On smaller samples like nuscenes and our sample layouts the loader completes this load process in one iteration so this bug doesn't arise under those conditions.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
FG-4728
