### PR TITLE
Fix detection of image formats

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -22,7 +22,10 @@ import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
 
 const log = Logger.getLogger(__filename);
-const IMAGE_FORMATS = new Set(["jpeg", "png", "webp"]);
+const IMAGE_FORMATS = ["jpeg", "png", "webp"];
+const isImageFormat = (checkFormat: string): boolean => {
+  return IMAGE_FORMATS.some((format) => checkFormat.includes(format));
+};
 export interface ImageRenderableSettings extends Partial<ColorModeSettings> {
   visible: boolean;
   frameLocked?: boolean;
@@ -214,7 +217,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     resizeWidth?: number,
   ): Promise<ImageBitmap | ImageData> {
     if ("format" in image) {
-      if (!IMAGE_FORMATS.has(image.format)) {
+      if (!isImageFormat(image.format)) {
         throw new Error(`Unsupported format: "${image.format}"`);
       }
       return await decodeCompressedImageToBitmap(image, resizeWidth);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -22,10 +22,6 @@ import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
 
 const log = Logger.getLogger(__filename);
-const IMAGE_FORMATS = ["jpeg", "png", "webp", "jpg"];
-const isImageFormat = (checkFormat: string): boolean => {
-  return IMAGE_FORMATS.some((format) => checkFormat.includes(format));
-};
 export interface ImageRenderableSettings extends Partial<ColorModeSettings> {
   visible: boolean;
   frameLocked?: boolean;
@@ -217,9 +213,6 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     resizeWidth?: number,
   ): Promise<ImageBitmap | ImageData> {
     if ("format" in image) {
-      if (!isImageFormat(image.format)) {
-        throw new Error(`Unsupported format: "${image.format}"`);
-      }
       return await decodeCompressedImageToBitmap(image, resizeWidth);
     }
     return await (this.decoder ??= new WorkerImageDecoder()).decode(image, this.userData.settings);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -22,7 +22,7 @@ import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
 
 const log = Logger.getLogger(__filename);
-const IMAGE_FORMATS = ["jpeg", "png", "webp"];
+const IMAGE_FORMATS = ["jpeg", "png", "webp", "jpg"];
 const isImageFormat = (checkFormat: string): boolean => {
   return IMAGE_FORMATS.some((format) => checkFormat.includes(format));
 };


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
Image formats are not always just `jpeg` they can be "mono8; jpeg compressed". We used to support this, it regressed in https://github.com/foxglove/studio/pull/6894


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
