### PR TITLE
Reduce console errors for LINE_LIST annotations with an odd number of points

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -199,7 +199,10 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
     }
 
     const { points, outlineColor, outlineColors, thickness, style, fillColor } = this.#annotation;
-    const pointsLength = points.length;
+    let pointsLength = points.length;
+    if (style === "line_list" && pointsLength % 2 !== 0) {
+      pointsLength--;
+    }
     if (pointsLength < 2) {
       this.visible = false;
       return;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -1015,3 +1015,81 @@ export const UpdateLineEnableVertexColors: StoryObj<UpdateLineArgs> = {
     await ctx.parameters.storyReady;
   },
 };
+
+export const OddLengthLineList: StoryObj = {
+  render: function Story() {
+    const width = 60;
+    const height = 45;
+    const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
+      width,
+      height,
+      frameId: "camera",
+      imageTopic: "camera",
+      calibrationTopic: "calibration",
+    });
+
+    const annotationsMessage: MessageEvent<Partial<ImageAnnotations>> = {
+      topic: "annotations",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        points: [
+          {
+            timestamp: { sec: 0, nsec: 0 },
+            type: PointsAnnotationType.LINE_LIST,
+            points: [
+              { x: 20 + 0, y: 10 + 0 },
+              { x: 20 + 0, y: 10 + 8 },
+              { x: 20 + 2, y: 10 + 6 },
+              { x: 20 + 5, y: 10 + 2 },
+              { x: 20 + 3, y: 10 + 1 },
+            ],
+            outline_color: { r: 0, g: 0, b: 0, a: 1 },
+            outline_colors: [
+              // 1 color per line
+              { r: 1, g: 0, b: 0, a: 1 },
+              { r: 0, g: 1, b: 0, a: 0.75 },
+              { r: 0, g: 0, b: 1, a: 0.75 },
+            ],
+            fill_color: { r: 0, g: 0, b: 0, a: 0 },
+            thickness: 2,
+          },
+        ],
+      },
+      schemaName: "foxglove.ImageAnnotations",
+      sizeInBytes: 0,
+    };
+
+    const fixture: Fixture = {
+      topics: [
+        { name: "calibration", schemaName: "foxglove.CameraCalibration" },
+        { name: "camera", schemaName: "foxglove.RawImage" },
+        { name: "annotations", schemaName: "foxglove.ImageAnnotations" },
+      ],
+      frame: {
+        calibration: [calibrationMessage],
+        camera: [cameraMessage],
+        annotations: [annotationsMessage],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    };
+    return (
+      <div style={{ width: 1200, height: 900, flexShrink: 0 }}>
+        <PanelSetup fixture={fixture} includeSettings>
+          <ImagePanel
+            overrideConfig={{
+              ...ImagePanel.defaultConfig,
+              imageMode: {
+                calibrationTopic: "calibration",
+                imageTopic: "camera",
+                annotations: { annotations: { visible: true } },
+              },
+            }}
+          />
+        </PanelSetup>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Previously a LINE_LIST annotation with an odd number of points would spew console errors when it encountered NaNs inside `computeBoundingSphere()`. Instead we now just ignore the extra point; this matches how we handle ROS Marker line lists:

https://github.com/foxglove/studio/blob/f15de61e9cd4d92400731108c6f9bf5f3bf3b822/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts#L81-L83

I've added a story to show that we can render these, but note that the story does not capture the console.error behavior so it wouldn't have detected this issue on main.