### PR TITLE
Generalized fix for sending block data to plot worker

### DIFF
--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -42,12 +42,56 @@ describe("refreshBlockTopics", () => {
   });
 });
 
+// This functionality is far more complex than it appears at first glance and
+// it is worth documenting why this is the case here rather than in some
+// external document that will probably not be updated.
+//
+// I came up with a concise way of describing this problem to make the state
+// machine's behavior easier to understand. Message blocks can be represented
+// as a 1D array of cells, each of which can be in one of four states:
+// s = same
+// c = changed
+// n = new
+// e = empty
+//
+// Blocks are accumulated and sent using a cursor system, here represented by
+// the pipe character ("|"). This indicates that all of the data prior to the
+// cursor has been sent.
+//
+// For example:
+// ssss|nnneee
+// |    |  |
+// |    |  empty data that has not been loaded
+// |    new data
+// unchanged
+//
+// processBlocks does the following:
+// * moves the cursor forward according to a set of rules and returns the new
+//   data as a set of bundles that can be forwarded to the plot worker
+// * indicates whether the existing data already sent should be cleared
+// * stores the first message of each block that was sent so we can detect
+//   changed blocks
+//
+// In this case, processBlocks would return a new state that looks like this:
+// sssssss|eee
+//
+// In instances where the data should be cleared, we append an asterisk ("*")
+// to the end of the state string.
+//
+// Some examples:
+// ssss|nnneee -> sssssss|eee (data accumulating normally)
+// s|nene -> sses|e (skipping empty data)
+// cs|nnneee -> s|snnneee* (a block was changed before the cursor)
+// sss|ccsss -> sssss|sss (a block was changed after the cursor)
+//
+// We use this system for describing each test case.
 describe("processBlocks", () => {
   const subscriptions: SubscribePayload[] = [createSubscription(FAKE_TOPIC)];
   const initial = refreshBlockTopics(subscriptions, initBlockState());
   const block = createBlock(1);
 
   it("should send data as it arrives", () => {
+    // |ne -> s|e
     const first = processBlocks([block, {}], subscriptions, initial);
     {
       const {
@@ -61,6 +105,7 @@ describe("processBlocks", () => {
       expect(newData).toEqual([block]);
     }
 
+    // s|n -> ss|
     const second = processBlocks([block, block], subscriptions, first.state);
     {
       const {
@@ -76,6 +121,7 @@ describe("processBlocks", () => {
   });
 
   it("should skip empty blocks", () => {
+    // |nene -> ses|e
     const {
       state: { messages, cursors },
       resetTopics,
@@ -91,9 +137,11 @@ describe("processBlocks", () => {
     const newBlock = createBlock(2);
 
     // we have loaded a full range of data
+    // |nnn -> sss|
     const before = processBlocks([block, block, block], subscriptions, initial);
 
     // change some of it
+    // ccs| -> ss|s
     const first = processBlocks([newBlock, newBlock, block], subscriptions, before.state);
     {
       const {
@@ -107,6 +155,7 @@ describe("processBlocks", () => {
       expect(newData).toEqual([newBlock, newBlock]);
     }
 
+    // ss|c -> sss|
     const second = processBlocks([newBlock, newBlock, newBlock], subscriptions, first.state);
     {
       const {
@@ -124,8 +173,10 @@ describe("processBlocks", () => {
   it("should resend all data up to and including change if there is a change in the middle", () => {
     const newBlock = createBlock(2);
 
+    // |nnn -> sss|
     const before = processBlocks([block, block, block], subscriptions, initial);
 
+    // scs| -> ss|s*
     const first = processBlocks([block, newBlock, block], subscriptions, before.state);
     {
       const {
@@ -140,6 +191,7 @@ describe("processBlocks", () => {
     }
 
     // if we get new blocks but there were no more changes, just send the rest
+    // ss|s -> sss|
     const second = processBlocks([block, newBlock, block], subscriptions, first.state);
     {
       const {

--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksSubscriptions";
+import { SubscribePayload } from "@foxglove/studio-base/players/types";
+import { initBlockState, processBlocks, refreshBlockTopics } from "./blocks";
+import { fromSec } from "@foxglove/rostime";
+
+const FAKE_TOPIC = "/foo";
+const createSubscription = (topic: string): SubscribePayload => ({
+  topic,
+});
+
+const createBlock = (topic: string, value: unknown): MessageBlock => ({
+  [topic]: [
+    {
+      topic,
+      schemaName: "",
+      sizeInBytes: 0,
+      message: value,
+      receiveTime: fromSec(0),
+    },
+  ],
+});
+
+describe("refreshBlockTopics", () => {
+  it("should clear out unused topics and add new ones", () => {
+    const { messages, cursors } = refreshBlockTopics([createSubscription(FAKE_TOPIC)], {
+      messages: [
+        {
+          "/bar": "baz",
+        },
+      ],
+      cursors: {
+        "/bar": 0,
+      },
+    });
+    expect(messages).toEqual([{ [FAKE_TOPIC]: undefined }]);
+    expect(cursors).toEqual({ [FAKE_TOPIC]: 0 });
+  });
+});
+
+describe("processBlocks", () => {
+  const subscriptions: SubscribePayload[] = [createSubscription(FAKE_TOPIC)];
+  const initial = refreshBlockTopics(subscriptions, initBlockState());
+
+  it("should send data as it arrives", () => {
+    const block = createBlock(FAKE_TOPIC, 1);
+    const first = processBlocks([block, {}], subscriptions, initial);
+    {
+      const {
+        state: { messages, cursors },
+        resetTopics,
+        newData,
+      } = first;
+      expect(messages[0]?.[FAKE_TOPIC]).toEqual(1);
+      expect(cursors[FAKE_TOPIC]).toEqual(1);
+      expect(resetTopics).toEqual([]);
+      expect(newData).toEqual([
+        {
+          [FAKE_TOPIC]: block[FAKE_TOPIC],
+        },
+      ]);
+    }
+
+    const second = processBlocks([block, block], subscriptions, first.state);
+    {
+      const {
+        state: { messages, cursors },
+        resetTopics,
+        newData,
+      } = second;
+      expect(messages[1]?.[FAKE_TOPIC]).toEqual(1);
+      expect(cursors[FAKE_TOPIC]).toEqual(2);
+      expect(resetTopics).toEqual([]);
+      expect(newData).toEqual([
+        {
+          [FAKE_TOPIC]: block[FAKE_TOPIC],
+        },
+      ]);
+    }
+  });
+});

--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -87,14 +87,13 @@ describe("processBlocks", () => {
     expect(newData).toEqual([block, block]);
   });
 
-  it("should not send data beyond changed data if change is from beginning", () => {
+  it("should not send data beyond changed data", () => {
     const newBlock = createBlock(2);
 
     // we have loaded a full range of data
     const before = processBlocks([block, block, block], subscriptions, initial);
 
-    // suddenly we get new data starting from the beginning, which we take to
-    // mean that all of the subsequent data will change, too
+    // change some of it
     const first = processBlocks([newBlock, newBlock, block], subscriptions, before.state);
     {
       const {
@@ -122,7 +121,7 @@ describe("processBlocks", () => {
     }
   });
 
-  it("should resend all data if there is a change in the middle", () => {
+  it("should resend all data up to and including change if there is a change in the middle", () => {
     const newBlock = createBlock(2);
 
     const before = processBlocks([block, block, block], subscriptions, initial);
@@ -134,9 +133,9 @@ describe("processBlocks", () => {
         newData,
       } = after;
       expect(messages[1]?.[FAKE_TOPIC]).toEqual(2);
-      expect(cursors[FAKE_TOPIC]).toEqual(3);
+      expect(cursors[FAKE_TOPIC]).toEqual(2);
       expect(resetTopics).toEqual([FAKE_TOPIC]);
-      expect(newData).toEqual([block, newBlock, block]);
+      expect(newData).toEqual([block, newBlock]);
     }
   });
 });

--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -2,10 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { fromSec } from "@foxglove/rostime";
 import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksSubscriptions";
 import { SubscribePayload } from "@foxglove/studio-base/players/types";
+
 import { initBlockState, processBlocks, refreshBlockTopics } from "./blocks";
-import { fromSec } from "@foxglove/rostime";
 
 const FAKE_TOPIC = "/foo";
 const createSubscription = (topic: string): SubscribePayload => ({
@@ -72,6 +73,18 @@ describe("processBlocks", () => {
       expect(resetTopics).toEqual([]);
       expect(newData).toEqual([block]);
     }
+  });
+
+  it("should skip empty blocks", () => {
+    const {
+      state: { messages, cursors },
+      resetTopics,
+      newData,
+    } = processBlocks([block, {}, block, {}], subscriptions, initial);
+    expect(messages[2]?.[FAKE_TOPIC]).toEqual(1);
+    expect(cursors[FAKE_TOPIC]).toEqual(3);
+    expect(resetTopics).toEqual([]);
+    expect(newData).toEqual([block, block]);
   });
 
   it("should not send data beyond changed data if change is from beginning", () => {

--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -12,10 +12,10 @@ const createSubscription = (topic: string): SubscribePayload => ({
   topic,
 });
 
-const createBlock = (topic: string, value: unknown): MessageBlock => ({
-  [topic]: [
+const createBlock = (value: unknown): MessageBlock => ({
+  [FAKE_TOPIC]: [
     {
-      topic,
+      topic: FAKE_TOPIC,
       schemaName: "",
       sizeInBytes: 0,
       message: value,
@@ -44,9 +44,9 @@ describe("refreshBlockTopics", () => {
 describe("processBlocks", () => {
   const subscriptions: SubscribePayload[] = [createSubscription(FAKE_TOPIC)];
   const initial = refreshBlockTopics(subscriptions, initBlockState());
+  const block = createBlock(1);
 
   it("should send data as it arrives", () => {
-    const block = createBlock(FAKE_TOPIC, 1);
     const first = processBlocks([block, {}], subscriptions, initial);
     {
       const {
@@ -57,11 +57,7 @@ describe("processBlocks", () => {
       expect(messages[0]?.[FAKE_TOPIC]).toEqual(1);
       expect(cursors[FAKE_TOPIC]).toEqual(1);
       expect(resetTopics).toEqual([]);
-      expect(newData).toEqual([
-        {
-          [FAKE_TOPIC]: block[FAKE_TOPIC],
-        },
-      ]);
+      expect(newData).toEqual([block]);
     }
 
     const second = processBlocks([block, block], subscriptions, first.state);
@@ -74,11 +70,60 @@ describe("processBlocks", () => {
       expect(messages[1]?.[FAKE_TOPIC]).toEqual(1);
       expect(cursors[FAKE_TOPIC]).toEqual(2);
       expect(resetTopics).toEqual([]);
-      expect(newData).toEqual([
-        {
-          [FAKE_TOPIC]: block[FAKE_TOPIC],
-        },
-      ]);
+      expect(newData).toEqual([block]);
+    }
+  });
+
+  it("should not send data beyond changed data if change is from beginning", () => {
+    const newBlock = createBlock(2);
+
+    // we have loaded a full range of data
+    const before = processBlocks([block, block, block], subscriptions, initial);
+
+    // suddenly we get new data starting from the beginning, which we take to
+    // mean that all of the subsequent data will change, too
+    const first = processBlocks([newBlock, newBlock, block], subscriptions, before.state);
+    {
+      const {
+        state: { messages, cursors },
+        resetTopics,
+        newData,
+      } = first;
+      expect(messages[1]?.[FAKE_TOPIC]).toEqual(2);
+      expect(cursors[FAKE_TOPIC]).toEqual(2);
+      expect(resetTopics).toEqual([FAKE_TOPIC]);
+      expect(newData).toEqual([newBlock, newBlock]);
+    }
+
+    const second = processBlocks([newBlock, newBlock, newBlock], subscriptions, first.state);
+    {
+      const {
+        state: { messages, cursors },
+        resetTopics,
+        newData,
+      } = second;
+      expect(messages[2]?.[FAKE_TOPIC]).toEqual(2);
+      expect(cursors[FAKE_TOPIC]).toEqual(3);
+      expect(resetTopics).toEqual([]);
+      expect(newData).toEqual([newBlock]);
+    }
+  });
+
+  it("should resend all data if there is a change in the middle", () => {
+    const newBlock = createBlock(2);
+
+    const before = processBlocks([block, block, block], subscriptions, initial);
+    const after = processBlocks([block, newBlock, block], subscriptions, before.state);
+    {
+      const {
+        state: { messages, cursors },
+        resetTopics,
+        newData,
+      } = after;
+      expect(messages[1]?.[FAKE_TOPIC]).toEqual(2);
+      expect(cursors[FAKE_TOPIC]).toEqual(3);
+      expect(resetTopics).toEqual([FAKE_TOPIC]);
+      expect(newData).toEqual([block, newBlock, block]);
     }
   });
 });

--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -125,17 +125,32 @@ describe("processBlocks", () => {
     const newBlock = createBlock(2);
 
     const before = processBlocks([block, block, block], subscriptions, initial);
-    const after = processBlocks([block, newBlock, block], subscriptions, before.state);
+
+    const first = processBlocks([block, newBlock, block], subscriptions, before.state);
     {
       const {
         state: { messages, cursors },
         resetTopics,
         newData,
-      } = after;
+      } = first;
       expect(messages[1]?.[FAKE_TOPIC]).toEqual(2);
       expect(cursors[FAKE_TOPIC]).toEqual(2);
       expect(resetTopics).toEqual([FAKE_TOPIC]);
       expect(newData).toEqual([block, newBlock]);
+    }
+
+    // if we get new blocks but there were no more changes, just send the rest
+    const second = processBlocks([block, newBlock, block], subscriptions, first.state);
+    {
+      const {
+        state: { messages, cursors },
+        resetTopics,
+        newData,
+      } = second;
+      expect(messages[2]?.[FAKE_TOPIC]).toEqual(1);
+      expect(cursors[FAKE_TOPIC]).toEqual(3);
+      expect(resetTopics).toEqual([]);
+      expect(newData).toEqual([block]);
     }
   });
 });

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -93,24 +93,18 @@ export function processBlocks(
         return !R.equals(oldFirst, block[topic]?.[0]?.message) && oldFirst != undefined;
       });
       const lastChanged = R.findLastIndex(R.identity, changes);
-      const haveChanged = lastChanged !== -1 && lastChanged < currentCursor;
+      const haveChanged = lastChanged !== -1;
 
-      if (!haveChanged) {
+      if (!haveChanged || lastChanged >= currentCursor) {
         return {
           topic,
-          range: [currentCursor, newCursor],
+          range: [currentCursor, haveChanged ? Math.min(newCursor, lastChanged + 1) : newCursor],
           shouldReset: false,
         };
       }
-
-      // if only a single block changed (not all of them from 0), which can
-      // happen with a non-deterministic user script, resend the loaded range.
-      // otherwise, the blocks on this topic are changing completely. this
-      // happens due to changes in message slicing and user scripts.
-      const didAllChange = R.all(R.identity, changes.slice(0, Math.max(0, lastChanged)));
       return {
         topic,
-        range: [0, didAllChange ? lastChanged + 1 : currentCursor],
+        range: [0, lastChanged + 1],
         shouldReset: true,
       };
     }),

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -80,12 +80,7 @@ export function processBlocks(
         }
 
         const oldFirst = status[topic];
-        const newFirst = topicMessages[0]?.message;
-        if (R.equals(oldFirst, newFirst)) {
-          return false;
-        }
-
-        return oldFirst != undefined;
+        return !R.equals(oldFirst, topicMessages[0]?.message) && oldFirst != undefined;
       }, blocksWithStatuses);
 
       const endCursor = lastChanged !== -1 ? lastChanged + 1 : currentCursor + newBlocks.length;
@@ -152,7 +147,6 @@ export function processBlocks(
 
   return {
     state: {
-      ...state,
       messages: newMessages,
       cursors: newCursors,
     },

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -64,6 +64,7 @@ export function processBlocks(
   const { cursors } = state;
   const messages: FirstMessages[] = blocks.map((_, i) => state.messages[i] ?? {});
   const blocksWithStatuses = R.zip(blocks, messages);
+
   const work: Work[] = R.pipe(
     R.map((v: SubscribePayload): [send: Range, shouldReset: boolean] => {
       const { topic } = v;
@@ -118,6 +119,7 @@ export function processBlocks(
     messages,
     work,
   );
+
   const newCursors = R.reduce(
     (a: Cursors, [{ topic }, [[, end]]]: Work): Cursors => ({
       ...a,
@@ -126,6 +128,7 @@ export function processBlocks(
     cursors,
     work,
   );
+
   const newData: Messages[] = R.pipe(
     R.reduce(
       (a: string[][], v: [SubscribePayload, [Range, boolean]]): string[][] => {
@@ -146,6 +149,7 @@ export function processBlocks(
     R.filter(([block, topics]) => !R.isEmpty(block) && topics.length > 0),
     R.map(([block, topics]) => R.pick(topics, block) as Messages),
   )(work);
+
   return {
     state: {
       ...state,

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -1,0 +1,158 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as R from "ramda";
+
+import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksSubscriptions";
+import { SubscribePayload } from "@foxglove/studio-base/players/types";
+import { Messages } from "./internalTypes";
+
+// We need to keep track of the block data we've already sent to the worker and
+// detect when it has changed, which can happen when the user changes a user
+// script or they trigger a subscription to different fields.
+// mapping from topic -> the first message on that topic in the block
+type FirstMessages = Record<string, unknown>;
+type Cursors = Record<string, number>;
+export type BlockState = {
+  // for each block, a mapping from topic -> the first message on that topic
+  messages: FirstMessages[];
+  // a mapping from topic -> the index of the last block we sent
+  cursors: Cursors;
+};
+
+export const initBlockState = (): BlockState => ({
+  messages: [],
+  cursors: {},
+});
+
+export function refreshBlockTopics(
+  subscriptions: SubscribePayload[],
+  state: BlockState,
+): BlockState {
+  const { cursors, messages } = state;
+  const topics = subscriptions.map((v) => v.topic);
+  return {
+    ...state,
+    messages: R.map(
+      (block) =>
+        R.pipe(
+          R.map((topic: string): [string, unknown] => [topic, block[topic]]),
+          R.fromPairs,
+        )(topics),
+      messages,
+    ),
+    cursors: R.pipe(
+      R.map((topic: string): [string, number] => [topic, cursors[topic] ?? 0]),
+      R.fromPairs,
+    )(topics),
+  };
+}
+
+type Range = [start: number, end: number];
+type Work = [SubscribePayload, [Range, boolean]];
+
+export function processBlocks(
+  blocks: readonly MessageBlock[],
+  subscriptions: SubscribePayload[],
+  state: BlockState,
+): {
+  state: BlockState;
+  resetTopics: string[];
+  newData: Messages[];
+} {
+  const { cursors } = state;
+  const messages: FirstMessages[] = blocks.map((_, i) => state.messages[i] ?? {});
+  const blocksWithStatuses = R.zip(blocks, messages);
+  const work: Work[] = R.pipe(
+    R.map((v: SubscribePayload): [send: Range, shouldReset: boolean] => {
+      const { topic } = v;
+      const currentCursor = cursors[topic] ?? 0;
+      const newBlocks = R.takeWhile(
+        (block) => block[topic] != undefined,
+        blocks.slice(currentCursor),
+      );
+      const lastChanged = R.findLastIndex(([block, status]) => {
+        const topicMessages = block[topic];
+        if (topicMessages == undefined) {
+          return false;
+        }
+
+        const oldFirst = status[topic];
+        const newFirst = topicMessages[0]?.message;
+        if (R.equals(oldFirst, newFirst)) {
+          return false;
+        }
+
+        return oldFirst != undefined;
+      }, blocksWithStatuses);
+
+      const endCursor = lastChanged !== -1 ? lastChanged + 1 : currentCursor + newBlocks.length;
+
+      if (lastChanged !== -1 && lastChanged < currentCursor) {
+        return [[0, endCursor], true];
+      }
+
+      return [[currentCursor, endCursor], false];
+    }),
+    R.zip(subscriptions),
+    // filter out any topics that neither changed nor had new data
+    R.filter(([, [[start, end], shouldReset]]) => shouldReset || start != end),
+  )(subscriptions);
+
+  const newMessages = R.reduce(
+    (a: FirstMessages[], work: Work) => {
+      const [{ topic }, [[start, end]]] = work;
+      return R.pipe(
+        (v: FirstMessages[]): [MessageBlock, FirstMessages][] => R.zip(blocks.slice(start, end), v),
+        R.map(
+          ([block, existing]: [MessageBlock, FirstMessages]): FirstMessages => ({
+            ...existing,
+            [topic]: block[topic]?.[0]?.message,
+          }),
+        ),
+        R.concat(a.slice(0, start)),
+        R.concat(R.__, a.slice(end)),
+      )(a.slice(start, end));
+    },
+    messages,
+    work,
+  );
+  const newCursors = R.reduce(
+    (a: Cursors, [{ topic }, [[, end]]]: Work): Cursors => ({
+      ...a,
+      [topic]: end,
+    }),
+    cursors,
+    work,
+  );
+  const newData: Messages[] = R.pipe(
+    R.reduce(
+      (a: string[][], v: [SubscribePayload, [Range, boolean]]): string[][] => {
+        const [{ topic }, [[start, end]]] = v;
+        for (let i = start; i < end; i++) {
+          const bucket = a[i];
+          if (bucket == undefined) {
+            continue;
+          }
+          bucket.push(topic);
+        }
+        return a;
+      },
+      blocks.map((): string[] => []),
+    ),
+    R.zip(blocks),
+    // remove all blocks that are empty or have no topics
+    R.filter(([block, topics]) => !R.isEmpty(block) && topics.length > 0),
+    R.map(([block, topics]) => R.pick(topics, block) as Messages),
+  )(work);
+  return {
+    state: {
+      ...state,
+      messages: newMessages,
+      cursors: newCursors,
+    },
+    resetTopics: R.chain(([{ topic }, [, shouldReset]]) => (shouldReset ? [topic] : []), work),
+    newData,
+  };
+}

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -27,6 +27,9 @@ export const initBlockState = (): BlockState => ({
   cursors: {},
 });
 
+/**
+ * Prune any topics not used by `subscriptions` from BlockState.
+ */
 export function refreshBlockTopics(
   subscriptions: SubscribePayload[],
   state: BlockState,
@@ -55,6 +58,10 @@ type Update = {
   shouldReset: boolean;
 };
 
+/**
+ * Inspect the state of `blocks` to determine what data needs to be sent to the
+ * plot worker.
+ */
 export function processBlocks(
   blocks: readonly MessageBlock[],
   subscriptions: SubscribePayload[],
@@ -122,6 +129,7 @@ export function processBlocks(
           }),
         ),
         R.concat(a.slice(0, start)),
+        // eslint-disable-next-line no-underscore-dangle
         R.concat(R.__, a.slice(end)),
       )(a.slice(start, end));
     },

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -6,6 +6,7 @@ import * as R from "ramda";
 
 import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksSubscriptions";
 import { SubscribePayload } from "@foxglove/studio-base/players/types";
+
 import { Messages } from "./internalTypes";
 
 // We need to keep track of the block data we've already sent to the worker and
@@ -34,13 +35,11 @@ export function refreshBlockTopics(
   const topics = subscriptions.map((v) => v.topic);
   return {
     ...state,
-    messages: R.map(
-      (block) =>
-        R.pipe(
-          R.map((topic: string): [string, unknown] => [topic, block[topic]]),
-          R.fromPairs,
-        )(topics),
-      messages,
+    messages: messages.map((block) =>
+      R.pipe(
+        R.map((topic: string): [string, unknown] => [topic, block[topic]]),
+        R.fromPairs,
+      )(topics),
     ),
     cursors: R.pipe(
       R.map((topic: string): [string, number] => [topic, cursors[topic] ?? 0]),
@@ -50,7 +49,11 @@ export function refreshBlockTopics(
 }
 
 type Range = [start: number, end: number];
-type Work = [SubscribePayload, [Range, boolean]];
+type Update = {
+  topic: string;
+  range: Range;
+  shouldReset: boolean;
+};
 
 export function processBlocks(
   blocks: readonly MessageBlock[],
@@ -65,44 +68,51 @@ export function processBlocks(
   const messages: FirstMessages[] = blocks.map((_, i) => state.messages[i] ?? {});
   const blocksWithStatuses = R.zip(blocks, messages);
 
-  const work: Work[] = R.pipe(
-    R.map((v: SubscribePayload): [send: Range, shouldReset: boolean] => {
+  const updates: Update[] = R.pipe(
+    R.map((v: SubscribePayload): Update => {
       const { topic } = v;
       const currentCursor = cursors[topic] ?? 0;
 
-      // find the last new block from the cursor to the end
+      // 1. check for any new, non-empty unsent blocks
       const lastNew = R.findLastIndex(
         (block) => block[topic] != undefined,
         blocks.slice(currentCursor),
       );
       const newCursor = lastNew === -1 ? currentCursor : lastNew + currentCursor + 1;
 
+      // 2. check whether any blocks below the current cursor have changed
       const changes = blocksWithStatuses.map(([block, status]) => {
         const oldFirst = status[topic];
         return !R.equals(oldFirst, block[topic]?.[0]?.message) && oldFirst != undefined;
       });
       const lastChanged = R.findLastIndex(R.identity, changes);
-      const haveChanged = lastChanged !== -1;
+      const haveChanged = lastChanged !== -1 && lastChanged < currentCursor;
 
-      if (!haveChanged || lastChanged >= currentCursor) {
-        return [[currentCursor, newCursor], false];
+      if (!haveChanged) {
+        return {
+          topic,
+          range: [currentCursor, newCursor],
+          shouldReset: false,
+        };
       }
 
+      // if only a single block changed (not all of them from 0), which can
+      // happen with a non-deterministic user script, resend the loaded range.
+      // otherwise, the blocks on this topic are changing completely. this
+      // happens due to changes in message slicing and user scripts.
       const didAllChange = R.all(R.identity, changes.slice(0, Math.max(0, lastChanged)));
-      if (didAllChange) {
-        return [[0, lastChanged + 1], true];
-      }
-
-      return [[0, currentCursor], true];
+      return {
+        topic,
+        range: [0, didAllChange ? lastChanged + 1 : currentCursor],
+        shouldReset: true,
+      };
     }),
-    R.zip(subscriptions),
     // filter out any topics that neither changed nor had new data
-    R.filter(([, [[start, end], shouldReset]]) => shouldReset || start != end),
+    R.filter(({ shouldReset, range: [start, end] }: Update) => shouldReset || start !== end),
   )(subscriptions);
 
   const newMessages = R.reduce(
-    (a: FirstMessages[], work: Work) => {
-      const [{ topic }, [[start, end]]] = work;
+    (a: FirstMessages[], { topic, range: [start, end] }: Update) => {
       return R.pipe(
         (v: FirstMessages[]): [MessageBlock, FirstMessages][] => R.zip(blocks.slice(start, end), v),
         R.map(
@@ -116,22 +126,25 @@ export function processBlocks(
       )(a.slice(start, end));
     },
     messages,
-    work,
+    updates,
   );
 
   const newCursors = R.reduce(
-    (a: Cursors, [{ topic }, [[, end]]]: Work): Cursors => ({
+    (a: Cursors, { topic, range: [, end] }: Update): Cursors => ({
       ...a,
       [topic]: end,
     }),
     cursors,
-    work,
+    updates,
   );
 
   const newData: Messages[] = R.pipe(
     R.reduce(
-      (a: string[][], v: [SubscribePayload, [Range, boolean]]): string[][] => {
-        const [{ topic }, [[start, end]]] = v;
+      (a: string[][], v: Update): string[][] => {
+        const {
+          topic,
+          range: [start, end],
+        } = v;
         for (let i = start; i < end; i++) {
           const bucket = a[i];
           if (bucket == undefined) {
@@ -147,14 +160,14 @@ export function processBlocks(
     // remove all blocks that are empty or have no topics
     R.filter(([block, topics]) => !R.isEmpty(block) && topics.length > 0),
     R.map(([block, topics]) => R.pick(topics, block) as Messages),
-  )(work);
+  )(updates);
 
   return {
     state: {
       messages: newMessages,
       cursors: newCursors,
     },
-    resetTopics: R.chain(([{ topic }, [, shouldReset]]) => (shouldReset ? [topic] : []), work),
+    resetTopics: R.chain(({ topic, shouldReset }) => (shouldReset ? [topic] : []), updates),
     newData,
   };
 }

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -69,27 +69,31 @@ export function processBlocks(
     R.map((v: SubscribePayload): [send: Range, shouldReset: boolean] => {
       const { topic } = v;
       const currentCursor = cursors[topic] ?? 0;
-      const newBlocks = R.takeWhile(
+
+      // find the last new block from the cursor to the end
+      const lastNew = R.findLastIndex(
         (block) => block[topic] != undefined,
         blocks.slice(currentCursor),
       );
-      const lastChanged = R.findLastIndex(([block, status]) => {
-        const topicMessages = block[topic];
-        if (topicMessages == undefined) {
-          return false;
-        }
+      const newCursor = lastNew === -1 ? currentCursor : lastNew + currentCursor + 1;
 
+      const changes = blocksWithStatuses.map(([block, status]) => {
         const oldFirst = status[topic];
-        return !R.equals(oldFirst, topicMessages[0]?.message) && oldFirst != undefined;
-      }, blocksWithStatuses);
+        return !R.equals(oldFirst, block[topic]?.[0]?.message) && oldFirst != undefined;
+      });
+      const lastChanged = R.findLastIndex(R.identity, changes);
+      const haveChanged = lastChanged !== -1;
 
-      const endCursor = lastChanged !== -1 ? lastChanged + 1 : currentCursor + newBlocks.length;
-
-      if (lastChanged !== -1 && lastChanged < currentCursor) {
-        return [[0, endCursor], true];
+      if (!haveChanged || lastChanged >= currentCursor) {
+        return [[currentCursor, newCursor], false];
       }
 
-      return [[currentCursor, endCursor], false];
+      const didAllChange = R.all(R.identity, changes.slice(0, Math.max(0, lastChanged)));
+      if (didAllChange) {
+        return [[0, lastChanged + 1], true];
+      }
+
+      return [[0, currentCursor], true];
     }),
     R.zip(subscriptions),
     // filter out any topics that neither changed nor had new data

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -25,17 +25,12 @@ import { TypedDataProvider } from "@foxglove/studio-base/components/TimeBasedCha
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { SubscribePayload, MessageEvent } from "@foxglove/studio-base/players/types";
 
-import { PlotParams, Messages } from "./internalTypes";
+import { PlotParams } from "./internalTypes";
 import { getPaths } from "./params";
+import { initBlockState, refreshBlockTopics, processBlocks } from "./blocks";
 import { PlotData } from "./plotData";
 
 type Service = Comlink.Remote<(typeof import("./useDatasets.worker"))["service"]>;
-
-// We need to keep track of the block data we've already sent to the worker and
-// detect when it has changed, which can happen when the user changes a user
-// script or they trigger a subscription to different fields.
-// mapping from topic -> the first message on that topic in the block
-type BlockStatus = Record<string, unknown>;
 type Client = {
   params: PlotParams | undefined;
   setter: (topics: SubscribePayload[]) => void;
@@ -44,8 +39,7 @@ type Client = {
 let worker: Worker | undefined;
 let service: Service | undefined;
 let numClients: number = 0;
-let blockStatus: BlockStatus[] = [];
-let lastBlockSent: Record<string, number> = {};
+let blockState = initBlockState();
 let clients: Record<string, Client> = {};
 
 const pending: ((service: Service) => void)[] = [];
@@ -153,15 +147,7 @@ function chooseClient() {
     (v) => mergeSubscriptions(v) as SubscribePayload[],
   )(clientList);
   clientList[0]?.setter(subscriptions);
-
-  const blockTopics = R.pipe(
-    R.filter((v: SubscribePayload) => v.preloadType === "full"),
-    R.map((v) => v.topic),
-  )(subscriptions);
-
-  // Also clear the status of any topics we're no longer using
-  blockStatus = blockStatus.map((block) => R.pick(blockTopics, block));
-  lastBlockSent = R.pick(blockTopics, lastBlockSent);
+  blockState = refreshBlockTopics(subscriptions, blockState);
 }
 
 // Subscribe to "current" messages (those near the seek head) and forward new
@@ -231,120 +217,24 @@ function useData(id: string, params: PlotParams) {
 
   const blocks = useBlocks(blockSubscriptions);
   useEffect(() => {
-    const statuses: BlockStatus[] = blocks.map((_, i) => blockStatus[i] ?? {});
-    const blocksWithStatuses = R.zip(blocks, statuses);
-    const cursors: Record<string, number> = R.pipe(
-      R.map((v: SubscribePayload): [string, number] => [v.topic, lastBlockSent[v.topic] ?? 0]),
-      R.fromPairs,
-    )(blockSubscriptions);
+    const {
+      state: newState,
+      resetTopics,
+      newData,
+    } = processBlocks(blocks, blockSubscriptions, blockState);
 
-    type Range = [start: number, end: number];
-    type Work = [SubscribePayload, [Range, boolean]];
-    const work: Work[] = R.pipe(
-      R.map((v: SubscribePayload): [send: Range, shouldReset: boolean] => {
-        const { topic } = v;
-        const currentCursor = cursors[topic] ?? 0;
-        const newBlocks = R.takeWhile(
-          (block) => block[topic] != undefined,
-          blocks.slice(currentCursor),
-        );
-        const lastChanged = R.findLastIndex(([block, status]) => {
-          const topicMessages = block[topic];
-          if (topicMessages == undefined) {
-            return false;
-          }
+    blockState = newState;
 
-          const oldFirst = status[topic];
-          const newFirst = topicMessages[0]?.message;
-          if (R.equals(oldFirst, newFirst)) {
-            return false;
-          }
-
-          return oldFirst != undefined;
-        }, blocksWithStatuses);
-
-        const endCursor = lastChanged !== -1 ? lastChanged + 1 : currentCursor + newBlocks.length;
-
-        if (lastChanged !== -1 && lastChanged < currentCursor) {
-          return [[0, endCursor], true];
-        }
-
-        return [[currentCursor, endCursor], false];
-      }),
-      R.zip(blockSubscriptions),
-      // filter out any topics that neither changed nor had new data
-      R.filter(([, [[start, end], shouldReset]]) => shouldReset || start != end),
-    )(blockSubscriptions);
-
-    const resetWork: Work[] = R.filter(([, [, shouldReset]]) => shouldReset, work);
-
-    if (resetWork.length > 0) {
-      const resetTopics: string[] = resetWork.map(([{ topic }]) => topic);
-      void service?.addBlock(
-        R.pipe(
-          R.map((topic: string): [string, MessageEvent[]] => [topic, []]),
-          R.fromPairs,
-        )(resetTopics),
-        resetTopics,
-      );
-
-      for (const [{ topic }, [[, end]]] of resetWork) {
-        for (let i = 0; i < end; i++) {
-          const status = blockStatus[i];
-          if (status == undefined) {
-            continue;
-          }
-          status[topic] = undefined;
-        }
-      }
-    }
-
-    const bundles = R.reduce(
-      (a: string[][], v: [SubscribePayload, [Range, boolean]]): string[][] => {
-        const [{ topic }, [[start, end]]] = v;
-        for (let i = start; i < end; i++) {
-          const bucket = a[i];
-          if (bucket == undefined) {
-            continue;
-          }
-          bucket.push(topic);
-        }
-        return a;
-      },
-      blocks.map((): string[] => []),
-      work,
+    void service?.addBlock(
+      R.pipe(
+        R.map((topic: string): [string, MessageEvent[]] => [topic, []]),
+        R.fromPairs,
+      )(resetTopics),
+      resetTopics,
     );
 
-    for (let i = 0; i < bundles.length; i++) {
-      const topics = bundles[i];
-      const block = blocks[i];
-      const status = blockStatus[i] ?? {};
-      if (topics == undefined || block == undefined) {
-        continue;
-      }
-
-      const messages: Messages = {};
-      for (const topic of topics) {
-        const topicMessages = block[topic];
-        if (topicMessages == undefined) {
-          continue;
-        }
-        messages[topic] = topicMessages as MessageEvent[];
-
-        lastBlockSent[topic] = i + 1;
-        const first = topicMessages[0];
-        if (first == undefined) {
-          continue;
-        }
-        status[topic] = first.message;
-      }
-
-      blockStatus[i] = status;
-      if (R.isEmpty(messages)) {
-        continue;
-      }
-
-      void service?.addBlock(messages, []);
+    for (const bundle of newData) {
+      void service?.addBlock(bundle, []);
     }
   }, [blockSubscriptions, blocks]);
 }
@@ -393,7 +283,7 @@ export default function useDatasets(params: PlotParams): {
       if (numClients === 0) {
         worker?.terminate();
         worker = service = undefined;
-        blockStatus = [];
+        blockState = initBlockState();
       }
     };
   }, []);

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -60,9 +60,6 @@ async function waitService(): Promise<Service> {
 
 const getIsLive = (ctx: MessagePipelineContext) => ctx.seekPlayback == undefined;
 
-const getPayloadString = (payload: SubscribePayload): string =>
-  `${payload.topic}:${(payload.fields ?? []).join(",")}`;
-
 /**
  * Get the SubscribePayload for a single path by subscribing to all fields
  * referenced in leading MessagePathFilters and the first field of the
@@ -159,7 +156,7 @@ function chooseClient() {
 
   const blockTopics = R.pipe(
     R.filter((v: SubscribePayload) => v.preloadType === "full"),
-    R.map(getPayloadString),
+    R.map((v) => v.topic),
   )(subscriptions);
 
   // Also clear the status of any topics we're no longer using
@@ -234,57 +231,120 @@ function useData(id: string, params: PlotParams) {
 
   const blocks = useBlocks(blockSubscriptions);
   useEffect(() => {
-    for (const [index, block] of blocks.entries()) {
-      if (R.isEmpty(block)) {
+    const statuses: BlockStatus[] = blocks.map((_, i) => blockStatus[i] ?? {});
+    const blocksWithStatuses = R.zip(blocks, statuses);
+    const cursors: Record<string, number> = R.pipe(
+      R.map((v: SubscribePayload): [string, number] => [v.topic, lastBlockSent[v.topic] ?? 0]),
+      R.fromPairs,
+    )(blockSubscriptions);
+
+    type Range = [start: number, end: number];
+    type Work = [SubscribePayload, [Range, boolean]];
+    const work: Work[] = R.pipe(
+      R.map((v: SubscribePayload): [send: Range, shouldReset: boolean] => {
+        const { topic } = v;
+        const currentCursor = cursors[topic] ?? 0;
+        const newBlocks = R.takeWhile(
+          (block) => block[topic] != undefined,
+          blocks.slice(currentCursor),
+        );
+        const lastChanged = R.findLastIndex(([block, status]) => {
+          const topicMessages = block[topic];
+          if (topicMessages == undefined) {
+            return false;
+          }
+
+          const oldFirst = status[topic];
+          const newFirst = topicMessages[0]?.message;
+          if (R.equals(oldFirst, newFirst)) {
+            return false;
+          }
+
+          return oldFirst != undefined;
+        }, blocksWithStatuses);
+
+        const endCursor = lastChanged !== -1 ? lastChanged + 1 : currentCursor + newBlocks.length;
+
+        if (lastChanged !== -1 && lastChanged < currentCursor) {
+          return [[0, endCursor], true];
+        }
+
+        return [[currentCursor, endCursor], false];
+      }),
+      R.zip(blockSubscriptions),
+      // filter out any topics that neither changed nor had new data
+      R.filter(([, [[start, end], shouldReset]]) => shouldReset || start != end),
+    )(blockSubscriptions);
+
+    const resetWork: Work[] = R.filter(([, [, shouldReset]]) => shouldReset, work);
+
+    if (resetWork.length > 0) {
+      const resetTopics: string[] = resetWork.map(([{ topic }]) => topic);
+      void service?.addBlock(
+        R.pipe(
+          R.map((topic: string): [string, MessageEvent[]] => [topic, []]),
+          R.fromPairs,
+        )(resetTopics),
+        resetTopics,
+      );
+
+      for (const [{ topic }, [[, end]]] of resetWork) {
+        for (let i = 0; i < end; i++) {
+          const status = blockStatus[i];
+          if (status == undefined) {
+            continue;
+          }
+          status[topic] = undefined;
+        }
+      }
+    }
+
+    const bundles = R.reduce(
+      (a: string[][], v: [SubscribePayload, [Range, boolean]]): string[][] => {
+        const [{ topic }, [[start, end]]] = v;
+        for (let i = start; i < end; i++) {
+          const bucket = a[i];
+          if (bucket == undefined) {
+            continue;
+          }
+          bucket.push(topic);
+        }
+        return a;
+      },
+      blocks.map((): string[] => []),
+      work,
+    );
+
+    for (let i = 0; i < bundles.length; i++) {
+      const topics = bundles[i];
+      const block = blocks[i];
+      const status = blockStatus[i] ?? {};
+      if (topics == undefined || block == undefined) {
         continue;
       }
 
-      // Package any new messages into a single bundle to send to the worker
       const messages: Messages = {};
-      // Make a note of any topics that had new data so we can clear out
-      // accumulated points in the worker
-      const resetData: Set<string> = new Set<string>();
-      const status: BlockStatus = blockStatus[index] ?? {};
-      for (const payload of blockSubscriptions) {
-        const ref = getPayloadString(payload);
-        const topicMessages = block[payload.topic];
+      for (const topic of topics) {
+        const topicMessages = block[topic];
         if (topicMessages == undefined) {
           continue;
         }
+        messages[topic] = topicMessages as MessageEvent[];
 
-        const first = topicMessages[0]?.message;
-        const existing = status[ref];
-
-        // keep track of the block index that we last sent; if there's a new
-        // change BEFORE that index, we need to reset the plot data; otherwise
-        // we do not
-        const lastSent = lastBlockSent[ref];
-        if (R.equals(existing, first)) {
+        lastBlockSent[topic] = i + 1;
+        const first = topicMessages[0];
+        if (first == undefined) {
           continue;
         }
-
-        // we already had a message in this block, meaning the data itself has
-        // changed; we have to rebuild the plots
-        if (existing != undefined && lastSent != undefined && index < lastSent) {
-          resetData.add(payload.topic);
-
-          // clear out the status of all subsequent blocks for this ref
-          for (let i = index + 1; i < blockStatus.length; i++) {
-            blockStatus[i] = R.omit([ref], blockStatus[i]);
-          }
-        }
-
-        status[ref] = first;
-        messages[payload.topic] = topicMessages as MessageEvent[];
-        lastBlockSent[ref] = index;
+        status[topic] = first.message;
       }
-      blockStatus[index] = status;
 
+      blockStatus[i] = status;
       if (R.isEmpty(messages)) {
         continue;
       }
 
-      void service?.addBlock(messages, Array.from(resetData));
+      void service?.addBlock(messages, []);
     }
   }, [blockSubscriptions, blocks]);
 }

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -25,9 +25,9 @@ import { TypedDataProvider } from "@foxglove/studio-base/components/TimeBasedCha
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { SubscribePayload, MessageEvent } from "@foxglove/studio-base/players/types";
 
+import { initBlockState, refreshBlockTopics, processBlocks } from "./blocks";
 import { PlotParams } from "./internalTypes";
 import { getPaths } from "./params";
-import { initBlockState, refreshBlockTopics, processBlocks } from "./blocks";
 import { PlotData } from "./plotData";
 
 type Service = Comlink.Remote<(typeof import("./useDatasets.worker"))["service"]>;


### PR DESCRIPTION
**User-Facing Changes**
Fixes for a range of issues affecting plot preloading.

**Description**
This PR does the following:
* Breaks out the logic we use to decide when to send block data to the plot worker.
* Adds a test suite for it.

This is a complicated state machine with a few nasty edge cases. The existing logic did not handle them very well and was hard to reason about. To learn more about why this is hard, read [this comment](https://github.com/foxglove/studio/blob/d85325f895fec865bfb6c8fb8bada542224e665d/packages/studio-base/src/panels/Plot/blocks.test.ts#L45) in the test file.

I added tests for all of the edge cases I could come up with and ensured that this PR fixes the three ([#1](https://github.com/foxglove/studio/pull/6928) [#2](https://linear.app/foxglove/issue/FG-5215/strange-plot-behavior-when-used-alongside-map-panel) [#3](https://github.com/foxglove/studio/issues/6957)) recent bugs users experienced related to this functionality.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
