### PR TITLE
Fix backquote overlay shortcut

### DIFF
--- a/packages/studio-base/src/components/KeyListener.tsx
+++ b/packages/studio-base/src/components/KeyListener.tsx
@@ -29,10 +29,12 @@ function callHandlers(handlers: KeyHandlers | undefined, event: KeyboardEvent): 
     return;
   }
 
-  if (typeof handlers[event.key] === "function") {
+  const handler = handlers[event.key] ?? handlers[event.code];
+
+  if (typeof handler === "function") {
     let preventDefault = true;
     try {
-      preventDefault = handlers[event.key]?.(event) ?? true;
+      preventDefault = handler(event) ?? true;
     } finally {
       if (preventDefault) {
         event.preventDefault();

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -446,7 +446,7 @@ export default function Panel<
     const { keyUpHandlers, keyDownHandlers } = useMemo(
       () => ({
         keyUpHandlers: {
-          "`": () => {
+          Backquote: () => {
             setQuickActionsKeyPressed(false);
           },
           "~": () => {
@@ -460,7 +460,7 @@ export default function Panel<
               selectAllPanels();
             }
           },
-          "`": () => {
+          Backquote: () => {
             setQuickActionsKeyPressed(true);
           },
           "~": () => {


### PR DESCRIPTION
**User-Facing Changes**
Fix backquote overlay shortcut with key combinations.

**Description**
When the meta option key is pressed and the backquote key is released we receive a `key` of `Dead` on a Mac. We can get around this by looking at the `code` instead.

<img width="585" alt="Screenshot 2023-09-12 at 7 00 34 AM" src="https://github.com/foxglove/studio/assets/93935560/f05400b5-b577-471a-a6c4-051eee9ccf71">


I tried but wasn't able to get a story for this working. Because we use css `:hover` classes to control the visibility of the overlay the `userEvent.hover` function from the testing library doesn't seem to work.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
FG-4825