### PR TITLE
Fix block data for user scripts

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import * as _ from "lodash-es";
 import moize from "moize";
+import * as R from "ramda";
 
-import { filterMap } from "@foxglove/den/collection";
 import { Immutable } from "@foxglove/studio";
 import { SubscribePayload } from "@foxglove/studio-base/players/types";
 
@@ -20,6 +19,66 @@ export function makeSubscriptionMemoizer(): (val: SubscribePayload) => Subscribe
 }
 
 /**
+ * Merge two SubscribePayloads, using either all of the fields or the union of
+ * the specific fields requested.
+ */
+function mergeSubscription(
+  a: Immutable<SubscribePayload>,
+  b: Immutable<SubscribePayload>,
+): Immutable<SubscribePayload> {
+  const isAllFields = a.fields == undefined || b.fields == undefined;
+  const fields = R.pipe(
+    R.chain((payload: Immutable<SubscribePayload>): readonly string[] => payload.fields ?? []),
+    R.map((v) => v.trim()),
+    R.filter((v: string) => v.length > 0),
+    R.uniq,
+  )([a, b]);
+
+  return {
+    ...a,
+    ...(fields.length > 0 && !isAllFields ? { fields } : {}),
+  };
+}
+
+/**
+ * Merge subscriptions that subscribe to the same topic, paying attention to
+ * the fields they need. This ignores `preloadType`.
+ */
+function denormalizeSubscriptions(
+  subscriptions: Immutable<SubscribePayload[]>,
+): Immutable<SubscribePayload[]> {
+  return R.pipe(
+    R.groupBy((v: Immutable<SubscribePayload>) => v.topic),
+    R.values,
+    // Filter out any set of payloads that contains _only_ empty `fields`
+    R.filter((payloads: Immutable<SubscribePayload[]> | undefined) => {
+      // Handle this later
+      if (payloads == undefined) {
+        return true;
+      }
+
+      return !R.all(
+        (v: Immutable<SubscribePayload>) => v.fields != undefined && v.fields.length === 0,
+        payloads,
+      );
+    }),
+    // Now reduce them down to a single payload for each topic
+    R.map((payloads: Immutable<SubscribePayload[]> | undefined): Immutable<SubscribePayload> => {
+      const first = payloads?.[0];
+      if (first == undefined) {
+        // by definition, we can only get here iff there is at least one
+        // payload
+        return {
+          topic: "/impossible",
+        };
+      }
+
+      return R.reduce(mergeSubscription, first, payloads ?? []);
+    }),
+  )(subscriptions);
+}
+
+/**
  * Merges individual topic subscriptions into a set of subscriptions to send on to the player.
  *
  * If any client requests a "whole" subscription to a topic then all fields will be fetched for that
@@ -28,40 +87,9 @@ export function makeSubscriptionMemoizer(): (val: SubscribePayload) => Subscribe
  */
 export function mergeSubscriptions(
   subscriptions: Immutable<SubscribePayload[]>,
-): Immutable<SubscribePayload>[] {
-  const fullSubsByTopic = new Map<string, Immutable<SubscribePayload>>();
-  const partialSubsByTopic = new Map<string, Immutable<SubscribePayload>>();
-  for (const sub of subscriptions) {
-    const target = sub.preloadType === "full" ? fullSubsByTopic : partialSubsByTopic;
-    const existing = target.get(sub.topic);
-    if (existing) {
-      if (existing.fields == undefined) {
-        // Nothing to do, already subscribed to the whole topic.
-      } else if (sub.fields == undefined) {
-        // Replace any slice subscription with a subscription to the whole topic.
-        target.set(sub.topic, sub);
-      } else {
-        // Skip slice subscriptions with no non-empty fields selected.
-        const nonEmptyFields = filterMap(sub.fields, (field) => {
-          const trimmed = field.trim();
-          return trimmed.length > 0 ? trimmed : undefined;
-        });
-        if (nonEmptyFields.length > 0) {
-          target.set(sub.topic, { ...sub, fields: _.union(existing.fields, nonEmptyFields) });
-        }
-      }
-    } else {
-      if (sub.fields == undefined) {
-        // If no subscription for this topic exists, register a whole topic subscription.
-        target.set(sub.topic, sub);
-      } else {
-        // Only register a slice sub if some fields are selected.
-        const hasNonEmptyField = sub.fields.some((field) => field.trim().length > 0);
-        if (hasNonEmptyField) {
-          target.set(sub.topic, sub);
-        }
-      }
-    }
-  }
-  return [...fullSubsByTopic.values(), ...partialSubsByTopic.values()];
+): Immutable<SubscribePayload[]> {
+  return R.pipe(
+    R.partition((v: Immutable<SubscribePayload>) => v.preloadType === "full"),
+    ([full, partial]) => [...denormalizeSubscriptions(full), ...denormalizeSubscriptions(partial)],
+  )(subscriptions);
 }

