### PR TITLE
Fix crash in eslint-plugin-studio

### DIFF
--- a/packages/eslint-plugin-studio/link-target.js
+++ b/packages/eslint-plugin-studio/link-target.js
@@ -11,7 +11,7 @@ module.exports = {
   create: (context) => {
     return {
       [`JSXElement > JSXOpeningElement > JSXAttribute[name.name="href"]`]: (node) => {
-        if (node.parent.attributes.some((attr) => attr.name.name === "target")) {
+        if (node.parent.attributes.some((attr) => attr.name?.name === "target")) {
           return;
         }
         context.report({


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
Fix unhandled undefined in eslint-plugin-studio

```
Oops! Something went wrong! :(

ESLint: 8.49.0

TypeError: Cannot read properties of undefined (reading 'name')
Occurred while linting /packages/console/components/AppLink.tsx:96
Rule: "@foxglove/studio/link-target"
    at /studio/packages/eslint-plugin-studio/link-target.js:14:61
    at Array.some (<anonymous>)
```