### PR TITLE
Lift problems state into separate store

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -8,6 +8,7 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 
 import GlobalCss from "@foxglove/studio-base/components/GlobalCss";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import ProblemsContextProvider from "@foxglove/studio-base/providers/ProblemsContextProvider";
 import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/StudioLogsSettingsProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
 
@@ -72,6 +73,7 @@ export function App(props: AppProps): JSX.Element {
 
   const providers = [
     /* eslint-disable react/jsx-key */
+    <ProblemsContextProvider />,
     <TimelineInteractionStateProvider />,
     <UserNodeStateProvider />,
     <CurrentLayoutProvider />,

--- a/packages/studio-base/src/components/ProblemsList.stories.tsx
+++ b/packages/studio-base/src/components/ProblemsList.stories.tsx
@@ -4,12 +4,14 @@
 
 import { useTheme } from "@mui/material";
 import { StoryFn, StoryObj } from "@storybook/react";
+import { useEffect } from "react";
 
 import { fromDate } from "@foxglove/rostime";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { ProblemsList } from "@foxglove/studio-base/components/ProblemsList";
-import { WorkspaceContextStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+import { useProblemsActions } from "@foxglove/studio-base/context/ProblemsContext";
 import { PlayerPresence, PlayerProblem, Topic } from "@foxglove/studio-base/players/types";
+import ProblemsContextProvider from "@foxglove/studio-base/providers/ProblemsContextProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 function makeProblems(): PlayerProblem[] {
@@ -53,7 +55,9 @@ export default {
       return (
         <WorkspaceContextProvider>
           <div style={{ height: "100%", background: theme.palette.background.paper }}>
-            <Story />
+            <ProblemsContextProvider>
+              <Story />
+            </ProblemsContextProvider>
           </div>
         </WorkspaceContextProvider>
       );
@@ -113,24 +117,20 @@ export const WithErrorsJapanese: StoryObj = {
 
 export const WithSessionProblems: StoryObj = {
   render: function Story() {
-    const initialState: Pick<WorkspaceContextStore, "session"> = {
-      session: {
-        problems: [
-          {
-            message: "Session problem error",
-            severity: "error",
-            tag: "tag-1",
-            tip: "Something really bad happened",
-          },
-          {
-            message: "Session problem warn",
-            severity: "warn",
-            tag: "tag-2",
-            tip: "Something kinda bad happened",
-          },
-        ],
-      },
-    };
+    const problemsActions = useProblemsActions();
+    useEffect(() => {
+      problemsActions.setProblem("tag-1", {
+        message: "Session problem error",
+        severity: "error",
+        tip: "Something really bad happened",
+      });
+      problemsActions.setProblem("tag-2", {
+        message: "Session problem warn",
+        severity: "warn",
+        tip: "Something kinda bad happened",
+      });
+    }, [problemsActions]);
+
     return (
       <MockMessagePipelineProvider
         startTime={START_TIME}
@@ -139,7 +139,7 @@ export const WithSessionProblems: StoryObj = {
         presence={PlayerPresence.RECONNECTING}
         problems={makeProblems()}
       >
-        <WorkspaceContextProvider initialState={initialState}>
+        <WorkspaceContextProvider>
           <ProblemsList />
         </WorkspaceContextProvider>
       </MockMessagePipelineProvider>

--- a/packages/studio-base/src/components/ProblemsList.tsx
+++ b/packages/studio-base/src/components/ProblemsList.tsx
@@ -24,9 +24,9 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import {
-  WorkspaceContextStore,
-  useWorkspaceStore,
-} from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+  ProblemsContextStore,
+  useProblemsStore,
+} from "@foxglove/studio-base/context/ProblemsContext";
 import { PlayerProblem } from "@foxglove/studio-base/players/types";
 import { DetailsType, NotificationSeverity } from "@foxglove/studio-base/util/sendNotification";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -96,7 +96,7 @@ const useStyles = makeStyles()((theme) => ({
 const EMPTY_PLAYER_PROBLEMS: PlayerProblem[] = [];
 const selectPlayerProblems = ({ playerState }: MessagePipelineContext) =>
   playerState.problems ?? EMPTY_PLAYER_PROBLEMS;
-const selectSessionProblems = (store: WorkspaceContextStore) => store.session.problems;
+const selectProblems = (store: ProblemsContextStore) => store.problems;
 
 function ProblemIcon({ severity }: { severity: NotificationSeverity }): JSX.Element {
   const { palette } = useTheme();
@@ -147,7 +147,7 @@ export function ProblemsList(): JSX.Element {
   const { t } = useTranslation("problemsList");
   const { classes } = useStyles();
   const playerProblems = useMessagePipeline(selectPlayerProblems);
-  const sessionProblems = useWorkspaceStore(selectSessionProblems);
+  const sessionProblems = useProblemsStore(selectProblems);
 
   const allProblems = useMemo(() => {
     return [...sessionProblems, ...playerProblems];

--- a/packages/studio-base/src/context/ProblemsContext.ts
+++ b/packages/studio-base/src/context/ProblemsContext.ts
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext } from "react";
+import { StoreApi, useStore } from "zustand";
+
+import { useGuaranteedContext } from "@foxglove/hooks";
+import { Immutable } from "@foxglove/studio";
+import { PlayerProblem } from "@foxglove/studio-base/players/types";
+
+export type SessionProblem = PlayerProblem;
+
+type TaggedProblem = SessionProblem & { tag: string };
+
+export type ProblemsContextStore = Immutable<{
+  problems: TaggedProblem[];
+  actions: {
+    clearProblem: (tag: string) => void;
+    setProblem: (tag: string, problem: Immutable<SessionProblem>) => void;
+  };
+}>;
+
+export const ProblemsContext = createContext<undefined | StoreApi<ProblemsContextStore>>(undefined);
+
+ProblemsContext.displayName = "ProblemsContext";
+
+/**
+ * Fetches values from the problems store.
+ */
+export function useProblemsStore<T>(selector: (store: ProblemsContextStore) => T): T {
+  const context = useGuaranteedContext(ProblemsContext);
+  return useStore(context, selector);
+}
+
+const selectActions = (store: ProblemsContextStore) => store.actions;
+
+/**
+ * Convenience hook for accessing problems store actions.
+ */
+export function useProblemsActions(): ProblemsContextStore["actions"] {
+  return useProblemsStore(selectActions);
+}

--- a/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
@@ -11,15 +11,12 @@ import { useGuaranteedContext } from "@foxglove/hooks";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
 import { IDataSourceFactory } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import { PlayerProblem } from "@foxglove/studio-base/players/types";
 
 export const LeftSidebarItemKeys = ["panel-settings", "topics", "problems"] as const;
 export type LeftSidebarItemKey = (typeof LeftSidebarItemKeys)[number];
 
 export const RightSidebarItemKeys = ["events", "variables", "studio-logs-settings"] as const;
 export type RightSidebarItemKey = (typeof RightSidebarItemKeys)[number];
-
-export type SessionProblem = PlayerProblem & { tag: string };
 
 export type WorkspaceContextStore = {
   dialogs: {
@@ -39,9 +36,6 @@ export type WorkspaceContextStore = {
   };
   playbackControls: {
     repeat: boolean;
-  };
-  session: {
-    problems: SessionProblem[];
   };
   sidebars: {
     left: {

--- a/packages/studio-base/src/context/Workspace/migrations.ts
+++ b/packages/studio-base/src/context/Workspace/migrations.ts
@@ -60,9 +60,6 @@ export function migrateV0WorkspaceState(
       active: undefined,
       shown: v0State.featureTours.shown,
     },
-    session: {
-      problems: [],
-    },
     sidebars: {
       left: {
         item: v0State.leftSidebarItem,

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
@@ -8,7 +8,6 @@ import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
 import { useMountedState } from "react-use";
 
 import { useGuaranteedContext } from "@foxglove/hooks";
-import { Immutable } from "@foxglove/studio";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
@@ -26,13 +25,12 @@ import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 
 import {
-  WorkspaceContext,
-  WorkspaceContextStore,
   LeftSidebarItemKey,
   LeftSidebarItemKeys,
   RightSidebarItemKey,
   RightSidebarItemKeys,
-  SessionProblem,
+  WorkspaceContext,
+  WorkspaceContextStore,
 } from "./WorkspaceContext";
 import { useOpenFile } from "./useOpenFile";
 
@@ -60,11 +58,6 @@ export type WorkspaceActions = {
 
   playbackControlActions: {
     setRepeat: Dispatch<SetStateAction<boolean>>;
-  };
-
-  sessionActions: {
-    clearProblem: (tag: string) => void;
-    setProblem: (tag: string, problem: Immutable<SessionProblem>) => void;
   };
 
   sidebarActions: {
@@ -255,21 +248,6 @@ export function useWorkspaceActions(): WorkspaceActions {
           set((draft) => {
             const repeat = setterValue(setter, draft.playbackControls.repeat);
             draft.playbackControls.repeat = repeat;
-          });
-        },
-      },
-
-      sessionActions: {
-        clearProblem: (tag: string) => {
-          set((draft) => {
-            draft.session.problems = draft.session.problems.filter((prob) => prob.tag !== tag);
-          });
-        },
-
-        setProblem: (tag: string, problem: Immutable<SessionProblem>) => {
-          set((draft) => {
-            draft.session.problems = draft.session.problems.filter((prob) => prob.tag !== tag);
-            draft.session.problems.unshift(problem);
           });
         },
       },

--- a/packages/studio-base/src/providers/ProblemsContextProvider.tsx
+++ b/packages/studio-base/src/providers/ProblemsContextProvider.tsx
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable } from "immer";
+import { ReactNode, useState } from "react";
+import { StoreApi, create } from "zustand";
+
+import {
+  ProblemsContext,
+  ProblemsContextStore,
+  SessionProblem,
+} from "@foxglove/studio-base/context/ProblemsContext";
+
+function createProblemsStore(): StoreApi<ProblemsContextStore> {
+  return create<ProblemsContextStore>((set, get) => {
+    return {
+      problems: [],
+      actions: {
+        clearProblem: (tag: string) => {
+          set({
+            problems: get().problems.filter((prob) => prob.tag !== tag),
+          });
+        },
+        setProblem: (tag: string, problem: Immutable<SessionProblem>) => {
+          const newProblems = get().problems.filter((prob) => prob.tag !== tag);
+
+          set({
+            problems: [{ tag, ...problem }, ...newProblems],
+          });
+        },
+      },
+    };
+  });
+}
+
+export default function ProblemsContextProvider({
+  children,
+}: {
+  children?: ReactNode;
+}): JSX.Element {
+  const [store] = useState(createProblemsStore);
+  return <ProblemsContext.Provider value={store}>{children}</ProblemsContext.Provider>;
+}

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -33,9 +33,6 @@ export function makeWorkspaceContextInitialState(): WorkspaceContextStore {
       active: undefined,
       shown: [],
     },
-    session: {
-      problems: [],
-    },
     sidebars: {
       left: {
         item: "panel-settings",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Lift problems state into a separate store.

I'd prefer to keep this in the workspace store and not add yet one more context but components like the layout mananager that sit above the workspace need to be able to use this.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
