### PR TITLE
Maintain fields for preloading across user node input topics

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -652,7 +652,7 @@ describe("UserNodePlayer", () => {
       // the message the script will use.
       expect(fakePlayer.subscriptions).toEqual([
         { topic: "/np_input", preloadType: "full" },
-        { topic: "/np_input", preloadType: "partial" },
+        { topic: "/np_input" },
       ]);
     });
 

--- a/packages/studio-base/src/players/UserNodePlayer/subscriptions.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/subscriptions.test.ts
@@ -156,4 +156,32 @@ describe("remapVirtualSubscriptions", () => {
       },
     ]);
   });
+  it("should not coalesce sliced input subscriptions and whole message input subscriptions across preload types", () => {
+    const subscriptions: SubscribePayload[] = [
+      {
+        topic: "/output",
+        preloadType: "partial",
+      },
+      {
+        topic: "/input",
+        preloadType: "full",
+        fields: ["one", "two"],
+      },
+    ];
+    const inputsByOutputTopic = {
+      "/output": ["/input"],
+    };
+    const expected = [
+      {
+        topic: "/input",
+        preloadType: "full",
+        fields: ["one", "two"],
+      },
+      {
+        topic: "/input",
+        preloadType: "partial",
+      },
+    ];
+    expect(call(subscriptions, inputsByOutputTopic)).toEqual(expected);
+  });
 });

--- a/packages/studio-base/src/players/UserNodePlayer/subscriptions.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/subscriptions.ts
@@ -58,17 +58,6 @@ export function remapVirtualSubscriptions(
 
       // Leave the subscription unmodified if it is not a user script topic
       if (topics == undefined) {
-        // If this is an input to a user script, we need to upgrade it to a
-        // subscription of all the fields
-        // if (neededInputTopics.includes(subscription.topic)) {
-        //   return [
-        //     {
-        //       topic: subscription.topic,
-        //       preloadType,
-        //     },
-        //   ];
-        // }
-
         return [subscription];
       }
 

--- a/packages/studio-base/src/players/UserNodePlayer/subscriptions.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/subscriptions.ts
@@ -52,13 +52,6 @@ export function remapVirtualSubscriptions(
     R.filter(([, topics]: SubscriberInputs) => topics?.length !== 0),
   )(subscriptions);
 
-  // An array of all of the input topics used by the user nodes referenced by
-  // `subscriptions`
-  const neededInputTopics = R.pipe(
-    R.chain(([, v]: SubscriberInputs): readonly string[] => v ?? []),
-    R.uniq,
-  )(payloadInputsPairs);
-
   return R.pipe(
     R.chain(([subscription, topics]: SubscriberInputs): SubscribePayload[] => {
       const preloadType = subscription.preloadType ?? "partial";
@@ -67,14 +60,14 @@ export function remapVirtualSubscriptions(
       if (topics == undefined) {
         // If this is an input to a user script, we need to upgrade it to a
         // subscription of all the fields
-        if (neededInputTopics.includes(subscription.topic)) {
-          return [
-            {
-              topic: subscription.topic,
-              preloadType,
-            },
-          ];
-        }
+        // if (neededInputTopics.includes(subscription.topic)) {
+        //   return [
+        //     {
+        //       topic: subscription.topic,
+        //       preloadType,
+        //     },
+        //   ];
+        // }
 
         return [subscription];
       }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- n/a

**Description**
Maintains field slicing for preloaded input topics when output topic is not preloaded.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
