### PR TITLE
Fix visibility filter padding in panel settings

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -479,12 +479,15 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
         </>
       )}
       {state.open && selectVisibilityFilterEnabled && hasChildren && (
-        <FieldEditor
-          key="visibilityFilter"
-          field={{ ...getSelectVisibilityFilterField(t), value: state.visibilityFilter }}
-          path={makeStablePath(props.path, "visibilityFilter")}
-          actionHandler={selectVisibilityFilter}
-        />
+        <>
+          <Stack paddingBottom={0.5} style={{ gridColumn: "span 2" }} />
+          <FieldEditor
+            key="visibilityFilter"
+            field={{ ...getSelectVisibilityFilterField(t), value: state.visibilityFilter }}
+            path={makeStablePath(props.path, "visibilityFilter")}
+            actionHandler={selectVisibilityFilter}
+          />
+        </>
       )}
       {state.open && childNodes}
       {indent === 1 && <Divider style={{ gridColumn: "span 2" }} />}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes the top padding for the visibility filter as remarked in https://github.com/foxglove/studio/pull/6710#issuecomment-1701816475

**Before**:

   <img width="393" alt="image" src="https://github.com/foxglove/studio/assets/637671/6a862651-81d4-4aca-a5c7-3881560acf93">

**After**:

![image](https://github.com/foxglove/studio/assets/9250155/a6b7f3e3-8bf7-42a0-a76e-a5d120753669)

