### PR TITLE
Don't send partial datasets to main thread

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -452,8 +452,6 @@ function addCurrent(events: readonly MessageEvent[]): void {
     }
 
     const newData = buildPlot(params, newMessages);
-    client.addPartial?.(getProvidedData(newData));
-
     mutateClient(client.id, {
       ...client,
       current: {


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
This should fix the issue with plots flashing that we have seen in a couple of cases.

When working on plot optimizations I devised a strategy for live data playback wherein we would send current messages as quickly as possible to the plot renderer and then periodically downsample them. There was a bug where this was not happening correctly, but it turns out that the success of this strategy relies on the frequency of the data. If it's too high, `postMessage`ing every point as it arrives is too slow and we can't keep up with real time.

It seems that this behavior, though vestigial, can lead to the plots flashing under certain circumstances that I am unable to reproduce. For now, just disabling this does nothing untoward and since there are only two possible ways to render a new dataset, one we know is working and one probably isn't, it's fine to disable the latter until I can circle back on this when I make improvements to downsampling.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
