### PR TITLE
Fix strategy for resetting preloaded plot data

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -271,12 +271,7 @@ function useData(id: string, params: PlotParams) {
 
         // we already had a message in this block, meaning the data itself has
         // changed; we have to rebuild the plots
-        if (
-          existing != undefined &&
-          existing != first &&
-          lastSent != undefined &&
-          index < lastSent
-        ) {
+        if (existing != undefined && lastSent != undefined && index < lastSent) {
           resetData.add(payload.topic);
         }
 

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -45,6 +45,7 @@ let worker: Worker | undefined;
 let service: Service | undefined;
 let numClients: number = 0;
 let blockStatus: BlockStatus[] = [];
+let lastBlockSent: Record<string, number> = {};
 let clients: Record<string, Client> = {};
 
 const pending: ((service: Service) => void)[] = [];
@@ -164,6 +165,7 @@ function chooseClient() {
 
   // Also clear the status of any topics we're no longer using
   blockStatus = blockStatus.map((block) => R.pick(blockTopics, block));
+  lastBlockSent = R.pick(blockTopics, lastBlockSent);
 }
 
 // Subscribe to "current" messages (those near the seek head) and forward new
@@ -238,8 +240,6 @@ function useData(id: string, params: PlotParams) {
 
   const blocks = useBlocks(blockSubscriptions);
   useEffect(() => {
-    const wasReset: Record<string, boolean> = {};
-
     for (const [index, block] of blocks.entries()) {
       if (R.isEmpty(block)) {
         continue;
@@ -260,19 +260,29 @@ function useData(id: string, params: PlotParams) {
 
         const first = topicMessages[0]?.message;
         const existing = status[ref];
+
+        // keep track of the block index that we last sent; if there's a new
+        // change BEFORE that index, we need to reset the plot data; otherwise
+        // we do not
+        const lastSent = lastBlockSent[ref];
         if (R.equals(existing, first)) {
           continue;
         }
 
         // we already had a message in this block, meaning the data itself has
         // changed; we have to rebuild the plots
-        if (existing != undefined && wasReset[ref] == undefined) {
+        if (
+          existing != undefined &&
+          existing != first &&
+          lastSent != undefined &&
+          index < lastSent
+        ) {
           resetData.add(payload.topic);
-          wasReset[ref] = true;
         }
 
         status[ref] = first;
         messages[payload.topic] = topicMessages as MessageEvent[];
+        lastBlockSent[ref] = index;
       }
       blockStatus[index] = status;
 


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
The intention behind the code this PR modifies was to reset the preloaded plot data whenever the underlying data in the blocks changed. This was designed to handle cases where the user plots a different subfield of a message: because of message slicing, this can result in data _within a topic_ being updated.

Suffice it to say that the code did not actually do this; it reset the plot data _on every changed block_ resulting in a "scrolling" motion as shown in the attached video.


https://github.com/foxglove/studio/assets/4588553/9809cf38-7e6e-4d31-b1c2-ead75dfde0e1



Instead, we need to use a cursor system, wherein if (and only if) a block changes _before_ a block we've already sent, we clear out plot data. That's what this PR implements.

In general I'm pretty unsatisfied with how this code looks now after handling all of this complexity, but I'd like to prioritize fixing `main` and revisit this ASAP.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
