### PR TITLE
Fix issue with disappearing preloaded plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -1146,7 +1146,7 @@ export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
 
 export const IndexBasedXAxisForArray: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useReadySignal({ count: 1 });
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -277,6 +277,7 @@ function setLive(value: boolean): void {
 function unregister(id: string): void {
   const { [id]: _client, ...rest } = clients;
   clients = rest;
+  evictCache();
 }
 
 function receiveMetadata(topics: readonly Topic[], datatypes: Immutable<RosDatatypes>): void {
@@ -379,8 +380,6 @@ function addBlock(block: Messages, resetTopics: string[]): void {
     });
     client.queueRebuild();
   }
-
-  evictCache();
 }
 
 function clearCurrent(): void {


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
Plots that used block data were cleared when switching tabs. This PR fixes that.

The problem was that `addBlock` could come before `register` had completed, and thus `evictCache` would clear out the new block that just got added. (Theoretically this is a timing problem but it's more complicated than it seems at first glance; waiting for `register` to complete before doing `addBlock` would not make sense, since the `addBlock` mechanism in the rendering thread has already done the work to determine that a client actually needs the block data.)

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
