### PR TITLE
Remove `instanceof DOMException` from AbortError detection

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -707,7 +707,7 @@ export class IterablePlayer implements Player {
       await this.#resetPlaybackIterator();
       this.#setState(this.#isPlaying ? "play" : "idle");
     } catch (err) {
-      if (this.#nextState && err instanceof DOMException && err.name === "AbortError") {
+      if (this.#nextState && err.name === "AbortError") {
         log.debug("Aborted backfill");
       } else {
         throw err;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
In testing I observed that when an AbortError happens in a worker and is proxied/sent via Comlink, sometimes we end up with an error that is not in fact an `instanceof DOMException`. The `name` check still works though.

Relates to FG-4786