### PR TITLE
call service panel list all supported services

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -58,9 +58,10 @@ import { useSharedPanelState } from "./useSharedPanelState";
 
 const log = Logger.getLogger(__filename);
 
+export const VERSION_CONFIG_KEY = "foxgloveConfigVersion";
+
 type VersionedPanelConfig = Record<string, unknown> & { [VERSION_CONFIG_KEY]: number };
 
-export const VERSION_CONFIG_KEY = "foxgloveConfigVersion";
 
 function isVersionedPanelConfig(config: unknown): config is VersionedPanelConfig {
   return (
@@ -117,6 +118,8 @@ function PanelExtensionAdapter(
 
   const { playerState, pauseFrame, setSubscriptions, seekPlayback, sortedTopics } =
     messagePipelineContext;
+
+  const initialPlayerState = useLatest(playerState);
 
   const { capabilities, profile: dataSourceProfile } = playerState;
 
@@ -311,6 +314,8 @@ function PanelExtensionAdapter(
 
     return {
       initialState: initialState.current,
+
+      playerState: initialPlayerState.current,
 
       saveState: (state) => {
         if (!isMounted()) {
@@ -519,6 +524,7 @@ function PanelExtensionAdapter(
     dataSourceProfile,
     getMessagePipelineContext,
     initialState,
+    initialPlayerState,
     isMounted,
     openSiblingPanel,
     panelId,

--- a/packages/studio-base/src/panels/CallService/settings.ts
+++ b/packages/studio-base/src/panels/CallService/settings.ts
@@ -13,15 +13,9 @@ import { Config } from "./types";
 
 export const defaultConfig: Config = {
   requestPayload: "{}",
+  requestTimeout: 5,
   layout: "vertical",
 };
-
-function serviceError(serviceName?: string) {
-  if (!serviceName) {
-    return "Service cannot be empty";
-  }
-  return undefined;
-}
 
 export function settingsActionReducer(prevConfig: Config, action: SettingsTreeAction): Config {
   return produce(prevConfig, (draft) => {
@@ -36,12 +30,15 @@ export function useSettingsTree(config: Config): SettingsTreeNodes {
   const settings = useMemo(
     (): SettingsTreeNodes => ({
       general: {
+        label: "General",
         fields: {
-          serviceName: {
-            label: "Service name",
-            input: "string",
-            error: serviceError(config.serviceName),
-            value: config.serviceName ?? "",
+          requestTimeout: {
+            label: "Request Timeout(Second)",
+            input: "number",
+            precision: 0,
+            min: 5,
+            step: 1,
+            value: config.requestTimeout,
           },
           layout: {
             label: "Layout",

--- a/packages/studio-base/src/panels/CallService/types.ts
+++ b/packages/studio-base/src/panels/CallService/types.ts
@@ -5,6 +5,7 @@
 export type Config = {
   serviceName?: string;
   requestPayload?: string;
+  requestTimeout: number;
   layout?: "vertical" | "horizontal";
   buttonText?: string;
   buttonTooltip?: string;

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { MessageDefinition } from "@foxglove/message-definition";
+import { ConstantValue, MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
 import { Immutable } from "@foxglove/studio";
@@ -33,6 +33,23 @@ export type ParsedMessageDefinitionsByTopic = {
 };
 
 export type TopicSelection = Map<string, SubscribePayload>;
+
+export type ComposedDefinitionsValue =
+  | ConstantValue
+  | ComposedDefinitions
+  | Array<ComposedDefinitions>;
+export type ComposedDefinitions = {
+  [key: string]: ComposedDefinitionsValue;
+};
+export type ServiceNameSchema = Map<
+  string,
+  {
+    requestSchema: string;
+    requestDefinitions: MessageDefinitionField[];
+    requestComposedDefinitions: ComposedDefinitions;
+    responseSchema: string;
+  }
+>;
 
 // A `Player` is a class that manages playback state. It manages subscriptions,
 // current time, which topics and datatypes are available, and so on.
@@ -187,6 +204,8 @@ export type PlayerStateActiveData = {
   // topic must refer to a datatype that is present in this list, every datatypes that refers to
   // another datatype must refer to a datatype that is present in this list).
   datatypes: RosDatatypes;
+
+  serviceNameSchema?: ServiceNameSchema;
 
   // A map of topic names to the set of publisher IDs publishing each topic.
   publishedTopics?: Map<string, Set<string>>;

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -282,6 +282,11 @@ export type PanelExtensionContext = {
    */
   readonly initialState: unknown;
 
+  /**
+     * Initial player state
+     */
+  readonly playerState: unknown;
+
   /** Actions the panel may perform related to the user's current layout. */
   readonly layout: LayoutActions;
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**

List all supported services

In the past, I needed to remember the service name and request before I could call the service correctly. But there are so many service names and requests that I can't remember them all. This feature can list all the service names supported by the currently connected robot. After the user selects a service name, the corresponding request prompt will appear. He only needs to modify the value to correctly call the service.


https://github.com/foxglove/studio/assets/23401125/03a6dbe3-ff7a-4707-95dc-e14cc8b58ffa


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
