### PR TITLE
Use i18next in studio-desktop & StudioWindow

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -4,4 +4,4 @@
 
 import { main } from "@foxglove/studio-desktop/src/main";
 
-main();
+void main();

--- a/packages/studio-base/src/i18n/en/desktopWindow.ts
+++ b/packages/studio-base/src/i18n/en/desktopWindow.ts
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const desktopWindow = {
+  newWindow: "New Window",
+  settings: "Settings…",
+  file: "File",
+  edit: "Edit",
+  view: "View",
+  advanced: "Advanced",
+  inspectSharedWorker: "Inspect Shared Worker…",
+  noSharedWorkers: "No Shared Workers",
+  checkForUpdates: "Check for Updates…",
+};

--- a/packages/studio-base/src/i18n/en/index.ts
+++ b/packages/studio-base/src/i18n/en/index.ts
@@ -17,3 +17,4 @@ export * from "./plot";
 export * from "./settingsEditor";
 export * from "./stateTransitions";
 export * from "./threeDee";
+export * from "./desktopWindow";

--- a/packages/studio-base/src/i18n/index.ts
+++ b/packages/studio-base/src/i18n/index.ts
@@ -16,20 +16,22 @@ export type Language = keyof typeof translations;
 
 export const defaultNS = "general";
 
