### PR TITLE
Remove time-based plot data culling strategy

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -525,28 +525,20 @@ function updateView(id: string, view: PlotViewport): void {
   client.queueRebuild();
 }
 
-const CULL_THRESHOLD = fromSec(10);
+const MESSAGE_CULL_THRESHOLD = 15_000;
 
 function compressClients(): void {
   if (!isLive) {
     return;
   }
 
-  current = R.map((messages) => {
-    if (messages.length > 10000) {
-      return messages.slice(messages.length - 10000);
-    }
-
-    const start = messages.at(0)?.receiveTime;
-    const end = messages.at(-1)?.receiveTime;
-    if (end == undefined || start == undefined) {
-      return messages;
-    }
-
-    const cutoff = subtractTimes(end, CULL_THRESHOLD);
-    const index = R.findIndex(({ receiveTime }) => compareTimes(receiveTime, cutoff) > 0, messages);
-    return messages.slice(index);
-  }, current);
+  current = R.map(
+    (messages) =>
+      messages.length > MESSAGE_CULL_THRESHOLD
+        ? messages.slice(messages.length - MESSAGE_CULL_THRESHOLD)
+        : messages,
+    current,
+  );
 
   for (const client of R.values(clients)) {
     const { params } = client;

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -5,7 +5,6 @@
 import * as Comlink from "comlink";
 import * as R from "ramda";
 
-import { compare as compareTimes, subtract as subtractTimes, fromSec } from "@foxglove/rostime";
 import { Immutable } from "@foxglove/studio";
 import { iterateTyped } from "@foxglove/studio-base/components/Chart/datasets";
 import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/constants";


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
Before, the plot dataset worker would cull messages that were older than 10 seconds in live scenarios. This was misguided: the volume of data points is what causes issues, not the time range over which they were published. See [this Slack conversation](https://foxglove.slack.com/archives/C028UEY858S/p1694183183952909) for more context. Now we just evict messages based on their quantity. I also upped the maximum number of messages to 15,000, from 10,000.

I think in the future we could make this smarter, but that's a story for another day.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
