### PR TITLE
Display a message while loading extensions

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -25,6 +25,7 @@ import { makeStyles } from "tss-react/mui";
 
 import { EmptyPanelLayout } from "@foxglove/studio-base/components/EmptyPanelLayout";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppContext } from "@foxglove/studio-base/context/AppContext";
 import {
   LayoutState,
@@ -188,10 +189,13 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
   return <ErrorBoundary>{bodyToRender}</ErrorBoundary>;
 }
 
-function LoadingState(): JSX.Element {
+function ExtensionsLoadingState(): JSX.Element {
   return (
     <EmptyState>
-      <CircularProgress size={28} />
+      <Stack gap={1} alignItems="center">
+        <CircularProgress size={28} />
+        <span>Loading extensions…</span>
+      </Stack>
     </EmptyState>
   );
 }
@@ -217,7 +221,7 @@ export default function PanelLayout(): JSX.Element {
   );
 
   if (registeredExtensions == undefined) {
-    return <LoadingState />;
+    return <ExtensionsLoadingState />;
   }
 
   if (layoutExists) {

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -139,6 +139,7 @@ function createExtensionRegistryStore(
         return;
       }
 
+      const start = performance.now();
       const extensionList: ExtensionInfo[] = [];
       const allContributionPoints: ContributionPoints = {
         panels: {},
@@ -165,7 +166,9 @@ function createExtensionRegistryStore(
           log.error("Error loading extension list", err);
         }
       }
-      log.debug(`Found ${extensionList.length} extension(s)`);
+      log.info(
+        `Loaded ${extensionList.length} extensions in ${(performance.now() - start).toFixed(1)}ms`,
+      );
       set({
         installedExtensions: extensionList,
         installedPanels: allContributionPoints.panels,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Instead of just a spinner, display a message to the user to indicate that extensions are loading.

<img width="195" alt="image" src="https://github.com/foxglove/studio/assets/14237/4e342897-ae1b-4451-92a1-41e772ff2481">

Resolves FG-5114