### PR TITLE
Don't subscribe to block data unless we actually need it for plotting

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -568,7 +568,7 @@ const useStyles = makeStyles()(() => ({
 
 export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 6 });
+    const readySignal = useReadySignal({ count: 10 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     const { classes } = useStyles();
 

--- a/packages/studio-base/src/panels/Plot/params.ts
+++ b/packages/studio-base/src/panels/Plot/params.ts
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import * as R from "ramda";
+
+
+import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+
+import { PlotParams, BasePlotPath, PlotPath } from "./internalTypes";
+
+export function getPaths(paths: readonly PlotPath[], xAxisPath?: BasePlotPath): string[] {
+  return R.chain(
+    (path: BasePlotPath | undefined): string[] => {
+      if (path == undefined) {
+        return [];
+      }
+
+      return [path.value];
+    },
+    [xAxisPath, ...paths],
+  );
+}
+
+export function isSingleMessage(params: PlotParams): boolean {
+  const { xAxisVal } = params;
+  return xAxisVal === "currentCustom" || xAxisVal === "index";
+}
+
+export function isBounded(params: PlotParams): boolean {
+  const { followingViewWidth } = params;
+  return followingViewWidth != undefined && followingViewWidth > 0;
+}
+
+export function getParamPaths(params: PlotParams): readonly string[] {
+  return getPaths(params.paths, params.xAxisPath);
+}
+
+type ParsedPath = {
+  parsed: RosPath;
+  value: string;
+};
+
+export function getParamTopics(params: PlotParams): readonly string[] {
+  return R.pipe(
+    R.chain((path: string): ParsedPath[] => {
+      const parsed = parseRosPath(path);
+      if (parsed == undefined) {
+        return [];
+      }
+
+      return [
+        {
+          parsed,
+          value: path,
+        },
+      ];
+    }),
+    R.map((v: ParsedPath) => v.parsed.topicName),
+    R.uniq,
+  )(getParamPaths(params));
+}

--- a/packages/studio-base/src/panels/Plot/params.ts
+++ b/packages/studio-base/src/panels/Plot/params.ts
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import * as R from "ramda";
 
-
 import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
 import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -184,19 +184,6 @@ export function reducePlotData(data: PlotData[]): PlotData {
   return reduced;
 }
 
-export function getPaths(paths: readonly PlotPath[], xAxisPath?: BasePlotPath): string[] {
-  return R.chain(
-    (path: BasePlotPath | undefined): string[] => {
-      if (path == undefined) {
-        return [];
-      }
-
-      return [path.value];
-    },
-    [xAxisPath, ...paths],
-  );
-}
-
 type PathData = [PlotPath, PlotDataItem[] | undefined];
 export function buildPlotData(
   args: Im<{

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -136,12 +136,21 @@ function chooseClient() {
       const isOnlyCurrent = isBounded(params) || isSingleMessage(params);
       return R.pipe(
         getPayloadsFromPaths,
-        R.map(
-          (v): SubscribePayload => ({
+        R.chain((v): SubscribePayload[] => {
+          const partial: SubscribePayload = {
             ...v,
-            preloadType: isOnlyCurrent ? "partial" : "full",
-          }),
-        ),
+            preloadType: "partial",
+          };
+
+          if (isOnlyCurrent) {
+            return [partial];
+          }
+
+          // Subscribe to both "partial" and "full" when using "full" In
+          // theory, "full" should imply "partial" but not doing this breaks
+          // MockMessagePipelineProvider
+          return [partial, { ...partial, preloadType: "full" }];
+        }),
       )(getPaths(yAxisPaths, xAxisPath));
     }),
     (v) => mergeSubscriptions(v) as SubscribePayload[],

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -7,7 +7,7 @@ import * as R from "ramda";
 import { useEffect, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 
-import { useShallowMemo, useDeepMemo } from "@foxglove/hooks";
+import { useDeepMemo } from "@foxglove/hooks";
 import { Immutable } from "@foxglove/studio";
 import { useMessageReducer as useCurrent, useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import { useBlocksSubscriptions as useBlocks } from "@foxglove/studio-base/PanelAPI/useBlocksSubscriptions";
@@ -20,17 +20,32 @@ import {
   useMessagePipeline,
   MessagePipelineContext,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { mergeSubscriptions } from "@foxglove/studio-base/components/MessagePipeline/subscriptions";
 import { TypedDataProvider } from "@foxglove/studio-base/components/TimeBasedChart/types";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { SubscribePayload, MessageEvent } from "@foxglove/studio-base/players/types";
 
 import { PlotParams, Messages } from "./internalTypes";
-import { getPaths, PlotData } from "./plotData";
+import { getPaths, isSingleMessage, isBounded } from "./params";
+import { PlotData } from "./plotData";
 
 type Service = Comlink.Remote<(typeof import("./useDatasets.worker"))["service"]>;
+
+// We need to keep track of the block data we've already sent to the worker and
+// detect when it has changed, which can happen when the user changes a user
+// script or they trigger a subscription to different fields.
+// mapping from topic -> the first message on that topic in the block
+type BlockStatus = Record<string, unknown>;
+type Client = {
+  params: PlotParams;
+  setter: (topics: SubscribePayload[]) => void;
+};
+
 let worker: Worker | undefined;
 let service: Service | undefined;
 let numClients: number = 0;
+let blockStatus: BlockStatus[] = [];
+let clients: Record<string, Client> = {};
 
 const pending: ((service: Service) => void)[] = [];
 async function waitService(): Promise<Service> {
@@ -44,40 +59,8 @@ async function waitService(): Promise<Service> {
 
 const getIsLive = (ctx: MessagePipelineContext) => ctx.seekPlayback == undefined;
 
-// We need to keep track of the block data we've already sent to the worker and
-// detect when it has changed, which can happen when the user changes a user
-// script or they trigger a subscription to different fields.
-// mapping from topic -> the first message on that topic in the block
-type BlockStatus = Record<string, unknown>;
-let blockStatus: BlockStatus[] = [];
-
 const getPayloadString = (payload: SubscribePayload): string =>
   `${payload.topic}:${(payload.fields ?? []).join(",")}`;
-
-type Client = {
-  topics: SubscribePayload[];
-  setter: (topics: SubscribePayload[]) => void;
-};
-let clients: Record<string, Client> = {};
-
-function normalizePaths(topics: SubscribePayload[]): SubscribePayload[] {
-  return R.pipe(
-    R.groupBy((payload: SubscribePayload) => payload.topic),
-    // Combine subscriptions to the same topic (but different fields)
-    R.mapObjIndexed(
-      (payloads: SubscribePayload[] | undefined, topic: string): SubscribePayload => ({
-        topic,
-        fields: R.pipe(
-          // Aggregate all fields
-          R.chain((payload: SubscribePayload): string[] => payload.fields ?? []),
-          // Ensure there are no duplicates
-          R.uniq,
-        )(payloads ?? []),
-      }),
-    ),
-    R.values,
-  )(topics);
-}
 
 /**
  * Get the SubscribePayload for a single path by subscribing to all fields
@@ -133,7 +116,7 @@ function getPayloadsFromPaths(paths: readonly string[]): SubscribePayload[] {
       return [payload];
     }),
     // Then simplify
-    normalizePaths,
+    (v: SubscribePayload[]) => mergeSubscriptions(v) as SubscribePayload[],
   )(paths);
 }
 
@@ -145,25 +128,44 @@ function chooseClient() {
   }
 
   const clientList = R.values(clients);
-  const topics = R.pipe(
-    R.chain((client: Client) => client.topics),
-    normalizePaths,
+  const subscriptions = R.pipe(
+    R.chain((client: Client): SubscribePayload[] => {
+      const { params } = client;
+      const { xAxisPath, paths: yAxisPaths } = params;
+
+      const isOnlyCurrent = isBounded(params) || isSingleMessage(params);
+      return R.pipe(
+        getPayloadsFromPaths,
+        R.map(
+          (v): SubscribePayload => ({
+            ...v,
+            preloadType: isOnlyCurrent ? "partial" : "full",
+          }),
+        ),
+      )(getPaths(yAxisPaths, xAxisPath));
+    }),
+    (v) => mergeSubscriptions(v) as SubscribePayload[],
   )(clientList);
-  R.head(clientList)?.setter(topics);
+  clientList[0]?.setter(subscriptions);
+
+  const blockTopics = R.pipe(
+    R.filter((v: SubscribePayload) => v.preloadType === "full"),
+    R.map(getPayloadString),
+  )(subscriptions);
 
   // Also clear the status of any topics we're no longer using
-  blockStatus = blockStatus.map((block) => R.pick(topics.map(getPayloadString), block));
+  blockStatus = blockStatus.map((block) => R.pick(blockTopics, block));
 }
 
 // Subscribe to "current" messages (those near the seek head) and forward new
 // messages to the worker as they arrive.
-function useData(id: string, topics: SubscribePayload[]) {
-  const [subscribed, setSubscribed] = React.useState<SubscribePayload[]>([]);
+function useData(id: string, params: PlotParams) {
+  const [subscriptions, setSubscribed] = React.useState<SubscribePayload[]>([]);
   useEffect(() => {
     clients = {
       ...clients,
       [id]: {
-        topics,
+        params,
         setter: setSubscribed,
       },
     };
@@ -173,7 +175,7 @@ function useData(id: string, topics: SubscribePayload[]) {
       clients = rest;
       chooseClient();
     };
-  }, [id, topics]);
+  }, [id, params]);
 
   const isLive = useMessagePipeline<boolean>(getIsLive);
   useEffect(() => {
@@ -183,8 +185,13 @@ function useData(id: string, topics: SubscribePayload[]) {
     })();
   }, [isLive]);
 
+  const [blockSubscriptions, currentSubscriptions] = React.useMemo(
+    () => R.partition((v) => v.preloadType === "full", subscriptions),
+    [subscriptions],
+  );
+
   useCurrent<number>({
-    topics: subscribed,
+    topics: currentSubscriptions,
     restore: React.useCallback((state: number | undefined): number => {
       if (state == undefined) {
         void service?.clearCurrent();
@@ -200,9 +207,7 @@ function useData(id: string, topics: SubscribePayload[]) {
     ),
   });
 
-  const blocks = useBlocks(
-    React.useMemo(() => subscribed.map((v) => ({ ...v, preloadType: "full" })), [subscribed]),
-  );
+  const blocks = useBlocks(blockSubscriptions);
   useEffect(() => {
     const wasReset: Record<string, boolean> = {};
 
@@ -217,7 +222,7 @@ function useData(id: string, topics: SubscribePayload[]) {
       // accumulated points in the worker
       const resetData: Set<string> = new Set<string>();
       const status: BlockStatus = blockStatus[index] ?? {};
-      for (const payload of subscribed) {
+      for (const payload of blockSubscriptions) {
         const ref = getPayloadString(payload);
         const topicMessages = block[payload.topic];
         if (topicMessages == undefined) {
@@ -248,7 +253,7 @@ function useData(id: string, topics: SubscribePayload[]) {
 
       void service?.addBlock(messages, Array.from(resetData));
     }
-  }, [subscribed, blocks]);
+  }, [blockSubscriptions, blocks]);
 }
 
 // Mirror all of the topics and datatypes to the worker as necessary.
@@ -274,16 +279,7 @@ export default function useDatasets(params: PlotParams): {
   getFullData: () => Promise<PlotData | undefined>;
 } {
   const id = useMemo(() => uuidv4(), []);
-
   const stableParams = useDeepMemo(params);
-  const { xAxisPath, paths: yAxisPaths } = stableParams;
-
-  const allPaths = useMemo(() => {
-    return getPaths(yAxisPaths, xAxisPath);
-  }, [xAxisPath, yAxisPaths]);
-
-  const stablePaths = useShallowMemo(allPaths);
-  const topics = useMemo(() => getPayloadsFromPaths(stablePaths), [stablePaths]);
 
   useEffect(() => {
     if (worker == undefined) {
@@ -318,7 +314,7 @@ export default function useDatasets(params: PlotParams): {
     };
   }, [id]);
 
-  useData(id, topics);
+  useData(id, stableParams);
 
   // We also need to send along params on register to avoid a race condition
   const paramsRef = React.useRef<PlotParams>();

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -7,7 +7,6 @@ import * as R from "ramda";
 
 import { Immutable } from "@foxglove/studio";
 import { iterateTyped } from "@foxglove/studio-base/components/Chart/datasets";
-import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
 import { messagePathStructures } from "@foxglove/studio-base/components/MessagePathSyntax/messagePathsForDatatype";
 import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import { fillInGlobalVariablesInPath } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
@@ -31,9 +30,9 @@ import {
   TypedData,
   Messages,
 } from "./internalTypes";
+import { isSingleMessage, isBounded, getParamPaths, getParamTopics } from "./params";
 import {
   buildPlotData,
-  getPaths,
   resolvePath,
   appendPlotData,
   reducePlotData,
@@ -51,11 +50,6 @@ type Cursors = Record<string, number>;
 type Accumulated = {
   cursors: Cursors;
   data: PlotData;
-};
-
-type ParsedPath = {
-  parsed: RosPath;
-  value: string;
 };
 
 type Client = {
@@ -108,40 +102,6 @@ function getNewMessages(
   }
 
   return [newCursors, newMessages];
-}
-
-function getParamPaths(params: PlotParams): readonly string[] {
-  return getPaths(params.paths, params.xAxisPath);
-}
-
-function getParamTopics(params: PlotParams): readonly string[] {
-  return R.pipe(
-    R.chain((path: string): ParsedPath[] => {
-      const parsed = parseRosPath(path);
-      if (parsed == undefined) {
-        return [];
-      }
-
-      return [
-        {
-          parsed,
-          value: path,
-        },
-      ];
-    }),
-    R.map((v: ParsedPath) => v.parsed.topicName),
-    R.uniq,
-  )(getParamPaths(params));
-}
-
-function isSingleMessage(params: PlotParams): boolean {
-  const { xAxisVal } = params;
-  return xAxisVal === "currentCustom" || xAxisVal === "index";
-}
-
-function isBounded(params: PlotParams): boolean {
-  const { followingViewWidth } = params;
-  return followingViewWidth != undefined && followingViewWidth > 0;
 }
 
 function getPathData(messages: Messages, path: BasePlotPath): PlotDataItem[] | undefined {


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
One of the challenges of plotting large `.mcap` datasets is that we currently subscribe to both block and current data, even if the plot only needs current data. This uses a lot of unnecessary resources. This PR makes it so that when a plot is either bounded (has a limited time range) or plots a single message, we only subscribe to current data.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
