### PR TITLE
Don't track other pointer events in NumberInput

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -130,10 +130,6 @@ export function NumberInput(
     event.currentTarget.releasePointerCapture(event.pointerId);
   }, []);
 
-  const onPointerLeave = useCallback(() => {
-    isDragging.current = false;
-  }, []);
-
   const onPointerMove = useCallback(
     (event: React.PointerEvent<HTMLInputElement>) => {
       if (event.buttons !== 1 || !isDragging.current) {
@@ -172,7 +168,6 @@ export function NumberInput(
         onPointerDown,
         onPointerUp,
         onPointerMove,
-        onPointerLeave,
       }}
       InputProps={{
         readOnly,

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -114,8 +114,10 @@ export function NumberInput(
     [disabled, readOnly, min, max, onChange, precision],
   );
 
+  const isDragging = useRef(false);
   const onPointerDown = useCallback(
     (event: React.PointerEvent) => {
+      isDragging.current = true;
       event.currentTarget.setPointerCapture(event.pointerId);
       const scrubStart = latestValue.current ?? placeHolderValue ?? 0;
       scrubValue.current = isFinite(scrubStart) ? scrubStart : 0;
@@ -124,24 +126,26 @@ export function NumberInput(
   );
 
   const onPointerUp = useCallback((event: React.PointerEvent) => {
+    isDragging.current = false;
     event.currentTarget.releasePointerCapture(event.pointerId);
+  }, []);
+
+  const onPointerLeave = useCallback(() => {
+    isDragging.current = false;
   }, []);
 
   const onPointerMove = useCallback(
     (event: React.PointerEvent<HTMLInputElement>) => {
-      if (event.buttons === 1) {
-        event.preventDefault();
-        event.currentTarget.blur();
-        const scale = event.shiftKey ? 10 : 1;
-        const delta =
-          Math.sign(event.movementX) *
-          Math.pow(Math.abs(event.movementX), 1.5) *
-          0.1 *
-          step *
-          scale;
-        scrubValue.current = round(scrubValue.current + delta, Constants.ScrubPrecision);
-        updateValue(scrubValue.current);
+      if (event.buttons !== 1 || !isDragging.current) {
+        return;
       }
+      event.preventDefault();
+      event.currentTarget.blur();
+      const scale = event.shiftKey ? 10 : 1;
+      const delta =
+        Math.sign(event.movementX) * Math.pow(Math.abs(event.movementX), 1.5) * 0.1 * step * scale;
+      scrubValue.current = round(scrubValue.current + delta, Constants.ScrubPrecision);
+      updateValue(scrubValue.current);
     },
     [step, updateValue],
   );
@@ -168,6 +172,7 @@ export function NumberInput(
         onPointerDown,
         onPointerUp,
         onPointerMove,
+        onPointerLeave,
       }}
       InputProps={{
         readOnly,


### PR DESCRIPTION
**User-Facing Changes**
One less bug.

**Description**
The mouse event handlers in `NumberInput` did not track whether a click and drag had initiated in the input element or not. This fixes that.

https://github.com/foxglove/studio/assets/4588553/7c787585-30cc-4b46-ad30-3b4eb4d13564



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
