### PR TITLE
Use actual point value instead of computed y coordinate in plot legend

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -162,9 +162,9 @@ export function PlotLegendRow({
       if (timeToCompare == undefined || pt.x > timeToCompare) {
         break;
       }
-      value = pt.y;
+      value = pt.value;
     }
-    return value;
+    return value?.toString();
   }, [showPlotValuesInLegend, hoverValue?.value, currentTime, correspondingData]);
 
   return (


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where values shown in the Plot legend were sometimes inaccurate.

**Description**
I'm not sure if this ever worked properly...
Fixes #6914
Fixes FG-5129