### PR TITLE
Use preload data for all plots again

### DIFF
--- a/packages/studio-base/src/panels/Plot/params.ts
+++ b/packages/studio-base/src/panels/Plot/params.ts
@@ -26,11 +26,6 @@ export function isSingleMessage(params: PlotParams): boolean {
   return xAxisVal === "currentCustom" || xAxisVal === "index";
 }
 
-export function isBounded(params: PlotParams): boolean {
-  const { followingViewWidth } = params;
-  return followingViewWidth != undefined && followingViewWidth > 0;
-}
-
 export function getParamPaths(params: PlotParams): readonly string[] {
   return getPaths(params.paths, params.xAxisPath);
 }

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -26,7 +26,7 @@ import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { SubscribePayload, MessageEvent } from "@foxglove/studio-base/players/types";
 
 import { PlotParams, Messages } from "./internalTypes";
-import { getPaths, isSingleMessage, isBounded } from "./params";
+import { getPaths } from "./params";
 import { PlotData } from "./plotData";
 
 type Service = Comlink.Remote<(typeof import("./useDatasets.worker"))["service"]>;
@@ -138,7 +138,6 @@ function chooseClient() {
 
       const { xAxisPath, paths: yAxisPaths } = params;
 
-      const isOnlyCurrent = isBounded(params) || isSingleMessage(params);
       return R.pipe(
         getPayloadsFromPaths,
         R.chain((v): SubscribePayload[] => {
@@ -146,10 +145,6 @@ function chooseClient() {
             ...v,
             preloadType: "partial",
           };
-
-          if (isOnlyCurrent) {
-            return [partial];
-          }
 
           // Subscribe to both "partial" and "full" when using "full" In
           // theory, "full" should imply "partial" but not doing this breaks

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -30,7 +30,7 @@ import {
   TypedData,
   Messages,
 } from "./internalTypes";
-import { isSingleMessage, isBounded, getParamPaths, getParamTopics } from "./params";
+import { isSingleMessage, getParamPaths, getParamTopics } from "./params";
 import {
   buildPlotData,
   resolvePath,
@@ -195,10 +195,7 @@ function getClientData(client: Client): PlotData | undefined {
   const { bounds: currentBounds } = currentData;
 
   let datasets: PlotData[] = [];
-  if (isSingleMessage(params) || isBounded(params)) {
-    // bounded and single-message plots _only_ use current data
-    datasets = [currentData];
-  } else if (blockBounds.x.min <= currentBounds.x.min && blockBounds.x.max > currentBounds.x.max) {
+  if (blockBounds.x.min <= currentBounds.x.min && blockBounds.x.max > currentBounds.x.max) {
     // ignore current data if block data covers it already
     datasets = [blockData];
   } else {


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
Now we attempt to load all preload data for a plot regardless of whether it's bounded.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
