### PR TITLE
Lint: `@typescript-eslint/require-await` already set upstream

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -157,8 +157,6 @@ overrides:
       "@typescript-eslint/no-unsafe-assignment": off
       "@typescript-eslint/no-unsafe-call": off
 
-      "@typescript-eslint/require-await": off # Async functions without await are used to satisfy interface requirements
-
       # These could theoretically be turned on (or merit investigation) but are currently noisy
       "@typescript-eslint/no-misused-promises": off # Often used with e.g. useCallback(async () => {})
       "@typescript-eslint/restrict-template-expressions": off


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
Remove unnecessary `@typescript-eslint/require-await` lint override because it is already disabled in `plugin:@foxglove/typescript`

https://github.com/foxglove/eslint-plugin/blob/df51e999f945ce7bd54ba4659e4d4156644b14cb/configs/typescript.js#L60