### PR TITLE
Enable vertex colors for LINE_STRIP and LINE_LOOP point annotations

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -67,6 +67,8 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
   #style?: LineStyle;
   /** Number of points that was last used for configuring geometry */
   #numPoints?: number;
+  /** Wheter to use vertex colors, used for configuring geometry */
+  #useVertexColors?: boolean;
   #positionBuffer = new Float32Array();
   #colorBuffer = new Uint8Array();
 
@@ -212,6 +214,7 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
     const isPolygon = style === "polygon";
     const isLineStrip = style === "line_strip";
     const isLineList = style === "line_list";
+    const useVertexColors = outlineColors.length > 0;
 
     // Update line width if thickness or scale has changed
     if (this.#annotationNeedsUpdate || this.#scaleNeedsUpdate) {
@@ -232,6 +235,7 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
       this.#cameraModelNeedsUpdate = false;
       if (
         this.#numPoints == undefined ||
+        this.#useVertexColors == undefined ||
         !this.#geometry ||
         pointsLength > this.#numPoints ||
         this.#style !== style
@@ -239,31 +243,34 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         // Need to recreate the geometry when length changes: https://github.com/mrdoob/three.js/issues/21488
         this.#geometry?.dispose();
         this.#numPoints = pointsLength;
+        this.#useVertexColors = useVertexColors;
         this.#style = style;
         const positionBufferSize = isPolygon ? (pointsLength + 1) * 3 : pointsLength * 3;
         this.#positionBuffer = new Float32Array(positionBufferSize);
-        this.#colorBuffer = new Uint8Array(pointsLength * 8);
         this.#geometry = isLineList ? new LineSegmentsGeometry() : new LineGeometry();
 
-        // [rgba, rgba]
-        const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(
-          this.#colorBuffer,
-          isLineList ? 8 : 4 /* stride */,
-          1,
-        );
-        this.#geometry.setAttribute(
-          "instanceColorStart",
-          new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0, true),
-        );
-        this.#geometry.setAttribute(
-          "instanceColorEnd",
-          new THREE.InterleavedBufferAttribute(
-            instanceColorBuffer,
-            4,
-            isLineList ? 4 : 0 /* offset */,
-            true,
-          ),
-        );
+        if (useVertexColors) {
+          this.#colorBuffer = new Uint8Array(pointsLength * 8);
+          // [rgba, rgba]
+          const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(
+            this.#colorBuffer,
+            isLineList ? 8 : 4 /* stride */,
+            1,
+          );
+          this.#geometry.setAttribute(
+            "instanceColorStart",
+            new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0, true),
+          );
+          this.#geometry.setAttribute(
+            "instanceColorEnd",
+            new THREE.InterleavedBufferAttribute(
+              instanceColorBuffer,
+              4,
+              isLineList ? 4 : 0 /* offset */,
+              true,
+            ),
+          );
+        }
         this.#linePrepass.geometry = this.#geometry;
         this.#line.geometry = this.#geometry;
       }
@@ -285,16 +292,18 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         positions[i * 3 + 1] = tempVec3.y;
         positions[i * 3 + 2] = tempVec3.z;
 
-        // Support the case where outline_colors is half the length of points, one color per line (hasExactColors),
-        // and where outline_colors matches the length of points. Fall back to marker.outline_color
-        // as needed
-        const color = hasExactColors
-          ? outlineColors[i >>> 1]!
-          : outlineColors[i] ?? outlineColor ?? FALLBACK_COLOR;
-        colors[i * 4 + 0] = SRGBToLinear(color.r) * 255;
-        colors[i * 4 + 1] = SRGBToLinear(color.g) * 255;
-        colors[i * 4 + 2] = SRGBToLinear(color.b) * 255;
-        colors[i * 4 + 3] = color.a * 255;
+        if (useVertexColors) {
+          // Support the case where outline_colors is half the length of points, one color per line (hasExactColors),
+          // and where outline_colors matches the length of points. Fall back to marker.outline_color
+          // as needed
+          const color = hasExactColors
+            ? outlineColors[i >>> 1]!
+            : outlineColors[i] ?? outlineColor ?? FALLBACK_COLOR;
+          colors[i * 4 + 0] = SRGBToLinear(color.r) * 255;
+          colors[i * 4 + 1] = SRGBToLinear(color.g) * 255;
+          colors[i * 4 + 2] = SRGBToLinear(color.b) * 255;
+          colors[i * 4 + 3] = color.a * 255;
+        }
         if (i === 0) {
           shape?.moveTo(tempVec3.x, tempVec3.y);
         } else {
@@ -307,10 +316,12 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         positions[pointsLength * 3 + 0] = positions[0]!;
         positions[pointsLength * 3 + 1] = positions[1]!;
         positions[pointsLength * 3 + 2] = positions[2]!;
-        colors[pointsLength * 4 + 0] = colors[0]!;
-        colors[pointsLength * 4 + 1] = colors[1]!;
-        colors[pointsLength * 4 + 2] = colors[2]!;
-        colors[pointsLength * 4 + 3] = colors[3]!;
+        if (useVertexColors) {
+          colors[pointsLength * 4 + 0] = colors[0]!;
+          colors[pointsLength * 4 + 1] = colors[1]!;
+          colors[pointsLength * 4 + 2] = colors[2]!;
+          colors[pointsLength * 4 + 3] = colors[3]!;
+        }
         shape?.closePath();
       }
 
