### PR TITLE
Make state transition x axis settings behave more like plot

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -213,8 +213,8 @@ export const WithXAxisMinMax: StoryObj = {
       <PanelSetup fixture={fixture} pauseFrame={pauseFrame} includeSettings>
         <StateTransitions
           overrideConfig={{
-            xAxisMinValue: 13,
-            xAxisMaxValue: 14,
+            xAxisMinValue: 11,
+            xAxisMaxValue: 15,
             paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
             isSynced: true,
           }}
@@ -234,7 +234,7 @@ export const WithXAxisRange: StoryObj = {
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     const ourFixture = produce(fixture, (draft) => {
-      draft.activeData!.endTime = systemStateMessages.at(-1)?.header.stamp;
+      draft.activeData!.currentTime = systemStateMessages.at(-1)?.header.stamp;
     });
 
     return (

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -4,13 +4,7 @@
 
 import stringHash from "string-hash";
 
-import {
-  Time,
-  isGreaterThan,
-  isLessThan,
-  subtract as subtractTimes,
-  toSec,
-} from "@foxglove/rostime";
+import { Time, subtract as subtractTimes, toSec } from "@foxglove/rostime";
 import { MessageAndData } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { ChartDataset, ChartDatasets } from "@foxglove/studio-base/components/TimeBasedChart/types";
 import { expandedLineColors } from "@foxglove/studio-base/util/plotColors";
@@ -39,13 +33,11 @@ function makeValueIndexer() {
 }
 
 type Args = {
-  blocks: readonly (readonly MessageAndData[] | undefined)[];
-  minTime?: Time;
-  maxTime?: Time;
   path: StateTransitionPath;
-  pathIndex: number;
   startTime: Time;
   y: number;
+  pathIndex: number;
+  blocks: readonly (readonly MessageAndData[] | undefined)[];
 };
 
 /**
@@ -53,7 +45,7 @@ type Args = {
  * dataset with different labels and colors applied per-point.
  */
 export default function messagesToDatasets(args: Args): ChartDatasets {
-  const { minTime, maxTime, path, pathIndex, startTime, y, blocks } = args;
+  const { path, pathIndex, startTime, y, blocks } = args;
 
   const dataset: ChartDataset = {
     borderWidth: 10,
@@ -80,14 +72,6 @@ export default function messagesToDatasets(args: Args): ChartDatasets {
     for (const itemByPath of messages) {
       const timestamp = getTimestampForMessageEvent(itemByPath.messageEvent, path.timestampMethod);
       if (!timestamp) {
-        continue;
-      }
-
-      if (minTime && isGreaterThan(minTime, timestamp)) {
-        continue;
-      }
-
-      if (maxTime && isLessThan(maxTime, timestamp)) {
         continue;
       }
 


### PR DESCRIPTION
**User-Facing Changes**
Fix issue with x axis limits in state transitions.

**Description**
Make the x axis settings in state transitions behave more like they do in the plot panel. This is easier to do by setting the chart bounds instead of trimming the data.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
FG-4731