### PR TITLE
Fix topic stats disappearing when filtering the topic list

### DIFF
--- a/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
+++ b/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
@@ -80,6 +80,26 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
     });
   }, [latestFrequenciesByTopic, latestStats]);
 
+  // Update when new "data-topic" nodes are added, to support virtualized lists and filtering.
+  useEffect(() => {
+    if (!rootRef.current?.parentElement) {
+      return;
+    }
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          // updateStats() triggers mutations of text nodes, so only update if HTMLElements are added to avoid infinite loops
+          if (node instanceof HTMLElement && node.querySelector("[data-topic]")) {
+            updateStats();
+            return;
+          }
+        }
+      }
+    });
+    observer.observe(rootRef.current.parentElement, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [updateStats]);
+
   useEffect(() => {
     if (updateCount.current++ % interval === 0) {
       updateStats();


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**

Fixes FG-4839

The DirectTopicStatsUpdater didn't handle when rows were dynamically added or removed from the topic list. This PR fixes the issue by using a MutationObserver to see when nodes are added/removed from the parent element to trigger updates.

This is also a must-have for #6717 because we're going to virtualize the list using `react-window`.

<table><tr><th>Before</th><th>After</th></tr><tr><td>


https://github.com/foxglove/studio/assets/14237/8d0bb595-34c7-4691-8edd-64ea4db335d6



</td><td>


https://github.com/foxglove/studio/assets/14237/85b3c054-3863-49c7-bd2d-b71363d149b8


</td></tr></table>