### PR TITLE
Handle updated block data in plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -44,8 +44,11 @@ async function waitService(): Promise<Service> {
 
 const getIsLive = (ctx: MessagePipelineContext) => ctx.seekPlayback == undefined;
 
-// topic -> number of fields
-type BlockStatus = Record<string, number>;
+// We need to keep track of the block data we've already sent to the worker and
+// detect when it has changed, which can happen when the user changes a user
+// script or they trigger a subscription to different fields.
+// mapping from topic -> the first message on that topic in the block
+type BlockStatus = Record<string, unknown>;
 let blockStatus: BlockStatus[] = [];
 
 const getPayloadString = (payload: SubscribePayload): string =>
@@ -152,15 +155,6 @@ function chooseClient() {
   blockStatus = R.map((block) => R.pick(R.map(getPayloadString, topics), block), blockStatus);
 }
 
-function getNumFields(events: readonly MessageEvent[]): number {
-  const message = events[0]?.message;
-  if (message == undefined) {
-    return 0;
-  }
-
-  return Object.keys(message).length;
-}
-
 // Subscribe to "current" messages (those near the seek head) and forward new
 // messages to the worker as they arrive.
 function useData(id: string, topics: SubscribePayload[]) {
@@ -210,13 +204,18 @@ function useData(id: string, topics: SubscribePayload[]) {
     React.useMemo(() => R.map((v) => ({ ...v, preloadType: "full" }), subscribed), [subscribed]),
   );
   useEffect(() => {
+    const wasReset: Record<string, boolean> = {};
+
     for (const [index, block] of blocks.entries()) {
       if (R.isEmpty(block)) {
-        break;
+        continue;
       }
 
       // Package any new messages into a single bundle to send to the worker
       const messages: Messages = {};
+      // Make a note of any topics that had new data so we can clear out
+      // accumulated points in the worker
+      const resetData: Record<string, boolean> = {};
       const status: BlockStatus = blockStatus[index] ?? {};
       for (const payload of subscribed) {
         const ref = getPayloadString(payload);
@@ -225,19 +224,29 @@ function useData(id: string, topics: SubscribePayload[]) {
           continue;
         }
 
-        const numFields = getNumFields(topicMessages);
-        if (status[ref] === numFields) {
+        const first = topicMessages[0]?.message;
+        const existing = status[ref];
+        if (R.equals(existing, first)) {
           continue;
         }
 
-        status[ref] = numFields;
+        // we already had a message in this block, meaning the data itself has
+        // changed; we have to rebuild the plots
+        if (existing != undefined && wasReset[ref] == undefined) {
+          resetData[payload.topic] = true;
+          wasReset[ref] = true;
+        }
+
+        status[ref] = first;
         messages[payload.topic] = topicMessages as MessageEvent[];
       }
       blockStatus[index] = status;
 
-      if (!R.isEmpty(messages)) {
-        void service?.addBlock(messages);
+      if (R.isEmpty(messages)) {
+        continue;
       }
+
+      void service?.addBlock(messages, R.keys(resetData));
     }
   }, [subscribed, blocks]);
 }

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -215,7 +215,7 @@ function useData(id: string, topics: SubscribePayload[]) {
       const messages: Messages = {};
       // Make a note of any topics that had new data so we can clear out
       // accumulated points in the worker
-      const resetData: Record<string, boolean> = {};
+      const resetData: Set<string> = new Set<string>();
       const status: BlockStatus = blockStatus[index] ?? {};
       for (const payload of subscribed) {
         const ref = getPayloadString(payload);
@@ -233,7 +233,7 @@ function useData(id: string, topics: SubscribePayload[]) {
         // we already had a message in this block, meaning the data itself has
         // changed; we have to rebuild the plots
         if (existing != undefined && wasReset[ref] == undefined) {
-          resetData[payload.topic] = true;
+          resetData.add(payload.topic);
           wasReset[ref] = true;
         }
 
@@ -246,7 +246,7 @@ function useData(id: string, topics: SubscribePayload[]) {
         continue;
       }
 
-      void service?.addBlock(messages, R.keys(resetData));
+      void service?.addBlock(messages, Array.from(resetData));
     }
   }, [subscribed, blocks]);
 }

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -396,7 +396,7 @@ function addBlock(block: Messages, resetTopics: string[]): void {
 
   blocks = R.pipe(
     // Remove data for any topics that have been reset
-    R.pick(R.difference(R.keys(blocks), resetTopics)),
+    R.omit(resetTopics),
     // Merge the new block into the existing blocks
     (newBlocks) => R.mergeWith(R.concat, newBlocks, block),
   )(blocks);

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -391,20 +391,31 @@ function evictCache() {
   current = R.pick(topics, current);
 }
 
-function addBlock(block: Messages): void {
+function addBlock(block: Messages, resetTopics: string[]): void {
   const topics = R.keys(block);
-  blocks = R.mergeWith(R.concat, blocks, block);
+
+  blocks = R.pipe(
+    // Remove data for any topics that have been reset
+    R.pick(R.difference(R.keys(blocks), resetTopics)),
+    // Merge the new block into the existing blocks
+    (newBlocks) => R.mergeWith(R.concat, newBlocks, block),
+  )(blocks);
 
   for (const client of R.values(clients)) {
     const { params } = client;
     const relevantTopics = R.intersection(topics, client.topics);
+    const shouldReset = R.intersection(relevantTopics, resetTopics).length > 0;
     if (params == undefined || isSingleMessage(params) || relevantTopics.length === 0) {
       continue;
     }
 
     mutateClient(client.id, {
       ...client,
-      blocks: accumulate(client.blocks, params, blocks),
+      blocks: accumulate(
+        shouldReset ? initAccumulated(client.topics) : client.blocks,
+        params,
+        blocks,
+      ),
     });
     client.queueRebuild();
   }


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
The plot data pipeline was not detecting changes to block data and clearing out the plot. This can occur when the user makes a change to a user script, the output of which they're rendering in a plot.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
