### PR TITLE
Fix for single-message plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -46,7 +46,7 @@ const exampleConfig: PlotConfig = {
 };
 
 function Wrapper(Wrapped: StoryFn): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 20 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   return (

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -18,7 +18,6 @@ export default {
   parameters: {
     chromatic: { delay: 50 },
   },
-  decorators: [Wrapper],
 };
 
 const labeledPaths = paths.map((path, index) => {
@@ -121,6 +120,7 @@ export const Light: StoryObj = {
   },
 
   parameters: { useReadySignal: true, colorScheme: "light" },
+  decorators: [Wrapper],
 };
 
 export const Dark: StoryObj = {
@@ -135,21 +135,27 @@ export const Dark: StoryObj = {
   },
 
   parameters: { useReadySignal: true, colorScheme: "dark" },
+  decorators: [Wrapper],
 };
 
 export const LimitWidth: StoryObj = {
   render: function Story() {
+    const readySignal = useReadySignal({ count: 6 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
     return (
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-        }}
-      >
-        <Plot
-          overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
-        />
-      </div>
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+          }}
+        >
+          <Plot
+            overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
+          />
+        </div>
+      </PanelSetup>
     );
   },
 

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -1161,7 +1161,7 @@ export const IndexBasedXAxisForArray: StoryObj = {
 
 export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useReadySignal({ count: 1 });
 
     const [ourFixture, setOurFixture] = useState(structuredClone(fixture));
 

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -270,6 +270,11 @@ function rebuild(id: string) {
     return;
   }
 
+  // We do not downsample single-message plots (for now)
+  if (isSingleMessage(params)) {
+    return;
+  }
+
   const downsampled = mapDatasets((dataset) => {
     const indices = downsample(dataset, iterateTyped(dataset.data), view);
     const resolved = resolveTypedIndices(dataset.data, indices);


### PR DESCRIPTION
**User-Facing Changes**
Fix a small issue affecting single-message plots.

**Description**
When a plot only uses a single message (ie its x-axis is either a custom data source or indices) we should not use our debounced rebuilding mechanism.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
