### PR TITLE
Repair string references in the plot data worker

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -20,6 +20,7 @@ import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables"
 import { Topic, MessageEvent } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/enums";
+import { pack } from "@foxglove/studio-base/util/strPack";
 
 import { resolveTypedIndices } from "./datasets";
 import {
@@ -278,12 +279,12 @@ function unregister(id: string): void {
 }
 
 function receiveMetadata(topics: readonly Topic[], datatypes: Immutable<RosDatatypes>): void {
-  metadata = {
+  metadata = pack({
     topics,
     datatypes,
     enumValues: enumValuesByDatatypeAndField(datatypes),
     structures: messagePathStructures(datatypes),
-  };
+  });
 }
 
 function refreshClient(id: string) {
@@ -356,7 +357,7 @@ function addBlock(block: Messages, resetTopics: string[]): void {
     // Remove data for any topics that have been reset
     R.omit(resetTopics),
     // Merge the new block into the existing blocks
-    (newBlocks) => R.mergeWith(R.concat, newBlocks, block),
+    (newBlocks) => R.mergeWith(R.concat, newBlocks, pack(block)),
   )(blocks);
 
   for (const client of R.values(clients)) {

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -20,7 +20,7 @@ import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables"
 import { Topic, MessageEvent } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/enums";
-import { pack } from "@foxglove/studio-base/util/strPack";
+import strPack from "@foxglove/studio-base/util/strPack";
 
 import { resolveTypedIndices } from "./datasets";
 import {
@@ -279,7 +279,7 @@ function unregister(id: string): void {
 }
 
 function receiveMetadata(topics: readonly Topic[], datatypes: Immutable<RosDatatypes>): void {
-  metadata = pack({
+  metadata = strPack({
     topics,
     datatypes,
     enumValues: enumValuesByDatatypeAndField(datatypes),
@@ -357,7 +357,7 @@ function addBlock(block: Messages, resetTopics: string[]): void {
     // Remove data for any topics that have been reset
     R.omit(resetTopics),
     // Merge the new block into the existing blocks
-    (newBlocks) => R.mergeWith(R.concat, newBlocks, pack(block)),
+    (newBlocks) => R.mergeWith(R.concat, newBlocks, strPack(block)),
   )(blocks);
 
   for (const client of R.values(clients)) {

--- a/packages/studio-base/src/util/strPack.test.ts
+++ b/packages/studio-base/src/util/strPack.test.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { pack } from "./strPack";
+import strPack from "./strPack";
 
 describe("strPack", () => {
   it("rewrites an object", () => {
@@ -13,6 +13,6 @@ describe("strPack", () => {
       ok: ["ok"],
       map,
     };
-    expect(pack(before)).toEqual(before);
+    expect(strPack(before)).toEqual(before);
   });
 });

--- a/packages/studio-base/src/util/strPack.test.ts
+++ b/packages/studio-base/src/util/strPack.test.ts
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { pack } from "./strPack";
+
+describe("strPack", () => {
+  it("rewrites an object", () => {
+    const map = new Map<string, string>();
+    map.set("foo", "bar");
+    const before = {
+      test: 2,
+      ok: ["ok"],
+      map,
+    };
+    expect(pack(before)).toEqual(before);
+  });
+});

--- a/packages/studio-base/src/util/strPack.ts
+++ b/packages/studio-base/src/util/strPack.ts
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type Mapping = Record<string, string>;
+
+const packValue = (value: unknown, map: Mapping): unknown => {
+  if (value == undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((element) => packValue(element, map));
+  }
+
+  if (value instanceof Map) {
+    const transformed = new Map<string, unknown>();
+    for (const [key, otherValue] of value.entries()) {
+      const newKey = packValue(key, map);
+      if (typeof newKey !== "string") {
+        continue;
+      }
+      transformed.set(newKey, packValue(otherValue, map));
+    }
+    return transformed;
+  }
+
+  switch (typeof value) {
+    case "object": {
+      const transformed: Record<string, unknown> = {};
+      for (const [key, otherValue] of Object.entries(value)) {
+        const newKey = packValue(key, map);
+        if (typeof newKey !== "string") {
+          continue;
+        }
+        transformed[newKey] = packValue(otherValue, map);
+      }
+      return transformed;
+    }
+    case "string":
+      if (!(value in map)) {
+        map[value] = value;
+      }
+      // point all instances of the same string to the same reference
+      return map[value];
+    default:
+      return value;
+  }
+};
+
+export function pack<T>(data: T): T {
+  const map: Mapping = {};
+  return packValue(data, map) as T;
+}

--- a/packages/studio-base/src/util/strPack.ts
+++ b/packages/studio-base/src/util/strPack.ts
@@ -58,7 +58,7 @@ const packValue = (value: unknown, map: Mapping): unknown => {
  * useful to do after `postMessage()`, since `structuredClone()` duplicates
  * strings.
  */
-export function pack<T>(data: T): T {
+export default function strPack<T>(data: T): T {
   const map: Mapping = {};
   return packValue(data, map) as T;
 }

--- a/packages/studio-base/src/util/strPack.ts
+++ b/packages/studio-base/src/util/strPack.ts
@@ -25,6 +25,11 @@ const packValue = (value: unknown, map: Mapping): unknown => {
     return transformed;
   }
 
+  if (value instanceof Set) {
+    // we do not dedupe in sets for now
+    return value;
+  }
+
   switch (typeof value) {
     case "object": {
       const transformed: Record<string, unknown> = {};

--- a/packages/studio-base/src/util/strPack.ts
+++ b/packages/studio-base/src/util/strPack.ts
@@ -48,6 +48,11 @@ const packValue = (value: unknown, map: Mapping): unknown => {
   }
 };
 
+/**
+ * Deduplicate all string references in the given data structure. This is
+ * useful to do after `postMessage()`, since `structuredClone()` duplicates
+ * strings.
+ */
 export function pack<T>(data: T): T {
   const map: Mapping = {};
   return packValue(data, map) as T;


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
We were using a fair amount of memory storing multiple copies of strings in the plot worker, because `structuredClone()` creates new strings _for each reference_ to a string. This PR adds a new library (`strPack`) that combines references to identical strings.

It's not a perfect solution. I also did not touch anything in the main thread despite similar issues. But this attempt alone shaves off 20% of our memory usage in the worker, which is a pretty serious gain for what ultimately was not that much work.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
