### PR TITLE
Fix for calculating state transition bounds

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -201,11 +201,11 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
   React.useEffect(() => {
     setDatasetBounds((oldBounds) => {
-      if (provided != undefined && R.equals(oldBounds, provided.bounds)) {
+      if (provided != undefined && !R.equals(oldBounds, provided.bounds)) {
         return provided.bounds;
       }
 
-      if (typedProvided != undefined && R.equals(oldBounds, typedProvided.bounds)) {
+      if (typedProvided != undefined && !R.equals(oldBounds, typedProvided.bounds)) {
         return typedProvided.bounds;
       }
 


### PR DESCRIPTION
**User-Facing Changes**
Fix where the state transition panel showed incorrect bounds after loading data.

**Description**
The code that decided when to update a chart's bounds was incorrect, which led to some issues.

Regressed in #6584
Fixes #6843