### PR TITLE
Sort Topics search results by score across both topcs & paths

### DIFF
--- a/packages/studio-base/src/components/TopicList/useTopicListSearch.test.ts
+++ b/packages/studio-base/src/components/TopicList/useTopicListSearch.test.ts
@@ -44,4 +44,19 @@ describe("useTopicListSearch", () => {
     const { result } = renderHook(() => useTopicListSearch({ topics, datatypes, filterText: "d" }));
     expect(result.current.map(itemToString)).toEqual(["abc", "xyz", "xyz.abcd"]);
   });
+
+  it("sorts better matches to the top", () => {
+    const topics: UseTopicListSearchParams["topics"] = [
+      { name: "footballer", schemaName: "ABCD" },
+      { name: "xyz", schemaName: "XYZW" },
+    ];
+    const datatypes: UseTopicListSearchParams["datatypes"] = new Map([
+      ["ABCD", { definitions: [{ name: "lmnop", type: "string" }] }],
+      ["XYZW", { definitions: [{ name: "foobar", type: "string" }] }],
+    ]);
+    const { result } = renderHook(() =>
+      useTopicListSearch({ topics, datatypes, filterText: "foobar" }),
+    );
+    expect(result.current.map(itemToString)).toEqual(["xyz", "xyz.foobar", "footballer"]);
+  });
 });


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Improves search from #6717 by sorting topics with better message path matches to the top. Previously, topics that matched the query would always be sorted to the top, meaning that poor topic matches would show up above good path matches.

Before | After
--- | ---
<img width="490" alt="image" src="https://github.com/foxglove/studio/assets/14237/9a68558e-0644-42bc-917d-f40a79d7298a"> | <img width="471" alt="image" src="https://github.com/foxglove/studio/assets/14237/06c3908f-eaa1-47b7-9b8c-ca9b66a33d2e">
