### PR TITLE
Stabilize block subscriptions in useDatasets

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -175,7 +175,9 @@ function useData(id: string, topics: SubscribePayload[]) {
     ),
   });
 
-  const blocks = useBlocks(R.map((v) => ({ ...v, preloadType: "full" }), subscribed));
+  const blocks = useBlocks(
+    React.useMemo(() => R.map((v) => ({ ...v, preloadType: "full" }), subscribed), [subscribed]),
+  );
   useEffect(() => {
     for (const [index, block] of blocks.entries()) {
       if (R.isEmpty(block)) {


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
`setSubscriptions` was being called on every rerender. Make that not happen.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