@@ -346,12 +357,20 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         this.#fill = undefined;
       }
 
-      this.#linePrepassMaterial.vertexColors = true;
-      this.#lineMaterial.vertexColors = true;
-      this.#lineMaterial.color.setRGB(1, 1, 1); // any non-white color will tint the vertex colors
-      this.#lineMaterial.setOpacity(1);
-      this.#geometry.getAttribute("instanceColorStart").needsUpdate = true;
-      this.#geometry.getAttribute("instanceColorEnd").needsUpdate = true;
+      if (useVertexColors) {
+        this.#linePrepassMaterial.vertexColors = true;
+        this.#lineMaterial.vertexColors = true;
+        this.#lineMaterial.color.setRGB(1, 1, 1); // any non-white color will tint the vertex colors
+        this.#lineMaterial.setOpacity(1);
+        this.#geometry.getAttribute("instanceColorStart").needsUpdate = true;
+        this.#geometry.getAttribute("instanceColorEnd").needsUpdate = true;
+      } else {
+        const color = outlineColor ?? FALLBACK_COLOR;
+        this.#linePrepassMaterial.vertexColors = false;
+        this.#lineMaterial.vertexColors = false;
+        this.#lineMaterial.color.setRGB(color.r, color.g, color.b).convertSRGBToLinear();
+        this.#lineMaterial.setOpacity(color.a);
+      }
       this.#lineMaterial.needsUpdate = true;
 
       this.#geometry.setPositions(positions);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -238,6 +238,7 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         this.#useVertexColors == undefined ||
         !this.#geometry ||
         pointsLength > this.#numPoints ||
+        useVertexColors !== this.#useVertexColors ||
         this.#style !== style
       ) {
         // Need to recreate the geometry when length changes: https://github.com/mrdoob/three.js/issues/21488

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/RenderableLineAnnotation.ts
@@ -240,46 +240,35 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         this.#geometry?.dispose();
         this.#numPoints = pointsLength;
         this.#style = style;
-        switch (style) {
-          case "polygon":
-            this.#positionBuffer = new Float32Array((pointsLength + 1) * 3);
-            // color buffer is unused (we don't use vertex colors)
-            this.#geometry = new LineGeometry();
-            break;
-          case "line_strip":
-            this.#positionBuffer = new Float32Array(pointsLength * 3);
-            // color buffer is unused (we don't use vertex colors)
-            this.#geometry = new LineGeometry();
-            break;
-          case "line_list": {
-            this.#positionBuffer = new Float32Array(pointsLength * 3);
-            this.#colorBuffer = new Uint8Array(pointsLength * 8);
-            this.#geometry = new LineSegmentsGeometry();
+        const positionBufferSize = isPolygon ? (pointsLength + 1) * 3 : pointsLength * 3;
+        this.#positionBuffer = new Float32Array(positionBufferSize);
+        this.#colorBuffer = new Uint8Array(pointsLength * 8);
+        this.#geometry = isLineList ? new LineSegmentsGeometry() : new LineGeometry();
 
-            // [rgba, rgba]
-            const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(
-              this.#colorBuffer,
-              8,
-              1,
-            );
-            this.#geometry.setAttribute(
-              "instanceColorStart",
-              new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0, true),
-            );
-            this.#geometry.setAttribute(
-              "instanceColorEnd",
-              new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 4, true),
-            );
-            break;
-          }
-        }
+        // [rgba, rgba]
+        const instanceColorBuffer = new THREE.InstancedInterleavedBuffer(
+          this.#colorBuffer,
+          isLineList ? 8 : 4 /* stride */,
+          1,
+        );
+        this.#geometry.setAttribute(
+          "instanceColorStart",
+          new THREE.InterleavedBufferAttribute(instanceColorBuffer, 4, 0, true),
+        );
+        this.#geometry.setAttribute(
+          "instanceColorEnd",
+          new THREE.InterleavedBufferAttribute(
+            instanceColorBuffer,
+            4,
+            isLineList ? 4 : 0 /* offset */,
+            true,
+          ),
+        );
         this.#linePrepass.geometry = this.#geometry;
         this.#line.geometry = this.#geometry;
       }
 
