### PR TITLE
Make user script bottom bar resizable

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -154,6 +154,7 @@
     "react-monaco-editor": "0.54.0",
     "react-mosaic-component": "6.0.1",
     "react-refresh-typescript": "2.0.9",
+    "react-resizable-panels": "0.0.55",
     "react-resize-detector": "9.1.0",
     "react-transition-group": "4.4.5",
     "react-use": "17.4.0",

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/LogsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/LogsSection.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles()({
 });
 
 const LogsSection = ({ logs }: { logs: readonly UserNodeLog[] }): JSX.Element => {
+  // Manage auto-scroll behavior when user is also manually scrolling the list.
   const [autoScroll, setAutoScroll] = useState(true);
 
   const { classes } = useStyles();

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/LogsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/LogsSection.tsx
@@ -3,13 +3,56 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Link, List, ListItem, ListItemButton, ListItemText, Typography } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
 import Tree from "react-json-tree";
+import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import { UserNodeLog } from "@foxglove/studio-base/players/UserNodePlayer/types";
 import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
 
+const useStyles = makeStyles()({
+  list: {
+    height: "100%",
+    overflowY: "auto",
+  },
+});
+
 const LogsSection = ({ logs }: { logs: readonly UserNodeLog[] }): JSX.Element => {
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  const { classes } = useStyles();
+
+  const listRef = useRef<HTMLUListElement>(ReactNull);
+
+  useEffect(() => {
+    if (autoScroll) {
+      if (listRef.current) {
+        listRef.current.scrollTop = listRef.current.scrollHeight;
+      }
+    }
+  }, [autoScroll, logs]);
+
+  useEffect(() => {
+    const ref = listRef.current;
+    function listener(event: WheelEvent) {
+      if (event.deltaY < 0) {
+        setAutoScroll(false);
+      } else {
+        const scrolledUp = ref != undefined && ref.scrollHeight - ref.scrollTop > ref.clientHeight;
+        if (scrolledUp) {
+          setAutoScroll(true);
+        }
+      }
+    }
+
+    ref?.addEventListener("wheel", listener);
+
+    return () => {
+      ref?.removeEventListener("wheel", listener);
+    };
+  }, []);
+
   const jsonTreeTheme = useJsonTreeTheme();
   const valueColorMap: Record<string, string> = {
     string: jsonTreeTheme.base0B,
@@ -32,7 +75,7 @@ const LogsSection = ({ logs }: { logs: readonly UserNodeLog[] }): JSX.Element =>
     );
   }
   return (
-    <List dense disablePadding>
+    <List dense disablePadding ref={listRef} className={classes.list}>
       {logs.map(({ source, value }, idx) => {
         const renderTreeObj = value != undefined && typeof value === "object";
         return (

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
@@ -36,6 +36,12 @@ type BottomBarModes = "logs" | "diagnostics";
 const TAB_HEIGHT = 36;
 
 const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    overflowY: "hidden",
+  },
   badge: {
     alignItems: "center",
 
@@ -90,10 +96,7 @@ const BottomBar = ({
 
   return (
     <>
-      <Paper
-        elevation={0}
-        style={{ height: "100%", overflowY: "hidden", display: "flex", flexDirection: "column" }}
-      >
+      <Paper elevation={0} className={classes.root}>
         <Divider />
         <Stack
           direction="row"

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
@@ -12,18 +12,8 @@
 //   You may not use this file except in compliance with the License.
 //
 
-import {
-  Badge,
-  Button,
-  Paper,
-  Tab,
-  Tabs,
-  Divider,
-  Collapse,
-  tabClasses,
-  badgeClasses,
-} from "@mui/material";
-import { useState, useRef, useEffect, ReactElement } from "react";
+import { Badge, Button, Divider, Paper, Tab, Tabs, badgeClasses, tabClasses } from "@mui/material";
+import { ReactElement, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -33,14 +23,15 @@ import LogsSection from "@foxglove/studio-base/panels/NodePlayground/BottomBar/L
 import { Diagnostic, UserNodeLog } from "@foxglove/studio-base/players/UserNodePlayer/types";
 
 type Props = {
-  nodeId?: string;
-  isSaved: boolean;
-  save: () => void;
   diagnostics: readonly Diagnostic[];
+  isSaved: boolean;
   logs: readonly UserNodeLog[];
+  nodeId?: string;
+  onChangeTab: () => void;
+  save: () => void;
 };
 
-type BottomBarModes = "logs" | "diagnostics" | "closed";
+type BottomBarModes = "logs" | "diagnostics";
 
 const TAB_HEIGHT = 36;
 
@@ -76,35 +67,33 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactElement => {
+const BottomBar = ({
+  diagnostics,
+  isSaved,
+  logs,
+  nodeId,
+  onChangeTab,
+  save,
+}: Props): ReactElement => {
   const { classes } = useStyles();
-  const [bottomBarDisplay, setBottomBarDisplay] = useState<BottomBarModes>("closed");
-  const [autoScroll, setAutoScroll] = useState(true);
+  const [bottomBarDisplay, setBottomBarDisplay] = useState<BottomBarModes>("diagnostics");
 
   const { clearUserNodeLogs } = useUserNodeState();
-  const scrollContainer = useRef<HTMLDivElement>(ReactNull);
 
   const handleChange = (_event: React.SyntheticEvent, value: BottomBarModes) => {
     setBottomBarDisplay(value);
   };
 
-  const handleClick = (value: BottomBarModes) => {
-    if (bottomBarDisplay === value) {
-      setBottomBarDisplay("closed");
-    }
+  const handleClick = () => {
+    onChangeTab();
   };
-
-  useEffect(() => {
-    if (autoScroll) {
-      if (scrollContainer.current) {
-        scrollContainer.current.scrollTop = scrollContainer.current.scrollHeight;
-      }
-    }
-  }, [autoScroll, logs]);
 
   return (
     <>
-      <Paper elevation={0}>
+      <Paper
+        elevation={0}
+        style={{ height: "100%", overflowY: "hidden", display: "flex", flexDirection: "column" }}
+      >
         <Divider />
         <Stack
           direction="row"
@@ -116,7 +105,7 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactEl
           <Tabs
             className={classes.tabs}
             textColor="inherit"
-            value={bottomBarDisplay !== "closed" ? bottomBarDisplay : false}
+            value={bottomBarDisplay}
             onChange={handleChange}
           >
             <Tab
@@ -133,7 +122,7 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactEl
               value="diagnostics"
               data-testid="np-errors"
               onClick={() => {
-                handleClick("diagnostics");
+                handleClick();
               }}
             />
             <Tab
@@ -150,11 +139,11 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactEl
               value="logs"
               data-testid="np-logs"
               onClick={() => {
-                handleClick("logs");
+                handleClick();
               }}
             />
           </Tabs>
-          <Stack direction="row" alignItems="center" gap={0.5}>
+          <Stack direction="row" alignItems="center" gap={0.5} fullHeight>
             {bottomBarDisplay === "logs" && (
               <Button
                 size="small"
@@ -188,31 +177,9 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactEl
             </Button>
           </Stack>
         </Stack>
-        {bottomBarDisplay !== "closed" && <Divider />}
-      </Paper>
-      <Paper elevation={0}>
-        <Stack fullHeight position="relative">
-          <Collapse
-            onScroll={({ currentTarget }) => {
-              const scrolledUp =
-                currentTarget.scrollHeight - currentTarget.scrollTop > currentTarget.clientHeight;
-              if (scrolledUp && autoScroll) {
-                setAutoScroll(false);
-              } else if (!scrolledUp && !autoScroll) {
-                setAutoScroll(true);
-              }
-            }}
-            ref={scrollContainer}
-            in={bottomBarDisplay !== "closed"}
-          >
-            <Stack overflow="auto" style={{ height: 150 }}>
-              {bottomBarDisplay === "diagnostics" && (
-                <DiagnosticsSection diagnostics={diagnostics} />
-              )}
-              {bottomBarDisplay === "logs" && <LogsSection logs={logs} />}
-            </Stack>
-          </Collapse>
-        </Stack>
+        <Divider />
+        {bottomBarDisplay === "diagnostics" && <DiagnosticsSection diagnostics={diagnostics} />}
+        {bottomBarDisplay === "logs" && <LogsSection logs={logs} />}
       </Paper>
     </>
   );

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -31,6 +31,7 @@ import {
   PanelResizeHandle,
   Panel as ResizablePanel,
 } from "react-resizable-panels";
+import tc from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
 
@@ -118,7 +119,25 @@ const useStyles = makeStyles()((theme) => ({
     },
   },
   resizeHandle: {
-    height: 4,
+    position: "relative",
+    height: 10,
+    marginTop: -10,
+
+    ":hover": {
+      backgroundPosition: "50% 0",
+      backgroundSize: "100% 50px",
+      backgroundImage: `radial-gradient(${[
+        "at center center",
+        `${theme.palette.action.focus} 0%`,
+        "transparent 70%",
+        "transparent 100%",
+      ].join(",")})`,
+      boxShadow: `0 2px 0 0 ${
+        theme.palette.mode === "dark"
+          ? tc(theme.palette.divider).lighten().toString()
+          : tc(theme.palette.divider).darken().toString()
+      }`,
+    },
   },
 }));
 
@@ -429,7 +448,7 @@ function NodePlayground(props: Props) {
             </IconButton>
           </Stack>
 
-          <PanelGroup direction="vertical">
+          <PanelGroup direction="vertical" units="pixels">
             {selectedNodeId == undefined && <WelcomeScreen addNewNode={addNewNode} />}
             <ResizablePanel>
               <Suspense
@@ -464,7 +483,13 @@ function NodePlayground(props: Props) {
               </Suspense>
             </ResizablePanel>
             <PanelResizeHandle className={classes.resizeHandle} />
-            <ResizablePanel collapsible collapsedSize={5} defaultSize={5} ref={bottomBarRef}>
+            <ResizablePanel
+              collapsible
+              minSize={38}
+              collapsedSize={38}
+              defaultSize={38}
+              ref={bottomBarRef}
+            >
               <BottomBar
                 diagnostics={selectedNodeDiagnostics}
                 isSaved={isNodeSaved}

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -25,6 +25,12 @@ import {
   inputClasses,
 } from "@mui/material";
 import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import {
+  ImperativePanelHandle,
+  PanelGroup,
+  PanelResizeHandle,
+  Panel as ResizablePanel,
+} from "react-resizable-panels";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
 
@@ -110,6 +116,9 @@ const useStyles = makeStyles()((theme) => ({
     [`.${inputClasses.input}`]: {
       padding: theme.spacing(1),
     },
+  },
+  resizeHandle: {
+    height: 4,
   },
 }));
 
@@ -344,6 +353,12 @@ function NodePlayground(props: Props) {
     };
   }, []);
 
+  const bottomBarRef = useRef<ImperativePanelHandle>(ReactNull);
+
+  const onChangeBottomBarTab = useCallback(() => {
+    bottomBarRef.current?.expand();
+  }, []);
+
   return (
     <Stack fullHeight>
       <PanelToolbar />
@@ -414,17 +429,9 @@ function NodePlayground(props: Props) {
             </IconButton>
           </Stack>
 
-          <Stack flexGrow={1} overflow="hidden ">
+          <PanelGroup direction="vertical">
             {selectedNodeId == undefined && <WelcomeScreen addNewNode={addNewNode} />}
-            <Stack
-              flexGrow={1}
-              fullWidth
-              overflow="hidden"
-              style={{
-                display: selectedNodeId != undefined ? "flex" : "none",
-                /* Ensures the monaco-editor starts loading before the user opens it */
-              }}
-            >
+            <ResizablePanel>
               <Suspense
                 fallback={
                   <Stack
@@ -455,19 +462,21 @@ function NodePlayground(props: Props) {
                   />
                 )}
               </Suspense>
-            </Stack>
-            <Stack>
+            </ResizablePanel>
+            <PanelResizeHandle className={classes.resizeHandle} />
+            <ResizablePanel collapsible collapsedSize={5} defaultSize={5} ref={bottomBarRef}>
               <BottomBar
-                nodeId={selectedNodeId}
+                diagnostics={selectedNodeDiagnostics}
                 isSaved={isNodeSaved}
+                logs={selectedNodeLogs}
+                nodeId={selectedNodeId}
+                onChangeTab={onChangeBottomBarTab}
                 save={() => {
                   saveNode(currentScript?.code);
                 }}
-                diagnostics={selectedNodeDiagnostics}
-                logs={selectedNodeLogs}
               />
-            </Stack>
-          </Stack>
+            </ResizablePanel>
+          </PanelGroup>
         </Stack>
       </Stack>
     </Stack>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,6 +2826,7 @@ __metadata:
     react-monaco-editor: 0.54.0
     react-mosaic-component: 6.0.1
     react-refresh-typescript: 2.0.9
+    react-resizable-panels: 0.0.55
     react-resize-detector: 9.1.0
     react-transition-group: 4.4.5
     react-use: 17.4.0
@@ -18689,6 +18690,16 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 2c7fe9cbd766f5e54beb4bec2e2efb2de3583037b23fef8fa511ab426ed7f1ae992382db5acd8ab5bfb030a4b93a06a2ebca41377d6eeaf0e6791bb0a59616a4
+  languageName: node
+  linkType: hard
+
+"react-resizable-panels@npm:0.0.55":
+  version: 0.0.55
+  resolution: "react-resizable-panels@npm:0.0.55"
+  peerDependencies:
+    react: ^16.14.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+  checksum: a7cb938403b57d2489638eb2cf93fddcb420fbd51b8af2b959881ada83ba052f79f51610d650019e577f0e6018542e9195e4bfe45e4e884b4821744c45837646
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Make user script bottom bar resizable

**Description**
Uses the [react-resizable-panels](https://github.com/bvaughn/react-resizable-panels) library to make the bottom bar resizable.

https://github.com/foxglove/studio/assets/93935560/9304be6c-c93c-4914-97cb-1ce453a62251

@2metres Can you help with styling? When the user can resize to reveal the bottom bar at any time it doesn't make sense to have no tab selected IMO. Also the resize handle could be better.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
FG-3816