### PR TITLE
Fix broken client behavior on plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -37,7 +37,7 @@ type Service = Comlink.Remote<(typeof import("./useDatasets.worker"))["service"]
 // mapping from topic -> the first message on that topic in the block
 type BlockStatus = Record<string, unknown>;
 type Client = {
-  params: PlotParams;
+  params: PlotParams | undefined;
   setter: (topics: SubscribePayload[]) => void;
 };
 
@@ -131,6 +131,10 @@ function chooseClient() {
   const subscriptions = R.pipe(
     R.chain((client: Client): SubscribePayload[] => {
       const { params } = client;
+      if (params == undefined) {
+        return [];
+      }
+
       const { xAxisPath, paths: yAxisPaths } = params;
 
       const isOnlyCurrent = isBounded(params) || isSingleMessage(params);
@@ -174,7 +178,7 @@ function useData(id: string, params: PlotParams) {
     clients = {
       ...clients,
       [id]: {
-        params,
+        params: undefined,
         setter: setSubscribed,
       },
     };
@@ -183,6 +187,18 @@ function useData(id: string, params: PlotParams) {
       const { [id]: _client, ...rest } = clients;
       clients = rest;
       chooseClient();
+    };
+  }, [id]);
+
+  useEffect(() => {
+    const { [id]: client } = clients;
+    if (client == undefined) {
+      return;
+    }
+
+    clients = {
+      ...clients,
+      [id]: { ...client, params },
     };
   }, [id, params]);
 

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -174,6 +174,7 @@ function chooseClient() {
 // messages to the worker as they arrive.
 function useData(id: string, params: PlotParams) {
   const [subscriptions, setSubscribed] = React.useState<SubscribePayload[]>([]);
+  // Register client when the panel mounts and unregister when it unmounts
   useEffect(() => {
     clients = {
       ...clients,
@@ -190,6 +191,7 @@ function useData(id: string, params: PlotParams) {
     };
   }, [id]);
 
+  // Update registration when params change
   useEffect(() => {
     const { [id]: client } = clients;
     if (client == undefined) {

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -200,6 +200,7 @@ function useData(id: string, params: PlotParams) {
       ...clients,
       [id]: { ...client, params },
     };
+    chooseClient();
   }, [id, params]);
 
   const isLive = useMessagePipeline<boolean>(getIsLive);


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
Due to my own inaccurate understanding of `useEffect` (which I have used since its release and whose idiosyncrasies I have defended to the death--pride truly cometh before the fall) there was a bug that could cause repeated client registrations, which manifested in some odd plot behavior, such as in stories.

Fixes FG-5031