### PR TITLE
Fix data platform topics sometimes not being streamed

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -322,9 +322,14 @@ export class IterablePlayer implements Player {
     this.#blockLoader?.setTopics(this.#preloadTopics);
 
     // If the player is playing, the playing state will detect any subscription changes and adjust
-    // iterators accordignly. However if we are idle or already seeking then we need to manually
+    // iterators accordingly. However if we are idle or already seeking then we need to manually
     // trigger the backfill.
-    if (this.#state === "idle" || this.#state === "seek-backfill" || this.#state === "play") {
+    if (
+      this.#state === "idle" ||
+      this.#state === "seek-backfill" ||
+      this.#state === "play" ||
+      this.#state === "start-play"
+    ) {
       if (!this.#isPlaying && this.#currentTime) {
         this.#seekTarget ??= this.#currentTime;
         this.#untilTime = undefined;


### PR DESCRIPTION
**User-Facing Changes**
Fix data platform topics sometimes not being streamed

**Description**
Fixes that a subscription change is ignored when the iterable player is in the `start-play` state and when there is no [seek target](https://github.com/foxglove/studio/blob/c648303a3d017a7fa32afcc278bb145c5692f641/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts#L596-L600). This mostly happened when loading a recording from data platform,  as the `start-play` state seems to take longer compared to when loading a local recording (which also uses the iterable player under the hood)

Resolves FG-5159