### PR TITLE
Fix issue where sliced messages are visible in raw message panel

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.test.ts
@@ -5,7 +5,7 @@
 import { mergeSubscriptions } from "@foxglove/studio-base/components/MessagePipeline/subscriptions";
 import { SubscribePayload } from "@foxglove/studio-base/players/types";
 
-describe("simplifySubscriptionsById", () => {
+describe("mergeSubscriptions", () => {
   it("combines full and partial subscriptions", () => {
     const subs: SubscribePayload[] = [
       { topic: "a", preloadType: "full" },
@@ -47,6 +47,21 @@ describe("simplifySubscriptionsById", () => {
     expect(result).toEqual([
       { topic: "b", preloadType: "full", fields: ["one", "two"] },
       { topic: "b", preloadType: "partial", fields: ["one", "two", "three"] },
+    ]);
+  });
+
+  it("switches to subscribing to all fields", () => {
+    const subs: SubscribePayload[] = [
+      { topic: "a", preloadType: "partial", fields: ["one", "two"] },
+      { topic: "a", preloadType: "full", fields: ["one", "two"] },
+      { topic: "a", preloadType: "partial" },
+    ];
+
+    const result = mergeSubscriptions(subs);
+
+    expect(result).toEqual([
+      { topic: "a", preloadType: "full", fields: ["one", "two"] },
+      { topic: "a", preloadType: "partial" },
     ]);
   });
 });

--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
@@ -36,7 +36,7 @@ function mergeSubscription(
 
   return {
     ...a,
-    ...(fields.length > 0 && !isAllFields ? { fields } : {}),
+    fields: fields.length > 0 && !isAllFields ? fields : undefined,
   };
 }
 


### PR DESCRIPTION

**User-Facing Changes**
None.

**Description**
There was a bug in `mergeSubscriptions` that resulted in fields being included in the `SubscribePayload` when they should not have been.

Fixed:
<img width="728" alt="Снимок экрана 2023-09-21 в 11 36 16 AM" src="https://github.com/foxglove/studio/assets/4588553/09964b10-9e5d-44fb-8208-96a13216ffbc">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
