### PR TITLE
Fix bug with subscription fields

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.test.ts
@@ -69,7 +69,6 @@ describe("mergeSubscriptions", () => {
     const subs: SubscribePayload[] = [
       { topic: "a", preloadType: "partial", fields: ["one", "two"] },
       { topic: "a", preloadType: "full" },
-      { topic: "a", preloadType: "partial" },
     ];
 
     const result = mergeSubscriptions(subs);

--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.test.ts
@@ -64,4 +64,19 @@ describe("mergeSubscriptions", () => {
       { topic: "a", preloadType: "partial" },
     ]);
   });
+
+  it("switches to subscribing to all fields across preloadType", () => {
+    const subs: SubscribePayload[] = [
+      { topic: "a", preloadType: "partial", fields: ["one", "two"] },
+      { topic: "a", preloadType: "full" },
+      { topic: "a", preloadType: "partial" },
+    ];
+
+    const result = mergeSubscriptions(subs);
+
+    expect(result).toEqual([
+      { topic: "a", preloadType: "full" },
+      { topic: "a", preloadType: "partial" },
+    ]);
+  });
 });

--- a/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
+++ b/packages/studio-base/src/components/MessagePipeline/subscriptions.ts
@@ -86,6 +86,16 @@ export function mergeSubscriptions(
   subscriptions: Immutable<SubscribePayload[]>,
 ): Immutable<SubscribePayload[]> {
   return R.pipe(
+    R.chain((v: Immutable<SubscribePayload>): Immutable<SubscribePayload>[] => {
+      const { preloadType } = v;
+      if (preloadType !== "full") {
+        return [v];
+      }
+
+      // a "full" subscription to all fields implies a "partial" subscription
+      // to those fields, too
+      return [v, { ...v, preloadType: "partial" }];
+    }),
     R.partition((v: Immutable<SubscribePayload>) => v.preloadType === "full"),
     ([full, partial]) => [...denormalizeSubscriptions(full), ...denormalizeSubscriptions(partial)],
   )(subscriptions);

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -402,7 +402,6 @@ function PanelExtensionAdapter(
 
           return {
             topic: item.topic,
-            convertTo: item.convertTo,
             preloadType: item.preload === true ? "full" : "partial",
           };
         });


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue where plotting a signal used by a map panel caused the map panel to fail.

**Description**
An `SubscriptionPayload` with `preloadType="full"` but no `fields` property implies a subscription to `"partial"` as well. We were not handling this correctly, which meant that we were dropping subscriptions to all message fields under certain circumstances.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
