### PR TITLE
Add lint rule to replace R.min, R.max, & R.map with builtins

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -21,6 +21,7 @@ extends:
   - plugin:@foxglove/react
   - plugin:@foxglove/jest
   - plugin:storybook/recommended
+  - plugin:@foxglove/studio/all
 
 settings:
   import/internal-regex: "^@foxglove"
@@ -28,8 +29,6 @@ settings:
 rules:
   "@foxglove/license-header": error
   "@foxglove/prefer-hash-private": error
-  "@foxglove/studio/link-target": error
-  "@foxglove/studio/lodash-imports": error
 
   tss-unused-classes/unused-classes: error
 

--- a/packages/eslint-plugin-studio/index.js
+++ b/packages/eslint-plugin-studio/index.js
@@ -6,5 +6,17 @@ module.exports = {
   rules: {
     "link-target": require("./link-target"),
     "lodash-imports": require("./lodash-imports"),
+    "ramda-usage": require("./ramda-usage"),
+  },
+
+  configs: {
+    all: {
+      plugins: ["@foxglove/studio"],
+      rules: {
+        "@foxglove/studio/link-target": "error",
+        "@foxglove/studio/lodash-imports": "error",
+        "@foxglove/studio/ramda-usage": "error",
+      },
+    },
   },
 };

--- a/packages/eslint-plugin-studio/lodash-imports.test.ts
+++ b/packages/eslint-plugin-studio/lodash-imports.test.ts
@@ -22,7 +22,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run("lodash-imports", rule, {
   valid: [
-    `
+    /* ts */ `
     import * as _ from "lodash-es";
     _.isEqual(1, 1);
     `,

--- a/packages/eslint-plugin-studio/ramda-usage.js
+++ b/packages/eslint-plugin-studio/ramda-usage.js
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+const { ESLintUtils } = require("@typescript-eslint/utils");
+
+/**
+ * @type {import("eslint").Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: "problem",
+    fixable: "code",
+    messages: {
+      useMath: `Use built-in Math.{{name}} instead of R.{{name}} when applying arguments directly`,
+      useArrayMap: `Use built-in Array#map instead of R.map`,
+    },
+  },
+  create: (context) => {
+    return {
+      /**
+       * Transform `R.min/max(a, b)` to `Math.min/max(a, b)`
+       */
+      [`CallExpression[arguments.length=2] > MemberExpression.callee[object.name="R"]:matches([property.name="min"], [property.name="max"])`]:
+        (/** @type {import("estree").MemberExpression} */ node) => {
+          context.report({
+            node,
+            messageId: "useMath",
+            data: { name: node.property.name },
+            fix(fixer) {
+              return fixer.replaceText(node.object, "Math");
+            },
+          });
+        },
+
+      /**
+       * Transform `R.map(fn, array)` to `array.map(fn)`
+       */
+      [`CallExpression[arguments.length=2] > MemberExpression.callee[object.name="R"][property.name="map"]`]:
+        (/** @type {import("estree").MemberExpression} */ node) => {
+          /** @type {import("estree").CallExpression} */
+          const callExpr = node.parent;
+          const { esTreeNodeToTSNodeMap, program } = ESLintUtils.getParserServices(context);
+          const sourceCode = context.getSourceCode();
+          const checker = program.getTypeChecker();
+          const tsNode = esTreeNodeToTSNodeMap.get(callExpr.arguments[1]);
+          const type = checker.getTypeAtLocation(tsNode);
+          if (!checker.isArrayType(type) && !checker.isTupleType(type)) {
+            return;
+          }
+          context.report({
+            node: callExpr,
+            messageId: "useArrayMap",
+            fix(fixer) {
+              return fixer.replaceText(
+                callExpr,
+                // Add parentheses indiscriminately, leave it to prettier to clean up
+                `(${sourceCode.getText(callExpr.arguments[1])}).map(${sourceCode.getText(
+                  callExpr.arguments[0],
+                )})`,
+              );
+            },
+          });
+        },
+    };
+  },
+};

--- a/packages/eslint-plugin-studio/ramda-usage.test.ts
+++ b/packages/eslint-plugin-studio/ramda-usage.test.ts
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { TSESLint } from "@typescript-eslint/utils";
+import path from "path";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rule = require("./ramda-usage") as TSESLint.RuleModule<"useMath" | "useArrayMap">;
+
+const ruleTester = new RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2020,
+    tsconfigRootDir: path.join(__dirname, "fixture"),
+    project: "tsconfig.json",
+  },
+});
+
+ruleTester.run("ramda-usage", rule, {
+  valid: [
+    /* ts */ `
+    import * as R from "ramda";
+    R.max(1)(2);
+    R.max;
+    R.map((x) => x + 1);
+    R.map((x) => x + 1, {a: 1, b: 2});
+    `,
+  ],
+
+  invalid: [
+    {
+      code: /* ts */ `
+        import * as R from "ramda";
+        R.min(1, 2);
+        R.max(1, 2);
+      `,
+      errors: [
+        { messageId: "useMath", data: { name: "min" }, line: 3 },
+        { messageId: "useMath", data: { name: "max" }, line: 4 },
+      ],
+      output: /* ts */ `
+        import * as R from "ramda";
+        Math.min(1, 2);
+        Math.max(1, 2);
+      `,
+    },
+
+    {
+      code: /* ts */ `
+        import * as R from "ramda";
+        R.map((x) => x + 1, [1, 2]);
+        R.map((x) => x + 1, [1, 2].reverse(/*hi*/));
+        R.map((x) => x + 1, [1] as const);
+        foo("bar", R.map((x) => x + 1, [1]));
+      `,
+      errors: [
+        { messageId: "useArrayMap", line: 3 },
+        { messageId: "useArrayMap", line: 4 },
+        { messageId: "useArrayMap", line: 5 },
+        { messageId: "useArrayMap", line: 6 },
+      ],
+      output: /* ts */ `
+        import * as R from "ramda";
+        ([1, 2]).map((x) => x + 1);
+        ([1, 2].reverse(/*hi*/)).map((x) => x + 1);
+        ([1] as const).map((x) => x + 1);
+        foo("bar", ([1]).map((x) => x + 1));
+      `,
+    },
+  ],
+});

