### PR TITLE
Workaround missing process.versions in user script workers

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/index.ts
@@ -26,6 +26,10 @@ let unsentErrors: string[] = [];
   unsentErrors.push(String(event.reason instanceof Error ? event.reason.message : event.reason));
 };
 
+// Workaround for missing process.versions in worker.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(process as any).versions ??= {};
+
 if (!inSharedWorker()) {
   // In Chrome, web workers currently (as of March 2020) inherit their Content Security Policy from
   // their associated page, ignoring any policy in the headers of their source file. SharedWorkers


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with user scripts that import from `@foxglove/schemas` failing to run.

**Description**
Hack missing `process.versions` by replacing it with an empty object.

I think the underlying issue here is that we're running typescript in the browser but it thinks its running in a node environment in which `process.versions` should be available.

Fixes a regression from https://github.com/foxglove/studio/pull/6723

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
