### PR TITLE
Fixes locally installed message converters not being preferred over org provided ones

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -11,12 +11,15 @@ import {
   Subscription,
 } from "@foxglove/studio";
 import { Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
+import { ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
 
 // Branded string to ensure that users go through the `converterKey` function to compute a lookup key
 type Brand<K, T> = K & { __brand: T };
 type ConverterKey = Brand<string, "ConverterKey">;
 
-type MessageConverter = RegisterMessageConverterArgs<unknown>;
+type MessageConverter = RegisterMessageConverterArgs<unknown> & {
+  extensionNamespace?: ExtensionNamespace;
+};
 
 type TopicSchemaConverterMap = Map<ConverterKey, MessageConverter[]>;
 
@@ -135,16 +138,13 @@ export function collateTopicSchemaConversions(
     }
 
     // Find a converter that can go from the original topic schema to the target schema
-    // Note: We only support one converter per unique from/to pair so this _find_ only needs to
-    //       find one converter rather than multiple converters. Local message converters are
-    //       preferred over org provided converters.
-    const converters = (messageConverters ?? [])
-      .filter(
-        (conv) =>
-          conv.fromSchemaName === subscriberTopic.schemaName &&
-          conv.toSchemaName === subscription.convertTo,
-      )
-      .sort((conv) => (conv.extensionNamespace === "local" ? -1 : 0));
+    let converters = (messageConverters ?? []).filter(
+      (conv) =>
+        conv.fromSchemaName === subscriberTopic.schemaName &&
+        conv.toSchemaName === subscription.convertTo,
+    );
+    // Sort by extension namespace to prefer 'local' converters over 'org' provided ones
+    converters = _.sortBy(converters, (conv) => conv.extensionNamespace ?? "unknown");
     const converter = converters[0];
 
     if (converter) {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -138,14 +138,13 @@ export function collateTopicSchemaConversions(
     }
 
     // Find a converter that can go from the original topic schema to the target schema
-    let converters = (messageConverters ?? []).filter(
+    const converters = (messageConverters ?? []).filter(
       (conv) =>
         conv.fromSchemaName === subscriberTopic.schemaName &&
         conv.toSchemaName === subscription.convertTo,
     );
-    // Sort by extension namespace to prefer 'local' converters over 'org' provided ones
-    converters = _.sortBy(converters, (conv) => conv.extensionNamespace ?? "unknown");
-    const converter = converters[0];
+    // Prefer 'local' converters over 'org' provided ones
+    const converter = _.minBy(converters, (conv) => conv.extensionNamespace ?? "unknown");
 
     if (converter) {
       existingConverters ??= [];

--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -136,12 +136,16 @@ export function collateTopicSchemaConversions(
 
     // Find a converter that can go from the original topic schema to the target schema
     // Note: We only support one converter per unique from/to pair so this _find_ only needs to
-    //       find one converter rather than multiple converters.
-    const converter = messageConverters?.find(
-      (conv) =>
-        conv.fromSchemaName === subscriberTopic.schemaName &&
-        conv.toSchemaName === subscription.convertTo,
-    );
+    //       find one converter rather than multiple converters. Local message converters are
+    //       preferred over org provided converters.
+    const converters = (messageConverters ?? [])
+      .filter(
+        (conv) =>
+          conv.fromSchemaName === subscriberTopic.schemaName &&
+          conv.toSchemaName === subscription.convertTo,
+      )
+      .sort((conv) => (conv.extensionNamespace === "local" ? -1 : 0));
+    const converter = converters[0];
 
     if (converter) {
       existingConverters ??= [];

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
@@ -189,6 +189,7 @@ describe("ExtensionCatalogProvider", () => {
         fromSchemaName: "from.Schema",
         toSchemaName: "to.Schema",
         converter: expect.any(Function),
+        extensionNamespace: "org",
       },
     ]);
   });

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -79,7 +79,10 @@ function activateExtension(
       log.debug(
         `Extension ${extension.qualifiedName} registering message converter from: ${args.fromSchemaName} to: ${args.toSchemaName}`,
       );
-      messageConverters.push(args as RegisterMessageConverterArgs<unknown>);
+      messageConverters.push({
+        ...args,
+        extensionNamespace: extension.namespace,
+      } as RegisterMessageConverterArgs<unknown>);
     },
 
     registerTopicAliases: (aliasFunction: TopicAliasFunction) => {

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -24,9 +24,13 @@ import { ExtensionInfo, ExtensionNamespace } from "@foxglove/studio-base/types/E
 
 const log = Logger.getLogger(__filename);
 
+type MessageConverter = RegisterMessageConverterArgs<unknown> & {
+  extensionNamespace?: ExtensionNamespace;
+};
+
 type ContributionPoints = {
   panels: Record<string, RegisteredPanel>;
-  messageConverters: RegisterMessageConverterArgs<unknown>[];
+  messageConverters: MessageConverter[];
   topicAliasFunctions: TopicAliasFunctions;
 };
 
@@ -82,7 +86,7 @@ function activateExtension(
       messageConverters.push({
         ...args,
         extensionNamespace: extension.namespace,
-      } as RegisterMessageConverterArgs<unknown>);
+      } as MessageConverter);
     },
 
     registerTopicAliases: (aliasFunction: TopicAliasFunction) => {

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -454,6 +454,7 @@ export type RegisterMessageConverterArgs<Src> = {
   fromSchemaName: string;
   toSchemaName: string;
   converter: (msg: Src, event: Immutable<MessageEvent<Src>>) => unknown;
+  extensionNamespace?: string;
 };
 
 type BaseTopic = { name: string; schemaName?: string };

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -454,7 +454,6 @@ export type RegisterMessageConverterArgs<Src> = {
   fromSchemaName: string;
   toSchemaName: string;
   converter: (msg: Src, event: Immutable<MessageEvent<Src>>) => unknown;
-  extensionNamespace?: string;
 };
 
 type BaseTopic = { name: string; schemaName?: string };


### PR DESCRIPTION
**User-Facing Changes**
Fixes locally installed message converters not being preferred over org provided ones

**Description**
Rather than just changing the [extension loader ordering](https://github.com/foxglove/studio/blob/2d7bb15b8571e5ee531d103a6e4568dae5c56559/packages/studio-desktop/src/renderer/Root.tsx#L67-L70), this patch is slightly more explicit by selecting a message converter based on the extension namespace. Message converters with `local` namespace are preferred over `org` provided ones.

Fixes #6787
Resolves FG-4948
