### PR TITLE
<fix>: fix cancel dragged panel

### DIFF
--- a/packages/studio-base/src/components/PanelCatalog/PanelListItem.tsx
+++ b/packages/studio-base/src/components/PanelCatalog/PanelListItem.tsx
@@ -76,10 +76,10 @@ export function PanelListItem(props: Props): JSX.Element {
     },
     options: { dropEffect: "copy" },
     end: (_item, monitor) => {
-      const dropResult = monitor.getDropResult() ?? {};
+      const dropResult = monitor.getDropResult();
 
       // do nothing when the user wants to cancel a dragged panel
-      if (_.isEmpty(dropResult)) {
+      if (dropResult == undefined) {
         return;
       }
 

--- a/packages/studio-base/src/components/PanelCatalog/PanelListItem.tsx
+++ b/packages/studio-base/src/components/PanelCatalog/PanelListItem.tsx
@@ -4,6 +4,7 @@
 
 import { ReOrderDotsVertical16Filled } from "@fluentui/react-icons";
 import { Fade, ListItem, ListItemButton, ListItemText, Tooltip, Typography } from "@mui/material";
+import * as _ from "lodash-es";
 import { useCallback, useEffect, useRef } from "react";
 import { useDrag } from "react-dnd";
 import { MosaicDragType, MosaicPath } from "react-mosaic-component";
@@ -76,6 +77,12 @@ export function PanelListItem(props: Props): JSX.Element {
     options: { dropEffect: "copy" },
     end: (_item, monitor) => {
       const dropResult = monitor.getDropResult() ?? {};
+
+      // do nothing when the user wants to cancel a dragged panel
+      if (_.isEmpty(dropResult)) {
+        return;
+      }
+
       const { position, path, tabId } = dropResult;
       // dropping outside mosaic does nothing. If we have a tabId, but no
       // position or path, we're dragging into an empty tab.

--- a/packages/studio-base/src/components/PanelCatalog/PanelListItem.tsx
+++ b/packages/studio-base/src/components/PanelCatalog/PanelListItem.tsx
@@ -4,7 +4,6 @@
 
 import { ReOrderDotsVertical16Filled } from "@fluentui/react-icons";
 import { Fade, ListItem, ListItemButton, ListItemText, Tooltip, Typography } from "@mui/material";
-import * as _ from "lodash-es";
 import { useCallback, useEffect, useRef } from "react";
 import { useDrag } from "react-dnd";
 import { MosaicDragType, MosaicPath } from "react-mosaic-component";


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
When the user wants to cancel a dragged panel, he will let go at an invalid place, but there is a bug here, and a new panel will still be added that the user just canceled.

**Before**

https://github.com/foxglove/studio/assets/23401125/faa8f111-86e4-4e3e-a5f0-89329c51027b



**After**


https://github.com/foxglove/studio/assets/23401125/709cd715-8900-44a8-8ec9-cc409898f481



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
