### PR TITLE
Add session problems to workspace store

### DIFF
--- a/packages/studio-base/src/components/ProblemsList.stories.tsx
+++ b/packages/studio-base/src/components/ProblemsList.stories.tsx
@@ -8,8 +8,41 @@ import { StoryFn, StoryObj } from "@storybook/react";
 import { fromDate } from "@foxglove/rostime";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { ProblemsList } from "@foxglove/studio-base/components/ProblemsList";
-import { PlayerPresence, Topic } from "@foxglove/studio-base/players/types";
+import { WorkspaceContextStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+import { PlayerPresence, PlayerProblem, Topic } from "@foxglove/studio-base/players/types";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+
+function makeProblems(): PlayerProblem[] {
+  return [
+    {
+      severity: "error",
+      message: "Connection lost",
+      tip: "A tip that we might want to show the user",
+      error: Object.assign(new Error("Fake Error"), {
+        stack: `Error: Original Error
+at Story (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/studio-base-src-components-ProblemsList-stories.039002bb.iframe.bundle.js:58:28)
+at undecoratedStoryFn (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:2794)
+at hookified (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:7:17032)
+at https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:1915
+at jsxDecorator (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/1983.4cb8db42.iframe.bundle.js:13838:1100)
+at hookified (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:7:17032)
+at https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:1454
+at https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:1915
+at Ch (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/1983.4cb8db42.iframe.bundle.js:47712:137)
+at ck (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/1983.4cb8db42.iframe.bundle.js:47822:460)`,
+      }),
+    },
+    {
+      severity: "warn",
+      message: "Connection lost",
+    },
+    {
+      severity: "info",
+      message: "Connection lost",
+      tip: "A tip that we might want to show the user",
+    },
+  ];
+}
 
 export default {
   title: "components/ProblemsList",
@@ -62,35 +95,7 @@ export const WithErrors: StoryObj = {
         endTime={END_TIME}
         topics={TOPICS}
         presence={PlayerPresence.RECONNECTING}
-        problems={[
-          {
-            severity: "error",
-            message: "Connection lost",
-            tip: "A tip that we might want to show the user",
-            error: Object.assign(new Error("Fake Error"), {
-              stack: `Error: Original Error
-    at Story (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/studio-base-src-components-ProblemsList-stories.039002bb.iframe.bundle.js:58:28)
-    at undecoratedStoryFn (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:2794)
-    at hookified (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:7:17032)
-    at https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:1915
-    at jsxDecorator (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/1983.4cb8db42.iframe.bundle.js:13838:1100)
-    at hookified (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:7:17032)
-    at https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:1454
-    at https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/sb-preview/runtime.mjs:34:1915
-    at Ch (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/1983.4cb8db42.iframe.bundle.js:47712:137)
-    at ck (https://603ec8bf7908b500231841e2-nozcuvybhv.capture.chromatic.com/1983.4cb8db42.iframe.bundle.js:47822:460)`,
-            }),
-          },
-          {
-            severity: "warn",
-            message: "Connection lost",
-          },
-          {
-            severity: "info",
-            message: "Connection lost",
-            tip: "A tip that we might want to show the user",
-          },
-        ]}
+        problems={makeProblems()}
       >
         <ProblemsList />
       </MockMessagePipelineProvider>
@@ -104,4 +109,40 @@ export const WithErrorsChinese: StoryObj = {
 export const WithErrorsJapanese: StoryObj = {
   ...WithErrors,
   parameters: { forceLanguage: "ja" },
+};
+
+export const WithSessionProblems: StoryObj = {
+  render: function Story() {
+    const initialState: Pick<WorkspaceContextStore, "session"> = {
+      session: {
+        problems: [
+          {
+            message: "Session problem error",
+            severity: "error",
+            tag: "tag-1",
+            tip: "Something really bad happened",
+          },
+          {
+            message: "Session problem warn",
+            severity: "warn",
+            tag: "tag-2",
+            tip: "Something kinda bad happened",
+          },
+        ],
+      },
+    };
+    return (
+      <MockMessagePipelineProvider
+        startTime={START_TIME}
+        endTime={END_TIME}
+        topics={TOPICS}
+        presence={PlayerPresence.RECONNECTING}
+        problems={makeProblems()}
+      >
+        <WorkspaceContextProvider initialState={initialState}>
+          <ProblemsList />
+        </WorkspaceContextProvider>
+      </MockMessagePipelineProvider>
+    );
+  },
 };

--- a/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
@@ -11,12 +11,15 @@ import { useGuaranteedContext } from "@foxglove/hooks";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
 import { IDataSourceFactory } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { PlayerProblem } from "@foxglove/studio-base/players/types";
 
 export const LeftSidebarItemKeys = ["panel-settings", "topics", "problems"] as const;
 export type LeftSidebarItemKey = (typeof LeftSidebarItemKeys)[number];
 
 export const RightSidebarItemKeys = ["events", "variables", "studio-logs-settings"] as const;
 export type RightSidebarItemKey = (typeof RightSidebarItemKeys)[number];
+
+export type SessionProblem = PlayerProblem & { tag: string };
 
 export type WorkspaceContextStore = {
   dialogs: {
@@ -36,6 +39,9 @@ export type WorkspaceContextStore = {
   };
   playbackControls: {
     repeat: boolean;
+  };
+  session: {
+    problems: SessionProblem[];
   };
   sidebars: {
     left: {

--- a/packages/studio-base/src/context/Workspace/migrations.ts
+++ b/packages/studio-base/src/context/Workspace/migrations.ts
@@ -60,6 +60,9 @@ export function migrateV0WorkspaceState(
       active: undefined,
       shown: v0State.featureTours.shown,
     },
+    session: {
+      problems: [],
+    },
     sidebars: {
       left: {
         item: v0State.leftSidebarItem,

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
@@ -8,6 +8,7 @@ import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
 import { useMountedState } from "react-use";
 
 import { useGuaranteedContext } from "@foxglove/hooks";
+import { Immutable } from "@foxglove/studio";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
@@ -31,6 +32,7 @@ import {
   LeftSidebarItemKeys,
   RightSidebarItemKey,
   RightSidebarItemKeys,
+  SessionProblem,
 } from "./WorkspaceContext";
 import { useOpenFile } from "./useOpenFile";
 
@@ -58,6 +60,11 @@ export type WorkspaceActions = {
 
   playbackControlActions: {
     setRepeat: Dispatch<SetStateAction<boolean>>;
+  };
+
+  sessionActions: {
+    clearProblem: (tag: string) => void;
+    setProblem: (tag: string, problem: Immutable<SessionProblem>) => void;
   };
 
   sidebarActions: {
@@ -248,6 +255,21 @@ export function useWorkspaceActions(): WorkspaceActions {
           set((draft) => {
             const repeat = setterValue(setter, draft.playbackControls.repeat);
             draft.playbackControls.repeat = repeat;
+          });
+        },
+      },
+
+      sessionActions: {
+        clearProblem: (tag: string) => {
+          set((draft) => {
+            draft.session.problems = draft.session.problems.filter((prob) => prob.tag !== tag);
+          });
+        },
+
+        setProblem: (tag: string, problem: Immutable<SessionProblem>) => {
+          set((draft) => {
+            draft.session.problems = draft.session.problems.filter((prob) => prob.tag !== tag);
+            draft.session.problems.unshift(problem);
           });
         },
       },

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -33,6 +33,9 @@ export function makeWorkspaceContextInitialState(): WorkspaceContextStore {
       active: undefined,
       shown: [],
     },
+    session: {
+      problems: [],
+    },
     sidebars: {
       left: {
         item: "panel-settings",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add a new `session` field in the workspace store that contains a `problems` array and add new methods in `useWorkspaceActions` to add and clear problems. Problems are identified by a unique string tag. It is the responsibility of the caller to generate unique tags to manage its problems.

Problems in the workspace session will be displayed at the top of the problems list in the sidebar.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
FG-3512