### PR TITLE
Fix state transition tooltip not showing label / path value

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -55,6 +55,9 @@ const useStyles = makeStyles()((theme) => ({
     height: 12,
     width: 12,
   },
+  colorIconReplacement: {
+    gridColumn: "1",
+  },
   path: {
     opacity: 0.9,
     whiteSpace: "nowrap",
@@ -151,7 +154,7 @@ export default function TimeBasedChartTooltipContent(
   return (
     <div className={cx(classes.root, classes.grid)} data-testid="TimeBasedChartTooltipContent">
       {sortedItems.map(([datasetIndex, item], idx) => {
-        const color = colorsByDatasetIndex?.[datasetIndex] ?? "auto";
+        const color = colorsByDatasetIndex?.[datasetIndex];
         const label = labelsByDatasetIndex?.[datasetIndex];
         const tooltip = item.tooltip;
         const value =
@@ -163,7 +166,11 @@ export default function TimeBasedChartTooltipContent(
 
         return (
           <Fragment key={idx}>
-            <Square12Filled className={classes.icon} primaryFill={color} />
+            {color ? (
+              <Square12Filled className={classes.icon} primaryFill={color} />
+            ) : (
+              <span className={classes.colorIconReplacement} />
+            )}
             <div className={classes.path}>{label ?? ""}</div>
             <div className={classes.value}>
               {value}

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -45,12 +45,12 @@ type Args = {
  * dataset with different labels and colors applied per-point.
  */
 export default function messagesToDatasets(args: Args): ChartDatasets {
-  const { path, pathIndex, startTime, y, blocks } = args;
+  const { path, startTime, y, blocks } = args;
 
   const dataset: ChartDataset = {
     borderWidth: 10,
     data: [],
-    label: pathIndex.toString(),
+    label: path.label ?? "" ? path.label : path.value,
     pointBackgroundColor: "rgba(0, 0, 0, 0.4)",
     pointBorderColor: "transparent",
     pointHoverRadius: 3,

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -50,7 +50,7 @@ export default function messagesToDatasets(args: Args): ChartDatasets {
   const dataset: ChartDataset = {
     borderWidth: 10,
     data: [],
-    label: path.label ?? "" ? path.label : path.value,
+    label: path.label ? path.label : path.value,
     pointBackgroundColor: "rgba(0, 0, 0, 0.4)",
     pointBorderColor: "transparent",
     pointHoverRadius: 3,


### PR DESCRIPTION
**User-Facing Changes**
Fix state transition tooltip not showing label / path value

**Description**
The tooltip was showing the stringified series index instead of the appropriate label / path value.

| Before                                                                                           | After (this PR)                                                                                  |
|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| ![image](https://github.com/foxglove/studio/assets/9250155/6ebfb6bc-cafd-4448-bfbc-688372c9f289) | ![image](https://github.com/foxglove/studio/assets/9250155/c42326fd-538f-4c76-955d-663004c59234) |