### PR TITLE
Better handling of block changes for user script data

### DIFF
--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -287,6 +287,11 @@ function useData(id: string, params: PlotParams) {
         // changed; we have to rebuild the plots
         if (existing != undefined && lastSent != undefined && index < lastSent) {
           resetData.add(payload.topic);
+
+          // clear out the status of all subsequent blocks for this ref
+          for (let i = index + 1; i < blockStatus.length; i++) {
+            blockStatus[i] = R.omit([ref], blockStatus[i]);
+          }
         }
 
         status[ref] = first;


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue where under certain circumstances, plots displayed user script messages incorrectly.

**Description**
User scripts can be nondeterministic (which makes complete sense) which can result in differences in block messages in unexpected ways. The mechanism for `useDatasets` to send new block data on to the worker did not account for this and assumed that if one block changed, all subsequent blocks would be changed, too, (and thus they would be sent to the worker) but this is not always true.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
