### PR TITLE
Image: show error on annotation topics that synchronization is waiting for

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -9,6 +9,7 @@ import { filterMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { toNanoSec } from "@foxglove/rostime";
 import { Immutable, SettingsTreeAction, SettingsTreeFields, Topic } from "@foxglove/studio";
+import { Path } from "@foxglove/studio-base/panels/ThreeDeeRender/LayerErrors";
 import {
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,
   ImageRenderable,
@@ -164,6 +165,12 @@ export class ImageMode
       },
       labelPool: renderer.labelPool,
       messageHandler: this.#messageHandler,
+      addSettingsError(path: Path, errorId: string, errorMessage: string) {
+        renderer.settings.errors.add(path, errorId, errorMessage);
+      },
+      removeSettingsError(path: Path, errorId: string) {
+        renderer.settings.errors.remove(path, errorId);
+      },
     });
     this.add(this.#annotations);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { partition } from "lodash";
+
 import { AVLTree } from "@foxglove/avl";
 import {
   Time,
@@ -358,15 +360,11 @@ function findSynchronizedSetAndRemoveOlderItems(
     if (!messageState.image) {
       continue;
     }
-    presentAnnotationTopics = [];
-    missingAnnotationTopics = [];
-    for (const topic of visibleAnnotations) {
-      if (messageState.annotationsByTopic.get(topic) != undefined) {
-        presentAnnotationTopics.push(topic);
-      } else {
-        missingAnnotationTopics.push(topic);
-      }
-    }
+    [presentAnnotationTopics, missingAnnotationTopics] = partition(
+      Array.from(visibleAnnotations),
+      (topic) => messageState.annotationsByTopic.has(topic),
+    );
+
     // If we have an image and all the messages for annotation topics then we have a synchronized set.
     if (missingAnnotationTopics.length === 0) {
       validEntry = entry;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.ts
@@ -58,6 +58,11 @@ type MessageHandlerState = {
   image?: MessageEvent<AnyImage>;
   cameraInfo?: CameraInfo;
   annotationsByTopic: Map<string, NormalizedAnnotations>;
+
+  /** Topics that were present in a potential synchronized set */
+  presentAnnotationTopics?: string[];
+  /** Topics that were missing so that a synchronized set could not be found */
+  missingAnnotationTopics?: string[];
 };
 
 export type MessageRenderState = Readonly<Partial<MessageHandlerState>>;
@@ -287,19 +292,18 @@ export class MessageHandler {
   /** Do not use. only public for testing */
   public getRenderState(): Readonly<Partial<MessageHandlerState>> {
     if (this.#config.synchronize === true) {
-      const validEntry = findSynchronizedSetAndRemoveOlderItems(
-        this.#tree,
-        this.#visibleAnnotations(),
-      );
-      if (validEntry) {
+      const result = findSynchronizedSetAndRemoveOlderItems(this.#tree, this.#visibleAnnotations());
+      if (result.found) {
         return {
           cameraInfo: this.#lastReceivedMessages.cameraInfo,
-          image: validEntry[1].image,
-          annotationsByTopic: validEntry[1].annotationsByTopic,
+          image: result.messages.image,
+          annotationsByTopic: result.messages.annotationsByTopic,
         };
       }
       return {
         cameraInfo: this.#lastReceivedMessages.cameraInfo,
+        presentAnnotationTopics: result.presentAnnotationTopics,
+        missingAnnotationTopics: result.missingAnnotationTopics,
       };
     }
 
@@ -317,26 +321,54 @@ export class MessageHandler {
   }
 }
 
+type SynchronizationResult =
+  | {
+      found: true;
+      /** Synchronized set of messages found with matching timestamps */
+      messages: SynchronizationItem;
+    }
+  | {
+      found: false;
+      /**
+       * Annotations that were present at the matching timestamp.
+       */
+      presentAnnotationTopics: string[] | undefined;
+      /**
+       * Annotations that were missing and caused there to be no synchronized set, or undefined if no
+       * images were received at all.
+       */
+      missingAnnotationTopics: string[] | undefined;
+    };
+
 /**
  * Find the newest entry where we have everything synchronized and remove all older entries from tree.
  * @param tree - AVL tree that stores a [image?, annotations?] in sorted order by timestamp.
  * @param visibleAnnotations - visible annotation topics
- * @returns - the newest synchronized item with all active annotations and image, or undefined if none found
+ * @returns - the newest synchronized item with all active annotations and image, or set of missing annotations if synchronization failed
  */
 function findSynchronizedSetAndRemoveOlderItems(
   tree: AVLTree<Time, SynchronizationItem>,
   visibleAnnotations: Set<string>,
-): [Time, SynchronizationItem] | undefined {
+): SynchronizationResult {
   let validEntry: [Time, SynchronizationItem] | undefined = undefined;
+  let presentAnnotationTopics: string[] | undefined;
+  let missingAnnotationTopics: string[] | undefined;
   for (const entry of tree.entries()) {
     const messageState = entry[1];
-    const hasOnlyVisibleAnnotations =
-      visibleAnnotations.size === messageState.annotationsByTopic.size &&
-      Array.from(visibleAnnotations.keys()).every(
-        (topic) => messageState.annotationsByTopic.get(topic) != undefined,
-      );
+    if (!messageState.image) {
+      continue;
+    }
+    presentAnnotationTopics = [];
+    missingAnnotationTopics = [];
+    for (const topic of visibleAnnotations) {
+      if (messageState.annotationsByTopic.get(topic) != undefined) {
+        presentAnnotationTopics.push(topic);
+      } else {
+        missingAnnotationTopics.push(topic);
+      }
+    }
     // If we have an image and all the messages for annotation topics then we have a synchronized set.
-    if (messageState.image && hasOnlyVisibleAnnotations) {
+    if (missingAnnotationTopics.length === 0) {
       validEntry = entry;
     }
   }
@@ -348,7 +380,8 @@ function findSynchronizedSetAndRemoveOlderItems(
       tree.shift();
       minKey = tree.minKey();
     }
+    return { found: true, messages: validEntry[1] };
   }
 
-  return validEntry;
+  return { found: false, missingAnnotationTopics, presentAnnotationTopics };
 }


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Resolves FG-3596

When "Sync annotations" is enabled and no image can be displayed because some annotations are missing, an error is now shown on the missing annotations in settings:

<img width="471" alt="image" src="https://github.com/foxglove/studio/assets/14237/b2767b73-1c40-43fe-bc45-bb88c32f1fc2">
