### PR TITLE
Fix user scripts bottom bar not expanding when clicking a tab

### DIFF
--- a/packages/studio-base/src/panels/UserScriptEditor/index.tsx
+++ b/packages/studio-base/src/panels/UserScriptEditor/index.tsx
@@ -397,7 +397,7 @@ function UserScriptEditor(props: Props) {
             </Stack>
           )}
 
-          <PanelGroup direction="vertical" units="pixels">
+          <PanelGroup direction="vertical" units="percentages">
             {selectedNodeId == undefined && <WelcomeScreen addNewNode={addNewNode} />}
             <ResizablePanel>
               <Suspense
@@ -434,9 +434,9 @@ function UserScriptEditor(props: Props) {
             <PanelResizeHandle className={classes.resizeHandle} />
             <ResizablePanel
               collapsible
-              minSize={38}
-              collapsedSize={38}
-              defaultSize={38}
+              collapsedSize={0}
+              defaultSize={30}
+              style={{ minHeight: "38px" }}
               ref={bottomBarRef}
             >
               <BottomBar


### PR DESCRIPTION
**User-Facing Changes**
Not worth being mentioned in release notes

**Description**
When clicking a tab of the collapsed bottom bar in the user scripts panel, the bottom bar does not expand (see FG-5998 for a screencast). This is due to a [bug](https://github.com/bvaughn/react-resizable-panels/issues/194) in the underlying `react-resizable-panels` library. This patch mitigates this issue by using `percentages` as units which makes the expanding behavior work but comes with the following drawbacks:
- The bottom bar is by default expanded to 30% of the panel's content
- The bottom bars default size is relative, meaning that for a very small user script panel it is not obvious that the bottom bar can be expanded.

[Screencast from 05.10.2023 13:14:54.webm](https://github.com/foxglove/studio/assets/9250155/437c7b38-432f-433a-9a58-7c0e4942e484)

Resolves FG-5998
