### PR TITLE
Handle top-level topic filters

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.test.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.test.ts
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+
+import { pathToPayload } from "./useDatasets";
+
+describe("getPayload", () => {
+  const call = (path: string) => {
+    const parsed = parseRosPath(path);
+    if (parsed == undefined) {
+      throw new Error(`invalid path: ${path}`);
+    }
+
+    return pathToPayload(parsed);
+  };
+  it("ignores path without a property", () => {
+    expect(call("/foo")).toEqual(undefined);
+  });
+  it("subscribes to one field", () => {
+    expect(call("/foo.bar")).toEqual({
+      topic: "/foo",
+      fields: ["bar", "header"],
+    });
+  });
+  it("subscribes to field and filter", () => {
+    expect(call("/foo{baz==2}.bar")).toEqual({
+      topic: "/foo",
+      fields: ["baz", "bar", "header"],
+    });
+  });
+  it("subscribes to multiple filters", () => {
+    expect(call("/foo{baz==2}{fox==3}.bar")).toEqual({
+      topic: "/foo",
+      fields: ["baz", "fox", "bar", "header"],
+    });
+  });
+});

--- a/packages/studio-base/src/panels/Plot/useDatasets.test.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.test.ts
@@ -36,4 +36,10 @@ describe("getPayload", () => {
       fields: ["baz", "fox", "bar", "header"],
     });
   });
+  it("should ignore filters that come later", () => {
+    expect(call("/foo{fox==3}.bar{blah==2}")).toEqual({
+      topic: "/foo",
+      fields: ["fox", "bar", "header"],
+    });
+  });
 });

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -86,8 +86,8 @@ export function pathToPayload(path: RosPath): SubscribePayload | undefined {
 
   // We want to take _all_ of the filters that start the path, since these can
   // be chained
-  const [filters, rest] = R.partition((part: MessagePathPart) => part.type === "filter", parts);
-  const firstField = rest[0];
+  const filters = R.takeWhile((part: MessagePathPart) => part.type === "filter", parts);
+  const firstField = R.find((part: MessagePathPart) => part.type === "name", parts);
   if (firstField == undefined || firstField.type !== "name") {
     return undefined;
   }

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -116,8 +116,7 @@ export function pathToPayload(path: RosPath): SubscribePayload | undefined {
 
 function getPayloadsFromPaths(paths: readonly string[]): SubscribePayload[] {
   return R.pipe(
-    // Parse all of the paths
-    R.chain((path: string) => {
+    R.chain((path: string): SubscribePayload[] => {
       const parsed = parseRosPath(path);
       if (parsed == undefined) {
         return [];

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -11,7 +11,10 @@ import { useShallowMemo, useDeepMemo } from "@foxglove/hooks";
 import { Immutable } from "@foxglove/studio";
 import { useMessageReducer as useCurrent, useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import { useBlocksSubscriptions as useBlocks } from "@foxglove/studio-base/PanelAPI/useBlocksSubscriptions";
-import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
+import {
+  RosPath,
+  MessagePathPart,
+} from "@foxglove/studio-base/components/MessagePathSyntax/constants";
 import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import {
   useMessagePipeline,
@@ -73,6 +76,44 @@ function normalizePaths(topics: SubscribePayload[]): SubscribePayload[] {
   )(topics);
 }
 
+/**
+ * Get the SubscribePayload for a single path by subscribing to all fields
+ * referenced in leading MessagePathFilters and the first field of the
+ * message.
+ */
+export function pathToPayload(path: RosPath): SubscribePayload | undefined {
+  const { messagePath: parts, topicName: topic } = path;
+
+  // We want to take _all_ of the filters that start the path, since these can
+  // be chained
+  const [filters, rest] = R.partition((part: MessagePathPart) => part.type === "filter", parts);
+  const firstField = rest[0];
+  if (firstField == undefined || firstField.type !== "name") {
+    return undefined;
+  }
+
+  return {
+    topic,
+    fields: R.pipe(
+      R.chain((part: MessagePathPart): string[] => {
+        if (part.type !== "filter") {
+          return [];
+        }
+        const { path: filterPath } = part;
+        const field = filterPath[0];
+        if (field == undefined) {
+          return [];
+        }
+
+        return [field];
+      }),
+      // Always subscribe to the header field
+      (filterFields) => [...filterFields, firstField.name, "header"],
+      R.uniq,
+    )(filters),
+  };
+}
+
 function getPayloadsFromPaths(paths: readonly string[]): SubscribePayload[] {
   return R.pipe(
     // Parse all of the paths
@@ -82,21 +123,12 @@ function getPayloadsFromPaths(paths: readonly string[]): SubscribePayload[] {
         return [];
       }
 
-      return [parsed];
-    }),
-    // Then build field subscriptions
-    R.chain((path: RosPath): SubscribePayload[] => {
-      const field = R.head(path.messagePath);
-      if (field == undefined || field.type !== "name") {
+      const payload = pathToPayload(parsed);
+      if (payload == undefined) {
         return [];
       }
-      return [
-        {
-          topic: path.topicName,
-          // Always pull the header field for header stamps
-          fields: [field.name, "header"],
-        },
-      ];
+
+      return [payload];
     }),
     // Then simplify
     normalizePaths,


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
Plots paths that use top-level filters (e.g. `/diagnostics{header.frame_id==""}`) are broken right now, which is causing issues for at least a couple of users. This PR fixes it and adds tests for paths like these to ensure we're always subscribing to them appropriately.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
