### PR TITLE
Remove icons from PanelActionDropdown

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -11,13 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import {
-  Delete20Regular,
-  FullScreenMaximize20Regular,
-  ShapeSubtract20Regular,
-  SplitHorizontal20Regular,
-  SplitVertical20Regular,
-} from "@fluentui/react-icons";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { Divider, Menu, MenuItem } from "@mui/material";
@@ -149,7 +142,6 @@ function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
         {
           key: "vsplit",
           text: "Split right",
-          icon: <SplitVertical20Regular />,
           onClick: () => {
             split(panelContext?.id, "row");
           },
@@ -157,7 +149,6 @@ function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
         {
           key: "hsplit",
           text: "Split down",
-          icon: <SplitHorizontal20Regular />,
           onClick: () => {
             split(panelContext?.id, "column");
           },
@@ -169,7 +160,6 @@ function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
       items.push({
         key: "enter-fullscreen",
         text: "Fullscreen",
-        icon: <FullScreenMaximize20Regular />,
         onClick: enterFullscreen,
         "data-testid": "panel-menu-fullscreen",
       });
@@ -180,7 +170,6 @@ function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
     items.push({
       key: "remove",
       text: "Remove panel",
-      icon: <Delete20Regular />,
       onClick: close,
       "data-testid": "panel-menu-remove",
       className: classes.error,
@@ -238,7 +227,6 @@ function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
           onClick={handleSubmenuClick}
           onMouseEnter={handleSubmenuMouseEnter}
         >
-          <ShapeSubtract20Regular />
           Change panel
           <ChevronRightIcon className={classes.icon} fontSize="small" />
         </MenuItem>
@@ -260,7 +248,6 @@ function PanelActionsDropdownComponent({ isUnknownPanel }: Props): JSX.Element {
               className={cx(classes.menuItem, item.className)}
               data-testid={item["data-testid"]}
             >
-              {item.icon}
               {item.text}
             </MenuItem>
           ),


### PR DESCRIPTION
**User-Facing Changes**
Removes icons from PanelActionDropdown for consistency

**Description**

|: Before :|: After :|
|---|---|
|  <img src="https://github.com/foxglove/studio/assets/924528/a9cc83c0-7cb8-47a3-adf8-c7bab4200c9d"> | <img alt="Screen Shot 2023-09-06 at 2 35 20 pm" src="https://github.com/foxglove/studio/assets/924528/83df5a57-a159-4ea6-8a9c-9266e1e9c759"> |