-      const useVertexColors = isLineList;
-      const hasExactColors = outlineColors.length === pointsLength / 2;
-
+      const hasExactColors = isLineList && outlineColors.length === pointsLength / 2;
       const shapeFillColor =
         (isPolygon || isLineStrip) && fillColor != undefined && fillColor.a > 0
           ? fillColor
@@ -289,24 +278,23 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
       const positions = this.#positionBuffer;
       const colors = this.#colorBuffer;
       for (let i = 0; i < pointsLength; i++) {
-        // Support the case where outline_colors is half the length of points, one color per line,
-        // and where outline_colors matches the length of points. Fall back to marker.outline_color
-        // as needed
         const point = points[i]!;
         this.#cameraModel.projectPixelTo3dPlane(tempVec3, point);
 
         positions[i * 3 + 0] = tempVec3.x;
         positions[i * 3 + 1] = tempVec3.y;
         positions[i * 3 + 2] = tempVec3.z;
-        if (useVertexColors) {
-          const color = hasExactColors
-            ? outlineColors[i >>> 1]!
-            : outlineColors[i] ?? outlineColor ?? FALLBACK_COLOR;
-          colors[i * 4 + 0] = SRGBToLinear(color.r) * 255;
-          colors[i * 4 + 1] = SRGBToLinear(color.g) * 255;
-          colors[i * 4 + 2] = SRGBToLinear(color.b) * 255;
-          colors[i * 4 + 3] = color.a * 255;
-        }
+
+        // Support the case where outline_colors is half the length of points, one color per line (hasExactColors),
+        // and where outline_colors matches the length of points. Fall back to marker.outline_color
+        // as needed
+        const color = hasExactColors
+          ? outlineColors[i >>> 1]!
+          : outlineColors[i] ?? outlineColor ?? FALLBACK_COLOR;
+        colors[i * 4 + 0] = SRGBToLinear(color.r) * 255;
+        colors[i * 4 + 1] = SRGBToLinear(color.g) * 255;
+        colors[i * 4 + 2] = SRGBToLinear(color.b) * 255;
+        colors[i * 4 + 3] = color.a * 255;
         if (i === 0) {
           shape?.moveTo(tempVec3.x, tempVec3.y);
         } else {
@@ -319,12 +307,10 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         positions[pointsLength * 3 + 0] = positions[0]!;
         positions[pointsLength * 3 + 1] = positions[1]!;
         positions[pointsLength * 3 + 2] = positions[2]!;
-        if (useVertexColors) {
-          colors[pointsLength * 4 + 0] = colors[0]!;
-          colors[pointsLength * 4 + 1] = colors[1]!;
-          colors[pointsLength * 4 + 2] = colors[2]!;
-          colors[pointsLength * 4 + 3] = colors[3]!;
-        }
+        colors[pointsLength * 4 + 0] = colors[0]!;
+        colors[pointsLength * 4 + 1] = colors[1]!;
+        colors[pointsLength * 4 + 2] = colors[2]!;
+        colors[pointsLength * 4 + 3] = colors[3]!;
         shape?.closePath();
       }
 
@@ -360,20 +346,12 @@ export class RenderableLineAnnotation extends Renderable<BaseUserData, /*TRender
         this.#fill = undefined;
       }
 
-      if (useVertexColors) {
-        this.#linePrepassMaterial.vertexColors = true;
-        this.#lineMaterial.vertexColors = true;
-        this.#lineMaterial.color.setRGB(1, 1, 1); // any non-white color will tint the vertex colors
-        this.#lineMaterial.setOpacity(1);
-        this.#geometry.getAttribute("instanceColorStart").needsUpdate = true;
-        this.#geometry.getAttribute("instanceColorEnd").needsUpdate = true;
-      } else {
-        const color = outlineColor ?? FALLBACK_COLOR;
-        this.#linePrepassMaterial.vertexColors = false;
-        this.#lineMaterial.vertexColors = false;
-        this.#lineMaterial.color.setRGB(color.r, color.g, color.b).convertSRGBToLinear();
-        this.#lineMaterial.setOpacity(color.a);
-      }
+      this.#linePrepassMaterial.vertexColors = true;
+      this.#lineMaterial.vertexColors = true;
+      this.#lineMaterial.color.setRGB(1, 1, 1); // any non-white color will tint the vertex colors
+      this.#lineMaterial.setOpacity(1);
+      this.#geometry.getAttribute("instanceColorStart").needsUpdate = true;
+      this.#geometry.getAttribute("instanceColorEnd").needsUpdate = true;
       this.#lineMaterial.needsUpdate = true;
 
       this.#geometry.setPositions(positions);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageAnnotations.stories.tsx
@@ -1093,3 +1093,114 @@ export const OddLengthLineList: StoryObj = {
     );
   },
 };
+
+export const LinesWithAndWithoutVertexColors: StoryObj = {
+  render: function Story() {
+    const width = 60;
+    const height = 45;
+    const { calibrationMessage, cameraMessage } = makeRawImageAndCalibration({
+      width,
+      height,
+      frameId: "camera",
+      imageTopic: "camera",
+      calibrationTopic: "calibration",
+    });
+    const points = [
+      { x: 10 + 0, y: 10 + 0 },
+      { x: 10 - 5, y: 10 + 2 },
+      { x: 10 - 5, y: 10 + 8 },
+      { x: 10 + 0, y: 10 + 10 },
+      { x: 10 + 5, y: 10 + 8 },
+      { x: 10 + 5, y: 10 + 2 },
+    ];
+    const defaultPoints = {
+      timestamp: { sec: 0, nsec: 0 },
+      outline_color: { r: 0, g: 0, b: 0, a: 1 },
+      outline_colors: [
+        { r: 1, g: 0, b: 0, a: 1 },
+        { r: 0, g: 1, b: 0, a: 0.75 },
+        { r: 0, g: 0, b: 1, a: 0.75 },
+        { r: 1, g: 0, b: 1, a: 0.75 },
+      ],
+      fill_color: { r: 0, g: 0, b: 0, a: 0 },
+      thickness: 1,
+    };
+
+    const annotationsMessage: MessageEvent<Partial<ImageAnnotations>> = {
+      topic: "annotations",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        points: [
+          {
+            ...defaultPoints,
+            type: PointsAnnotationType.LINE_LIST,
+            points,
+          },
+          {
+            ...defaultPoints,
+            type: PointsAnnotationType.LINE_LOOP,
+            points: points.map(({ x, y }) => ({ x: x + 20, y })),
+          },
+          {
+            ...defaultPoints,
+            type: PointsAnnotationType.LINE_STRIP,
+            points: points.map(({ x, y }) => ({ x: x + 40, y })),
+          },
+          {
+            ...defaultPoints,
+            type: PointsAnnotationType.LINE_LIST,
+            points: points.map(({ x, y }) => ({ x, y: y + 20 })),
+            outline_colors: [],
+          },
+          {
+            ...defaultPoints,
+            type: PointsAnnotationType.LINE_LOOP,
+            points: points.map(({ x, y }) => ({ x: x + 20, y: y + 20 })),
+            outline_colors: [],
+          },
+          {
+            ...defaultPoints,
+            type: PointsAnnotationType.LINE_STRIP,
+            points: points.map(({ x, y }) => ({ x: x + 40, y: y + 20 })),
+            outline_colors: [],
+          },
+        ],
+      },
+      schemaName: "foxglove.ImageAnnotations",
+      sizeInBytes: 0,
+    };
+
+    const fixture: Fixture = {
+      topics: [
+        { name: "calibration", schemaName: "foxglove.CameraCalibration" },
+        { name: "camera", schemaName: "foxglove.RawImage" },
+        { name: "annotations", schemaName: "foxglove.ImageAnnotations" },
+      ],
+      frame: {
+        calibration: [calibrationMessage],
+        camera: [cameraMessage],
+        annotations: [annotationsMessage],
+      },
+      capabilities: [],
+      activeData: {
+        currentTime: { sec: 0, nsec: 0 },
+      },
+    };
+    return (
+      <div style={{ width: 1200, height: 900, flexShrink: 0 }}>
+        <PanelSetup fixture={fixture} includeSettings>
+          <ImagePanel
+            overrideConfig={{
+              ...ImagePanel.defaultConfig,
+              imageMode: {
+                calibrationTopic: "calibration",
+                imageTopic: "camera",
+                annotations: { annotations: { visible: true } },
+              },
+            }}
+          />
+        </PanelSetup>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
**User-Facing Changes**
Enable vertex colors for LINE_STRIP and LINE_LOOP point annotations

**Description**
Allows to set the line colors when using the [point annotation type](https://github.com/foxglove/schemas/blob/dcc3b66c69506258baf46baf08e99791340e33bb/schemas/ros1/PointsAnnotation.msg#L11-L21) `LINE_STRIP` or `LINE_LOOP`. This was so far only possible when using `LINE_LIST`.

- [x] Update documentation (https://github.com/foxglove/schemas/pull/134)


Addresses https://github.com/orgs/foxglove/discussions/715
Resolves FG-3505

**Layout for testing**:
[layout-with-user-script](https://github.com/foxglove/studio/files/12859119/foxglove-layout.2.json)

