### PR TITLE
Fix protobufDefinitionsToDatatypes for Timestamp/Duration

### DIFF
--- a/packages/mcap-support/src/parseProtobufSchema.test.ts
+++ b/packages/mcap-support/src/parseProtobufSchema.test.ts
@@ -200,7 +200,7 @@ describe("parseProtobufSchema", () => {
           {
             "isArray": false,
             "name": "sec",
-            "type": "int64",
+            "type": "int32",
           },
           {
             "isArray": false,
@@ -216,7 +216,7 @@ describe("parseProtobufSchema", () => {
           {
             "isArray": false,
             "name": "sec",
-            "type": "int64",
+            "type": "int32",
           },
           {
             "isArray": false,

--- a/packages/mcap-support/src/parseProtobufSchema.ts
+++ b/packages/mcap-support/src/parseProtobufSchema.ts
@@ -29,34 +29,28 @@ export function parseProtobufSchema(
   // {sec: number, nsec: number}, compatible with the rest of Studio. The standard Protobuf types
   // use different names (`seconds` and `nanos`), and `seconds` is an `int64`, which would be
   // deserialized as a bigint by default.
+  //
+  // protobufDefinitionsToDatatypes also has matching logic to rename the fields.
   const fixTimeType = (
     type: protobufjs.ReflectionObject | null /* eslint-disable-line no-restricted-syntax */,
   ) => {
     if (!type || !(type instanceof protobufjs.Type)) {
       return;
     }
-    // Rename fields so that protobufDefinitionsToDatatypes uses the new names
-    for (const field of type.fieldsArray) {
-      if (field.name === "seconds") {
-        field.name = "sec";
-      } else if (field.name === "nanos") {
-        field.name = "nsec";
-      }
-    }
     type.setup(); // ensure the original optimized toObject has been created
     const prevToObject = type.toObject; // eslint-disable-line @typescript-eslint/unbound-method
     const newToObject: typeof prevToObject = (message, options) => {
       const result = prevToObject.call(type, message, options);
-      const { sec, nsec } = result as { sec: bigint; nsec: number };
-      if (typeof sec !== "bigint" || typeof nsec !== "number") {
+      const { seconds, nanos } = result as { seconds: bigint; nanos: number };
+      if (typeof seconds !== "bigint" || typeof nanos !== "number") {
         return result;
       }
-      if (sec > BigInt(Number.MAX_SAFE_INTEGER)) {
+      if (seconds > BigInt(Number.MAX_SAFE_INTEGER)) {
         throw new Error(
-          `Timestamps with seconds greater than 2^53-1 are not supported (found seconds=${sec}, nanos=${nsec})`,
+          `Timestamps with seconds greater than 2^53-1 are not supported (found seconds=${seconds}, nanos=${nanos})`,
         );
       }
-      return { sec: Number(sec), nsec };
+      return { sec: Number(seconds), nsec: nanos };
     };
     type.toObject = newToObject;
   };

--- a/packages/mcap-support/src/protobufDefinitionsToDatatypes.ts
+++ b/packages/mcap-support/src/protobufDefinitionsToDatatypes.ts
@@ -74,6 +74,15 @@ export function protobufDefinitionsToDatatypes(
         throw new Error("Repeated bytes are not currently supported");
       }
       definitions.push({ type: "uint8", name: field.name, isArray: true });
+    } else if (
+      type.fullName === ".google.protobuf.Timestamp" ||
+      type.fullName === ".google.protobuf.Duration"
+    ) {
+      definitions.push({
+        type: "int32",
+        name: field.name === "seconds" ? "sec" : "nsec",
+        isArray: field.repeated,
+      });
     } else {
       definitions.push({
         type: protobufScalarToRosPrimitive(field.type),


### PR DESCRIPTION
**User-Facing Changes**
Fixed an incompatibility between timestamp/duration types in Protobuf messages and User Scripts.

**Description**
Fixes #6783 
Fixes FG-4764

Background:

Protobuf's standard Timestamp and Duration types use int64 `seconds` + int32 `nanos`, but most of Studio works with timestamps in `{sec,nsec}` format with `number` values.

Prior work:

- In #3443 I added code to modify these definitions to use `sec`/`nsec` instead for compatibility with the rest of Studio — however, I neglected to change the types in User Scripts.

- In #5727 I added `bigint` support to our Protobuf deserialization, which accidentally changed these timestamps to use `bigint` for `sec`, which I fixed in #5757.

- In #6249 I changed the User Script generated types to use the `sec`/`nsec` field names, but I didn't realize that they still used a `bigint` type for the `sec` field.

This PR finally fixes the User Script types so that they have `sec: number` instead of `sec: bigint`.