### PR TITLE
fix TypeError when custom message header.stamp is not object

### DIFF
--- a/packages/studio-base/src/util/time.test.ts
+++ b/packages/studio-base/src/util/time.test.ts
@@ -68,5 +68,14 @@ describe("time.getTimestampForMessageEvent", () => {
     expect(
       time.getTimestampForMessageEvent({ ...messageBase, message: {} }, "headerStamp"),
     ).toEqual(undefined);
+    expect(
+      time.getTimestampForMessageEvent(
+        {
+          ...messageBase,
+          message: { header: { stamp: 1694712977, seq: 0, frame_id: "" } },
+        },
+        "headerStamp",
+      ),
+    ).toEqual(undefined);
   });
 });

--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -51,13 +51,13 @@ export function getTimestampForMessage(message: unknown): Time | undefined {
   if ((message as Partial<StampedMessage>).header != undefined) {
     // This message has a "header" field
     const stamp = (message as Partial<StampedMessage>).header?.stamp;
-    if (stamp != undefined && "sec" in stamp && "nsec" in stamp) {
+    if (stamp != undefined && typeof stamp === "object" && "sec" in stamp && "nsec" in stamp) {
       return stamp;
     }
   } else if ((message as Partial<MarkerArray>).markers?.[0]?.header != undefined) {
     // This is a marker array message with a "markers" array and at least one entry
     const stamp = (message as MarkerArray).markers[0]?.header.stamp;
-    if (stamp != undefined && "sec" in stamp && "nsec" in stamp) {
+    if (stamp != undefined && typeof stamp === "object" && "sec" in stamp && "nsec" in stamp) {
       return stamp;
     }
   }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

None

**Description**

When a custom message has a header.stamp but does not follow the ros style, it will cause errors such as `TypeError: Cannot use 'in' operator to search for 'sec' in 1694712977`.

Add necessary judgments and test cases.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
