### PR TITLE
Add drag & drop support to Topics sidebar

### DIFF
--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -121,7 +121,7 @@ export const Basic: StoryObj<{ initialLayoutState: Partial<LayoutData> }> = {
     ];
     return (
       <MultiProvider providers={providers}>
-        <Workspace />
+        <Workspace disablePersistenceForStorybook />
       </MultiProvider>
     );
   },

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -162,8 +162,8 @@ export const DragTopicStart: typeof Basic = {
   play: async () => {
     fireEvent.click(await screen.findByText("Topics"));
 
-    const row = await screen.findByText("test.Foo");
-    fireEvent.dragStart(row);
+    const handle = await screen.findByTestId("TopicListDragHandle");
+    fireEvent.dragStart(handle);
   },
 };
 
@@ -172,8 +172,8 @@ export const DragTopicOver: typeof Basic = {
   play: async () => {
     fireEvent.click(await screen.findByText("Topics"));
 
-    const row = await screen.findByText("test.Foo");
-    fireEvent.dragStart(row);
+    const handle = await screen.findByTestId("TopicListDragHandle");
+    fireEvent.dragStart(handle);
     const dest = await screen.findByText("Drop here!");
     fireEvent.dragOver(dest);
   },
@@ -184,8 +184,8 @@ export const DragTopicDrop: typeof Basic = {
   play: async () => {
     fireEvent.click(await screen.findByText("Topics"));
 
-    const row = await screen.findByText("test.Foo");
-    fireEvent.dragStart(row);
+    const handle = await screen.findByTestId("TopicListDragHandle");
+    fireEvent.dragStart(handle);
     const dest = await screen.findByText("Drop here!");
     fireEvent.dragOver(dest);
     fireEvent.drop(dest);

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -3,18 +3,22 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
-import { fireEvent, screen } from "@storybook/testing-library";
+import { fireEvent, screen, userEvent } from "@storybook/testing-library";
+import { useEffect, useState } from "react";
 
+import { DraggedMessagePath } from "@foxglove/studio";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
-import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
 import Workspace from "./Workspace";
 
@@ -46,22 +50,73 @@ class MockPanelCatalog implements PanelCatalog {
       };
     },
   };
+
+  static #droppablePanel: PanelInfo = {
+    title: "Droppable Panel",
+    type: "Droppable",
+    module: async () => {
+      return {
+        default: Panel(
+          Object.assign(
+            function DroppablePanel() {
+              const { setMessagePathDropConfig } = usePanelContext();
+              const [droppedPath, setDroppedPath] = useState<DraggedMessagePath | undefined>();
+              useEffect(() => {
+                setMessagePathDropConfig({
+                  getDropStatus(path) {
+                    return { canDrop: true, message: "Example drop message" };
+                  },
+                  handleDrop(path) {
+                    setDroppedPath(path);
+                  },
+                });
+              }, [setMessagePathDropConfig]);
+              return (
+                <>
+                  <PanelToolbar />
+                  <div>Drop here!</div>
+                  {droppedPath && (
+                    <>
+                      <div>
+                        Path: <code>{droppedPath.path}</code>
+                      </div>
+                      <div>
+                        Root schema name: <code>{droppedPath.rootSchemaName}</code>
+                      </div>
+                    </>
+                  )}
+                </>
+              );
+            },
+            { panelType: "Droppable", defaultConfig: {} },
+          ),
+        ),
+      };
+    },
+  };
+
   public getPanels(): readonly PanelInfo[] {
-    return [MockPanelCatalog.#fakePanel];
+    return [MockPanelCatalog.#fakePanel, MockPanelCatalog.#droppablePanel];
   }
-  public getPanelByType(_type: string): PanelInfo | undefined {
-    return MockPanelCatalog.#fakePanel;
+  public getPanelByType(type: string): PanelInfo | undefined {
+    return this.getPanels().find((panel) => panel.type === type);
   }
 }
 
-export const Basic: StoryObj = {
-  render: () => {
+export const Basic: StoryObj<{ initialLayoutState: Partial<LayoutData> }> = {
+  args: {
+    initialLayoutState: { layout: "Fake" },
+  },
+  render: (args) => {
+    const fixture: Fixture = {
+      topics: [{ name: "foo", schemaName: "test.Foo" }],
+    };
     const providers = [
       /* eslint-disable react/jsx-key */
-      <PanelSetup>{undefined}</PanelSetup>,
+      <PanelSetup fixture={fixture}>{undefined}</PanelSetup>,
       <EventsProvider />,
       <PanelCatalogContext.Provider value={new MockPanelCatalog()} />,
-      <MockCurrentLayoutProvider initialState={{ layout: "Fake" }} />,
+      <MockCurrentLayoutProvider initialState={args.initialLayoutState} />,
       /* eslint-enable react/jsx-key */
     ];
     return (
@@ -72,10 +127,53 @@ export const Basic: StoryObj = {
   },
 };
 
-export const FullscreenPanel: StoryObj = {
+export const FullscreenPanel: typeof Basic = {
   ...Basic,
   play: async () => {
     fireEvent.click(await screen.findByTestId("panel-menu"));
     fireEvent.click(await screen.findByTestId("panel-menu-fullscreen"));
+  },
+};
+
+export const DragTopicOver: typeof Basic = {
+  ...Basic,
+  args: {
+    initialLayoutState: {
+      layout: {
+        direction: "column",
+        first: "Fake",
+        second: "Droppable",
+      },
+    },
+  },
+  play: async () => {
+    fireEvent.click(await screen.findByText("Topics"));
+
+    const row = await screen.findByText("test.Foo");
+    const dest = await screen.findByText("Drop here!");
+    fireEvent.dragStart(row);
+    fireEvent.dragOver(dest);
+  },
+};
+
+export const DragTopicDrop: typeof Basic = {
+  ...Basic,
+  args: {
+    initialLayoutState: {
+      layout: {
+        direction: "column",
+        first: "Fake",
+        second: "Droppable",
+      },
+    },
+  },
+  play: async () => {
+    fireEvent.click(await screen.findByText("Topics"));
+
+    const row = await screen.findByText("test.Foo");
+    const dest = await screen.findByText("Drop here!");
+    fireEvent.dragStart(row);
+    fireEvent.dragOver(dest);
+    fireEvent.drop(dest);
   },
 };

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -16,6 +16,7 @@ import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
+import Tab from "@foxglove/studio-base/panels/Tab";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
@@ -96,7 +97,11 @@ class MockPanelCatalog implements PanelCatalog {
   };
 
   public getPanels(): readonly PanelInfo[] {
-    return [MockPanelCatalog.#fakePanel, MockPanelCatalog.#droppablePanel];
+    return [
+      MockPanelCatalog.#fakePanel,
+      MockPanelCatalog.#droppablePanel,
+      { title: "Tab", type: "Tab", module: async () => ({ default: Tab }) },
+    ];
   }
   public getPanelByType(type: string): PanelInfo | undefined {
     return this.getPanels().find((panel) => panel.type === type);
@@ -135,14 +140,22 @@ export const FullscreenPanel: typeof Basic = {
   },
 };
 
-export const DragTopicOver: typeof Basic = {
+export const DragTopicStart: typeof Basic = {
   ...Basic,
   args: {
     initialLayoutState: {
       layout: {
         direction: "column",
         first: "Fake",
-        second: "Droppable",
+        second: "Tab!a",
+      },
+      configById: {
+        "Tab!a": {
+          activeTabIdx: 0,
+          tabs: [
+            { title: "Tab A", layout: { direction: "row", first: "Fake", second: "Droppable" } },
+          ],
+        },
       },
     },
   },
@@ -150,29 +163,30 @@ export const DragTopicOver: typeof Basic = {
     fireEvent.click(await screen.findByText("Topics"));
 
     const row = await screen.findByText("test.Foo");
-    const dest = await screen.findByText("Drop here!");
     fireEvent.dragStart(row);
+  },
+};
+
+export const DragTopicOver: typeof Basic = {
+  ...DragTopicStart,
+  play: async () => {
+    fireEvent.click(await screen.findByText("Topics"));
+
+    const row = await screen.findByText("test.Foo");
+    fireEvent.dragStart(row);
+    const dest = await screen.findByText("Drop here!");
     fireEvent.dragOver(dest);
   },
 };
 
 export const DragTopicDrop: typeof Basic = {
-  ...Basic,
-  args: {
-    initialLayoutState: {
-      layout: {
-        direction: "column",
-        first: "Fake",
-        second: "Droppable",
-      },
-    },
-  },
+  ...DragTopicStart,
   play: async () => {
     fireEvent.click(await screen.findByText("Topics"));
 
     const row = await screen.findByText("test.Foo");
-    const dest = await screen.findByText("Drop here!");
     fireEvent.dragStart(row);
+    const dest = await screen.findByText("Drop here!");
     fireEvent.dragOver(dest);
     fireEvent.drop(dest);
   },

--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
-import { fireEvent, screen, userEvent } from "@storybook/testing-library";
+import { fireEvent, screen } from "@storybook/testing-library";
 import { useEffect, useState } from "react";
 
 import { DraggedMessagePath } from "@foxglove/studio";
@@ -63,7 +63,7 @@ class MockPanelCatalog implements PanelCatalog {
               const [droppedPath, setDroppedPath] = useState<DraggedMessagePath | undefined>();
               useEffect(() => {
                 setMessagePathDropConfig({
-                  getDropStatus(path) {
+                  getDropStatus(_path) {
                     return { canDrop: true, message: "Example drop message" };
                   },
                   handleDrop(path) {

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -85,6 +85,8 @@ type WorkspaceProps = CustomWindowControlsProps & {
   deepLinks?: string[];
   appBarLeftInset?: number;
   onAppBarDoubleClick?: () => void;
+  // eslint-disable-next-line react/no-unused-prop-types
+  disablePersistenceForStorybook?: boolean;
 };
 
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
@@ -522,6 +524,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     <WorkspaceContextProvider
       initialState={initialState}
       workspaceStoreCreator={workspaceStoreCreator}
+      disablePersistenceForStorybook={props.disablePersistenceForStorybook}
     >
       <WorkspaceContent {...props} />
     </WorkspaceContextProvider>

--- a/packages/studio-base/src/components/MessagePathDragOverlay.tsx
+++ b/packages/studio-base/src/components/MessagePathDragOverlay.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export function PanelOverlay(prop: Props): JSX.Element | ReactNull {
+export function MessagePathDragOverlay(prop: Props): JSX.Element | ReactNull {
   const { isDragging, isOver, isValidTarget, message } = prop;
   const { classes, cx } = useStyles();
 

--- a/packages/studio-base/src/components/MockPanelContextProvider.tsx
+++ b/packages/studio-base/src/components/MockPanelContextProvider.tsx
@@ -30,6 +30,7 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<PanelConfig> = {
   setHasFullscreenDescendant: () => {},
   isFullscreen: false,
   connectToolbarDragHandle: () => {},
+  setMessagePathDropConfig: () => {},
 };
 
 function MockPanelContextProvider({

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -59,6 +59,7 @@ import {
   WorkspaceStoreSelectors,
 } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 import usePanelDrag from "@foxglove/studio-base/hooks/usePanelDrag";
+import { useMessagePathDrop } from "@foxglove/studio-base/services/messagePathDragging";
 import { TabPanelConfig } from "@foxglove/studio-base/types/layouts";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
@@ -126,6 +127,27 @@ const useStyles = makeStyles()((theme) => ({
     ".MuiButton-startIcon": {
       margin: 0,
     },
+  },
+  messagePathDropOverlay: {
+    position: "absolute",
+    inset: 0,
+    overflow: "hidden",
+    padding: theme.spacing(2),
+    zIndex: theme.zIndex.modal,
+    backgroundColor: theme.palette.action.hover,
+    backdropFilter: "blur(4px)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  messagePathDropOverlayText: {
+    textAlign: "center",
+    fontSize: theme.typography.subtitle1.fontSize,
+    color: theme.palette.secondary.contrastText,
+    overflowWrap: "anywhere",
+    padding: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.light,
+    borderRadius: theme.shape.borderRadius * 2,
   },
 }));
 
@@ -462,6 +484,13 @@ export default function Panel<
       [parentPanelContext],
     );
 
+    const {
+      connectDropTarget: connectMessagePathDropTarget,
+      isOver: showDropOverlay,
+      message: dropMessage,
+      setMessagePathDropConfig,
+    } = useMessagePathDrop();
+
     // We use two separate sets of key handlers because the panel context and exitFullScreen
     // change often and invalidate our key handlers during user interactions.
     const { keyUpHandlers, keyDownHandlers } = useMemo(
@@ -555,6 +584,7 @@ export default function Panel<
             tabId,
             // disallow dragging the root panel in a layout
             connectToolbarDragHandle: isTopLevelPanel ? undefined : connectToolbarDragHandle,
+            setMessagePathDropConfig,
           }}
         >
           <KeyListener global keyUpHandlers={keyUpHandlers} keyDownHandlers={keyDownHandlers} />
@@ -583,6 +613,7 @@ export default function Panel<
                     connectOverlayDragPreview(el);
                     connectToolbarDragPreview(el);
                   }
+                  connectMessagePathDropTarget(el);
                 }}
               >
                 {isSelected && !fullscreen && numSelectedPanelsIfSelected > 1 && (
@@ -607,6 +638,11 @@ export default function Panel<
                         Create {numSelectedPanelsIfSelected} tabs
                       </Button>
                     </Stack>
+                  </div>
+                )}
+                {showDropOverlay && (
+                  <div className={classes.messagePathDropOverlay}>
+                    <div className={classes.messagePathDropOverlayText}>{dropMessage}</div>
                   </div>
                 )}
                 {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullscreen && (

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -485,6 +485,7 @@ export default function Panel<
     );
 
     const {
+      isDragging: _isDraggingMessagePath,
       connectDropTarget: connectMessagePathDropTarget,
       isOver: showDropOverlay,
       message: dropMessage,

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -44,10 +44,10 @@ import { makeStyles } from "tss-react/mui";
 import { useShallowMemo } from "@foxglove/hooks";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
+import { MessagePathDragOverlay } from "@foxglove/studio-base/components/MessagePathDragOverlay";
 import { MosaicPathContext } from "@foxglove/studio-base/components/MosaicPathContext";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import PanelErrorBoundary from "@foxglove/studio-base/components/PanelErrorBoundary";
-import { PanelOverlay } from "@foxglove/studio-base/components/PanelOverlay";
 import { PanelRoot, PANEL_ROOT_CLASS_NAME } from "@foxglove/studio-base/components/PanelRoot";
 import Stack from "@foxglove/studio-base/components/Stack";
 import {
@@ -468,8 +468,8 @@ export default function Panel<
       isDragging,
       isOver,
       isValidTarget,
-      connectDropTarget: connectMessagePathDropTarget,
-      message: dropMessage,
+      connectMessagePathDropTarget,
+      dropMessage,
       setMessagePathDropConfig,
     } = useMessagePathDrop();
 
@@ -622,12 +622,14 @@ export default function Panel<
                     </Stack>
                   </div>
                 )}
-                <PanelOverlay
-                  isDragging={isDragging}
-                  isValidTarget={isValidTarget}
-                  isOver={isOver}
-                  message={dropMessage}
-                />
+                {type !== TAB_PANEL_TYPE && (
+                  <MessagePathDragOverlay
+                    isDragging={isDragging}
+                    isValidTarget={isValidTarget}
+                    isOver={isOver}
+                    message={dropMessage}
+                  />
+                )}
                 {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullscreen && (
                   <div
                     className={classes.actionsOverlay}

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -47,6 +47,7 @@ import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import { MosaicPathContext } from "@foxglove/studio-base/components/MosaicPathContext";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import PanelErrorBoundary from "@foxglove/studio-base/components/PanelErrorBoundary";
+import { PanelOverlay } from "@foxglove/studio-base/components/PanelOverlay";
 import { PanelRoot, PANEL_ROOT_CLASS_NAME } from "@foxglove/studio-base/components/PanelRoot";
 import Stack from "@foxglove/studio-base/components/Stack";
 import {
@@ -127,27 +128,6 @@ const useStyles = makeStyles()((theme) => ({
     ".MuiButton-startIcon": {
       margin: 0,
     },
-  },
-  messagePathDropOverlay: {
-    position: "absolute",
-    inset: 0,
-    overflow: "hidden",
-    padding: theme.spacing(2),
-    zIndex: theme.zIndex.modal,
-    backgroundColor: theme.palette.action.hover,
-    backdropFilter: "blur(4px)",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  messagePathDropOverlayText: {
-    textAlign: "center",
-    fontSize: theme.typography.subtitle1.fontSize,
-    color: theme.palette.secondary.contrastText,
-    overflowWrap: "anywhere",
-    padding: theme.spacing(1),
-    backgroundColor: theme.palette.secondary.light,
-    borderRadius: theme.shape.borderRadius * 2,
   },
 }));
 
@@ -485,9 +465,10 @@ export default function Panel<
     );
 
     const {
-      isDragging: _isDraggingMessagePath,
+      isDragging,
+      isOver,
+      isValidTarget,
       connectDropTarget: connectMessagePathDropTarget,
-      isOver: showDropOverlay,
       message: dropMessage,
       setMessagePathDropConfig,
     } = useMessagePathDrop();
@@ -641,11 +622,12 @@ export default function Panel<
                     </Stack>
                   </div>
                 )}
-                {showDropOverlay && (
-                  <div className={classes.messagePathDropOverlay}>
-                    <div className={classes.messagePathDropOverlayText}>{dropMessage}</div>
-                  </div>
-                )}
+                <PanelOverlay
+                  isDragging={isDragging}
+                  isValidTarget={isValidTarget}
+                  isOver={isOver}
+                  message={dropMessage}
+                />
                 {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullscreen && (
                   <div
                     className={classes.actionsOverlay}

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { MessagePathDropConfig } from "@foxglove/studio";
 import { SaveConfig, PanelConfig, OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
 
 export type PanelContextType<T> = {
@@ -35,6 +36,8 @@ export type PanelContextType<T> = {
   setHasFullscreenDescendant: (hasFullscreenDescendant: boolean) => void;
 
   connectToolbarDragHandle?: (el: Element | ReactNull) => void;
+
+  setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
 };
 
 // Context used for components to know which panel they are inside

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -120,7 +120,7 @@ function PanelExtensionAdapter(
 
   const { capabilities, profile: dataSourceProfile } = playerState;
 
-  const { openSiblingPanel } = usePanelContext();
+  const { openSiblingPanel, setMessagePathDropConfig } = usePanelContext();
 
   const [panelId] = useState(() => uuid());
   const isMounted = useSynchronousMountedState();
@@ -508,6 +508,10 @@ function PanelExtensionAdapter(
         }
         setDefaultPanelTitle(title);
       },
+
+      EXPERIMENTAL_setMessagePathDropConfig(dropConfig) {
+        setMessagePathDropConfig(dropConfig);
+      },
     };
   }, [
     capabilities,
@@ -526,6 +530,7 @@ function PanelExtensionAdapter(
     setSharedPanelState,
     setSubscriptions,
     updatePanelSettingsTree,
+    setMessagePathDropConfig,
   ]);
 
   const panelContainerRef = useRef<HTMLDivElement>(ReactNull);

--- a/packages/studio-base/src/components/PanelOverlay.tsx
+++ b/packages/studio-base/src/components/PanelOverlay.tsx
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Backdrop, Chip } from "@mui/material";
+import tc from "tinycolor2";
+import { makeStyles } from "tss-react/mui";
+
+type Props = {
+  message?: string;
+  isDragging: boolean;
+  isOver: boolean;
+  isValidTarget: boolean;
+};
+
+const useStyles = makeStyles()((theme) => ({
+  backdrop: {
+    position: "absolute",
+    zIndex: theme.zIndex.modal - 1,
+    alignItems: "flex-end",
+    padding: theme.spacing(2),
+  },
+  invalidTarget: {
+    backgroundColor: tc(theme.palette.background.default)
+      .setAlpha(1 - theme.palette.action.disabledOpacity)
+      .toRgbString(),
+  },
+  validTarget: {
+    borderRadius: theme.shape.borderRadius,
+    border: `2px solid ${theme.palette.primary.main}`,
+    backgroundColor: tc(theme.palette.primary.main)
+      .setAlpha(theme.palette.action.hoverOpacity)
+      .toRgbString(),
+  },
+  chip: {
+    boxShadow: theme.shadows[2],
+    paddingInline: theme.spacing(2),
+  },
+}));
+
+export function PanelOverlay(prop: Props): JSX.Element | ReactNull {
+  const { isDragging, isOver, isValidTarget, message } = prop;
+  const { classes, cx } = useStyles();
+
+  if (!isDragging) {
+    return ReactNull;
+  }
+
+  if (!isValidTarget) {
+    return <Backdrop open className={cx(classes.backdrop, classes.invalidTarget)} />;
+  }
+
+  if (isOver) {
+    return (
+      <Backdrop open className={cx(classes.backdrop, classes.validTarget)}>
+        {prop.message && (
+          <Chip size="small" color="primary" label={message} className={classes.chip} />
+        )}
+      </Backdrop>
+    );
+  }
+
+  return ReactNull;
+}

--- a/packages/studio-base/src/components/StatsChip.tsx
+++ b/packages/studio-base/src/components/StatsChip.tsx
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Divider, Paper } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
+
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "flex",
+    borderColor: theme.palette.action.selected,
+    borderRadius: "1em",
+    color: theme.palette.text.secondary,
+    backgroundColor: theme.palette.background.paper,
+
+    [`@container (max-width: 320px)`]: {
+      display: "none",
+    },
+  },
+  stat: {
+    whiteSpace: "nowrap",
+    minWidth: "1em",
+    textAlign: "center",
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.palette.text.secondary,
+    paddingBlock: theme.spacing(0.25),
+    fontFeatureSettings: `${theme.typography.fontFeatureSettings}, 'tnum'`,
+
+    "&:nth-child(1)": {
+      paddingInlineStart: theme.spacing(0.75),
+    },
+    "&:nth-last-child(1)": {
+      paddingInlineEnd: theme.spacing(0.75),
+    },
+  },
+  divider: {
+    borderColor: theme.palette.action.selected,
+    marginInline: theme.spacing(0.5),
+  },
+}));
+
+export function StatsChip({ topicName }: { topicName: string }): JSX.Element {
+  const { classes } = useStyles();
+  return (
+    <Paper variant="outlined" className={classes.root}>
+      <div className={classes.stat} data-topic={topicName} data-topic-stat="frequency">
+        &ndash;
+      </div>
+      <Divider className={classes.divider} orientation="vertical" flexItem />
+      <div className={classes.stat} data-topic={topicName} data-topic-stat="count">
+        &ndash;
+      </div>
+    </Paper>
+  );
+}

--- a/packages/studio-base/src/components/TopicList.stories.tsx
+++ b/packages/studio-base/src/components/TopicList.stories.tsx
@@ -4,6 +4,8 @@
 
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
@@ -42,9 +44,11 @@ export default {
     topicStats,
   },
   render: (args) => (
-    <MockMessagePipelineProvider {...args}>
-      <TopicList />
-    </MockMessagePipelineProvider>
+    <DndProvider backend={HTML5Backend}>
+      <MockMessagePipelineProvider {...args}>
+        <TopicList />
+      </MockMessagePipelineProvider>
+    </DndProvider>
   ),
 } as Meta<typeof MockMessagePipelineProvider>;
 

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -27,7 +27,7 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { StatsChip } from "@foxglove/studio-base/components/StatsChip";
+import { TopicStatsChip } from "@foxglove/studio-base/components/TopicStatsChip";
 import { PlayerPresence, TopicStats } from "@foxglove/studio-base/players/types";
 import { useMessagePathDrag } from "@foxglove/studio-base/services/messagePathDragging";
 import { Topic } from "@foxglove/studio-base/src/players/types";
@@ -142,7 +142,7 @@ function TopicListItem({
         }}
       />
       <Stack direction="row" alignItems="center" fullHeight gap={0.5} paddingX={0.5}>
-        <StatsChip topicName={topic.name} />
+        <TopicStatsChip topicName={topic.name} />
         <div
           className={classes.dragHandle}
           data-testid="TopicListDragHandle"

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -143,7 +143,12 @@ function TopicListItem({
       />
       <Stack direction="row" alignItems="center" fullHeight gap={0.5} paddingX={0.5}>
         <StatsChip topicName={topic.name} />
-        <div className={classes.dragHandle} ref={connectDragSource} style={{ cursor }}>
+        <div
+          className={classes.dragHandle}
+          data-testid="TopicListDragHandle"
+          ref={connectDragSource}
+          style={{ cursor }}
+        >
           <ReOrderDotsVertical16Regular />
         </div>
       </Stack>

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -26,6 +26,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { PlayerPresence, TopicStats } from "@foxglove/studio-base/players/types";
+import { useMessagePathDrag } from "@foxglove/studio-base/services/messagePathDragging";
 import { Topic } from "@foxglove/studio-base/src/players/types";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -86,6 +87,11 @@ function TopicListItem({
   topic: Topic;
   positions: Set<number>;
 }): JSX.Element {
+  const { connectDragSource, cursor } = useMessagePathDrag({
+    path: topic.name,
+    rootSchemaName: topic.schemaName,
+  });
+
   const { classes } = useStyles();
   return (
     <ListItem
@@ -112,6 +118,8 @@ function TopicListItem({
           </Typography>
         </Stack>
       }
+      ref={connectDragSource}
+      style={{ cursor }}
     >
       <ListItemText
         primary={

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -98,7 +98,7 @@ function TopicListItem({
   positions: Set<number>;
 }): JSX.Element {
   const { classes, cx } = useStyles();
-  const { connectDragSource, cursor, isDragging } = useMessagePathDrag({
+  const { connectDragSource, connectDragPreview, cursor, isDragging } = useMessagePathDrag({
     path: topic.name,
     rootSchemaName: topic.schemaName,
   });
@@ -108,8 +108,7 @@ function TopicListItem({
       key={topic.name}
       divider
       className={cx(classes.listItem, { isDragging })}
-      ref={connectDragSource}
-      style={{ cursor }}
+      ref={connectDragPreview}
     >
       <ListItemText
         className={classes.listItemText}
@@ -144,7 +143,9 @@ function TopicListItem({
       />
       <Stack direction="row" alignItems="center" fullHeight gap={0.5} paddingX={0.5}>
         <StatsChip topicName={topic.name} />
-        <ReOrderDotsVertical16Regular className={classes.dragHandle} />
+        <div className={classes.dragHandle} ref={connectDragSource} style={{ cursor }}>
+          <ReOrderDotsVertical16Regular />
+        </div>
       </Stack>
     </ListItem>
   );

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -88,12 +88,12 @@ function TopicListItem({
   topic: Topic;
   positions: Set<number>;
 }): JSX.Element {
+  const { classes } = useStyles();
   const { connectDragSource, cursor } = useMessagePathDrag({
     path: topic.name,
     rootSchemaName: topic.schemaName,
   });
 
-  const { classes } = useStyles();
   return (
     <ListItem
       key={topic.name}

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { ReOrderDotsVertical16Regular } from "@fluentui/react-icons";
 import ClearIcon from "@mui/icons-material/Clear";
 import SearchIcon from "@mui/icons-material/Search";
 import {
@@ -25,6 +26,7 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { StatsChip } from "@foxglove/studio-base/components/StatsChip";
 import { PlayerPresence, TopicStats } from "@foxglove/studio-base/players/types";
 import { useMessagePathDrag } from "@foxglove/studio-base/services/messagePathDragging";
 import { Topic } from "@foxglove/studio-base/src/players/types";
@@ -41,7 +43,7 @@ const topicToFzfResult = (item: TopicWithStats) =>
     end: 0,
   } as FzfResultItem<TopicWithStats>);
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles<void, "dragHandle">()((theme, _params, classes) => ({
   appBar: {
     top: 0,
     zIndex: theme.zIndex.appBar,
@@ -50,22 +52,17 @@ const useStyles = makeStyles()((theme) => ({
     backgroundColor: theme.palette.background.paper,
   },
   listItem: {
-    paddingRight: theme.spacing(1),
+    backgroundColor: theme.palette.background.paper,
+    containerType: "inline-size",
+    paddingRight: 0,
 
-    "&.MuiListItem-dense": {
-      ".MuiListItemText-root": {
-        marginTop: theme.spacing(0.5),
-        marginBottom: theme.spacing(0.5),
-      },
-    },
-    ".MuiListItemSecondaryAction-root": {
-      marginRight: theme.spacing(-1),
+    [`:not(:hover) .${classes.dragHandle}`]: {
+      visibility: "hidden",
     },
   },
-  textField: {
-    ".MuiOutlinedInput-notchedOutline": {
-      border: "none",
-    },
+  listItemText: {
+    marginTop: theme.spacing(0.5),
+    marginBottom: theme.spacing(0.5),
   },
   aliasedTopicName: {
     color: theme.palette.primary.main,
@@ -74,6 +71,10 @@ const useStyles = makeStyles()((theme) => ({
   },
   startAdornment: {
     display: "flex",
+  },
+  dragHandle: {
+    opacity: 0.6,
+    cursor: "grab",
   },
 }));
 
@@ -95,33 +96,14 @@ function TopicListItem({
   const { classes } = useStyles();
   return (
     <ListItem
-      className={classes.listItem}
-      divider
       key={topic.name}
-      secondaryAction={
-        <Stack style={{ textAlign: "right" }}>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            data-topic={topic.name}
-            data-topic-stat="count"
-          >
-            &mdash;
-          </Typography>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            data-topic={topic.name}
-            data-topic-stat="frequency"
-          >
-            &mdash;
-          </Typography>
-        </Stack>
-      }
+      divider
+      className={classes.listItem}
       ref={connectDragSource}
       style={{ cursor }}
     >
       <ListItemText
+        className={classes.listItemText}
         primary={
           <>
             <HighlightChars str={topic.name} indices={positions} />
@@ -150,8 +132,11 @@ function TopicListItem({
           noWrap: true,
           title: topic.schemaName,
         }}
-        style={{ marginRight: "48px" }}
       />
+      <Stack direction="row" alignItems="center" fullHeight gap={0.5} paddingX={0.5}>
+        <StatsChip topicName={topic.name} />
+        <ReOrderDotsVertical16Regular className={classes.dragHandle} />
+      </Stack>
     </ListItem>
   );
 }
@@ -191,7 +176,7 @@ export function TopicList(): JSX.Element {
         <header className={classes.appBar}>
           <TextField
             disabled
-            className={classes.textField}
+            variant="filled"
             fullWidth
             placeholder="Waiting for data..."
             InputProps={{
@@ -204,6 +189,7 @@ export function TopicList(): JSX.Element {
           {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15].map((i) => (
             <ListItem className={cx(classes.listItem, "loading")} divider key={i}>
               <ListItemText
+                className={classes.listItemText}
                 primary={<Skeleton animation={false} width="20%" />}
                 secondary={<Skeleton animation="wave" width="55%" />}
                 secondaryTypographyProps={{ variant: "caption" }}
@@ -224,7 +210,6 @@ export function TopicList(): JSX.Element {
           disabled={playerPresence !== PlayerPresence.PRESENT}
           onChange={(event) => setFilterText(event.target.value)}
           value={filterText}
-          className={classes.textField}
           fullWidth
           placeholder="Filter by topic or schema name…"
           InputProps={{
@@ -250,9 +235,9 @@ export function TopicList(): JSX.Element {
 
       {filteredTopics.length > 0 ? (
         <List key="topics" dense disablePadding>
-          {filteredTopics.map(({ item: topic, positions }) => {
-            return <MemoTopicListItem key={topic.name} topic={topic} positions={positions} />;
-          })}
+          {filteredTopics.map(({ item: topic, positions }) => (
+            <MemoTopicListItem key={topic.name} topic={topic} positions={positions} />
+          ))}
         </List>
       ) : (
         <EmptyState>

--- a/packages/studio-base/src/components/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import { Fzf, FzfResultItem } from "fzf";
 import { useMemo, useState } from "react";
+import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
 import { DirectTopicStatsUpdater } from "@foxglove/studio-base/components/DirectTopicStatsUpdater";
@@ -56,6 +57,14 @@ const useStyles = makeStyles<void, "dragHandle">()((theme, _params, classes) => 
     containerType: "inline-size",
     paddingRight: 0,
 
+    "&.isDragging:active": {
+      backgroundColor: tc(theme.palette.primary.main)
+        .setAlpha(theme.palette.action.hoverOpacity)
+        .toRgbString(),
+      outline: `1px solid ${theme.palette.primary.main}`,
+      outlineOffset: -1,
+      borderRadius: theme.shape.borderRadius,
+    },
     [`:not(:hover) .${classes.dragHandle}`]: {
       visibility: "hidden",
     },
@@ -88,8 +97,8 @@ function TopicListItem({
   topic: Topic;
   positions: Set<number>;
 }): JSX.Element {
-  const { classes } = useStyles();
-  const { connectDragSource, cursor } = useMessagePathDrag({
+  const { classes, cx } = useStyles();
+  const { connectDragSource, cursor, isDragging } = useMessagePathDrag({
     path: topic.name,
     rootSchemaName: topic.schemaName,
   });
@@ -98,7 +107,7 @@ function TopicListItem({
     <ListItem
       key={topic.name}
       divider
-      className={classes.listItem}
+      className={cx(classes.listItem, { isDragging })}
       ref={connectDragSource}
       style={{ cursor }}
     >

--- a/packages/studio-base/src/components/TopicStatsChip.tsx
+++ b/packages/studio-base/src/components/TopicStatsChip.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export function StatsChip({ topicName }: { topicName: string }): JSX.Element {
+export function TopicStatsChip({ topicName }: { topicName: string }): JSX.Element {
   const { classes } = useStyles();
   return (
     <Paper variant="outlined" className={classes.root}>

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -110,6 +110,18 @@ function RawMessages(props: Props) {
   const { topicPath, diffMethod, diffTopicPath, diffEnabled, showFullMessageForDiff } = config;
   const { topics, datatypes } = useDataSourceInfo();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+  const { setMessagePathDropConfig } = usePanelContext();
+
+  useEffect(() => {
+    setMessagePathDropConfig({
+      getDropStatus(_path) {
+        return { canDrop: true, effect: "replace" };
+      },
+      handleDrop(path) {
+        saveConfig({ topicPath: path.path });
+      },
+    });
+  }, [setMessagePathDropConfig, saveConfig]);
 
   const defaultGetItemString = useGetItemStringWithTimezone();
   const getItemString = useMemo(

--- a/packages/studio-base/src/panels/Table/index.tsx
+++ b/packages/studio-base/src/panels/Table/index.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { useEffect } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { useMessagesByTopic } from "@foxglove/studio-base/PanelAPI";
@@ -20,6 +21,7 @@ import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/cons
 import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import { useCachedGetMessagePathDataItems } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import Panel from "@foxglove/studio-base/components/Panel";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -58,6 +60,19 @@ function TablePanel({ config, saveConfig }: Props) {
   const msg = msgs?.[0];
   const cachedMessages = msg ? cachedGetMessagePathDataItems(topicPath, msg) ?? [] : [];
   const firstCachedMessage = cachedMessages[0];
+
+  const { setMessagePathDropConfig } = usePanelContext();
+
+  useEffect(() => {
+    setMessagePathDropConfig({
+      getDropStatus(_path) {
+        return { canDrop: true, effect: "replace" };
+      },
+      handleDrop(path) {
+        saveConfig({ topicPath: path.path });
+      },
+    });
+  }, [setMessagePathDropConfig, saveConfig]);
 
   return (
     <Stack flex="auto" overflow="hidden" position="relative">

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -65,7 +65,7 @@ const REMOVE_IMAGE_TIMEOUT_MS = 50;
 
 type ImageModeEvent = { type: "hasModifiedViewChanged" };
 
-const ALL_SUPPORTED_IMAGE_SCHEMAS = new Set([
+export const ALL_SUPPORTED_IMAGE_SCHEMAS = new Set([
   ...ROS_IMAGE_DATATYPES,
   ...ROS_COMPRESSED_IMAGE_DATATYPES,
   ...RAW_IMAGE_DATATYPES,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -48,7 +48,7 @@ const LEGACY_ANNOTATION_SCHEMAS = new Set([
   "webviz_msgs/ImageMarkerArray",
 ]);
 
-const ALL_SUPPORTED_SCHEMAS = new Set([
+export const ALL_SUPPORTED_ANNOTATION_SCHEMAS = new Set([
   ...IMAGE_ANNOTATIONS_DATATYPES,
   ...IMAGE_MARKER_DATATYPES,
   ...IMAGE_MARKER_ARRAY_DATATYPES,
@@ -83,7 +83,7 @@ export class ImageAnnotations extends THREE.Object3D {
     return [
       {
         type: "schema",
-        schemaNames: ALL_SUPPORTED_SCHEMAS,
+        schemaNames: ALL_SUPPORTED_ANNOTATION_SCHEMAS,
         subscription: { handler: this.#context.messageHandler.handleAnnotations },
       },
     ];
@@ -201,7 +201,7 @@ export class ImageAnnotations extends THREE.Object3D {
 
     const annotationTopics = this.#context
       .topics()
-      .filter((topic) => topicIsConvertibleToSchema(topic, ALL_SUPPORTED_SCHEMAS));
+      .filter((topic) => topicIsConvertibleToSchema(topic, ALL_SUPPORTED_ANNOTATION_SCHEMAS));
 
     // Sort annotation topics with prefixes matching the image topic to the top.
     if (config.imageTopic) {

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -111,6 +111,10 @@ export function useMessagePathDrop(): {
       return false;
     },
     collect(monitor) {
+      // don't run the code below when dragging other types of items (i.e. panels)
+      if (monitor.getItemType() !== MESSAGE_PATH_DRAG_TYPE) {
+        return { isDragging: false, isOver: false };
+      }
       const item = monitor.getItem<MessagePathDragObject | undefined>();
       const targetId = monitor.getHandlerId();
       if (!item || !messagePathDropConfig || targetId == undefined) {

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -88,6 +88,8 @@ export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragPara
  * `useMessagePathDrag()`.
  */
 export function useMessagePathDrop(): {
+  /** True if the target supports dragging (a config is set) and a drag has started */
+  isDragging: boolean;
   isOver: boolean;
   message: string | undefined;
   connectDropTarget: ConnectDropTarget;
@@ -97,7 +99,7 @@ export function useMessagePathDrop(): {
     MessagePathDropConfig | undefined
   >();
 
-  const [{ isOver, message }, connectDropTarget] = useDrop({
+  const [{ isDragging, isOver, message }, connectDropTarget] = useDrop({
     accept: MESSAGE_PATH_DRAG_TYPE,
     canDrop(item: MessagePathDragObject, _monitor) {
       if (!messagePathDropConfig) {
@@ -112,7 +114,10 @@ export function useMessagePathDrop(): {
       const item = monitor.getItem<MessagePathDragObject | undefined>();
       const targetId = monitor.getHandlerId();
       if (!item || !messagePathDropConfig || targetId == undefined) {
-        return { isOver: false };
+        return {
+          isDragging: item != undefined && messagePathDropConfig != undefined,
+          isOver: false,
+        };
       }
       const monitorIsOver = monitor.isOver({ shallow: true });
       const dropStatus = messagePathDropConfig.getDropStatus(item);
@@ -130,6 +135,7 @@ export function useMessagePathDrop(): {
       }
 
       return {
+        isDragging: true,
         isOver: monitorIsOver && monitor.canDrop(),
         message:
           dropStatus.message ??
@@ -141,5 +147,5 @@ export function useMessagePathDrop(): {
     },
   });
 
-  return { isOver, message, connectDropTarget, setMessagePathDropConfig };
+  return { isDragging, isOver, message, connectDropTarget, setMessagePathDropConfig };
 }

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -45,6 +45,7 @@ type MessagePathDragParams = {
 export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragParams): {
   connectDragSource: ConnectDragSource;
   cursor?: CSSProperties["cursor"];
+  isDragging: boolean;
 } {
   const [dropStatus, setDropStatus] = useState<MessagePathDropStatus | undefined>();
   const overDropTargets = useRef(new Set<string | symbol>());
@@ -80,7 +81,7 @@ export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragPara
     }
   }
 
-  return { connectDragSource, cursor };
+  return { connectDragSource, cursor, isDragging };
 }
 
 /**

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useMemo, useRef, useState } from "react";
+import { CSSProperties, useMemo, useRef, useState } from "react";
 import { ConnectDragSource, ConnectDropTarget, useDrag, useDrop } from "react-dnd";
 
 import { MessagePathDropConfig, MessagePathDropStatus } from "@foxglove/studio";
@@ -44,7 +44,7 @@ type MessagePathDragParams = {
  */
 export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragParams): {
   connectDragSource: ConnectDragSource;
-  cursor: string;
+  cursor?: CSSProperties["cursor"];
 } {
   const [dropStatus, setDropStatus] = useState<MessagePathDropStatus | undefined>();
   const overDropTargets = useRef(new Set<string | symbol>());
@@ -71,7 +71,7 @@ export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragPara
     },
   });
 
-  let cursor = "auto";
+  let cursor = undefined;
   if (isDragging && dropStatus) {
     if (!dropStatus.canDrop) {
       cursor = "no-drop";
@@ -91,6 +91,7 @@ export function useMessagePathDrop(): {
   /** True if the target supports dragging (a config is set) and a drag has started */
   isDragging: boolean;
   isOver: boolean;
+  isValidTarget: boolean;
   message: string | undefined;
   connectDropTarget: ConnectDropTarget;
   setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
@@ -99,7 +100,7 @@ export function useMessagePathDrop(): {
     MessagePathDropConfig | undefined
   >();
 
-  const [{ isDragging, isOver, message }, connectDropTarget] = useDrop({
+  const [{ isDragging, isOver, isValidTarget = false, message }, connectDropTarget] = useDrop({
     accept: MESSAGE_PATH_DRAG_TYPE,
     canDrop(item: MessagePathDragObject, _monitor) {
       if (!messagePathDropConfig) {
@@ -119,8 +120,9 @@ export function useMessagePathDrop(): {
       const targetId = monitor.getHandlerId();
       if (!item || !messagePathDropConfig || targetId == undefined) {
         return {
-          isDragging: item != undefined && messagePathDropConfig != undefined,
+          isDragging: item != undefined,
           isOver: false,
+          isValidTarget: item != undefined && messagePathDropConfig?.getDropStatus(item).canDrop,
         };
       }
       const monitorIsOver = monitor.isOver({ shallow: true });
@@ -141,6 +143,7 @@ export function useMessagePathDrop(): {
       return {
         isDragging: true,
         isOver: monitorIsOver && monitor.canDrop(),
+        isValidTarget: messagePathDropConfig.getDropStatus(item).canDrop,
         message:
           dropStatus.message ??
           (dropStatus.effect === "add" ? `Add ${item.path}` : `View ${item.path}`),
@@ -151,5 +154,12 @@ export function useMessagePathDrop(): {
     },
   });
 
-  return { isDragging, isOver, message, connectDropTarget, setMessagePathDropConfig };
+  return {
+    isDragging,
+    isOver,
+    isValidTarget,
+    message,
+    connectDropTarget,
+    setMessagePathDropConfig,
+  };
 }

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -3,7 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { CSSProperties, useMemo, useRef, useState } from "react";
-import { ConnectDragSource, ConnectDropTarget, useDrag, useDrop } from "react-dnd";
+import {
+  ConnectDragPreview,
+  ConnectDragSource,
+  ConnectDropTarget,
+  useDrag,
+  useDrop,
+} from "react-dnd";
 
 import { MessagePathDropConfig, MessagePathDropStatus } from "@foxglove/studio";
 
@@ -44,6 +50,7 @@ type MessagePathDragParams = {
  */
 export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragParams): {
   connectDragSource: ConnectDragSource;
+  connectDragPreview: ConnectDragPreview;
   cursor?: CSSProperties["cursor"];
   isDragging: boolean;
 } {
@@ -58,7 +65,7 @@ export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragPara
     }),
     [path, rootSchemaName],
   );
-  const [{ isDragging }, connectDragSource] = useDrag({
+  const [{ isDragging }, connectDragSource, connectDragPreview] = useDrag({
     type: MESSAGE_PATH_DRAG_TYPE,
     item: dragItem,
     options: {
@@ -73,15 +80,19 @@ export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragPara
   });
 
   let cursor = undefined;
-  if (isDragging && dropStatus) {
-    if (!dropStatus.canDrop) {
+  if (isDragging) {
+    if (!dropStatus) {
+      cursor = "auto";
+    } else if (!dropStatus.canDrop) {
       cursor = "no-drop";
     } else if (dropStatus.effect === "add") {
       cursor = "copy";
+    } else {
+      cursor = "auto";
     }
   }
 
-  return { connectDragSource, cursor, isDragging };
+  return { connectDragSource, connectDragPreview, cursor, isDragging };
 }
 
 /**
@@ -93,15 +104,15 @@ export function useMessagePathDrop(): {
   isDragging: boolean;
   isOver: boolean;
   isValidTarget: boolean;
-  message: string | undefined;
-  connectDropTarget: ConnectDropTarget;
+  dropMessage: string | undefined;
+  connectMessagePathDropTarget: ConnectDropTarget;
   setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
 } {
   const [messagePathDropConfig, setMessagePathDropConfig] = useState<
     MessagePathDropConfig | undefined
   >();
 
-  const [{ isDragging, isOver, isValidTarget = false, message }, connectDropTarget] = useDrop({
+  const [{ isDragging, isOver, isValidTarget, message }, connectDropTarget] = useDrop({
     accept: MESSAGE_PATH_DRAG_TYPE,
     canDrop(item: MessagePathDragObject, _monitor) {
       if (!messagePathDropConfig) {
@@ -115,19 +126,19 @@ export function useMessagePathDrop(): {
     collect(monitor) {
       // don't run the code below when dragging other types of items (i.e. panels)
       if (monitor.getItemType() !== MESSAGE_PATH_DRAG_TYPE) {
-        return { isDragging: false, isOver: false };
+        return { isDragging: false, isOver: false, isValidTarget: false };
       }
       const item = monitor.getItem<MessagePathDragObject | undefined>();
       const targetId = monitor.getHandlerId();
-      if (!item || !messagePathDropConfig || targetId == undefined) {
+      if (!item || targetId == undefined) {
         return {
           isDragging: item != undefined,
           isOver: false,
-          isValidTarget: item != undefined && messagePathDropConfig?.getDropStatus(item).canDrop,
+          isValidTarget: false,
         };
       }
       const monitorIsOver = monitor.isOver({ shallow: true });
-      const dropStatus = messagePathDropConfig.getDropStatus(item);
+      const dropStatus = messagePathDropConfig?.getDropStatus(item) ?? { canDrop: false };
 
       // Not ideal to have side effects in collect(), but this is the only place where we get
       // access to "isOver: false" when the drag leaves the target.
@@ -144,7 +155,7 @@ export function useMessagePathDrop(): {
       return {
         isDragging: true,
         isOver: monitorIsOver && monitor.canDrop(),
-        isValidTarget: messagePathDropConfig.getDropStatus(item).canDrop,
+        isValidTarget: dropStatus.canDrop,
         message:
           dropStatus.message ??
           (dropStatus.effect === "add" ? `Add ${item.path}` : `View ${item.path}`),
@@ -159,8 +170,8 @@ export function useMessagePathDrop(): {
     isDragging,
     isOver,
     isValidTarget,
-    message,
-    connectDropTarget,
+    dropMessage: message,
+    connectMessagePathDropTarget: connectDropTarget,
     setMessagePathDropConfig,
   };
 }

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useMemo, useRef, useState } from "react";
+import { ConnectDragSource, ConnectDropTarget, useDrag, useDrop } from "react-dnd";
+
+import { MessagePathDropConfig, MessagePathDropStatus } from "@foxglove/studio";
+
+const MESSAGE_PATH_DRAG_TYPE = Symbol("MESSAGE_PATH_DRAG_TYPE");
+
+/**
+ * Internal type used for message path drag & drop support (this can differ from the type exposed to the panel API).
+ */
+type MessagePathDragObject = {
+  path: string;
+  rootSchemaName: string | undefined;
+
+  /**
+   * Expose the drop info to the drag source so it can change cursor & appearance as necessary.
+   * Undefined indicates the drag is not over a target.
+   *
+   * See also:
+   * - https://github.com/react-dnd/react-dnd/issues/448
+   * - https://github.com/react-dnd/react-dnd/issues/3529
+   */
+  setDropStatus: (dropStatus: MessagePathDropStatus | undefined) => void;
+
+  /**
+   * The eligible drop targets that are currently being dragged over. Used to determine when the
+   * drag has left the last target.
+   */
+  overDropTargets: Set<string | symbol>;
+};
+
+type MessagePathDragParams = {
+  path: string;
+  rootSchemaName: string | undefined;
+};
+
+/**
+ * Use this to create a drag source for message paths that can be dropped onto target components
+ * that use `useMessagePathDrop()`.
+ */
+export function useMessagePathDrag({ path, rootSchemaName }: MessagePathDragParams): {
+  connectDragSource: ConnectDragSource;
+  cursor: string;
+} {
+  const [dropStatus, setDropStatus] = useState<MessagePathDropStatus | undefined>();
+  const overDropTargets = useRef(new Set<string | symbol>());
+  const dragItem = useMemo<MessagePathDragObject>(
+    () => ({
+      path,
+      rootSchemaName,
+      setDropStatus,
+      overDropTargets: overDropTargets.current,
+    }),
+    [path, rootSchemaName],
+  );
+  const [{ isDragging }, connectDragSource] = useDrag({
+    type: MESSAGE_PATH_DRAG_TYPE,
+    item: dragItem,
+    options: {
+      // Avoid the browser automatically using the "copy" cursor; we manage the cursor ourselves below
+      dropEffect: "move",
+    },
+    collect(monitor) {
+      return {
+        isDragging: monitor.isDragging(),
+      };
+    },
+  });
+
+  let cursor = "auto";
+  if (isDragging && dropStatus) {
+    if (!dropStatus.canDrop) {
+      cursor = "no-drop";
+    } else if (dropStatus.effect === "add") {
+      cursor = "copy";
+    }
+  }
+
+  return { connectDragSource, cursor };
+}
+
+/**
+ * Use this to create a drop target accepting message paths dragged from components that use
+ * `useMessagePathDrag()`.
+ */
+export function useMessagePathDrop(): {
+  isOver: boolean;
+  message: string | undefined;
+  connectDropTarget: ConnectDropTarget;
+  setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
+} {
+  const [messagePathDropConfig, setMessagePathDropConfig] = useState<
+    MessagePathDropConfig | undefined
+  >();
+
+  const [{ isOver, message }, connectDropTarget] = useDrop({
+    accept: MESSAGE_PATH_DRAG_TYPE,
+    canDrop(item: MessagePathDragObject, _monitor) {
+      if (!messagePathDropConfig) {
+        return false;
+      }
+      if (messagePathDropConfig.getDropStatus(item).canDrop) {
+        return true;
+      }
+      return false;
+    },
+    collect(monitor) {
+      const item = monitor.getItem<MessagePathDragObject | undefined>();
+      const targetId = monitor.getHandlerId();
+      if (!item || !messagePathDropConfig || targetId == undefined) {
+        return { isOver: false };
+      }
+      const monitorIsOver = monitor.isOver({ shallow: true });
+      const dropStatus = messagePathDropConfig.getDropStatus(item);
+
+      // Not ideal to have side effects in collect(), but this is the only place where we get
+      // access to "isOver: false" when the drag leaves the target.
+      if (monitorIsOver) {
+        item.overDropTargets.add(targetId);
+        item.setDropStatus(dropStatus);
+      } else {
+        item.overDropTargets.delete(targetId);
+        if (item.overDropTargets.size === 0) {
+          item.setDropStatus(undefined);
+        }
+      }
+
+      return {
+        isOver: monitorIsOver && monitor.canDrop(),
+        message:
+          dropStatus.message ??
+          (dropStatus.effect === "add" ? `Add ${item.path}` : `View ${item.path}`),
+      };
+    },
+    drop(item, _monitor) {
+      messagePathDropConfig?.handleDrop(item);
+    },
+  });
+
+  return { isOver, message, connectDropTarget, setMessagePathDropConfig };
+}

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -342,7 +342,7 @@ type Props = UnconnectedProps & {
 export default function PanelSetup(props: Props): JSX.Element {
   const theme = useTheme();
   return (
-    <WorkspaceContextProvider>
+    <WorkspaceContextProvider disablePersistenceForStorybook>
       <UserNodeStateProvider>
         <TimelineInteractionStateProvider>
           <MockCurrentLayoutProvider onAction={props.onLayoutAction}>

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -238,6 +238,16 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
         },
       },
     },
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: alpha(theme.palette.common.black, 0.4),
+        },
+        invisible: {
+          backgroundColor: "transparent",
+        },
+      },
+    },
     MuiDialog: {
       defaultProps: {
         PaperProps: {
@@ -245,11 +255,6 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
         },
       },
       styleOverrides: {
-        root: {
-          ".MuiBackdrop-root": {
-            backgroundColor: alpha(theme.palette.common.black, 0.4),
-          },
-        },
         paper: {
           // Prevent dialog from going underneath window title bar controls on Windows
           maxHeight: `calc(100% - 2 * (env(titlebar-area-height, ${theme.spacing(

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -238,6 +238,35 @@ export type RenderState = {
   appSettings?: Map<string, AppSettingValue>;
 };
 
+export type DraggedMessagePath = {
+  /** The full message path */
+  path: string;
+  /** The schema name of the top-level topic being dragged */
+  rootSchemaName: string | undefined;
+};
+
+export type MessagePathDropStatus = {
+  /** True if the panel would be able to accept this dragged message path. */
+  canDrop: boolean;
+  /**
+   * Indicate the type of operation that would occur if this path were dropped. Used to change the
+   * mouse cursor.
+   */
+  effect?: "replace" | "add";
+  /**
+   * A message to display to the user indicating what will happen when the path is dropped.
+   */
+  message?: string;
+};
+
+export type MessagePathDropConfig = {
+  /** Called when the user drags a message path over the panel. */
+  getDropStatus: (path: DraggedMessagePath) => MessagePathDropStatus;
+
+  /** Called when the user drops a message path on the panel. */
+  handleDrop: (path: DraggedMessagePath) => void;
+};
+
 export type PanelExtensionContext = {
   /**
    * The root element for the panel. Add your panel elements as children under this element.
@@ -394,6 +423,12 @@ export type PanelExtensionContext = {
    * manually. A value of `undefined` will display the panel's name in the title bar.
    */
   setDefaultPanelTitle(defaultTitle: string | undefined): void;
+
+  /**
+   * Updates the configuration for message path drag & drop support. A value of `undefined`
+   * indicates that the panel does not accept any dragged message paths.
+   */
+  EXPERIMENTAL_setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
 };
 
 export type ExtensionPanelRegistration = {


### PR DESCRIPTION
**User-Facing Changes**
None (will announce later after #6653 is merged)

**Description**

Adds ability to drag & drop topics from the Topics sidebar onto the Image, Raw Message, and Table panels.



https://github.com/foxglove/studio/assets/14237/32c4861d-061a-4a17-909e-1eeda9333fac


