### PR TITLE
Mark diagnostic messages as stale after a certain timeout

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
@@ -302,7 +302,7 @@ export default function DiagnosticStatus(props: Props): JSX.Element {
     [LEVELS.OK]: "success.main",
     [LEVELS.ERROR]: "error.main",
     [LEVELS.WARN]: "warning.main",
-    [LEVELS.STALE]: "info.main",
+    [LEVELS.STALE]: "text.secondary",
   };
 
   return (

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -17,16 +17,12 @@ const fixture: Fixture = {
   frame: {
     "/diagnostics": [
       makeDiagnosticMessage(LEVELS.OK, "name1", "hardware_id1", ["message 1", "message 2"]),
-      makeDiagnosticMessage(
-        LEVELS.OK,
-        "name2",
-        "hardware_id1",
-        ["message 3"],
-        [
+      makeDiagnosticMessage(LEVELS.OK, "name2", "hardware_id1", ["message 3"], {
+        values: [
           { key: "key", value: "value" },
           { key: "key <b>with html</b>", value: "value <tt>with html</tt>" },
         ],
-      ),
+      }),
       makeDiagnosticMessage(LEVELS.ERROR, "name1", "levels_id", ["error message"]),
       makeDiagnosticMessage(LEVELS.OK, "name2", "levels_id", ["ok message"]),
       makeDiagnosticMessage(LEVELS.STALE, "name3", "levels_id", ["stale message"]),
@@ -122,6 +118,41 @@ export const MovedDivider: StoryObj = {
             selectedHardwareId: "hardware_id1",
             selectedName: undefined,
             splitFraction: 0.25,
+          }}
+        />
+      </PanelSetup>
+    );
+  },
+};
+
+export const OldDiagnosticsMarkedStale: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup
+        includeSettings
+        fixture={{
+          ...fixture,
+          activeData: { currentTime: { sec: 10, nsec: 0 } },
+          frame: {
+            "/diagnostics": [
+              makeDiagnosticMessage(LEVELS.OK, "name1", "timeout_id", ["2 secs"], {
+                stamp: { sec: 2, nsec: 0 },
+              }),
+              makeDiagnosticMessage(LEVELS.OK, "name2", "timeout_id", ["4 secs"], {
+                stamp: { sec: 4, nsec: 0 },
+              }),
+              makeDiagnosticMessage(LEVELS.OK, "name3", "timeout_id", ["6 secs"], {
+                stamp: { sec: 6, nsec: 0 },
+              }),
+            ],
+          },
+        }}
+      >
+        <DiagnosticStatusPanel
+          overrideConfig={{
+            topicToRender: "/diagnostics",
+            selectedHardwareId: "timeout_id",
+            selectedName: undefined,
           }}
         />
       </PanelSetup>

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -14,11 +14,17 @@
 import { Autocomplete, TextField } from "@mui/material";
 import { produce } from "immer";
 import * as _ from "lodash-es";
-import { useCallback, useMemo, useEffect } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
+import { useInterval } from "react-use";
 
+import { Time, subtract, compare } from "@foxglove/rostime";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -30,7 +36,12 @@ import DiagnosticStatus from "./DiagnosticStatus";
 import { buildStatusPanelSettingsTree } from "./settings";
 import useAvailableDiagnostics from "./useAvailableDiagnostics";
 import useDiagnostics from "./useDiagnostics";
-import { DiagnosticStatusConfig as Config, getDisplayName } from "./util";
+import {
+  DiagnosticStatusConfig as Config,
+  DEFAULT_SECONDS_UNTIL_STALE,
+  LEVELS,
+  getDisplayName,
+} from "./util";
 
 type Props = {
   config: Config;
@@ -43,13 +54,32 @@ const ALLOWED_DATATYPES: string[] = [
   "ros.diagnostic_msgs.DiagnosticArray",
 ];
 
+const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
+
 // component to display a single diagnostic status from list
 function DiagnosticStatusPanel(props: Props) {
   const { saveConfig, config } = props;
   const { topics } = useDataSourceInfo();
   const { openSiblingPanel } = usePanelContext();
-  const { selectedHardwareId, selectedName, splitFraction, topicToRender, numericPrecision } =
-    config;
+  const currentTime = useMessagePipeline(selectCurrentTime);
+  const {
+    selectedHardwareId,
+    selectedName,
+    splitFraction,
+    topicToRender,
+    numericPrecision,
+    secondsUntilStale = DEFAULT_SECONDS_UNTIL_STALE,
+  } = config;
+
+  // The stale time marks the point in time a diagnostic message is considered stale when its timestamp is older.
+  const newStaleTime =
+    currentTime && secondsUntilStale >= 1
+      ? subtract(currentTime, { sec: Math.floor(secondsUntilStale), nsec: 0 })
+      : undefined;
+  const [staleTime, setStaleTime] = useState<Time | undefined>(newStaleTime);
+  useInterval(() => {
+    setStaleTime(newStaleTime);
+  }, 1000);
 
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
@@ -114,13 +144,18 @@ function DiagnosticStatusPanel(props: Props) {
     if (diagnosticsByName != undefined) {
       for (const diagnostic of diagnosticsByName.values()) {
         if (selectedName == undefined || selectedName === diagnostic.status.name) {
-          items.push(diagnostic);
+          const markStale = staleTime != undefined && compare(diagnostic.stamp, staleTime) < 0;
+          if (markStale) {
+            items.push({ ...diagnostic, status: { ...diagnostic.status, level: LEVELS.STALE } });
+          } else {
+            items.push(diagnostic);
+          }
         }
       }
     }
 
     return items;
-  }, [diagnostics, selectedHardwareId, selectedName]);
+  }, [diagnostics, selectedHardwareId, selectedName, staleTime]);
 
   // If there are available options but none match the user input we show a No matches
   // but if we don't have any options at all then we show waiting for diagnostics...
