### PR TITLE
Select a default sidebar item if the selected one is not present

### DIFF
--- a/packages/studio-base/src/components/Sidebars/Sidebars.tsx
+++ b/packages/studio-base/src/components/Sidebars/Sidebars.tsx
@@ -101,16 +101,10 @@ export function Sidebars<LeftKey extends string, RightKey extends string>(
   // Select an available item if the selected one is not actually available
   useEffect(() => {
     if (leftSidebarOpen && !leftItems.has(selectedLeftKey)) {
-      const anyLeftKey = [...leftItems.keys()][0];
-      if (anyLeftKey != undefined && anyLeftKey !== selectedLeftKey) {
-        onSelectLeftKey(anyLeftKey);
-      }
+      onSelectLeftKey([...leftItems.keys()][0]);
     }
     if (rightSidebarOpen && !rightItems.has(selectedRightKey)) {
-      const anyRightKey = [...rightItems.keys()][0];
-      if (anyRightKey != undefined && anyRightKey !== selectedRightKey) {
-        onSelectRightKey(anyRightKey);
-      }
+      onSelectRightKey([...rightItems.keys()][0]);
     }
   }, [
     leftItems,

--- a/packages/studio-base/src/components/Sidebars/Sidebars.tsx
+++ b/packages/studio-base/src/components/Sidebars/Sidebars.tsx
@@ -95,8 +95,33 @@ export function Sidebars<LeftKey extends string, RightKey extends string>(
   const [mosaicValue, setMosaicValue] = useState<MosaicNode<LayoutNode>>("children");
   const { classes } = useStyles();
 
-  const leftSidebarOpen = selectedLeftKey != undefined && leftItems.has(selectedLeftKey);
-  const rightSidebarOpen = selectedRightKey != undefined && rightItems.has(selectedRightKey);
+  const leftSidebarOpen = selectedLeftKey != undefined;
+  const rightSidebarOpen = selectedRightKey != undefined;
+
+  // Select an available item if the selected one is not actually available
+  useEffect(() => {
+    if (leftSidebarOpen && !leftItems.has(selectedLeftKey)) {
+      const anyLeftKey = [...leftItems.keys()][0];
+      if (anyLeftKey != undefined && anyLeftKey !== selectedLeftKey) {
+        onSelectLeftKey(anyLeftKey);
+      }
+    }
+    if (rightSidebarOpen && !rightItems.has(selectedRightKey)) {
+      const anyRightKey = [...rightItems.keys()][0];
+      if (anyRightKey != undefined && anyRightKey !== selectedRightKey) {
+        onSelectRightKey(anyRightKey);
+      }
+    }
+  }, [
+    leftItems,
+    leftSidebarOpen,
+    onSelectLeftKey,
+    onSelectRightKey,
+    rightItems,
+    rightSidebarOpen,
+    selectedLeftKey,
+    selectedRightKey,
+  ]);
 
   useEffect(() => {
     const leftTargetWidth = 320;


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Some sidebar items (such as "Studio Logs" / "Events") are conditionally included in the sidebar. If one was selected but no longer present then the sidebar could not be expanded. Now we auto-select one of the available items instead.

Fixes FG-5315