### PR TITLE
Test suite for plot worker state machine (just the tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 node_modules/
 storybook-screenshots/
 storybook-static/
+# for jest --coverage
+coverage/
 
 # Yarn
 .yarn/*

--- a/packages/studio-base/src/panels/Plot/processor/accumulate.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/accumulate.test.ts
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { getPathData } from "./accumulate";
+import { receiveMetadata } from "./messages";
+import { createState, createPath, FAKE_TOPICS, FAKE_PATH, FAKE_DATATYPES } from "./testing";
+
+describe("getPathData", () => {
+  it("ignores invalid path", () => {
+    const before = receiveMetadata(FAKE_TOPICS, FAKE_DATATYPES, createState(FAKE_PATH));
+    const pathData = getPathData(before.metadata, {}, {}, createPath("你好"));
+    expect(pathData).toEqual([]);
+  });
+});

--- a/packages/studio-base/src/panels/Plot/processor/clients.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/clients.test.ts
@@ -1,0 +1,265 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PlotViewport } from "@foxglove/studio-base/components/TimeBasedChart/types";
+
+import {
+  unregister,
+  compressClients,
+  MESSAGE_CULL_THRESHOLD,
+  register,
+  refreshClient,
+  receiveVariables,
+  updateParams,
+  updateView,
+  getClientData,
+} from "./clients";
+import { init, initClient, State, rebuildClient } from "./state";
+import {
+  FAKE_PATH,
+  CLIENT_ID,
+  createClient,
+  createData,
+  createPath,
+  createState,
+  createMessages,
+  createParams,
+} from "./testing";
+import { DatasetsByPath, PlotPath, TypedDataSet } from "../internalTypes";
+
+describe("refreshClient", () => {
+  it("ignores client without params", () => {
+    const client = initClient(CLIENT_ID, undefined);
+    const initial: State = { ...init(), clients: [client] };
+    const [newClient, effects] = refreshClient(client, initial);
+    expect(newClient).toEqual(client);
+    expect(effects).toEqual([]);
+  });
+
+  it("regenerates plots and triggers a rebuild", () => {
+    const initial = createState(FAKE_PATH);
+    const {
+      clients: [client],
+    } = initial;
+    if (client == undefined) {
+      throw new Error("client missing somehow");
+    }
+    const [newClient, effects] = refreshClient(client, initial);
+    expect(effects).toEqual([rebuildClient(client.id)]);
+    // we aren't testing accumulate(); just check whether the reference changed
+    expect(newClient.blocks).not.toBe(client.blocks);
+    expect(newClient.current).not.toBe(client.current);
+  });
+});
+
+describe("receiveVariables", () => {
+  const vars = {
+    foo: "bar",
+  };
+  it("does nothing when client does not use variables", () => {
+    const before = createState(FAKE_PATH);
+    const [after] = receiveVariables(vars, before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+  it("does nothing when client has no params", () => {
+    const client = initClient(CLIENT_ID, undefined);
+    const before: State = { ...init(), clients: [client] };
+    const [after] = receiveVariables(vars, before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+  it("does nothing when client has invalid path", () => {
+    const before = createState("你好");
+    const [after] = receiveVariables(vars, before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+  it("refreshes the client when it does use variables", () => {
+    const before = createState(`/topic.field[:]{id==$foo}`);
+    const [after, effects] = receiveVariables(vars, before);
+    expect(after.clients[0]).not.toBe(before.clients[0]);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+  });
+});
+
+describe("updateParams", () => {
+  it("ignores missing id", () => {
+    const before = createState();
+    const [after] = updateParams("123", createParams(), before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+  it("updates client", () => {
+    const before = createState("/foo.bar");
+    const params = createParams("/some.test");
+    const [after, effects] = updateParams(CLIENT_ID, params, before);
+    expect(after.clients[0]?.params).not.toEqual(before.clients[0]?.params);
+    expect(after.clients[0]?.topics).toEqual(["/some"]);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+  });
+});
+
+describe("updateView", () => {
+  const view: PlotViewport = {
+    width: 0,
+    height: 0,
+    bounds: {
+      x: { min: 0, max: 0 },
+      y: { min: 0, max: 0 },
+    },
+  };
+  it("ignores missing id", () => {
+    const before = createState();
+    const [after] = updateView("123", view, before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+  it("updates client", () => {
+    const before = createState("/foo.bar");
+    const [after, effects] = updateView(CLIENT_ID, view, before);
+    expect(after.clients[0]?.view).toEqual(view);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+  });
+});
+
+describe("register", () => {
+  it("ignores missing params", () => {
+    const [after, effects] = register(CLIENT_ID, undefined, init());
+    expect(after.clients.length).toEqual(1);
+    expect(effects).toEqual([]);
+  });
+  it("updates the client's params after registration", () => {
+    const [after, effects] = register(CLIENT_ID, createParams(FAKE_PATH), init());
+    expect(after.clients.length).toEqual(1);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+  });
+});
+
+describe("unregister", () => {
+  it("removes an existing client", () => {
+    const after = unregister(CLIENT_ID, createState());
+    expect(after.clients.length).toEqual(0);
+  });
+});
+
+describe("compressClients", () => {
+  it("does nothing if not live", () => {
+    const before = { ...createState(), isLive: false };
+    const [after, effects] = compressClients(before);
+    expect(effects.length).toEqual(0);
+    expect(after).toEqual(before);
+  });
+  it("removes excess current messages", () => {
+    const before = {
+      ...createState("/foo.data"),
+      isLive: true,
+      current: createMessages("/foo", "foo", MESSAGE_CULL_THRESHOLD + 1),
+    };
+    const [after, effects] = compressClients(before);
+    expect(after.current["/foo"]?.length).toEqual(MESSAGE_CULL_THRESHOLD);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+  });
+  it("does not remove messages < MESSAGE_CULL_THRESHOLD", () => {
+    const before = {
+      ...createState("/foo.data"),
+      isLive: true,
+      current: createMessages("/foo", "foo", MESSAGE_CULL_THRESHOLD - 1),
+    };
+    const [after, effects] = compressClients(before);
+    expect(after.current["/foo"]?.length).toEqual(MESSAGE_CULL_THRESHOLD - 1);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+  });
+});
+
+describe("getClientData", () => {
+  it("returns undefined if no params or view", () => {
+    expect(getClientData({ ...createClient(), view: undefined })).toEqual(undefined);
+  });
+
+  const getDataset = (datasets: DatasetsByPath | undefined): TypedDataSet | undefined => {
+    if (datasets == undefined) {
+      return undefined;
+    }
+
+    const first: PlotPath | undefined = datasets.keys().next().value;
+    if (first == undefined) {
+      return undefined;
+    }
+    return datasets.get(first);
+  };
+  it("returns only block data if block contains current", () => {
+    const initialClient = createClient(FAKE_PATH);
+    const path = createPath(FAKE_PATH);
+    const client = {
+      ...initialClient,
+      params: createParams(FAKE_PATH),
+      view: {
+        width: 0,
+        height: 0,
+        bounds: {
+          x: { min: 0, max: 0 },
+          y: { min: 0, max: 0 },
+        },
+      },
+      blocks: {
+        ...initialClient.blocks,
+        data: {
+          ...createData(path, 1),
+          bounds: {
+            x: { min: 0, max: 10 },
+            y: { min: 0, max: 0 },
+          },
+        },
+      },
+      current: {
+        ...initialClient.current,
+        data: {
+          ...createData(path, 2),
+          bounds: {
+            x: { min: 2, max: 8 },
+            y: { min: 0, max: 0 },
+          },
+        },
+      },
+    };
+    const result = getClientData(client);
+    expect(getDataset(result?.datasets)?.data.length).toEqual(1);
+  });
+  it("returns both kinds of data if they do not overlap", () => {
+    const initialClient = createClient(FAKE_PATH);
+    const path = createPath(FAKE_PATH);
+    const client = {
+      ...initialClient,
+      params: createParams(FAKE_PATH),
+      view: {
+        width: 0,
+        height: 0,
+        bounds: {
+          x: { min: 0, max: 0 },
+          y: { min: 0, max: 0 },
+        },
+      },
+      blocks: {
+        ...initialClient.blocks,
+        data: {
+          ...createData(path, 1),
+          bounds: {
+            x: { min: 0, max: 2 },
+            y: { min: 0, max: 0 },
+          },
+        },
+      },
+      current: {
+        ...initialClient.current,
+        data: {
+          ...createData(path, 2),
+          bounds: {
+            x: { min: 4, max: 8 },
+            y: { min: 0, max: 0 },
+          },
+        },
+      },
+    };
+    const result = getClientData(client);
+    // there are 3 slices because mergeTyped adds a slice with NaN to cause a
+    // split in the line
+    expect(getDataset(result?.datasets)?.data.length).toEqual(3);
+  });
+});

--- a/packages/studio-base/src/panels/Plot/processor/clients.ts
+++ b/packages/studio-base/src/panels/Plot/processor/clients.ts
@@ -141,7 +141,7 @@ export function unregister(id: string, state: State): State {
   });
 }
 
-const MESSAGE_CULL_THRESHOLD = 15_000;
+export const MESSAGE_CULL_THRESHOLD = 15_000;
 
 export function compressClients(state: State): StateAndEffects {
   const { isLive, current } = state;

--- a/packages/studio-base/src/panels/Plot/processor/messages.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/messages.test.ts
@@ -43,9 +43,7 @@ describe("addBlock", () => {
   it("resets the requested topics", () => {
     const [after] = addBlock({}, [FAKE_TOPIC], {
       ...init(),
-      blocks: {
-        [FAKE_TOPIC]: [],
-      },
+      blocks: createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1),
     });
     expect(Object.entries(after.blocks).length).toEqual(0);
   });

--- a/packages/studio-base/src/panels/Plot/processor/messages.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/messages.test.ts
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { addBlock, addCurrent, receiveMetadata, evictCache, clearCurrent } from "./messages";
+import { init, rebuildClient, SideEffectType, State } from "./state";
+import {
+  createParams,
+  createClient,
+  createMessages,
+  createMessageEvents,
+  createState,
+  FAKE_PATH,
+  CLIENT_ID,
+  FAKE_TOPIC,
+  FAKE_TOPICS,
+  FAKE_DATATYPES,
+  FAKE_SCHEMA,
+} from "./testing";
+import { EmptyPlotData } from "../plotData";
+
+describe("receiveMetadata", () => {
+  it("updates metadata", () => {
+    const before = init();
+    const after = receiveMetadata(FAKE_TOPICS, FAKE_DATATYPES, before);
+    expect(after.metadata).not.toEqual(before);
+  });
+});
+
+describe("evictCache", () => {
+  it("removes unused topics", () => {
+    const after = evictCache({
+      ...createState("/foo.bar"),
+      blocks: {
+        "/bar.baz": [],
+      },
+    });
+    expect(Object.entries(after.blocks).length).toEqual(0);
+  });
+});
+
+describe("addBlock", () => {
+  it("resets the requested topics", () => {
+    const [after] = addBlock({}, [FAKE_TOPIC], {
+      ...init(),
+      blocks: {
+        [FAKE_TOPIC]: [],
+      },
+    });
+    expect(Object.entries(after.blocks).length).toEqual(0);
+  });
+  it("concatenates messages", () => {
+    const [after] = addBlock(createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1), [], {
+      ...init(),
+      blocks: createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1),
+    });
+    expect(after.blocks[FAKE_TOPIC]?.length).toEqual(2);
+  });
+  it("ignores client without params", () => {
+    const before = {
+      ...init(),
+      clients: [createClient()],
+    };
+    const [after, effects] = addBlock({}, [], before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+    expect(effects.length).toEqual(0);
+  });
+  it("ignores client with single message params", () => {
+    const before: State = {
+      ...init(),
+      clients: [
+        {
+          ...createClient(),
+          params: {
+            ...createParams(FAKE_PATH),
+            xAxisVal: "index",
+          },
+        },
+      ],
+    };
+    const [after, effects] = addBlock({}, [], before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+    expect(effects.length).toEqual(0);
+  });
+  it("ignores client with no related topics", () => {
+    const before: State = createState("/bar.baz");
+    const [after, effects] = addBlock(createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1), [], before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+    expect(effects.length).toEqual(0);
+  });
+  it("builds plot data for client", () => {
+    const before: State = receiveMetadata(FAKE_TOPICS, FAKE_DATATYPES, createState(FAKE_PATH));
+    const [after, effects] = addBlock(createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1), [], before);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+    expect(after.clients[0]?.blocks).not.toEqual(before.clients[0]?.blocks);
+  });
+  it("clears out the plot data for a client", () => {
+    const before: State = receiveMetadata(FAKE_TOPICS, FAKE_DATATYPES, createState(FAKE_PATH));
+    const [after, effects] = addBlock(
+      createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1),
+      [FAKE_TOPIC],
+      before,
+    );
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+    expect(after.clients[0]?.blocks).not.toEqual(before.clients[0]?.blocks);
+    expect(after.clients[0]?.blocks.cursors?.[FAKE_TOPIC]).toEqual(1);
+  });
+});
+
+describe("addCurrent", () => {
+  it("concatenates messages", () => {
+    const [after] = addCurrent(createMessageEvents(FAKE_TOPIC, FAKE_SCHEMA, 1), {
+      ...createState(FAKE_PATH),
+      current: createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1),
+    });
+    expect(after.current[FAKE_TOPIC]?.length).toEqual(2);
+  });
+  it("ignores client without params", () => {
+    const before = {
+      ...init(),
+      clients: [createClient()],
+    };
+    const [after, effects] = addCurrent([], before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+    expect(effects.length).toEqual(0);
+  });
+  it("updates a client with single message plot", () => {
+    const before: State = {
+      ...init(),
+      clients: [
+        {
+          ...createClient(),
+          params: {
+            ...createParams(FAKE_PATH),
+            xAxisVal: "index",
+          },
+        },
+      ],
+    };
+    const [after, effects] = addCurrent(createMessageEvents(FAKE_TOPIC, FAKE_SCHEMA, 1), before);
+    expect(after.clients[0]).toEqual(before.clients[0]);
+    expect(effects.length).toEqual(1);
+    expect(effects[0]?.type).toEqual(SideEffectType.Data);
+  });
+  it("builds plot data for client", () => {
+    const before: State = receiveMetadata(FAKE_TOPICS, FAKE_DATATYPES, createState(FAKE_PATH));
+    const [after, effects] = addCurrent(createMessageEvents(FAKE_TOPIC, FAKE_SCHEMA, 1), before);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+    expect(after.clients[0]?.current).not.toEqual(before.clients[0]?.current);
+  });
+});
+
+describe("clearCurrent", () => {
+  it("clears existing client state", () => {
+    const [before] = addCurrent(
+      createMessageEvents(FAKE_TOPIC, FAKE_SCHEMA, 1),
+      createState(FAKE_PATH),
+    );
+    const [after, effects] = clearCurrent(before);
+    expect(effects).toEqual([rebuildClient(CLIENT_ID)]);
+    expect(after.clients[0]?.current).not.toEqual(before.clients[0]?.current);
+    expect(after.clients[0]?.current.data).toEqual(EmptyPlotData);
+  });
+});

--- a/packages/studio-base/src/panels/Plot/processor/state.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/state.test.ts
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { mutateClient, initClient } from "./state";
+import { createState } from "./testing";
+
+describe("mutateClient", () => {
+  it("ignores unrelated client", () => {
+    const before = createState();
+    const after = mutateClient(before, "test", {
+      ...initClient("test", undefined),
+    });
+    expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+});

--- a/packages/studio-base/src/panels/Plot/processor/state.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/state.test.ts
@@ -3,14 +3,19 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { mutateClient, initClient } from "./state";
-import { createState } from "./testing";
+import { createState, CLIENT_ID, FAKE_PATH } from "./testing";
 
 describe("mutateClient", () => {
   it("ignores unrelated client", () => {
     const before = createState();
-    const after = mutateClient(before, "test", {
-      ...initClient("test", undefined),
-    });
+    const after = mutateClient(before, "test", initClient("test", undefined));
     expect(after.clients[0]).toEqual(before.clients[0]);
+  });
+
+  it("updates a client", () => {
+    const before = createState(FAKE_PATH);
+    const client = initClient(CLIENT_ID, undefined);
+    const after = mutateClient(before, CLIENT_ID, client);
+    expect(after.clients[0]).toEqual(client);
   });
 });

--- a/packages/studio-base/src/panels/Plot/processor/testing.ts
+++ b/packages/studio-base/src/panels/Plot/processor/testing.ts
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as R from "ramda";
+
+import { fromSec } from "@foxglove/rostime";
+import { Immutable } from "@foxglove/studio";
+import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
+import { RosDatatypes, OptionalMessageDefinition } from "@foxglove/studio-base/types/RosDatatypes";
+
+import { initAccumulated } from "./accumulate";
+import { init, initClient, Client, State } from "./state";
+import { datumToTyped } from "../datasets";
+import { PlotParams, PlotPath, Messages, TypedDataSet } from "../internalTypes";
+import { getParamTopics } from "../params";
+import { PlotData } from "../plotData";
+
+export const CLIENT_ID = "foobar";
+export const FAKE_TOPIC = "/foo";
+export const FAKE_PATH = `${FAKE_TOPIC}.data`;
+export const FAKE_SCHEMA = "foo/Bar";
+export const FAKE_TOPICS: readonly Topic[] = [
+  {
+    name: FAKE_TOPIC,
+    schemaName: FAKE_SCHEMA,
+  },
+];
+export const FAKE_DATATYPES: Immutable<RosDatatypes> = new Map<
+  string,
+  OptionalMessageDefinition
+>().set(FAKE_SCHEMA, {
+  definitions: [{ name: "data", type: "float64", isArray: false }],
+});
+
+export const createMessageEvents = (
+  topic: string,
+  schemaName: string,
+  count: number,
+): MessageEvent[] =>
+  R.range(0, count).map(
+    (i): MessageEvent => ({
+      topic,
+      schemaName,
+      receiveTime: fromSec(i),
+      message: {
+        data: i,
+      },
+      sizeInBytes: 0,
+    }),
+  );
+
+export const createMessages = (topic: string, schemaName: string, count: number): Messages => ({
+  [topic]: createMessageEvents(topic, schemaName, count),
+});
+
+export const createPath = (path: string): PlotPath => ({
+  value: path,
+  enabled: true,
+  timestampMethod: "receiveTime",
+});
+
+/**
+ * Turn a list of signal paths into a full PlotParams.
+ */
+export const createParams = (...paths: string[]): PlotParams => ({
+  startTime: fromSec(0),
+  paths: paths.map(createPath),
+  invertedTheme: false,
+  xAxisVal: "timestamp",
+  followingViewWidth: undefined,
+  minXValue: undefined,
+  maxXValue: undefined,
+  minYValue: undefined,
+  maxYValue: undefined,
+});
+
+/**
+ * Initialize a PlotData with fake data for the given `path`.
+ */
+export const createData = (path: PlotPath, count: number): PlotData => {
+  const datasets = new Map<PlotPath, TypedDataSet>();
+  datasets.set(path, {
+    data: [
+      datumToTyped(
+        R.range(0, count).map((v) => ({
+          x: v,
+          y: v,
+          receiveTime: fromSec(v),
+        })),
+      ),
+    ],
+  });
+  return {
+    datasets,
+    bounds: {
+      x: { min: 0, max: 0 },
+      y: { min: 0, max: 0 },
+    },
+    pathsWithMismatchedDataLengths: [],
+  };
+};
+
+/**
+ * Create a Client that plots all of the given message paths.
+ */
+export const createClient = (...paths: string[]): Client => {
+  if (paths.length === 0) {
+    return initClient(CLIENT_ID, undefined);
+  }
+
+  const params = createParams(...paths);
+  const topics = getParamTopics(params);
+
+  return {
+    ...initClient(CLIENT_ID, undefined),
+    params,
+    topics,
+    blocks: initAccumulated(topics),
+    current: initAccumulated(topics),
+  };
+};
+
+/**
+ * Creates a State with a single Client that plots all of the given message
+ * paths.
+ */
+export const createState = (...paths: string[]): State => ({
+  ...init(),
+  clients: [createClient(...paths)],
+});


### PR DESCRIPTION
**User-Facing Changes**
None--see other PR.

**Description**
Adds tests for the plot worker state machine introduced in #6926.

Test coverage is comprehensive. The state machine itself (`clients.ts`, `messages.ts`, `state.ts`) has 100% coverage; getting `jest`'s numbers to be perfect is a little annoying so I won't bother with that for now.
<img width="548" alt="image" src="https://github.com/foxglove/studio/assets/4588553/da54b816-7df9-41a3-b956-9da98451fff4">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