@@ -142,9 +177,9 @@ function DiagnosticStatusPanel(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree({
       actionHandler,
-      nodes: buildStatusPanelSettingsTree(topicToRender, numericPrecision, availableTopics),
+      nodes: buildStatusPanelSettingsTree(config, topicToRender, availableTopics),
     });
-  }, [actionHandler, availableTopics, topicToRender, numericPrecision, updatePanelSettingsTree]);
+  }, [actionHandler, config, availableTopics, topicToRender, updatePanelSettingsTree]);
 
   return (
     <Stack flex="auto" overflow="hidden">

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -14,21 +14,17 @@
 import { Autocomplete, TextField } from "@mui/material";
 import { produce } from "immer";
 import * as _ from "lodash-es";
-import { useCallback, useMemo, useEffect, useState } from "react";
-import { useInterval } from "react-use";
+import { useCallback, useEffect, useMemo } from "react";
 
-import { Time, subtract, compare } from "@foxglove/rostime";
+import { compare } from "@foxglove/rostime";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
-import {
-  MessagePipelineContext,
-  useMessagePipeline,
-} from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
+import useStaleTime from "@foxglove/studio-base/panels/diagnostics/useStaleTime";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
@@ -54,14 +50,11 @@ const ALLOWED_DATATYPES: string[] = [
   "ros.diagnostic_msgs.DiagnosticArray",
 ];
 
-const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
-
 // component to display a single diagnostic status from list
 function DiagnosticStatusPanel(props: Props) {
   const { saveConfig, config } = props;
   const { topics } = useDataSourceInfo();
   const { openSiblingPanel } = usePanelContext();
-  const currentTime = useMessagePipeline(selectCurrentTime);
   const {
     selectedHardwareId,
     selectedName,
@@ -71,15 +64,7 @@ function DiagnosticStatusPanel(props: Props) {
     secondsUntilStale = DEFAULT_SECONDS_UNTIL_STALE,
   } = config;
 
-  // The stale time marks the point in time a diagnostic message is considered stale when its timestamp is older.
-  const newStaleTime =
-    currentTime && secondsUntilStale >= 1
-      ? subtract(currentTime, { sec: Math.floor(secondsUntilStale), nsec: 0 })
-      : undefined;
-  const [staleTime, setStaleTime] = useState<Time | undefined>(newStaleTime);
-  useInterval(() => {
-    setStaleTime(newStaleTime);
-  }, 1000);
+  const staleTime = useStaleTime(secondsUntilStale);
 
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -13,55 +13,50 @@
 
 import PushPinIcon from "@mui/icons-material/PushPin";
 import {
+  IconButton,
+  InputBase,
   ListItem,
-  ListItemText,
   ListItemButton,
+  ListItemText,
   MenuItem,
   Select,
-  InputBase,
-  IconButton,
+  Typography,
   iconButtonClasses,
+  inputBaseClasses,
   listItemTextClasses,
   selectClasses,
-  inputBaseClasses,
-  Typography,
 } from "@mui/material";
 import { produce } from "immer";
 import * as _ from "lodash-es";
-import { CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
-import { useInterval } from "react-use";
+import { CSSProperties, useCallback, useEffect, useMemo } from "react";
 import { AutoSizer } from "react-virtualized";
 import { FixedSizeList as List } from "react-window";
 import { makeStyles } from "tss-react/mui";
 
 import { filterMap } from "@foxglove/den/collection";
-import { Time, subtract } from "@foxglove/rostime";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
-import {
-  MessagePipelineContext,
-  useMessagePipeline,
-} from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import useDiagnostics from "@foxglove/studio-base/panels/diagnostics/useDiagnostics";
+import useStaleTime from "@foxglove/studio-base/panels/diagnostics/useStaleTime";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import toggle from "@foxglove/studio-base/util/toggle";
 
 import { buildSummarySettingsTree } from "./settings";
 import {
-  DiagnosticSummaryConfig,
+  DEFAULT_SECONDS_UNTIL_STALE,
   DiagnosticInfo,
   DiagnosticStatusConfig,
-  getDiagnosticsByLevel,
-  filterAndSortDiagnostics,
-  LEVEL_NAMES,
+  DiagnosticSummaryConfig,
   KNOWN_LEVELS,
-  DEFAULT_SECONDS_UNTIL_STALE,
+  LEVEL_NAMES,
+  filterAndSortDiagnostics,
+  getDiagnosticsByLevel,
   getDiagnosticsWithStales as markOldDiagnosticsAsStales,
 } from "./util";
 
@@ -162,8 +157,6 @@ const ALLOWED_DATATYPES: string[] = [
   "ros.diagnostic_msgs.DiagnosticArray",
 ];
 
-const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
-
 function DiagnosticSummary(props: Props): JSX.Element {
   const { config, saveConfig } = props;
   const { classes } = useStyles();
@@ -178,17 +171,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   } = config;
   const { openSiblingPanel } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
-  const currentTime = useMessagePipeline(selectCurrentTime);
-
-  // The stale time marks the point in time a diagnostic message is considered stale when its timestamp is older.
-  const newStaleTime =
-    currentTime && secondsUntilStale >= 1
-      ? subtract(currentTime, { sec: Math.floor(secondsUntilStale), nsec: 0 })
-      : undefined;
-  const [staleTime, setStaleTime] = useState<Time | undefined>(newStaleTime);
-  useInterval(() => {
-    setStaleTime(newStaleTime);
-  }, 1000);
+  const staleTime = useStaleTime(secondsUntilStale);
 
   const togglePinned = useCallback(
     (info: DiagnosticInfo) => {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -28,15 +28,21 @@ import {
 } from "@mui/material";
 import { produce } from "immer";
 import * as _ from "lodash-es";
-import { CSSProperties, useCallback, useEffect, useMemo } from "react";
+import { CSSProperties, useCallback, useEffect, useMemo, useState } from "react";
+import { useInterval } from "react-use";
 import { AutoSizer } from "react-virtualized";
 import { FixedSizeList as List } from "react-window";
 import { makeStyles } from "tss-react/mui";
 
 import { filterMap } from "@foxglove/den/collection";
+import { Time, subtract } from "@foxglove/rostime";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -55,6 +61,8 @@ import {
   filterAndSortDiagnostics,
   LEVEL_NAMES,
   KNOWN_LEVELS,
+  DEFAULT_SECONDS_UNTIL_STALE,
+  getDiagnosticsWithStales as markOldDiagnosticsAsStales,
 } from "./util";
 
 type NodeRowProps = {
@@ -154,13 +162,33 @@ const ALLOWED_DATATYPES: string[] = [
   "ros.diagnostic_msgs.DiagnosticArray",
 ];
 
+const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
+
 function DiagnosticSummary(props: Props): JSX.Element {
   const { config, saveConfig } = props;
   const { classes } = useStyles();
   const { topics } = useDataSourceInfo();
-  const { minLevel, topicToRender, pinnedIds, hardwareIdFilter, sortByLevel = true } = config;
+  const {
+    minLevel,
+    topicToRender,
+    pinnedIds,
+    hardwareIdFilter,
+    sortByLevel = true,
+    secondsUntilStale = DEFAULT_SECONDS_UNTIL_STALE,
+  } = config;
   const { openSiblingPanel } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+  const currentTime = useMessagePipeline(selectCurrentTime);
+
+  // The stale time marks the point in time a diagnostic message is considered stale when its timestamp is older.
+  const newStaleTime =
+    currentTime && secondsUntilStale >= 1
+      ? subtract(currentTime, { sec: Math.floor(secondsUntilStale), nsec: 0 })
+      : undefined;
+  const [staleTime, setStaleTime] = useState<Time | undefined>(newStaleTime);
+  useInterval(() => {
+    setStaleTime(newStaleTime);
+  }, 1000);
 
   const togglePinned = useCallback(
     (info: DiagnosticInfo) => {
@@ -223,8 +251,12 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   const diagnostics = useDiagnostics(diagnosticTopic);
 
+  const diagnosticsWithOldMarkedAsStales = useMemo(() => {
+    return staleTime ? markOldDiagnosticsAsStales(diagnostics, staleTime) : diagnostics;
+  }, [diagnostics, staleTime]);
+
   const summary = useMemo(() => {
-    if (diagnostics.size === 0) {
+    if (diagnosticsWithOldMarkedAsStales.size === 0) {
       return (
         <EmptyState>
           Waiting for <code>{topicToRender}</code> messages
@@ -236,11 +268,11 @@ function DiagnosticSummary(props: Props): JSX.Element {
       if (name == undefined || trimmedHardwareId == undefined) {
         return;
       }
-      const diagnosticsByName = diagnostics.get(trimmedHardwareId);
+      const diagnosticsByName = diagnosticsWithOldMarkedAsStales.get(trimmedHardwareId);
       return diagnosticsByName?.get(name);
     });
 
-    const nodesByLevel = getDiagnosticsByLevel(diagnostics);
+    const nodesByLevel = getDiagnosticsByLevel(diagnosticsWithOldMarkedAsStales);
     const levels = Array.from(nodesByLevel.keys()).sort().reverse();
     const sortedNodes = sortByLevel
       ? ([] as DiagnosticInfo[]).concat(
@@ -277,7 +309,15 @@ function DiagnosticSummary(props: Props): JSX.Element {
         )}
       </AutoSizer>
     );
-  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, minLevel, topicToRender]);
+  }, [
+    diagnosticsWithOldMarkedAsStales,
+    hardwareIdFilter,
+    pinnedIds,
+    renderRow,
+    sortByLevel,
+    minLevel,
+    topicToRender,
+  ]);
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -57,7 +57,7 @@ import {
   LEVEL_NAMES,
   filterAndSortDiagnostics,
   getDiagnosticsByLevel,
-  getDiagnosticsWithStales as markOldDiagnosticsAsStales,
+  getDiagnosticsWithStales,
 } from "./util";
 
 type NodeRowProps = {
@@ -235,7 +235,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   const diagnostics = useDiagnostics(diagnosticTopic);
 
   const diagnosticsWithOldMarkedAsStales = useMemo(() => {
-    return staleTime ? markOldDiagnosticsAsStales(diagnostics, staleTime) : diagnostics;
+    return staleTime ? getDiagnosticsWithStales(diagnostics, staleTime) : diagnostics;
   }, [diagnostics, staleTime]);
 
   const summary = useMemo(() => {

--- a/packages/studio-base/src/panels/diagnostics/settings.ts
+++ b/packages/studio-base/src/panels/diagnostics/settings.ts
@@ -4,7 +4,11 @@
 
 import { SettingsTreeNodes } from "@foxglove/studio";
 
-import { DiagnosticSummaryConfig } from "./util";
+import {
+  DEFAULT_SECONDS_UNTIL_STALE,
+  DiagnosticStatusConfig,
+  DiagnosticSummaryConfig,
+} from "./util";
 
 export function buildSummarySettingsTree(
   config: DiagnosticSummaryConfig,
@@ -30,14 +34,24 @@ export function buildSummarySettingsTree(
           options: topicOptions,
         },
         sortByLevel: { label: "Sort by level", input: "boolean", value: config.sortByLevel },
+        secondsUntilStale: {
+          label: "Stale timeout",
+          help: "Number of seconds after which entries will be marked as stale if no new diagnostic message(s) have been received",
+          input: "number",
+          placeholder: `${DEFAULT_SECONDS_UNTIL_STALE} seconds`,
+          min: 0,
+          step: 1,
+          precision: 0,
+          value: config.secondsUntilStale,
+        },
       },
     },
   };
 }
 
 export function buildStatusPanelSettingsTree(
+  config: DiagnosticStatusConfig,
   topicToRender: string,
-  numericPrecision: number | undefined,
   availableTopics: readonly string[],
 ): SettingsTreeNodes {
   const topicOptions = availableTopics.map((topic) => ({ label: topic, value: topic }));
@@ -66,7 +80,17 @@ export function buildStatusPanelSettingsTree(
           precision: 0,
           step: 1,
           placeholder: "auto",
-          value: numericPrecision,
+          value: config.numericPrecision,
+        },
+        secondsUntilStale: {
+          label: "Stale timeout",
+          help: "Number of seconds after which entries will be marked as stale if no new diagnostic message(s) have been received",
+          input: "number",
+          placeholder: `${DEFAULT_SECONDS_UNTIL_STALE} seconds`,
+          min: 0,
+          step: 1,
+          precision: 0,
+          value: config.secondsUntilStale,
         },
       },
     },

--- a/packages/studio-base/src/panels/diagnostics/useStaleTime.ts
+++ b/packages/studio-base/src/panels/diagnostics/useStaleTime.ts
@@ -5,9 +5,16 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Time, clampTime, subtract } from "@foxglove/rostime";
-import { useMessagePipelineGetter } from "@foxglove/studio-base/components/MessagePipeline";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+  useMessagePipelineGetter,
+} from "@foxglove/studio-base/components/MessagePipeline";
 
 const DEFAULT_UPDATE_INTERVAL_MS = 1_000;
+
+const selectLastSeekTime = (ctx: MessagePipelineContext) =>
+  ctx.playerState.activeData?.lastSeekTime;
 
 // Returns a time which specifies from when diagnostic messages are considered stale.
 export default function useStaleTime(
@@ -30,6 +37,11 @@ export default function useStaleTime(
       clearInterval(interval);
     };
   }, [getCurrentTime, updateIntervalMillis]);
+
+  const lastSeekTime = useMessagePipeline(selectLastSeekTime);
+  useEffect(() => {
+    setCurrentTime(getCurrentTime());
+  }, [getCurrentTime, lastSeekTime]);
 
   return useMemo(() => {
     const timeUntilStale: Time = { sec: Math.floor(secondsUntilStale), nsec: 0 };

--- a/packages/studio-base/src/panels/diagnostics/useStaleTime.ts
+++ b/packages/studio-base/src/panels/diagnostics/useStaleTime.ts
@@ -4,7 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { Time, subtract } from "@foxglove/rostime";
+import { Time, clampTime, subtract } from "@foxglove/rostime";
 import { useMessagePipelineGetter } from "@foxglove/studio-base/components/MessagePipeline";
 
 const DEFAULT_UPDATE_INTERVAL_MS = 1_000;
@@ -20,7 +20,7 @@ export default function useStaleTime(
     return playerState.activeData?.currentTime;
   }, [messagePipeline]);
 
-  const [currentTime, setCurrentTime] = useState<Time | undefined>(getCurrentTime());
+  const [currentTime, setCurrentTime] = useState<Time | undefined>(() => getCurrentTime());
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -32,8 +32,9 @@ export default function useStaleTime(
   }, [getCurrentTime, updateIntervalMillis]);
 
   return useMemo(() => {
+    const timeUntilStale: Time = { sec: Math.floor(secondsUntilStale), nsec: 0 };
     return currentTime && secondsUntilStale >= 1
-      ? subtract(currentTime, { sec: Math.floor(secondsUntilStale), nsec: 0 })
+      ? subtract(clampTime(currentTime, timeUntilStale, currentTime), timeUntilStale)
       : undefined;
   }, [currentTime, secondsUntilStale]);
 }

--- a/packages/studio-base/src/panels/diagnostics/useStaleTime.ts
+++ b/packages/studio-base/src/panels/diagnostics/useStaleTime.ts
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Time, subtract } from "@foxglove/rostime";
+import { useMessagePipelineGetter } from "@foxglove/studio-base/components/MessagePipeline";
+
+const DEFAULT_UPDATE_INTERVAL_MS = 1_000;
+
+// Returns a time which specifies from when diagnostic messages are considered stale.
+export default function useStaleTime(
+  secondsUntilStale: number,
+  updateIntervalMillis?: number,
+): Time | undefined {
+  const messagePipeline = useMessagePipelineGetter();
+  const getCurrentTime = useCallback(() => {
+    const { playerState } = messagePipeline();
+    return playerState.activeData?.currentTime;
+  }, [messagePipeline]);
+
+  const [currentTime, setCurrentTime] = useState<Time | undefined>(getCurrentTime());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTime(getCurrentTime());
+    }, updateIntervalMillis ?? DEFAULT_UPDATE_INTERVAL_MS);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [getCurrentTime, updateIntervalMillis]);
+
+  return useMemo(() => {
+    return currentTime && secondsUntilStale >= 1
+      ? subtract(currentTime, { sec: Math.floor(secondsUntilStale), nsec: 0 })
+      : undefined;
+  }, [currentTime, secondsUntilStale]);
+}


### PR DESCRIPTION
**User-Facing Changes**
Mark diagnostic messages as stale after a certain timeout

**Description**
Marks diagnostic messages as stale when no new messages with the same ID has been received within the configured timeout (default is 5 seconds)

Fixes #6705 
Resolves FG-4771

For reviewing purposes, you can use the following bag file that contains some diagnostic messages: [diagnostics_bag.zip](https://github.com/foxglove/studio/files/12540758/diagnostics.zip)