--- a/packages/studio-base/src/components/Chart/worker/proxy.ts
+++ b/packages/studio-base/src/components/Chart/worker/proxy.ts
@@ -79,6 +79,6 @@ function proxyDataset(dataset: TypedDataSet): NormalDataSet {
 export function proxyTyped(data: TypedChartData): ChartData<"scatter"> {
   return {
     ...data,
-    datasets: R.map(proxyDataset, data.datasets),
+    datasets: data.datasets.map(proxyDataset),
   };
 }

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -2,8 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import * as R from "ramda";
-
 import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets";
 import { RpcScales } from "@foxglove/studio-base/components/Chart/types";
 
@@ -81,7 +79,7 @@ export class Downsampler {
       }
 
       const downsampled = downsample(dataset, iterateObjects(dataset.data), view);
-      const resolved = R.map((i) => dataset.data[i], downsampled);
+      const resolved = downsampled.map((i) => dataset.data[i]);
 
       // NaN item values create gaps in the line
       const undefinedToNanData = resolved.map((item) => {

--- a/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
@@ -82,12 +82,12 @@ export function getTypedBounds(data: Datasets<TypedData[]>): Bounds | undefined 
 function mergeBounds(a: Bounds, b: Bounds): Bounds {
   return {
     x: {
-      min: R.min(a.x.min, b.x.min),
-      max: R.max(a.x.max, b.x.max),
+      min: Math.min(a.x.min, b.x.min),
+      max: Math.max(a.x.max, b.x.max),
     },
     y: {
-      min: R.min(a.y.min, b.y.min),
-      max: R.max(a.y.max, b.y.max),
+      min: Math.min(a.y.min, b.y.min),
+      max: Math.max(a.y.max, b.y.max),
     },
   };
 }
@@ -102,12 +102,11 @@ const makeMerge =
     return {
       bounds: mergeBounds(a.bounds, b.bounds),
       data: {
-        datasets: R.map(
+        datasets: R.zip(a.data.datasets, b.data.datasets).map(
           ([aSet, bSet]: [Dataset<T>, Dataset<T>]): Dataset<T> => ({
             ...aSet,
             data: mergeData(aSet.data, bSet.data),
           }),
-          R.zip(a.data.datasets, b.data.datasets),
         ),
       },
     };

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -326,7 +326,7 @@ export const sortPlotDataByHeaderStamp = createPlotMapping((dataset: TypedDataSe
 
   const resolved = resolveTypedIndices(
     dataset.data,
-    R.map(([index]) => index, indices),
+    indices.map(([index]) => index),
   );
 
   if (resolved == undefined) {

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -118,7 +118,7 @@ function chooseClient() {
   R.head(clientList)?.setter(topics);
 
   // Also clear the status of any topics we're no longer using
-  blockStatus = R.map((block) => R.pick(R.map(getPayloadString, topics), block), blockStatus);
+  blockStatus = blockStatus.map((block) => R.pick(topics.map(getPayloadString), block));
 }
 
 function getNumFields(events: readonly MessageEvent[]): number {
@@ -176,7 +176,7 @@ function useData(id: string, topics: SubscribePayload[]) {
   });
 
   const blocks = useBlocks(
-    React.useMemo(() => R.map((v) => ({ ...v, preloadType: "full" }), subscribed), [subscribed]),
+    React.useMemo(() => subscribed.map((v) => ({ ...v, preloadType: "full" })), [subscribed]),
   );
   useEffect(() => {
     for (const [index, block] of blocks.entries()) {

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -161,7 +161,7 @@ function buildPlot(params: PlotParams, messages: Messages): PlotData {
   const { paths, invertedTheme, startTime, xAxisPath, xAxisVal } = params;
   return buildPlotData({
     invertedTheme,
-    paths: R.map((path) => [path, getPathData(messages, path)], paths),
+    paths: paths.map((path) => [path, getPathData(messages, path)]),
     startTime,
     xAxisPath,
     xAxisData: xAxisPath != undefined ? getPathData(messages, xAxisPath) : undefined,

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -1103,13 +1103,10 @@ export default class UserNodePlayer implements Player {
         // Subscribe to all fields for all topics used by this user script
         // because we can't know what fields the user script actually uses
         // (for now)
-        return R.map(
-          (v) => ({
-            topic: v,
-            preloadType,
-          }),
-          topics,
-        );
+        return topics.map((v) => ({
+          topic: v,
+          preloadType,
+        }));
       }),
       mergeSubscriptions,
     )(payloadInputsPairs);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Relates to FG-4805
Adds a couple lint rules to prefer usage of JS builtins over Ramda functions:
- Replace `R.min`/`R.max` with `Math.min`/`Math.max` when they are used with 2 arguments
- Replace `R.map(fn, array)` with `array.map(fn)`