### PR TITLE
Remove vestiges of lazy message deserialization

### DIFF
--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -151,9 +151,6 @@ function typeForField(schema: SchemaT, field: FieldT): MessageDefinitionField[] 
 
 /**
  * Parse a flatbuffer binary schema and produce datatypes and a deserializer function.
- *
- * Note: Currently this does not support "lazy" message reading in the style of the ros1 message
- * reader, and so will relatively inefficiently deserialize the entire flatbuffer message.
  */
 export function parseFlatbufferSchema(
   schemaName: string,

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -28,7 +28,7 @@
     "@foxglove/log": "workspace:*",
     "@foxglove/mcap-support": "workspace:*",
     "@foxglove/message-definition": "0.3.0",
-    "@foxglove/ros1": "2.0.0",
+    "@foxglove/ros1": "3.0.0",
     "@foxglove/rosbag": "0.4.0",
     "@foxglove/rosbag2-web": "4.1.1",
     "@foxglove/roslibjs": "0.0.3",

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -225,27 +225,7 @@ function useData(id: string, params: PlotParams) {
     }, []),
     addMessages: React.useCallback(
       (_: number | undefined, messages: readonly MessageEvent[]): number => {
-        void service?.addCurrent(
-          messages.map((event) => {
-            const { message } = event;
-
-            // Handle LazyMessageReader messages, which cannot be
-            // `postMessage`d otherwise
-            // https://github.com/foxglove/rosmsg-serialization/blob/2c15caf4f344012737f5aab01103e3c525889f2e/src/__snapshots__/LazyMessageReader.test.ts.snap#L304
-            if (
-              typeof message === "object" &&
-              message != undefined &&
-              "toObject" in message &&
-              typeof message.toObject === "function"
-            ) {
-              return {
-                ...event,
-                message: (message as { toObject: () => unknown }).toObject(),
-              };
-            }
-            return event;
-          }),
-        );
+        void service?.addCurrent(messages);
         return 1;
       },
       [],

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -175,8 +175,7 @@ function Expander(info: CellContext<CellValue, unknown>) {
 }
 
 function getColumnsFromObject(val: CellValue, accessorPath: string) {
-  const obj = val.toJSON?.() ?? val;
-  if (isTypedArray(obj)) {
+  if (isTypedArray(val)) {
     return [
       columnHelper.accessor((row) => row, {
         id: "typedArray",
@@ -185,7 +184,7 @@ function getColumnsFromObject(val: CellValue, accessorPath: string) {
       }),
     ];
   }
-  const columns = Object.keys(obj).map((accessor) => {
+  const columns = Object.keys(val).map((accessor) => {
     const id = accessorPath.length !== 0 ? `${accessorPath}.${accessor}` : accessor;
     return columnHelper.accessor(accessor, {
       header: accessor,

--- a/packages/studio-base/src/panels/Table/types.ts
+++ b/packages/studio-base/src/panels/Table/types.ts
@@ -2,4 +2,4 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export type CellValue = { toJSON?: () => Record<string, unknown> };
+export type CellValue = Record<string, unknown>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/ObjectDetails.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/ObjectDetails.tsx
@@ -27,21 +27,11 @@ type Props = {
   readonly timezone: string | undefined;
 };
 
-function maybePlainObject(rawVal: unknown) {
-  if (typeof rawVal === "object" && rawVal && "toJSON" in rawVal) {
-    return (rawVal as { toJSON: () => unknown }).toJSON();
-  }
-  return rawVal;
-}
-
 function ObjectDetails({ interactionData, selectedObject, timezone }: Props): JSX.Element {
   const jsonTreeTheme = useJsonTreeTheme();
   const topic = interactionData?.topic ?? "";
 
-  // object to display may not be a plain-ole-data
-  // We need a plain object to sort the keys and omit interaction data
-  const plainObject = maybePlainObject(selectedObject);
-  const originalObject = _.omit(plainObject as Record<string, unknown>, "interactionData");
+  const originalObject = _.omit(selectedObject as Record<string, unknown>, "interactionData");
 
   if (topic.length === 0) {
     // show the original object directly if there is no interaction data
@@ -51,7 +41,6 @@ function ObjectDetails({ interactionData, selectedObject, timezone }: Props): JS
           data={selectedObject}
           shouldExpandNode={(_markerKeyPath, _data, level) => level < 2}
           invertTheme={false}
-          postprocessValue={maybePlainObject}
           theme={{ ...jsonTreeTheme, tree: { margin: 0 } }}
           hideRoot
         />
@@ -70,7 +59,6 @@ function ObjectDetails({ interactionData, selectedObject, timezone }: Props): JS
         getItemString={(nodeType, data, itemType, itemString, keyPath) =>
           getItemString(nodeType, data, itemType, itemString, keyPath, timezone)
         }
-        postprocessValue={maybePlainObject}
         labelRenderer={(markerKeyPath, _p1, _p2, _hasChildren) => {
           const label = _.first(markerKeyPath);
           return <span style={{ padding: "0 4px 0 0" }}>{label}</span>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -402,11 +402,9 @@ export function ThreeDeeRender(props: {
         setParameters(renderState.parameters);
 
         // currentFrame has messages on subscribed topics since the last render call
-        deepParseMessageEvents(renderState.currentFrame);
         setCurrentFrameMessages(renderState.currentFrame);
 
         // allFrames has messages on preloaded topics across all frames (as they are loaded)
-        deepParseMessageEvents(renderState.allFrames);
         setAllFrames(renderState.allFrames);
       });
     };
@@ -824,16 +822,4 @@ export function ThreeDeeRender(props: {
       </div>
     </ThemeProvider>
   );
-}
-
-function deepParseMessageEvents(messageEvents: ReadonlyArray<MessageEvent> | undefined): void {
-  if (!messageEvents) {
-    return;
-  }
-  for (const messageEvent of messageEvents) {
-    const maybeLazy = messageEvent.message as { toJSON?: () => unknown };
-    if ("toJSON" in maybeLazy) {
-      (messageEvent as { message: unknown }).message = maybeLazy.toJSON!();
-    }
-  }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/normalizeAnnotations.ts
@@ -205,16 +205,7 @@ function normalizeRosImageMarker(
   return undefined;
 }
 
-function toPOD(message: unknown): unknown {
-  return "toJSON" in (message as object)
-    ? (message as { toJSON: () => unknown }).toJSON()
-    : message;
-}
-
-function normalizeAnnotations(maybeLazyMessage: unknown, datatype: string): Annotation[] {
-  // The panel may send the annotations to a web worker, for this we need
-  const message = toPOD(maybeLazyMessage);
-
+function normalizeAnnotations(message: unknown, datatype: string): Annotation[] {
   // Cast to the union of all supported datatypes to ensure we handle all cases
   switch (datatype as (typeof ANNOTATION_DATATYPES)[number]) {
     // single marker

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -19,7 +19,7 @@ import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
 import roslib from "@foxglove/roslibjs";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
-import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
+import { MessageReader as ROS1MessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
 import { Time, fromMillis, toSec } from "@foxglove/rostime";
 import { ParameterValue } from "@foxglove/studio";
@@ -96,7 +96,7 @@ export default class RosbridgePlayer implements Player {
   #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
   #services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
   #messageReadersByDatatype: {
-    [datatype: string]: LazyMessageReader | ROS2MessageReader;
+    [datatype: string]: ROS1MessageReader | ROS2MessageReader;
   } = {};
   #start?: Time; // The time at which we started playing.
   #clockTime?: Time; // The most recent published `/clock` time, if available
@@ -248,7 +248,7 @@ export default class RosbridgePlayer implements Player {
       const topicsMissingDatatypes: string[] = [];
       const topics: TopicWithSchemaName[] = [];
       const datatypeDescriptions = [];
-      const messageReaders: Record<string, LazyMessageReader | ROS2MessageReader> = {};
+      const messageReaders: Record<string, ROS1MessageReader | ROS2MessageReader> = {};
 
       // Automatically detect the ROS version based on the datatypes.
       // The rosbridge server itself publishes /rosout so the topic should be reliably present.
@@ -284,7 +284,7 @@ export default class RosbridgePlayer implements Player {
         if (!messageReaders[type]) {
           messageReaders[type] =
             this.#rosVersion !== 2
-              ? new LazyMessageReader(parsedDefinition)
+              ? new ROS1MessageReader(parsedDefinition)
               : new ROS2MessageReader(parsedDefinition);
         }
       }
@@ -486,23 +486,6 @@ export default class RosbridgePlayer implements Player {
         try {
           const buffer = (message as { bytes: ArrayBuffer }).bytes;
           const bytes = new Uint8Array(buffer);
-
-          // This conditional can be removed when the ROS2 deserializer supports size()
-          if (messageReader instanceof LazyMessageReader) {
-            const msgSize = messageReader.size(bytes);
-            if (msgSize > bytes.byteLength) {
-              this.#problems.addProblem(problemId, {
-                severity: "error",
-                message: `Message buffer not large enough on ${topicName}`,
-                error: new Error(
-                  `Cannot read ${msgSize} byte message from ${bytes.byteLength} byte buffer`,
-                ),
-              });
-              this.#emitState();
-              return;
-            }
-          }
-
           const innerMessage = messageReader.readMessage(bytes);
 
           // handle clock messages before choosing receiveTime so the clock can set its own receive time

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -83,13 +83,6 @@ type NodeRegistrationCacheItem = {
   result: NodeRegistration;
 };
 
-function maybePlainObject(rawVal: unknown) {
-  if (typeof rawVal === "object" && rawVal && "toJSON" in rawVal) {
-    return (rawVal as { toJSON: () => unknown }).toJSON();
-  }
-  return rawVal;
-}
-
 /** Mutable state protected by a mutex lock */
 type ProtectedState = {
   nodeRegistrationCache: NodeRegistrationCacheItem[];
@@ -513,14 +506,11 @@ export default class UserNodePlayer implements Player {
           this.#addUserNodeLogs(nodeId, userNodeLogs);
         }
 
-        // To send the message over RPC we need to send a plain JS object. We invoke
-        // maybePlainObject which calls toJSON on the message and builds a plain js object of the
-        // entire message.
         const result = await rpc.send<ProcessMessageOutput>("processMessage", {
           message: {
             topic: msgEvent.topic,
             receiveTime: msgEvent.receiveTime,
-            message: maybePlainObject(msgEvent.message),
+            message: msgEvent.message,
             datatype: msgEvent.schemaName,
           },
           globalVariables,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,9 +2551,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ros1@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@foxglove/ros1@npm:2.0.0"
+"@foxglove/ros1@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@foxglove/ros1@npm:3.0.0"
   dependencies:
     "@foxglove/message-definition": ^0.2.0
     "@foxglove/rosmsg": ^4.0.0
@@ -2563,7 +2563,7 @@ __metadata:
     ipaddr.js: ^2.0.1
   bin:
     roscore: dist/nodejs/roscore.js
-  checksum: 87ba6c9749888ba2445575ae54efc0f042c917b439a56e31d1743f3b7e9d151754c1575e06fefc7b8e5fda5bbff52585e23d80bf7336582030bbb0a5140d7d44
+  checksum: 8fc81db65d042339302653e15ee3cde11ded6adc7ab2535da977c96cadbc3e15d26f4e000475b146dbb155c5347d751b8deb76fcda577b1b1f70d3fe043219cb
   languageName: node
   linkType: hard
 
@@ -2709,7 +2709,7 @@ __metadata:
     "@foxglove/log": "workspace:*"
     "@foxglove/mcap-support": "workspace:*"
     "@foxglove/message-definition": 0.3.0
-    "@foxglove/ros1": 2.0.0
+    "@foxglove/ros1": 3.0.0
     "@foxglove/rosbag": 0.4.0
     "@foxglove/rosbag2-web": 4.1.1
     "@foxglove/roslibjs": 0.0.3


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Depends on https://github.com/foxglove/ros1/pull/29
Resolves FG-5044

The ROS 1 native and Rosbridge sources were the only places using "lazy" message reading, which required a `toJSON` dance before sending messages to workers. There are several places we can remove this if we stop using lazy message reading.

Before merge:
- [x] Update `@foxglove/ros1` dependency