--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
@@ -63,18 +63,15 @@ function denormalizeSubscriptions(
       );
     }),
     // Now reduce them down to a single payload for each topic
-    R.map((payloads: Immutable<SubscribePayload[]> | undefined): Immutable<SubscribePayload> => {
-      const first = payloads?.[0];
-      if (first == undefined) {
-        // by definition, we can only get here iff there is at least one
-        // payload
-        return {
-          topic: "/impossible",
-        };
-      }
-
-      return R.reduce(mergeSubscription, first, payloads ?? []);
-    }),
+    R.chain(
+      (payloads: Immutable<SubscribePayload[]> | undefined): Immutable<SubscribePayload>[] => {
+        const first = payloads?.[0];
+        if (payloads == undefined || first == undefined || payloads.length === 0) {
+          return [];
+        }
+        return [R.reduce(mergeSubscription, first, payloads)];
+      },
+    ),
   )(subscriptions);
 }
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -177,8 +177,8 @@ describe("UserNodePlayer", () => {
       userNodePlayer.setSubscriptions([{ topic: "/studio/test" }, { topic: "/input/baz" }]);
       await Promise.resolve(); // wait for subscriptions to take effect
       expect(fakePlayer.subscriptions).toEqual([
-        { topic: "/studio/test", preloadType: "partial" },
-        { topic: "/input/baz", preloadType: "partial" },
+        { topic: "/studio/test" },
+        { topic: "/input/baz" },
       ]);
     });
 
@@ -601,7 +601,7 @@ describe("UserNodePlayer", () => {
       });
       userNodePlayer.setSubscriptions(topicNames.map((topic) => ({ topic })));
       await delay(10); // wait for subscriptions to take effect
