### PR TITLE
Allow arbitrary precision in settings number inputs

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -81,7 +81,7 @@ export function NumberInput(
     onChange,
     disabled,
     readOnly,
-    precision = 2,
+    precision = 100,
   } = props;
 
   const inputRef = useRef<HTMLInputElement>(ReactNull);
@@ -143,7 +143,7 @@ export function NumberInput(
   );
 
   const displayValue =
-    inputRef.current === document.activeElement ? value : value?.toFixed(precision);
+    inputRef.current === document.activeElement ? value : Number(value?.toFixed(precision));
 
   return (
     <TextField

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -493,7 +493,13 @@ export const LineGraphWithSettings: StoryObj = {
     return (
       <PlotWrapper
         pauseFrame={pauseFrame}
-        config={{ ...exampleConfig, minYValue: -1, maxYValue: 1, minXValue: 0, maxXValue: 3 }}
+        config={{
+          ...exampleConfig,
+          minYValue: -3.1415,
+          maxYValue: 0.00001,
+          minXValue: 0.001234,
+          maxXValue: 30,
+        }}
         includeSettings
       />
     );
@@ -507,8 +513,12 @@ export const LineGraphWithSettings: StoryObj = {
   name: "line graph with settings",
 
   play: async (ctx) => {
-    const label = await screen.findByTestId("settings__nodeHeaderToggle__yAxis");
-    await userEvent.click(label);
+    const yLabel = await screen.findByTestId("settings__nodeHeaderToggle__yAxis");
+    await userEvent.click(yLabel);
+
+    const xLabel = await screen.findByTestId("settings__nodeHeaderToggle__xAxis");
+    await userEvent.click(xLabel);
+
     await ctx.parameters.storyReady;
   },
 };


### PR DESCRIPTION
**User-Facing Changes**
Allow arbitrary precision in number inputs in settings fields.

**Description**
Instead of clamping these fields to 2 digits of precision by default allow arbitrary precision but remove trailing zeroes.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