-export async function initI18n(): Promise<void> {
-  await i18n
-    .use(LanguageDetector)
-    .use(initReactI18next)
-    .init({
-      resources: translations,
-      detection: {
-        order: ["localStorage", "navigator"],
-        caches: ["localStorage"],
-      },
-      fallbackLng: "en",
-      defaultNS,
-      interpolation: {
-        escapeValue: false, // not needed for react as it escapes by default
-      },
-    });
+export async function initI18n(options?: { context?: "browser" | "electron-main" }): Promise<void> {
+  const { context = "browser" } = options ?? {};
+  if (context === "browser") {
+    i18n.use(initReactI18next);
+    i18n.use(LanguageDetector);
+  }
+  await i18n.init({
+    resources: translations,
+    detection:
+      context === "browser"
+        ? { order: ["localStorage", "navigator"], caches: ["localStorage"] }
+        : undefined,
+    fallbackLng: "en",
+    defaultNS,
+    interpolation: {
+      escapeValue: false, // not needed for react as it escapes by default
+    },
+  });
 }

--- a/packages/studio-desktop/package.json
+++ b/packages/studio-desktop/package.json
@@ -35,6 +35,7 @@
     "eventemitter3": "5.0.1",
     "fork-ts-checker-webpack-plugin": "8.0.0",
     "html-webpack-plugin": "5.5.3",
+    "i18next": "23.4.4",
     "jszip": "3.10.1",
     "path-browserify": "1.0.1",
     "plist": "3.1.0",

--- a/packages/studio-desktop/src/common/types.ts
+++ b/packages/studio-desktop/src/common/types.ts
@@ -105,6 +105,9 @@ interface Desktop {
   unmaximizeWindow(): void;
   closeWindow(): void;
   reloadWindow(): void;
+
+  /** Notify the app that the language setting has been changed */
+  updateLanguage(): void;
 }
 
 export type { NativeMenuBridge, Storage, StorageContent, Desktop, DesktopExtension };

--- a/packages/studio-desktop/src/main/StudioWindow.ts
+++ b/packages/studio-desktop/src/main/StudioWindow.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+/// <reference types="../typings/i18next" />
+
 import {
   BrowserWindow,
   BrowserWindowConstructorOptions,
@@ -14,6 +16,7 @@ import {
   shell,
   systemPreferences,
 } from "electron";
+import i18n, { t } from "i18next";
 import path from "path";
 
 import Logger from "@foxglove/log";
@@ -201,7 +204,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
   const menuTemplate: MenuItemConstructorOptions[] = [];
 
   const checkForUpdatesItem: MenuItemConstructorOptions = {
-    label: "Check for Updates…",
+    label: t("desktopWindow:checkForUpdates"),
     click: () => void StudioAppUpdater.Instance().checkNow(),
     enabled: StudioAppUpdater.Instance().canCheckForUpdates(),
   };
@@ -215,7 +218,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
         checkForUpdatesItem,
         { type: "separator" },
         {
-          label: "Settings…",
+          label: t("desktopWindow:settings"),
           accelerator: "CommandOrControl+,",
           click: () => sendNativeAppMenuEvent("open-help-general", browserWindow),
         },
@@ -234,11 +237,11 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
 
   menuTemplate.push({
     role: "fileMenu",
-    label: "File",
+    label: t("desktopWindow:file"),
     id: "fileMenu",
     submenu: [
       {
-        label: "New Window",
+        label: t("desktopWindow:newWindow"),
         click: () => {
           new StudioWindow().load();
         },
@@ -250,7 +253,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
 
   menuTemplate.push({
     role: "editMenu",
-    label: "Edit",
+    label: t("desktopWindow:edit"),
     submenu: [
       { role: "undo" },
       { role: "redo" },
@@ -280,7 +283,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     const workers = browserWindow.webContents.getAllSharedWorkers();
     Menu.buildFromTemplate(
       workers.length === 0
-        ? [{ label: "No Shared Workers", enabled: false }]
+        ? [{ label: t("desktopWindow:noSharedWorkers"), enabled: false }]
         : workers.map(
             (worker) =>
               new MenuItem({
@@ -296,7 +299,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
 
   menuTemplate.push({
     role: "viewMenu",
-    label: "View",
+    label: t("desktopWindow:view"),
     submenu: [
       { role: "resetZoom" },
       { role: "zoomIn" },
@@ -305,13 +308,13 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       { role: "togglefullscreen" },
       { type: "separator" },
       {
-        label: "Advanced",
+        label: t("desktopWindow:advanced"),
         submenu: [
           { role: "reload" },
           { role: "forceReload" },
           { role: "toggleDevTools" },
           {
-            label: "Inspect Shared Worker…",
+            label: t("desktopWindow:inspectSharedWorker"),
             click() {
               showSharedWorkersMenu();
             },
@@ -325,20 +328,20 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     role: "help",
     submenu: [
       {
-        label: "About",
+        label: t("appBar:about"),
         click: () => sendNativeAppMenuEvent("open-help-about", browserWindow),
       },
       {
-        label: "View our docs",
+        label: t("appBar:viewOurDocs"),
         click: () => sendNativeAppMenuEvent("open-help-docs", browserWindow),
       },
       {
-        label: "Join our Slack",
+        label: t("appBar:joinOurSlack"),
         click: () => sendNativeAppMenuEvent("open-help-slack", browserWindow),
       },
       { type: "separator" },
       {
-        label: "Explore sample data",
+        label: t("appBar:exploreSampleData"),
         click: async () => {
           await simulateUserClick(browserWindow);
           sendNativeAppMenuEvent("open-demo", browserWindow);
@@ -366,6 +369,14 @@ class StudioWindow {
     const [newWindow, newMenu] = this.#buildBrowserWindow();
     this.#browserWindow = newWindow;
     this.#menu = newMenu;
+
+    i18n.on("languageChanged", () => {
+      const isAppMenu = Menu.getApplicationMenu() === this.#menu;
+      this.#rebuildMenu();
+      if (isAppMenu) {
+        Menu.setApplicationMenu(this.#menu);
+      }
+    });
   }
 
   public load(): void {
@@ -412,6 +423,11 @@ class StudioWindow {
     }
   }
 
+  #rebuildMenu() {
+    this.#menu = buildMenu(this.#browserWindow);
+    this.#rebuildFileMenu(this.#menu.getMenuItemById("fileMenu")!);
+  }
+
   #buildBrowserWindow(): [BrowserWindow, Menu] {
     const browserWindow = newStudioWindow(this.#deepLinks, () => {
       this.#reloadMainWindow();
@@ -439,7 +455,7 @@ class StudioWindow {
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "New Window",
+        label: t("desktopWindow:newWindow"),
         click: () => {
           new StudioWindow().load();
         },
@@ -454,7 +470,7 @@ class StudioWindow {
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "Open…",
+        label: t("appBar:open"),
         click: async () => {
           await simulateUserClick(browserWindow);
           this.#sendNativeAppMenuEvent("open");
@@ -464,7 +480,7 @@ class StudioWindow {
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "Open local file…",
+        label: t("appBar:openLocalFile"),
         click: async () => {
           await simulateUserClick(browserWindow);
           this.#sendNativeAppMenuEvent("open-file");
@@ -474,7 +490,7 @@ class StudioWindow {
 
     fileMenu.submenu?.append(
       new MenuItem({
-        label: "Open connection...",
+        label: t("appBar:openConnection"),
         click: async () => {
           await simulateUserClick(browserWindow);
           this.#sendNativeAppMenuEvent("open-connection");

--- a/packages/studio-desktop/src/main/index.ts
+++ b/packages/studio-desktop/src/main/index.ts
@@ -4,9 +4,11 @@
 
 import { app, BrowserWindow, ipcMain, Menu, session, nativeTheme } from "electron";
 import fs from "fs";
+import i18n from "i18next";
 
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
+import { initI18n } from "@foxglove/studio-base/src/i18n";
 
 import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";
@@ -47,7 +49,17 @@ function updateNativeColorScheme() {
     colorScheme === "dark" ? "dark" : colorScheme === "light" ? "light" : "system";
 }
 
-export function main(): void {
+async function updateLanguage() {
+  const language = getAppSetting<string>(AppSetting.LANGUAGE);
+  log.info(`Loaded language from settings: ${language}`);
+  await i18n.changeLanguage(language);
+  log.info(`Set language: ${i18n.language}`);
+}
+
+export async function main(): Promise<void> {
+  await initI18n({ context: "electron-main" });
+  await updateLanguage();
+
   // https://github.com/electron/electron/issues/28422#issuecomment-987504138
   app.commandLine.appendSwitch("enable-experimental-web-platform-features");
 
@@ -188,6 +200,10 @@ export function main(): void {
 
   ipcMain.handle("updateNativeColorScheme", () => {
     updateNativeColorScheme();
+  });
+
+  ipcMain.handle("updateLanguage", () => {
+    void updateLanguage();
   });
 
   // This method will be called when Electron has finished

--- a/packages/studio-desktop/src/preload/index.ts
+++ b/packages/studio-desktop/src/preload/index.ts
@@ -102,6 +102,9 @@ export function main(): void {
     async updateNativeColorScheme() {
       await ipcRenderer.invoke("updateNativeColorScheme");
     },
+    async updateLanguage() {
+      await ipcRenderer.invoke("updateLanguage");
+    },
     getDeepLinks(): string[] {
       return decodeRendererArg("deepLinks", window.process.argv) ?? [];
     },

--- a/packages/studio-desktop/src/renderer/Root.tsx
+++ b/packages/studio-desktop/src/renderer/Root.tsx
@@ -54,6 +54,16 @@ export default function Root(props: {
     };
   }, [appConfiguration]);
 
+  useEffect(() => {
+    const handler = () => {
+      desktopBridge.updateLanguage();
+    };
+    appConfiguration.addChangeListener(AppSetting.LANGUAGE, handler);
+    return () => {
+      appConfiguration.removeChangeListener(AppSetting.LANGUAGE, handler);
+    };
+  }, [appConfiguration]);
+
   const [extensionLoaders] = useState(() => [
     new IdbExtensionLoader("org"),
     new DesktopExtensionLoader(desktopBridge),

--- a/packages/studio-desktop/src/typings/i18next.d.ts
+++ b/packages/studio-desktop/src/typings/i18next.d.ts
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { translations, defaultNS } from "@foxglove/studio-base/src/i18n";
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    returnNull: false;
+    defaultNS: typeof defaultNS;
+    resources: (typeof translations)["en"];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2839,6 +2839,7 @@ __metadata:
     eventemitter3: 5.0.1
     fork-ts-checker-webpack-plugin: 8.0.0
     html-webpack-plugin: 5.5.3
+    i18next: 23.4.4
     jszip: 3.10.1
     path-browserify: 1.0.1
     plist: 3.1.0


### PR DESCRIPTION
**User-Facing Changes**
Improved language localization support for menus in the desktop app.

**Description**
Resolves FG-3972
Depends on #6698

<img width="230" alt="image" src="https://github.com/foxglove/studio/assets/14237/dbf946fd-8080-4f9b-8a81-e698e8043fae">
<img width="250" alt="image" src="https://github.com/foxglove/studio/assets/14237/24810992-265e-4a75-99c1-87c32a6222f4">
