### PR TITLE
Add wider support for image downloading

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -85,6 +85,10 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     return this.#disposed;
   }
 
+  public getDecodedImage(): ImageBitmap | ImageData | undefined {
+    return this.#decodedImage;
+  }
+
   public setTopic(topicName: string): void {
     this.name = topicName;
     this.userData.topic = topicName;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageTypes.ts
@@ -10,7 +10,6 @@ import {
   CompressedImage as RosCompressedImage,
   CAMERA_INFO_DATATYPES,
 } from "../../ros";
-import { ColorModeSettings } from "../colorMode";
 
 export const ALL_CAMERA_INFO_SCHEMAS = new Set([
   ...CAMERA_INFO_DATATYPES,
@@ -36,11 +35,3 @@ export function getTimestampFromImage(image: AnyImage): Time {
     return image.timestamp;
   }
 }
-/** Data needed to download an image */
-export type DownloadImageInfo = ColorModeSettings & {
-  topic: string;
-  image: AnyImage;
-  rotation: 0 | 90 | 180 | 270;
-  flipHorizontal: boolean;
-  flipVertical: boolean;
-};

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -441,8 +441,11 @@ export const DownloadRawImage: StoryObj<React.ComponentProps<typeof ImageModeFox
   args: { imageType: "raw" },
   play: async () => {
     const { click, pointer } = userEvent.setup();
+    // need to wait until the images are done decoding
+    await delay(300);
     await pointer({ target: document.querySelector("canvas")!, keys: "[MouseRight]" });
-    await click(await screen.findByText("Download image"));
+    const downloadButton = await screen.findByText("Download image");
+    await click(downloadButton);
   },
 };
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
Update download image feature to use already-decoded image instead of image message itself. This simplifies download image and allows support for downloading any form of decoded image bitmap or image data. 


<!-- link relevant GitHub issues -->
Resolves: FG-4138
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
