### PR TITLE
Fix extra lines rendering for LinePrimitives

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -161,8 +161,6 @@ class LinePrimitiveRenderable extends THREE.Object3D {
         this.#geometry == undefined ||
         this.#lineType !== this.#primitive.type ||
         !this.#positionBuffer ||
-        // Because `LineGeometry.setPosition` iterates through the positionBuffer to create an interleaved buffer of positions,
-        // we can't simply reuse the float32array with a larger length, we need to recreate it or we will get segments beyond the new length
         this.#positionBuffer.length < necessaryPositionBufferSize;
       if (geometryNeedsRecreated) {
         if (this.#geometry != undefined) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -163,7 +163,7 @@ class LinePrimitiveRenderable extends THREE.Object3D {
         !this.#positionBuffer ||
         // Because `LineGeometry.setPosition` iterates through the positionBuffer to create an interleaved buffer of positions,
         // we can't simply reuse the float32array with a larger length, we need to recreate it or we will get segments beyond the new length
-        this.#positionBuffer.length !== necessaryPositionBufferSize;
+        this.#positionBuffer.length < necessaryPositionBufferSize;
       if (geometryNeedsRecreated) {
         if (this.#geometry != undefined) {
           this.#geometry.dispose();
@@ -204,11 +204,7 @@ class LinePrimitiveRenderable extends THREE.Object3D {
       // depend on the key iteration order, since three.js derives the count from the first
       // instanced interleaved attribute it sees).
       // this represent the number of _lines_ to render
-      this.#geometry.instanceCount = isSegments
-        ? numVertices >>> 1
-        : isLoop
-        ? numVertices
-        : Math.max(numVertices - 1, 0);
+      this.#geometry.instanceCount = isSegments ? numVertices >>> 1 : Math.max(numVertices - 1, 0);
 
       if (useIndices) {
         serializePositionsWithIndices(this.#positionBuffer, this.#primitive);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -161,7 +161,9 @@ class LinePrimitiveRenderable extends THREE.Object3D {
         this.#geometry == undefined ||
         this.#lineType !== this.#primitive.type ||
         !this.#positionBuffer ||
-        this.#positionBuffer.length < necessaryPositionBufferSize;
+        // Because `LineGeometry.setPosition` iterates through the positionBuffer to create an interleaved buffer of positions,
+        // we can't simply reuse the float32array with a larger length, we need to recreate it or we will get segments beyond the new length
+        this.#positionBuffer.length !== necessaryPositionBufferSize;
       if (geometryNeedsRecreated) {
         if (this.#geometry != undefined) {
           this.#geometry.dispose();

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import * as THREE from "three";
 import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
 import { TeapotGeometry } from "three/examples/jsm/geometries/TeapotGeometry";
@@ -439,6 +439,10 @@ export const BasicEntities: StoryObj = {
   parameters: { colorScheme: "light", chromatic: { delay: 100 } },
 };
 
+// Sample data across two frames for testing `LINE_LOOP` primitives
+// each message contains two loops, one has points that make it a closed square
+// the other has points that make it an open square. They should both render as squares however
+// because we always close `LINE_LOOP` point arrays.
 const lineLoopSampleData = [
   {
     deletions: [
@@ -764,28 +768,33 @@ const lineLoopSampleData = [
   },
 ];
 
-const frame1: MessageEvent<Partial<SceneUpdate>> = {
-  topic: "scene",
-  schemaName: "foxglove.SceneUpdate",
-  sizeInBytes: 0,
-  receiveTime: { sec: 10, nsec: 0 },
-  message: lineLoopSampleData[0]!,
-};
-const frame2: MessageEvent<Partial<SceneUpdate>> = {
-  topic: "scene",
-  schemaName: "foxglove.SceneUpdate",
-  sizeInBytes: 0,
-  receiveTime: { sec: 11, nsec: 0 },
-  message: lineLoopSampleData[1]!,
-};
-
 function LineLoops(): JSX.Element {
   const readySignal = useReadySignal();
+
+  // We're testing a Line loop using a position buffer bigger than it needs from a previous frame
+  // So we need to test across multiple frames
+  const frames = useMemo(() => {
+    const frame1: MessageEvent<Partial<SceneUpdate>> = {
+      topic: "scene",
+      schemaName: "foxglove.SceneUpdate",
+      sizeInBytes: 0,
+      receiveTime: { sec: 10, nsec: 0 },
+      message: lineLoopSampleData[0]!,
+    };
+    const frame2: MessageEvent<Partial<SceneUpdate>> = {
+      topic: "scene",
+      schemaName: "foxglove.SceneUpdate",
+      sizeInBytes: 0,
+      receiveTime: { sec: 11, nsec: 0 },
+      message: lineLoopSampleData[1]!,
+    };
+    return [frame1, frame2];
+  }, []);
 
   const [fixture, setFixture] = useState({
     topics: [{ name: "scene", schemaName: "foxglove.SceneUpdate" }],
     frame: {
-      scene: [frame1],
+      scene: [frames[0]!],
     },
     capabilities: [],
     activeData: {
@@ -801,7 +810,7 @@ function LineLoops(): JSX.Element {
       setFixture((oldFixture) => {
         const newFixture = { ...oldFixture };
         newFixture.frame = {
-          scene: [frame2],
+          scene: [frames[1]!],
         };
         newFixture.activeData = {
           currentTime: { sec: 11, nsec: 0 },
@@ -818,7 +827,7 @@ function LineLoops(): JSX.Element {
       clearTimeout(timeOutID);
       clearTimeout(timeOutID2);
     };
-  }, [readySignal]);
+  }, [readySignal, frames]);
 
   return (
     <PanelSetup fixture={fixture}>
@@ -849,7 +858,9 @@ function LineLoops(): JSX.Element {
     </PanelSetup>
   );
 }
-
+// Tests `LinePrimitives` reusing of larger `#positionBuffers`. These squares move across frames and test
+// that we correctly handle the case where the `#positionBuffer` in `RenderableLines/LinePrimitiveRenderable` is bigger than
+// the number of points after a `SceneUpdate`
 export const LineLoopsDontConnect: StoryObj = {
   parameters: {
     useReadySignal: true,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
 import * as THREE from "three";
 import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
 import { TeapotGeometry } from "three/examples/jsm/geometries/TeapotGeometry";
@@ -14,6 +15,7 @@ import { ColorRGBA } from "@foxglove/studio-base/panels/ThreeDeeRender/ros";
 import { xyzrpyToPose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 
 import { makeColor, QUAT_IDENTITY, rad2deg } from "./common";
 import ThreeDeePanel from "../index";
@@ -435,4 +437,426 @@ export const BasicEntities: StoryObj = {
   },
 
   parameters: { colorScheme: "light", chromatic: { delay: 100 } },
+};
+
+const lineLoopSampleData = [
+  {
+    deletions: [
+      {
+        timestamp: {
+          sec: 23,
+          nsec: 0,
+        },
+        type: 1,
+        id: "",
+      },
+    ],
+    entities: [
+      {
+        timestamp: {
+          sec: 23,
+          nsec: 0,
+        },
+        frame_id: "test_frame",
+        id: "4",
+        lifetime: {
+          sec: 0,
+          nsec: 0,
+        },
+        frame_locked: true,
+        metadata: [],
+        arrows: [],
+        cubes: [],
+        spheres: [],
+        cylinders: [],
+        lines: [
+          {
+            type: 1,
+            pose: {
+              position: {
+                x: 0,
+                y: 0,
+                z: 0,
+              },
+              orientation: {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 1,
+              },
+            },
+            thickness: 1.5,
+            scale_invariant: true,
+            points: [
+              {
+                x: -0.5,
+                y: 0.7999999999999998,
+                z: 0,
+              },
+              {
+                x: 0.5,
+                y: 0.7999999999999998,
+                z: 0,
+              },
+              {
+                x: 0.5,
+                y: -0.20000000000000018,
+                z: 0,
+              },
+              {
+                x: -0.5,
+                y: -0.20000000000000018,
+                z: 0,
+              },
+              {
+                x: -0.5,
+                y: 0.7999999999999998,
+                z: 0,
+              },
+            ],
+            color: {
+              r: 1,
+              g: 1,
+              b: 1,
+              a: 1,
+            },
+            colors: [],
+            indices: [],
+          },
+        ],
+        triangles: [],
+        texts: [],
+        models: [],
+      },
+      {
+        timestamp: {
+          sec: 23,
+          nsec: 0,
+        },
+        frame_id: "test_frame",
+        id: "5",
+        lifetime: {
+          sec: 0,
+          nsec: 0,
+        },
+        frame_locked: true,
+        metadata: [],
+        arrows: [],
+        cubes: [],
+        spheres: [],
+        cylinders: [],
+        lines: [
+          {
+            type: 1,
+            pose: {
+              position: {
+                x: 0,
+                y: 0,
+                z: 0,
+              },
+              orientation: {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 1,
+              },
+            },
+            thickness: 1.5,
+            scale_invariant: true,
+            points: [
+              {
+                x: -0.20000000000000018,
+                y: 0.5,
+                z: 0,
+              },
+              {
+                x: 0.7999999999999998,
+                y: 0.5,
+                z: 0,
+              },
+              {
+                x: 0.7999999999999998,
+                y: -0.5,
+                z: 0,
+              },
+              {
+                x: -0.20000000000000018,
+                y: -0.5,
+                z: 0,
+              },
+            ],
+            color: {
+              r: 1,
+              g: 1,
+              b: 1,
+              a: 1,
+            },
+            colors: [],
+            indices: [],
+          },
+        ],
+        triangles: [],
+        texts: [],
+        models: [],
+      },
+    ],
+  },
+  {
+    deletions: [
+      {
+        timestamp: {
+          sec: 23,
+          nsec: 100000000,
+        },
+        type: 1,
+        id: "",
+      },
+    ],
+    entities: [
+      {
+        timestamp: {
+          sec: 23,
+          nsec: 100000000,
+        },
+        frame_id: "test_frame",
+        id: "4",
+        lifetime: {
+          sec: 0,
+          nsec: 0,
+        },
+        frame_locked: true,
+        metadata: [],
+        arrows: [],
+        cubes: [],
+        spheres: [],
+        cylinders: [],
+        lines: [
+          {
+            type: 1,
+            pose: {
+              position: {
+                x: 0,
+                y: 0,
+                z: 0,
+              },
+              orientation: {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 1,
+              },
+            },
+            thickness: 1.5,
+            scale_invariant: true,
+            points: [
+              {
+                x: -0.5,
+                y: 0.8599999999999999,
+                z: 0,
+              },
+              {
+                x: 0.5,
+                y: 0.8599999999999999,
+                z: 0,
+              },
+              {
+                x: 0.5,
+                y: -0.14000000000000012,
+                z: 0,
+              },
+              {
+                x: -0.5,
+                y: -0.14000000000000012,
+                z: 0,
+              },
+              {
+                x: -0.5,
+                y: 0.8599999999999999,
+                z: 0,
+              },
+            ],
+            color: {
+              r: 1,
+              g: 1,
+              b: 1,
+              a: 1,
+            },
+            colors: [],
+            indices: [],
+          },
+        ],
+        triangles: [],
+        texts: [],
+        models: [],
+      },
+      {
+        timestamp: {
+          sec: 23,
+          nsec: 100000000,
+        },
+        frame_id: "test_frame",
+        id: "5",
+        lifetime: {
+          sec: 0,
+          nsec: 0,
+        },
+        frame_locked: true,
+        metadata: [],
+        arrows: [],
+        cubes: [],
+        spheres: [],
+        cylinders: [],
+        lines: [
+          {
+            type: 1,
+            pose: {
+              position: {
+                x: 0,
+                y: 0,
+                z: 0,
+              },
+              orientation: {
+                x: 0,
+                y: 0,
+                z: 0,
+                w: 1,
+              },
+            },
+            thickness: 1.5,
+            scale_invariant: true,
+            points: [
+              {
+                x: -0.14000000000000012,
+                y: 0.5,
+                z: 0,
+              },
+              {
+                x: 0.8599999999999999,
+                y: 0.5,
+                z: 0,
+              },
+              {
+                x: 0.8599999999999999,
+                y: -0.5,
+                z: 0,
+              },
+              {
+                x: -0.14000000000000012,
+                y: -0.5,
+                z: 0,
+              },
+            ],
+            color: {
+              r: 1,
+              g: 1,
+              b: 1,
+              a: 1,
+            },
+            colors: [],
+            indices: [],
+          },
+        ],
+        triangles: [],
+        texts: [],
+        models: [],
+      },
+    ],
+  },
+];
+
+const frame1: MessageEvent<Partial<SceneUpdate>> = {
+  topic: "scene",
+  schemaName: "foxglove.SceneUpdate",
+  sizeInBytes: 0,
+  receiveTime: { sec: 10, nsec: 0 },
+  message: lineLoopSampleData[0]!,
+};
+const frame2: MessageEvent<Partial<SceneUpdate>> = {
+  topic: "scene",
+  schemaName: "foxglove.SceneUpdate",
+  sizeInBytes: 0,
+  receiveTime: { sec: 11, nsec: 0 },
+  message: lineLoopSampleData[1]!,
+};
+
+function LineLoops(): JSX.Element {
+  const readySignal = useReadySignal();
+
+  const [fixture, setFixture] = useState({
+    topics: [{ name: "scene", schemaName: "foxglove.SceneUpdate" }],
+    frame: {
+      scene: [frame1],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 10, nsec: 0 },
+      isPlaying: true,
+    },
+  });
+
+  useEffect(() => {
+    let timeOutID2: NodeJS.Timeout;
+
+    const timeOutID = setTimeout(() => {
+      setFixture((oldFixture) => {
+        const newFixture = { ...oldFixture };
+        newFixture.frame = {
+          scene: [frame2],
+        };
+        newFixture.activeData = {
+          currentTime: { sec: 11, nsec: 0 },
+          isPlaying: true,
+        };
+        return newFixture;
+      });
+      timeOutID2 = setTimeout(() => {
+        readySignal();
+      }, 100);
+    }, 500);
+
+    return () => {
+      clearTimeout(timeOutID);
+      clearTimeout(timeOutID2);
+    };
+  }, [readySignal]);
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDeePanel
+        overrideConfig={{
+          ...ThreeDeePanel.defaultConfig,
+          followTf: "root",
+          layers: {
+            grid: { layerId: "foxglove.Grid" },
+          },
+          cameraState: {
+            distance: 7,
+            perspective: true,
+            phi: 40,
+            targetOffset: [0, 0, 0],
+            thetaOffset: rad2deg(-0.25),
+            fovy: 45,
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+          topics: {
+            scene: { visible: true },
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export const LineLoopsDontConnect: StoryObj = {
+  parameters: {
+    useReadySignal: true,
+    colorScheme: "dark",
+  },
+  render: LineLoops,
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -861,7 +861,7 @@ function LineLoops(): JSX.Element {
 // Tests `LinePrimitives` reusing of larger `#positionBuffers`. These squares move across frames and test
 // that we correctly handle the case where the `#positionBuffer` in `RenderableLines/LinePrimitiveRenderable` is bigger than
 // the number of points after a `SceneUpdate`
-export const LineLoopsDontConnect: StoryObj = {
+export const UpdatedLineLoopsDontHaveExtraLines: StoryObj = {
   parameters: {
     useReadySignal: true,
     colorScheme: "dark",


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Fix occasional extra lines in SceneUpdate line primitives

**Description**

Fixed instanceCount for `LINE_LOOP` primitive types. Because we add one to the `numVertices` when we have a line loop, the  number of lines in a line loop should be `numVertices - 1`, or the original number of points on the primitive. The story I added has one square defined with 4 points (not closed) and the other defined with 5 points (already closed). We then add one in calculating `numVertices` because we close the loop in `serializePositions` even if the loop is already closed. This makes the number of lines (`instanceCount`) equal to 4 for the first and 5 for the second, whereas previously it was 5 and 6. This would cause the renderable to read additional points from existing, larger `positionBuffers` that were used after an update.

<!-- link relevant GitHub issues -->
Fixes: FG-4944
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
