### PR TITLE
Fix for plots on live ROS1 sources

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -209,7 +209,27 @@ function useData(id: string, params: PlotParams) {
     }, []),
     addMessages: React.useCallback(
       (_: number | undefined, messages: readonly MessageEvent[]): number => {
-        void service?.addCurrent(messages);
+        void service?.addCurrent(
+          messages.map((event) => {
+            const { message } = event;
+
+            // Handle LazyMessageReader messages, which cannot be
+            // `postMessage`d otherwise
+            // https://github.com/foxglove/rosmsg-serialization/blob/2c15caf4f344012737f5aab01103e3c525889f2e/src/__snapshots__/LazyMessageReader.test.ts.snap#L304
+            if (
+              typeof message === "object" &&
+              message != undefined &&
+              "toObject" in message &&
+              typeof message.toObject === "function"
+            ) {
+              return {
+                ...event,
+                message: (message as { toObject: () => unknown }).toObject(),
+              };
+            }
+            return event;
+          }),
+        );
         return 1;
       },
       [],


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
The messages produced by `LazyMessageReader` are empty after being `postMessage`d; we must call `toObject` on them.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
