### PR TITLE
Improve Plot empty state

### DIFF
--- a/packages/studio-base/src/i18n/en/plot.ts
+++ b/packages/studio-base/src/i18n/en/plot.ts
@@ -5,6 +5,7 @@
 export const plot = {
   accumulatedPath: "Path (accumulated)",
   addSeries: "Add series",
+  clickToAddASeries: "Click to add a series",
   color: "Color",
   currentPath: "Path (current)",
   deleteSeries: "Delete series",

--- a/packages/studio-base/src/i18n/ja/plot.ts
+++ b/packages/studio-base/src/i18n/ja/plot.ts
@@ -7,6 +7,7 @@ import { TypeOptions } from "i18next";
 export const plot: Partial<TypeOptions["resources"]["plot"]> = {
   accumulatedPath: "パス（累積）",
   addSeries: "シリーズを追加する",
+  clickToAddASeries: undefined,
   color: "カラー",
   currentPath: "パス（現在）",
   deleteSeries: "シリーズを削除する",

--- a/packages/studio-base/src/i18n/zh/plot.ts
+++ b/packages/studio-base/src/i18n/zh/plot.ts
@@ -7,6 +7,7 @@ import { TypeOptions } from "i18next";
 export const plot: Partial<TypeOptions["resources"]["plot"]> = {
   accumulatedPath: "地址（累积）",
   addSeries: "添加数据系列",
+  clickToAddASeries: undefined,
   color: "颜色",
   currentPath: "地址（当前）",
   deleteSeries: "删除数据系列",

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -25,6 +25,7 @@ import { PlotConfig } from "@foxglove/studio-base/panels/Plot/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { TypedDataSet } from "./internalTypes";
+import { DEFAULT_PATH } from "./settings";
 
 const minLegendWidth = 25;
 const maxLegendWidth = 800;
@@ -251,7 +252,7 @@ function PlotLegendComponent(props: Props): JSX.Element {
             overflow={legendDisplay === "floating" ? "auto" : undefined}
           >
             <div className={classes.container}>
-              {paths.map((path, index) => (
+              {(paths.length === 0 ? [DEFAULT_PATH] : paths).map((path, index) => (
                 <PlotLegendRow
                   currentTime={currentTime}
                   datasets={datasets}

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -4,12 +4,14 @@
 
 import {
   Dismiss12Regular,
+  Add12Regular,
   ErrorCircle16Filled,
   Square12Filled,
   Square12Regular,
 } from "@fluentui/react-icons";
 import { ButtonBase, Checkbox, Tooltip, Typography } from "@mui/material";
 import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
 
@@ -136,6 +138,7 @@ export function PlotLegendRow({
   const { id: panelId } = usePanelContext();
   const { setSelectedPanelIds } = useSelectedPanels();
   const { classes, cx } = useStyles();
+  const { t } = useTranslation("plot");
 
   const correspondingData = useMemo(() => {
     if (!showPlotValuesInLegend) {
@@ -211,7 +214,7 @@ export function PlotLegendRow({
           variant="body2"
           className={cx({ [classes.disabledPathLabel]: !path.enabled })}
         >
-          {plotPathDisplayName(path, index)}
+          {index === paths.length ? t("clickToAddASeries") : plotPathDisplayName(path, index)}
         </Typography>
         {hasMismatchedDataLength && (
           <Tooltip
@@ -234,20 +237,31 @@ export function PlotLegendRow({
         </div>
       )}
       <div>
-        <ButtonBase
-          title="Delete series"
-          aria-label="Delete series"
-          className={classes.removeButton}
-          onClick={() => {
-            const newPaths = paths.slice();
-            if (newPaths.length > 0) {
-              newPaths.splice(index, 1);
-            }
-            savePaths(newPaths);
-          }}
-        >
-          <Dismiss12Regular />
-        </ButtonBase>
+        {index === paths.length ? (
+          <ButtonBase
+            title="Add series"
+            aria-label="Add series"
+            className={classes.removeButton}
+            onClick={onClickPath}
+          >
+            <Add12Regular />
+          </ButtonBase>
+        ) : (
+          <ButtonBase
+            title="Delete series"
+            aria-label="Delete series"
+            className={classes.removeButton}
+            onClick={() => {
+              const newPaths = paths.slice();
+              if (newPaths.length > 0) {
+                newPaths.splice(index, 1);
+              }
+              savePaths(newPaths);
+            }}
+          >
+            <Dismiss12Regular />
+          </ButtonBase>
+        )}
       </div>
     </div>
   );

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -170,6 +170,9 @@ export function PlotLegendRow({
     return value;
   }, [showPlotValuesInLegend, hoverValue?.value, currentTime, correspondingData]);
 
+  // When there are no series configured we render an extra row to show an "add series" button.
+  const isAddSeriesRow = index === paths.length;
+
   return (
     <div
       className={cx(classes.root, {
@@ -214,7 +217,7 @@ export function PlotLegendRow({
           variant="body2"
           className={cx({ [classes.disabledPathLabel]: !path.enabled })}
         >
-          {index === paths.length ? t("clickToAddASeries") : plotPathDisplayName(path, index)}
+          {isAddSeriesRow ? t("clickToAddASeries") : plotPathDisplayName(path, index)}
         </Typography>
         {hasMismatchedDataLength && (
           <Tooltip

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -171,7 +171,7 @@ export function PlotLegendRow({
   }, [showPlotValuesInLegend, hoverValue?.value, currentTime, correspondingData]);
 
   // When there are no series configured we render an extra row to show an "add series" button.
-  const isAddSeriesRow = index === paths.length;
+  const isAddSeriesRow = paths.length === 0;
 
   return (
     <div

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -396,6 +396,13 @@ export default {
   excludeStories: ["paths", "fixture"],
 };
 
+export const Empty: StoryObj = {
+  render: function Story() {
+    return <PlotWrapper includeSettings pauseFrame={() => () => {}} config={Plot.defaultConfig} />;
+  },
+  parameters: { colorScheme: "light" },
+};
+
 export const LineGraph: StoryObj = {
   render: function Story() {
     const readySignal = useReadySignal({ count: 3 });

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -128,11 +128,7 @@ function Plot(props: Props) {
         saveConfig((prevConfig) => ({
           ...prevConfig,
           paths: [
-            // If there was only a single series and its path was empty (the default state of the
-            // panel), replace the series rather than adding to it
-            ...(prevConfig.paths.length === 1 && prevConfig.paths[0]?.value === ""
-              ? []
-              : prevConfig.paths),
+            ...prevConfig.paths,
             ...paths.map((path) => ({
               value: path.path,
               enabled: true,
@@ -154,12 +150,6 @@ function Plot(props: Props) {
       } as Partial<PlotConfig>);
     }
   }, [customTitle, legacyTitle, saveConfig]);
-
-  useEffect(() => {
-    if (yAxisPaths.length === 0) {
-      saveConfig({ paths: [{ value: "", enabled: true, timestampMethod: "receiveTime" }] });
-    }
-  }, [saveConfig, yAxisPaths.length]);
 
   const startTime = useMessagePipeline(selectStartTime);
   const currentTime = useMessagePipeline(selectCurrentTime);
@@ -358,7 +348,7 @@ function Plot(props: Props) {
 }
 
 const defaultConfig: PlotConfig = {
-  paths: [{ value: "", enabled: true, timestampMethod: "receiveTime" }],
+  paths: [],
   minYValue: undefined,
   maxYValue: undefined,
   showXAxisLabels: true,

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -202,8 +202,6 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         saveConfig((prevConfig) => ({
           ...prevConfig,
           paths: [
-            // If there was only a single series and its path was empty (the default state of the
-            // panel), replace the series rather than adding to it
             ...prevConfig.paths,
             ...draggedPaths.map((path) => ({
               value: path.path,
@@ -461,7 +459,9 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
                   }}
                 >
                   <Typography variant="inherit" noWrap>
-                    {stateTransitionPathDisplayName(path, "Click to add a series")}
+                    {paths.length === 0
+                      ? "Click to add a series"
+                      : stateTransitionPathDisplayName(path, index)}
                   </Typography>
                 </Button>
               </div>

--- a/packages/studio-base/src/panels/StateTransitions/settings.ts
+++ b/packages/studio-base/src/panels/StateTransitions/settings.ts
@@ -36,7 +36,7 @@ const makeSeriesNode = memoizeWeak(
             },
           ]
         : [],
-      label: stateTransitionPathDisplayName(path, `Series ${index + 1}`),
+      label: stateTransitionPathDisplayName(path, index),
       fields: {
         value: {
           label: "Message path",

--- a/packages/studio-base/src/panels/StateTransitions/shared.ts
+++ b/packages/studio-base/src/panels/StateTransitions/shared.ts
@@ -19,7 +19,7 @@ function presence<T>(value: undefined | T): undefined | T {
 
 export function stateTransitionPathDisplayName(
   path: Readonly<StateTransitionPath>,
-  fallbackMessage: string,
+  index: number,
 ): string {
-  return presence(path.label) ?? presence(path.value) ?? fallbackMessage;
+  return presence(path.label) ?? presence(path.value) ?? `Series ${index + 1}`;
 }


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Basically the same as #6860, but for the Plot panel. Also includes some minor cleanup/fixes leftover from #6860.

- Improve the empty state so the panel doesn't just say "Series 1", but teaches you how to add a series.
- Hide the "X" delete button when there are no series configured.

<img width="665" alt="image" src="https://github.com/foxglove/studio/assets/14237/51518c5e-5d67-4890-9e16-31e5447563ca">
