### PR TITLE
Fix issue with gaps that can appear in plots under certain circumstances

### DIFF
--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -390,7 +390,7 @@ export function sliceTyped(dataset: TypedData[], start: number, end?: number): T
   return [sliceSingle(startSlice, offset0), ...between, sliceSingle(endSlice, 0, offset1)];
 }
 
-function getXBounds(dataset: TypedData[]): [min: number, max: number] | undefined {
+export function getXBounds(dataset: TypedData[]): [min: number, max: number] | undefined {
   const min = dataset.at(0)?.x.at(0);
   const max = dataset.at(-1)?.x.at(-1);
   if (min == undefined || max == undefined) {

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -340,8 +340,8 @@ function sliceSingle(slice: TypedData, start: number, end?: number): TypedData {
     if (xVal == undefined || yVal == undefined) {
       continue;
     }
-    x[i] = xVal;
-    y[i] = yVal;
+    x[i - i0] = xVal;
+    y[i - i0] = yVal;
   }
 
   return {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -210,6 +210,11 @@ function Plot(props: Props) {
     invertedTheme: false,
     xAxisPath,
     xAxisVal,
+    minXValue,
+    maxXValue,
+    minYValue,
+    maxYValue,
+    followingViewWidth,
   });
 
   const {

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -91,4 +91,9 @@ export type PlotParams = {
   invertedTheme?: boolean;
   xAxisPath?: BasePlotPath;
   xAxisVal: PlotXAxisVal;
+  followingViewWidth: number | undefined;
+  minXValue: number | undefined;
+  maxXValue: number | undefined;
+  minYValue: string | number | undefined;
+  maxYValue: string | number | undefined;
 };

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -133,9 +133,9 @@ export function appendPlotData(a: PlotData, b: PlotData): PlotData {
 }
 
 /**
- * Merge two PlotData objects into a single PlotData object, discarding any overlapping
- * messages between the two items. Assumes they represent non-contiguous segments of a
- * chart.
+ * Merge two PlotData objects into a single PlotData object, discarding any
+ * overlapping messages between the two items. Assumes they represent
+ * non-contiguous segments of a chart.
  */
 function mergePlotData(a: PlotData, b: PlotData): PlotData {
   if (a === EmptyPlotData) {
@@ -156,8 +156,10 @@ function mergePlotData(a: PlotData, b: PlotData): PlotData {
   };
 }
 
-// Sort by start time, then end time, so that folding from the left gives us the
-// right consolidated interval.
+/**
+ * Sort by start time, then end time, so that folding from the left gives us
+ * the right consolidated interval.
+ */
 function compare(a: Im<PlotData>, b: Im<PlotData>): number {
   const rangeA = findXRanges(a).all;
   const rangeB = findXRanges(b).all;


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
After seeking to the beginning of an unbounded plot, gaps would appear while playing in addition to errant lines going back to the origin.
https://github.com/foxglove/studio/assets/4588553/34c7ef8e-b058-4139-825f-d9fcd8de8372

It turned out that there were two reasons for this:
* There was a bug in the `sliceSingle` function that was resulting in the addition of erroneous datapoints at (0, 0).
* In my refactor of plot generation, I neglected to include support for the `{min,max}{X,Y}` and `followingViewWidth` config properties, which meant that the plot would fail to update when those parameters were changed. This is related because we should adjust the datasets (ie "current" or "block" data) we're using depending on the needs of the plot.

This PR fixes both of these things. Bounded and unbounded plots are now working correctly without artifacts.

