### PR TITLE
update: Chinese translation

### DIFF
--- a/packages/studio-base/src/i18n/zh/threeDee.ts
+++ b/packages/studio-base/src/i18n/zh/threeDee.ts
@@ -112,10 +112,10 @@ export const threeDee: Partial<TypeOptions["resources"]["threeDee"]> = {
   decayTimeDefaultZeroSeconds: "0 秒",
 
   // Color Mode
-  colorBy: "颜色映射",
+  colorBy: "颜色映射值",
   colorModeBgraPacked: "BGRA （堆积）",
   colorModeBgrPacked: "BGR （堆积）",
-  colorModeColorMap: "颜色映射",
+  colorModeColorMap: "色板",
   colorModeFlat: "单色",
   colorModeRgbaSeparateFields: "RGBA （独立字段）",
   flatColor: "单色",


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
Optimize some Chinese translations

**Description**
In Chinese context, "color by" and "color map" have similar meanings, so in the initial translation, they are both translated as "颜色映射", but when "color by" and "color map" appear at the same time, the translation of the two will be the same, which can be confusing, so this pr optimizes the translation of the two, and distinguishes between the two in more detail.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
