### PR TITLE
Allow for iconButtons on settings fields and nodes

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -498,9 +498,9 @@ function FieldEditorComponent({
   const paddingLeft = 0.75 + 2 * (indent - 1);
   const { classes, cx } = useStyles();
 
-  const { settingsStatusButton } = useAppContext();
+  const { renderSettingsStatusButton } = useAppContext();
 
-  const statusButton = settingsStatusButton ? settingsStatusButton(field) : undefined;
+  const statusButton = renderSettingsStatusButton ? renderSettingsStatusButton(field) : undefined;
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -6,6 +6,7 @@ import CancelIcon from "@mui/icons-material/Cancel";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
   Autocomplete,
+  IconButton,
   MenuItem,
   MenuList,
   MenuListProps,
@@ -23,6 +24,7 @@ import { Immutable, SettingsTreeAction, SettingsTreeField } from "@foxglove/stud
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import Stack from "@foxglove/studio-base/components/Stack";
 
+import { icons } from "./icons";
 import { ColorGradientInput, ColorPickerInput, NumberInput, Vec2Input, Vec3Input } from "./inputs";
 
 /** Used to allow both undefined and empty string in select inputs. */
@@ -31,6 +33,9 @@ const UNDEFINED_SENTINEL_VALUE = uuid();
 const INVALID_SENTINEL_VALUE = uuid();
 
 const useStyles = makeStyles<void, "error">()((theme, _params, classes) => ({
+  actionButton: {
+    padding: theme.spacing(0.5),
+  },
   autocomplete: {
     ".MuiInputBase-root.MuiInputBase-sizeSmall": {
       paddingInline: 0,
@@ -497,6 +502,8 @@ function FieldEditorComponent({
   const paddingLeft = 0.75 + 2 * (indent - 1);
   const { classes, cx } = useStyles();
 
+  const IconComponent = field.iconButton?.icon ? icons[field.iconButton.icon] : undefined;
+
   return (
     <>
       <Stack
@@ -507,6 +514,22 @@ function FieldEditorComponent({
         paddingLeft={paddingLeft}
         fullHeight
       >
+        {field.iconButton && (
+          <Tooltip
+            arrow
+            placement="top"
+            title={<Typography variant="subtitle2">{field.iconButton.tooltip}</Typography>}
+          >
+            <IconButton
+              className={classes.actionButton}
+              data-node-function="edit-label"
+              color="primary"
+              onClick={field.iconButton.onClick}
+            >
+              {IconComponent ? <IconComponent fontSize="small" /> : <CancelIcon />}
+            </IconButton>
+          </Tooltip>
+        )}
         {field.error && (
           <Tooltip
             arrow

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -6,7 +6,6 @@ import CancelIcon from "@mui/icons-material/Cancel";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
   Autocomplete,
-  IconButton,
   MenuItem,
   MenuList,
   MenuListProps,
@@ -23,8 +22,8 @@ import { v4 as uuid } from "uuid";
 import { Immutable, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 
-import { icons } from "./icons";
 import { ColorGradientInput, ColorPickerInput, NumberInput, Vec2Input, Vec3Input } from "./inputs";
 
 /** Used to allow both undefined and empty string in select inputs. */
@@ -33,9 +32,6 @@ const UNDEFINED_SENTINEL_VALUE = uuid();
 const INVALID_SENTINEL_VALUE = uuid();
 
 const useStyles = makeStyles<void, "error">()((theme, _params, classes) => ({
-  actionButton: {
-    padding: theme.spacing(0.5),
-  },
   autocomplete: {
     ".MuiInputBase-root.MuiInputBase-sizeSmall": {
       paddingInline: 0,
@@ -502,7 +498,9 @@ function FieldEditorComponent({
   const paddingLeft = 0.75 + 2 * (indent - 1);
   const { classes, cx } = useStyles();
 
-  const IconComponent = field.iconButton?.icon ? icons[field.iconButton.icon] : undefined;
+  const { settingsStatusButton } = useAppContext();
+
+  const statusButton = settingsStatusButton ? settingsStatusButton(field) : undefined;
 
   return (
     <>
@@ -514,22 +512,7 @@ function FieldEditorComponent({
         paddingLeft={paddingLeft}
         fullHeight
       >
-        {field.iconButton && (
-          <Tooltip
-            arrow
-            placement="top"
-            title={<Typography variant="subtitle2">{field.iconButton.tooltip}</Typography>}
-          >
-            <IconButton
-              className={classes.actionButton}
-              data-node-function="edit-label"
-              color="primary"
-              onClick={field.iconButton.onClick}
-            >
-              {IconComponent ? <IconComponent fontSize="small" /> : <CancelIcon />}
-            </IconButton>
-          </Tooltip>
-        )}
+        {statusButton}
         {field.error && (
           <Tooltip
             arrow

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -202,7 +202,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     open: defaultOpen,
     visibilityFilter: "all",
   });
-  const { settingsStatusButton } = useAppContext();
+  const { renderSettingsStatusButton } = useAppContext();
   const { t } = useTranslation("settingsEditor");
   const { classes, cx, theme } = useStyles();
 
@@ -331,7 +331,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     [settings.actions],
   );
 
-  const statusButton = settingsStatusButton ? settingsStatusButton(settings) : undefined;
+  const statusButton = renderSettingsStatusButton
+    ? renderSettingsStatusButton(settings)
+    : undefined;
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -328,6 +328,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
       ),
     [settings.actions],
   );
+  const IconButtonComponent = settings.iconButton?.icon
+    ? icons[settings.iconButton.icon]
+    : undefined;
 
   return (
     <>
@@ -416,7 +419,23 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               <EditIcon fontSize="small" />
             </IconButton>
           )}
-          {settings.visible != undefined && (
+
+          {settings.iconButton && (
+            <Tooltip
+              arrow
+              placement="top"
+              title={<Typography variant="subtitle2">{settings.iconButton.tooltip}</Typography>}
+            >
+              <IconButton
+                className={classes.actionButton}
+                color="primary"
+                onClick={settings.iconButton.onClick}
+              >
+                {IconButtonComponent ? <IconButtonComponent fontSize="small" /> : undefined}
+              </IconButton>
+            </Tooltip>
+          )}
+          {settings.iconButton?.overrideVisible !== true && settings.visible != undefined && (
             <VisibilityToggle
               size="small"
               checked={visible}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -27,6 +27,7 @@ import {
 } from "@foxglove/studio";
 import { HighlightedText } from "@foxglove/studio-base/components/HighlightedText";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 
 import { FieldEditor } from "./FieldEditor";
 import { NodeActionsMenu } from "./NodeActionsMenu";
@@ -201,6 +202,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     open: defaultOpen,
     visibilityFilter: "all",
   });
+  const { settingsStatusButton } = useAppContext();
   const { t } = useTranslation("settingsEditor");
   const { classes, cx, theme } = useStyles();
 
@@ -328,9 +330,8 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
       ),
     [settings.actions],
   );
-  const IconButtonComponent = settings.iconButton?.icon
-    ? icons[settings.iconButton.icon]
-    : undefined;
+
+  const statusButton = settingsStatusButton ? settingsStatusButton(settings) : undefined;
 
   return (
     <>
@@ -419,31 +420,17 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               <EditIcon fontSize="small" />
             </IconButton>
           )}
-
-          {settings.iconButton && (
-            <Tooltip
-              arrow
-              placement="top"
-              title={<Typography variant="subtitle2">{settings.iconButton.tooltip}</Typography>}
-            >
-              <IconButton
-                className={classes.actionButton}
-                color="primary"
-                onClick={settings.iconButton.onClick}
-              >
-                {IconButtonComponent ? <IconButtonComponent fontSize="small" /> : undefined}
-              </IconButton>
-            </Tooltip>
-          )}
-          {settings.iconButton?.overrideVisible !== true && settings.visible != undefined && (
-            <VisibilityToggle
-              size="small"
-              checked={visible}
-              onChange={toggleVisibility}
-              style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
-              disabled={!allowVisibilityToggle}
-            />
-          )}
+          {statusButton
+            ? statusButton
+            : settings.visible != undefined && (
+                <VisibilityToggle
+                  size="small"
+                  checked={visible}
+                  onChange={toggleVisibility}
+                  style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
+                  disabled={!allowVisibilityToggle}
+                />
+              )}
           {inlineActions.map((action) => {
             const Icon = action.icon ? icons[action.icon] : undefined;
             const handler = () => {

--- a/packages/studio-base/src/components/SettingsTreeEditor/icons.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/icons.ts
@@ -5,6 +5,7 @@
 import Clock from "@mui/icons-material/AccessTime";
 import Add from "@mui/icons-material/Add";
 import Addchart from "@mui/icons-material/Addchart";
+import AutoAwesome from "@mui/icons-material/AutoAwesome";
 import Points from "@mui/icons-material/BlurOn";
 import Check from "@mui/icons-material/Check";
 import Circle from "@mui/icons-material/Circle";
@@ -46,6 +47,7 @@ import { SettingsIcon } from "@foxglove/studio";
 const icons: Record<SettingsIcon, typeof Add> = {
   Add,
   Addchart,
+  AutoAwesome,
   Background,
   Camera,
   Cells,

--- a/packages/studio-base/src/context/AppContext.ts
+++ b/packages/studio-base/src/context/AppContext.ts
@@ -26,7 +26,7 @@ interface IAppContext {
   layoutEmptyState?: JSX.Element;
   syncAdapters?: readonly JSX.Element[];
   workspaceExtensions?: readonly JSX.Element[];
-  settingsStatusButton?: (
+  renderSettingsStatusButton?: (
     nodeOrField: Immutable<SettingsTreeNode | SettingsTreeField>,
   ) => JSX.Element | undefined;
   workspaceStoreCreator?: (

--- a/packages/studio-base/src/context/AppContext.ts
+++ b/packages/studio-base/src/context/AppContext.ts
@@ -6,6 +6,7 @@ import { createContext, useContext } from "react";
 import { DeepPartial } from "ts-essentials";
 import { StoreApi } from "zustand";
 
+import { Immutable, SettingsTreeField, SettingsTreeNode } from "@foxglove/studio";
 import { AppBarMenuItem } from "@foxglove/studio-base/components/AppBar/types";
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { WorkspaceContextStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
@@ -25,6 +26,9 @@ interface IAppContext {
   layoutEmptyState?: JSX.Element;
   syncAdapters?: readonly JSX.Element[];
   workspaceExtensions?: readonly JSX.Element[];
+  settingsStatusButton?: (
+    nodeOrField: Immutable<SettingsTreeNode | SettingsTreeField>,
+  ) => JSX.Element | undefined;
   workspaceStoreCreator?: (
     initialState?: Partial<WorkspaceContextStore>,
   ) => StoreApi<WorkspaceContextStore>;

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -497,6 +497,7 @@ export interface ExtensionModule {
 export type SettingsIcon =
   | "Add"
   | "Addchart"
+  | "AutoAwesome"
   | "Background"
   | "Camera"
   | "Cells"
@@ -674,6 +675,8 @@ export type SettingsTreeField = SettingsTreeFieldValue & {
    * Optional message indicating any error state for the field.
    */
   error?: string;
+
+  iconButton?: SettingsTreeIconButton;
 };
 
 export type SettingsTreeFields = Record<string, undefined | SettingsTreeField>;
@@ -776,6 +779,15 @@ export type SettingsTreeNode = {
    * Filter Children by visibility status
    */
   enableVisibilityFilter?: boolean;
+
+  iconButton?: SettingsTreeIconButton;
+};
+
+type SettingsTreeIconButton = {
+  icon: SettingsIcon;
+  onClick: () => Promise<void> | void;
+  tooltip: string;
+  overrideVisible?: boolean;
 };
 
 /**

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -675,8 +675,6 @@ export type SettingsTreeField = SettingsTreeFieldValue & {
    * Optional message indicating any error state for the field.
    */
   error?: string;
-
-  iconButton?: SettingsTreeIconButton;
 };
 
 export type SettingsTreeFields = Record<string, undefined | SettingsTreeField>;
@@ -779,15 +777,6 @@ export type SettingsTreeNode = {
    * Filter Children by visibility status
    */
   enableVisibilityFilter?: boolean;
-
-  iconButton?: SettingsTreeIconButton;
-};
-
-type SettingsTreeIconButton = {
-  icon: SettingsIcon;
-  onClick: () => Promise<void> | void;
-  tooltip: string;
-  overrideVisible?: boolean;
 };
 
 /**


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
-n/a

**Description**
Allow for injection of `statusButton` functionality for settings nodes and settings fields. Replaces visibility button on settings node.

<!-- link relevant GitHub issues -->
FG-5191
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
