### PR TITLE
Move chromatic token into secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,13 @@ jobs:
 
       - run: yarn workspace @foxglove/studio-base run storybook:build
 
-      # Chromatic only runs on pushes or pulls to our source repo
       - uses: chromaui/action@v1
-        if: ${{ github.event.repository.full_name == 'foxglove/studio' }}
         with:
-          projectToken: f50040a29fb8
-          storybookBuildDir: storybook-static
           autoAcceptChanges: main
           exitOnceUploaded: true
           onlyChanged: true
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          storybookBuildDir: storybook-static
 
   integration:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
In the past, Github didn't let Dependabot access secrets at all. This meant that we could not run Chromatic on Dependabot PRs. We solved this by putting the Chromatic project token in the source code. This is ok; it's not particularly secret, but it required a slight hack to discourage people from using our Chromatic token on their own forks.

At some point Github added the ability to [expose individual secrets to Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#adding-a-repository-secret-for-dependabot). This PR updates Studio to use a secret for the Chromatic project token, and removes the previous workaround used to prevent forks submitting to Chromatic.