-      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", preloadType: "partial" }]);
+      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input" }]);
     });
 
     it("requests full subscriptions for input topics", async () => {
@@ -636,6 +636,20 @@ describe("UserNodePlayer", () => {
       // The underlying player subscription should not be sliced since we don't know which fields of
       // the message the script will use.
       expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", preloadType: "partial" }]);
+    });
+
+    it("passes through sliced subscriptions", async () => {
+      const fakePlayer = new FakePlayer();
+      const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
+      const topicNames = ["/np_input"];
+      void userNodePlayer.setUserNodes({
+        nodeId: { name: "someNodeName", sourceCode: nodeUserCode },
+      });
+      userNodePlayer.setSubscriptions(topicNames.map((topic) => ({ topic, fields: ["a"] })));
+      await delay(10); // wait for subscriptions to take effect
+
+      // A direct subscription to a topic should maintain the requested fields.
+      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", fields: ["a"] }]);
     });
 
     it("subscribes to underlying topics even when user script has a compilation error", async () => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -641,7 +641,8 @@ describe("UserNodePlayer", () => {
       // Subscribe to a slice of the output topic and a slice of the input topic.
       userNodePlayer.setSubscriptions([
         { topic: "/np_input", fields: ["a"] },
-        { topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`, fields: ["a"] },
+        { topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`, fields: ["a"], preloadType: "partial" },
+        { topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`, fields: ["a"], preloadType: "full" },
       ]);
 
       // Wait for subscriptions to take effect.
@@ -649,7 +650,10 @@ describe("UserNodePlayer", () => {
 
       // The underlying player subscription should not be sliced since we don't know which fields of
       // the message the script will use.
-      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", preloadType: "partial" }]);
+      expect(fakePlayer.subscriptions).toEqual([
+        { topic: "/np_input", preloadType: "full" },
+        { topic: "/np_input", preloadType: "partial" },
+      ]);
     });
 
     it("subscribes to underlying topics even when user script has a compilation error", async () => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -604,6 +604,20 @@ describe("UserNodePlayer", () => {
       expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input" }]);
     });
 
+    it("passes through sliced subscriptions", async () => {
+      const fakePlayer = new FakePlayer();
+      const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
+      const topicNames = ["/np_input"];
+      void userNodePlayer.setUserNodes({
+        nodeId: { name: "someNodeName", sourceCode: nodeUserCode },
+      });
+      userNodePlayer.setSubscriptions(topicNames.map((topic) => ({ topic, fields: ["a"] })));
+      await delay(10); // wait for subscriptions to take effect
+
+      // A direct subscription to a topic should maintain the requested fields.
+      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", fields: ["a"] }]);
+    });
+
     it("requests full subscriptions for input topics", async () => {
       const fakePlayer = new FakePlayer();
       const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
@@ -636,20 +650,6 @@ describe("UserNodePlayer", () => {
       // The underlying player subscription should not be sliced since we don't know which fields of
       // the message the script will use.
       expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", preloadType: "partial" }]);
-    });
-
-    it("passes through sliced subscriptions", async () => {
-      const fakePlayer = new FakePlayer();
-      const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
-      const topicNames = ["/np_input"];
-      void userNodePlayer.setUserNodes({
-        nodeId: { name: "someNodeName", sourceCode: nodeUserCode },
-      });
-      userNodePlayer.setSubscriptions(topicNames.map((topic) => ({ topic, fields: ["a"] })));
-      await delay(10); // wait for subscriptions to take effect
-
-      // A direct subscription to a topic should maintain the requested fields.
-      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", fields: ["a"] }]);
     });
 
     it("subscribes to underlying topics even when user script has a compilation error", async () => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -604,7 +604,7 @@ describe("UserNodePlayer", () => {
       expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input" }]);
     });
 
-    it("passes through sliced subscriptions", async () => {
+    it("does not subscribe to all fields when user node is unused", async () => {
       const fakePlayer = new FakePlayer();
       const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
       const topicNames = ["/np_input"];

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -177,8 +177,8 @@ describe("UserNodePlayer", () => {
       userNodePlayer.setSubscriptions([{ topic: "/studio/test" }, { topic: "/input/baz" }]);
       await Promise.resolve(); // wait for subscriptions to take effect
       expect(fakePlayer.subscriptions).toEqual([
-        { topic: "/studio/test" },
-        { topic: "/input/baz" },
+        { topic: "/studio/test", preloadType: "partial" },
+        { topic: "/input/baz", preloadType: "partial" },
       ]);
     });
 
@@ -601,21 +601,7 @@ describe("UserNodePlayer", () => {
       });
       userNodePlayer.setSubscriptions(topicNames.map((topic) => ({ topic })));
       await delay(10); // wait for subscriptions to take effect
-      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input" }]);
-    });
-
-    it("passes through sliced subscriptions", async () => {
-      const fakePlayer = new FakePlayer();
-      const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
-      const topicNames = ["/np_input"];
-      void userNodePlayer.setUserNodes({
-        nodeId: { name: "someNodeName", sourceCode: nodeUserCode },
-      });
-      userNodePlayer.setSubscriptions(topicNames.map((topic) => ({ topic, fields: ["a"] })));
-      await delay(10); // wait for subscriptions to take effect
-
-      // A direct subscription to a topic should maintain the requested fields.
-      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", fields: ["a"] }]);
+      expect(fakePlayer.subscriptions).toEqual([{ topic: "/np_input", preloadType: "partial" }]);
     });
 
     it("requests full subscriptions for input topics", async () => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -23,7 +23,7 @@ import { MutexLocked } from "@foxglove/den/async";
 import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
 import { Time, compare } from "@foxglove/rostime";
-import { ParameterValue } from "@foxglove/studio";
+import { Immutable, ParameterValue } from "@foxglove/studio";
 import { mergeSubscriptions } from "@foxglove/studio-base/components/MessagePipeline/subscriptions";
 import { Asset } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
@@ -49,6 +49,7 @@ import {
   PlayerStateActiveData,
   PublishPayload,
   SubscribePayload,
+  SubscriptionPreloadType,
   Topic,
   MessageEvent,
   PlayerProblem,
@@ -1045,35 +1046,37 @@ export default class UserNodePlayer implements Player {
     const nodeSubscriptions: Record<string, SubscribePayload> = {};
     const realTopicSubscriptions: SubscribePayload[] = [];
 
-    const mergedSubscriptions = R.pipe(
-      R.groupBy((v: SubscribePayload) => v.topic),
+    // We need a list of all of the topics used and their preload mode,
+    // regardless of the fields they subscribe to
+    const mergedSubscriptions: [string, SubscriptionPreloadType][] = R.pipe(
+      // First, make sure these are as reduced as possible
+      mergeSubscriptions,
+      R.groupBy((v: Immutable<SubscribePayload>) => v.topic),
       // Combine subscriptions to the same topic (but different fields)
       R.mapObjIndexed(
-        (payloads: SubscribePayload[] | undefined, topic: string): SubscribePayload => ({
-          topic,
-
-          // Aggregate all fields
-          fields: R.pipe(
-            R.chain((payload: SubscribePayload): string[] => payload.fields ?? []),
-            R.uniq,
-          )(payloads ?? []),
-
-          preloadType:
-            R.find((v: SubscribePayload) => v.preloadType === "full", payloads ?? []) != undefined
-              ? "full"
-              : "partial",
-        }),
+        (payloads: Immutable<SubscribePayload[]> | undefined): SubscriptionPreloadType => {
+          return R.find(
+            (v: Immutable<SubscribePayload>) => v.preloadType === "full",
+            payloads ?? [],
+          ) != undefined
+            ? "full"
+            : "partial";
+        },
       ),
-      R.values,
+      (v) => R.toPairs(v),
     )(subscriptions);
 
     // For each subscription, identify required input topics by looking up the subscribed topic in
     // the map of output topics -> inputs. Add these required input topics to the set of topic
     // subscriptions to the underlying player.
-    for (const subscription of mergedSubscriptions) {
-      const inputs = state.inputsByOutputTopic.get(subscription.topic);
+    for (const [topic, preloadType] of mergedSubscriptions) {
+      const inputs = state.inputsByOutputTopic.get(topic);
+      const subscription = {
+        topic,
+        preloadType,
+      };
       if (!inputs) {
-        nodeSubscriptions[subscription.topic] = subscription;
+        nodeSubscriptions[topic] = subscription;
         realTopicSubscriptions.push(subscription);
         continue;
       }
@@ -1083,11 +1086,11 @@ export default class UserNodePlayer implements Player {
         continue;
       }
 
-      nodeSubscriptions[subscription.topic] = subscription;
+      nodeSubscriptions[topic] = subscription;
       for (const inputTopic of inputs) {
         realTopicSubscriptions.push({
           topic: inputTopic,
-          preloadType: subscription.preloadType ?? "partial",
+          preloadType,
         });
       }
     }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -14,6 +14,7 @@
 import { Mutex } from "async-mutex";
 import * as _ from "lodash-es";
 import memoizeWeak from "memoize-weak";
+import * as R from "ramda";
 import ReactDOM from "react-dom";
 import shallowequal from "shallowequal";
 import { v4 as uuidv4 } from "uuid";
@@ -1044,10 +1045,32 @@ export default class UserNodePlayer implements Player {
     const nodeSubscriptions: Record<string, SubscribePayload> = {};
     const realTopicSubscriptions: SubscribePayload[] = [];
 
+    const mergedSubscriptions = R.pipe(
+      R.groupBy((v: SubscribePayload) => v.topic),
+      // Combine subscriptions to the same topic (but different fields)
+      R.mapObjIndexed(
+        (payloads: SubscribePayload[] | undefined, topic: string): SubscribePayload => ({
+          topic,
+
+          // Aggregate all fields
+          fields: R.pipe(
+            R.chain((payload: SubscribePayload): string[] => payload.fields ?? []),
+            R.uniq,
+          )(payloads ?? []),
+
+          preloadType:
+            R.find((v: SubscribePayload) => v.preloadType === "full", payloads ?? []) != undefined
+              ? "full"
+              : "partial",
+        }),
+      ),
+      R.values,
+    )(subscriptions);
+
     // For each subscription, identify required input topics by looking up the subscribed topic in
     // the map of output topics -> inputs. Add these required input topics to the set of topic
     // subscriptions to the underlying player.
-    for (const subscription of subscriptions) {
+    for (const subscription of mergedSubscriptions) {
       const inputs = state.inputsByOutputTopic.get(subscription.topic);
       if (!inputs) {
         nodeSubscriptions[subscription.topic] = subscription;
@@ -1072,8 +1095,7 @@ export default class UserNodePlayer implements Player {
     this.#nodeSubscriptions = nodeSubscriptions;
 
     // Merge subscriptions we pass on to the underlying player.
-    const mergedSubscriptions = mergeSubscriptions(realTopicSubscriptions);
-    this.#player.setSubscriptions(mergedSubscriptions);
+    this.#player.setSubscriptions(mergeSubscriptions(realTopicSubscriptions));
   }
 
   public close = (): void => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -23,7 +23,7 @@ import { MutexLocked } from "@foxglove/den/async";
 import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
 import { Time, compare } from "@foxglove/rostime";
-import { Immutable, ParameterValue } from "@foxglove/studio";
+import { ParameterValue } from "@foxglove/studio";
 import { mergeSubscriptions } from "@foxglove/studio-base/components/MessagePipeline/subscriptions";
 import { Asset } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
@@ -49,7 +49,6 @@ import {
   PlayerStateActiveData,
   PublishPayload,
   SubscribePayload,
-  SubscriptionPreloadType,
   Topic,
   MessageEvent,
   PlayerProblem,
@@ -1043,62 +1042,88 @@ export default class UserNodePlayer implements Player {
   }
 
   #setSubscriptionsUnlocked(subscriptions: SubscribePayload[], state: ProtectedState): void {
-    const nodeSubscriptions: Record<string, SubscribePayload> = {};
-    const realTopicSubscriptions: SubscribePayload[] = [];
+    // A mapping from the subscription to the input topics needed to satisfy
+    // that request.
+    type SubscriberInputs = [SubscribePayload, readonly string[] | undefined];
 
-    // We need a list of all of the topics used and their preload mode,
-    // regardless of the fields they subscribe to
-    const mergedSubscriptions: [string, SubscriptionPreloadType][] = R.pipe(
-      // First, make sure these are as reduced as possible
+    // Check all subscriptions against the list of topics this UserNodePlayer
+    // can provide
+    const inputs = R.pipe(
       mergeSubscriptions,
-      R.groupBy((v: Immutable<SubscribePayload>) => v.topic),
-      // Combine subscriptions to the same topic (but different fields)
-      R.mapObjIndexed(
-        (payloads: Immutable<SubscribePayload[]> | undefined): SubscriptionPreloadType => {
-          return R.find(
-            (v: Immutable<SubscribePayload>) => v.preloadType === "full",
-            payloads ?? [],
-          ) != undefined
-            ? "full"
-            : "partial";
-        },
-      ),
-      (v) => R.toPairs(v),
+      R.map((v): InputMapping => [v as SubscribePayload, state.inputsByOutputTopic.get(v.topic)]),
     )(subscriptions);
 
-    // For each subscription, identify required input topics by looking up the subscribed topic in
-    // the map of output topics -> inputs. Add these required input topics to the set of topic
-    // subscriptions to the underlying player.
-    for (const [topic, preloadType] of mergedSubscriptions) {
-      const inputs = state.inputsByOutputTopic.get(topic);
-      const subscription = {
-        topic,
-        preloadType,
-      };
-      if (!inputs) {
-        nodeSubscriptions[topic] = subscription;
-        realTopicSubscriptions.push(subscription);
-        continue;
-      }
+    // An array of all of the input topics used by the user nodes referenced by
+    // `subscriptions`
+    const neededInputTopics = R.pipe(
+      R.chain(([, v]: SubscriberInputs): readonly string[] => v ?? []),
+      R.uniq,
+    )(payloadInputsPairs);
 
-      // If the inputs array is empty then we don't have anything to subscribe to for this output
-      if (inputs.length === 0) {
-        continue;
-      }
+    this.#nodeSubscriptions = R.pipe(
+      // Ignore all subscriptions that resolved to empty (but not undefined)
+      // inputs
+      R.chain(([subscription, topics]: InputMapping): SubscribePayload[] =>
+        topics?.length !== 0 ? [subscription] : [],
+      ),
+      // Gather all of the payloads into subscriptions for the same topic
+      R.groupBy((v: SubscribePayload) => v.topic),
+      // Consolidate subscriptions to the same topic down to a single payload
+      // and ignore `fields`
+      R.mapObjIndexed((payloads: SubscribePayload[] | undefined, topic): SubscribePayload => {
+        // If at least one preloadType is explicitly "full", we need "full",
+        // but default to "partial"
+        const hasFull = R.any((v: SubscribePayload) => v.preloadType === "full", payloads ?? []);
 
-      nodeSubscriptions[topic] = subscription;
-      for (const inputTopic of inputs) {
-        realTopicSubscriptions.push({
-          topic: inputTopic,
-          preloadType,
-        });
-      }
-    }
-
-    this.#nodeSubscriptions = nodeSubscriptions;
+        return {
+          topic,
+          preloadType: hasFull ? "full" : "partial",
+        };
+      }),
+    )(payloadInputsPairs);
 
     // Merge subscriptions we pass on to the underlying player.
-    this.#player.setSubscriptions(mergeSubscriptions(realTopicSubscriptions));
+    this.#player.setSubscriptions(
+      R.pipe(
+        R.chain(([subscription, topics]: InputMapping): SubscribePayload[] => {
+          const preloadType = subscription.preloadType ?? "partial";
+
+          // Leave the subscription unmodified if it is not a user script topic
+          if (topics == undefined) {
+            // If this is an input to a user script, we need to upgrade it to a
+            // subscription of all the fields
+            if (inputTopics.includes(subscription.topic)) {
+              return [
+                {
+                  topic: subscription.topic,
+                  preloadType,
+                },
+              ];
+            }
+
+            return [subscription];
+          }
+
+          // If the inputs array is empty then we don't have anything to
+          // subscribe to for this output
+          if (topics.length === 0) {
+            return [];
+          }
+
+          // Subscribe to all fields for all topics used by this user script
+          // because we can't know what fields the user script actually uses
+          // (for now)
+          return R.map(
+            (v) => ({
+              topic: v,
+              preloadType,
+            }),
+            topics,
+          );
+        }),
+        mergeSubscriptions,
+      )(inputs),
+    );
   }
 
   public close = (): void => {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -1046,11 +1046,10 @@ export default class UserNodePlayer implements Player {
     // that request.
     type SubscriberInputs = [SubscribePayload, readonly string[] | undefined];
 
-    // Check all subscriptions against the list of topics this UserNodePlayer
-    // can provide
-    const inputs = R.pipe(
-      mergeSubscriptions,
-      R.map((v): InputMapping => [v as SubscribePayload, state.inputsByOutputTopic.get(v.topic)]),
+    // Pair all subscriptions with their user script input topics (if any)
+    const payloadInputsPairs = R.pipe(
+      R.map((v: SubscribePayload): SubscriberInputs => [v, state.inputsByOutputTopic.get(v.topic)]),
+      R.filter(([, topics]: SubscriberInputs) => topics?.length !== 0),
     )(subscriptions);
 
     // An array of all of the input topics used by the user nodes referenced by
@@ -1060,12 +1059,11 @@ export default class UserNodePlayer implements Player {
       R.uniq,
     )(payloadInputsPairs);
 
+    // #nodeSubscriptions is a mapping from topic name to a SubscribePayload
+    // that contains the resolved preloadType--in other words, the kind of data
+    // (current or block) that this subscription needs
     this.#nodeSubscriptions = R.pipe(
-      // Ignore all subscriptions that resolved to empty (but not undefined)
-      // inputs
-      R.chain(([subscription, topics]: InputMapping): SubscribePayload[] =>
-        topics?.length !== 0 ? [subscription] : [],
-      ),
+      R.map(([subscription]: SubscriberInputs) => subscription),
       // Gather all of the payloads into subscriptions for the same topic
       R.groupBy((v: SubscribePayload) => v.topic),
       // Consolidate subscriptions to the same topic down to a single payload
@@ -1082,48 +1080,42 @@ export default class UserNodePlayer implements Player {
       }),
     )(payloadInputsPairs);
 
+    const resolvedSubscriptions = R.pipe(
+      R.chain(([subscription, topics]: SubscriberInputs): SubscribePayload[] => {
+        const preloadType = subscription.preloadType ?? "partial";
+
+        // Leave the subscription unmodified if it is not a user script topic
+        if (topics == undefined) {
+          // If this is an input to a user script, we need to upgrade it to a
+          // subscription of all the fields
+          if (neededInputTopics.includes(subscription.topic)) {
+            return [
+              {
+                topic: subscription.topic,
+                preloadType,
+              },
+            ];
+          }
+
+          return [subscription];
+        }
+
+        // Subscribe to all fields for all topics used by this user script
+        // because we can't know what fields the user script actually uses
+        // (for now)
+        return R.map(
+          (v) => ({
+            topic: v,
+            preloadType,
+          }),
+          topics,
+        );
+      }),
+      mergeSubscriptions,
+    )(payloadInputsPairs);
+
     // Merge subscriptions we pass on to the underlying player.
-    this.#player.setSubscriptions(
-      R.pipe(
-        R.chain(([subscription, topics]: InputMapping): SubscribePayload[] => {
-          const preloadType = subscription.preloadType ?? "partial";
-
-          // Leave the subscription unmodified if it is not a user script topic
-          if (topics == undefined) {
-            // If this is an input to a user script, we need to upgrade it to a
-            // subscription of all the fields
-            if (inputTopics.includes(subscription.topic)) {
-              return [
-                {
-                  topic: subscription.topic,
-                  preloadType,
-                },
-              ];
-            }
-
-            return [subscription];
-          }
-
-          // If the inputs array is empty then we don't have anything to
-          // subscribe to for this output
-          if (topics.length === 0) {
-            return [];
-          }
-
-          // Subscribe to all fields for all topics used by this user script
-          // because we can't know what fields the user script actually uses
-          // (for now)
-          return R.map(
-            (v) => ({
-              topic: v,
-              preloadType,
-            }),
-            topics,
-          );
-        }),
-        mergeSubscriptions,
-      )(inputs),
-    );
+    this.#player.setSubscriptions(resolvedSubscriptions);
   }
 
   public close = (): void => {


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
We were incorrectly ignoring block subscriptions to topics defined in user scripts. Now we merge `SubscriberPayload`s before calculating the topics we need.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
