### PR TITLE
state transitions panel support display topic

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -182,6 +182,7 @@ type MessagePathInputBaseProps = {
   readOnly?: boolean;
   prioritizedDatatype?: string;
   variant?: TextFieldProps["variant"];
+  supportsDisplayTopic?: boolean; // Display the distribution of topic over the entire period of time
 };
 
 const useStyles = makeStyles()({
@@ -205,6 +206,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     inputStyle,
     disableAutocomplete = false,
     variant = "standard",
+    supportsDisplayTopic = false,
   } = props;
   const { classes } = useStyles();
   const topicFields = useMemo(() => getFieldPaths(topics, datatypes), [datatypes, topics]);
@@ -247,7 +249,10 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
       // add a "." so the user can keep typing to autocomplete the message path.
       const messageIsValidType = validTypes == undefined || validTypes.includes("message");
       const keepGoingAfterTopicName =
-        autocompleteType === "topicName" && !messageIsValidType && !isSimpleField;
+        autocompleteType === "topicName" &&
+        !messageIsValidType &&
+        !isSimpleField &&
+        !supportsDisplayTopic;
       const value = keepGoingAfterTopicName ? rawValue + "." : rawValue;
 
       onChangeProp(completeStart + value + completeEnd, props.index);
@@ -265,7 +270,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
         autocomplete.blur();
       }
     },
-    [onChangeProp, path, props.index, topicFields, validTypes],
+    [supportsDisplayTopic, onChangeProp, path, props.index, topicFields, validTypes],
   );
 
   const rosPath = useMemo(() => parseRosPath(path), [path]);
@@ -482,7 +487,10 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 
   const hasError =
     usesUnsupportedMathModifier ||
-    (autocompleteType != undefined && !disableAutocomplete && path.length > 0);
+    (autocompleteType != undefined &&
+      !disableAutocomplete &&
+      path.length > 0 &&
+      !supportsDisplayTopic);
 
   return (
     <Autocomplete

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -295,6 +295,7 @@ function FieldInput({
             });
           }}
           validTypes={field.validTypes}
+          supportsDisplayTopic={field.supportsDisplayTopic}
         />
       );
     case "select": {

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -191,10 +191,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   useEffect(() => {
     setMessagePathDropConfig({
-      getDropStatus(draggedPaths) {
-        if (draggedPaths.some((path) => !path.isLeaf)) {
-          return { canDrop: false };
-        }
+      getDropStatus() {
         return { canDrop: true, effect: "add" };
       },
       handleDrop(draggedPaths) {

--- a/packages/studio-base/src/panels/StateTransitions/settings.ts
+++ b/packages/studio-base/src/panels/StateTransitions/settings.ts
@@ -43,6 +43,7 @@ const makeSeriesNode = memoizeWeak(
           input: "messagepath",
           value: path.value,
           validTypes: plotableRosTypes,
+          supportsDisplayTopic: true,
         },
         label: {
           input: "string",

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -586,6 +586,8 @@ export type SettingsTreeFieldValue =
       validTypes?: string[];
       /** True if the input should allow math modifiers like @abs. */
       supportsMathModifiers?: boolean;
+      /** True if the input should allow display the distribution of topic over the entire period of time */
+      supportsDisplayTopic?: boolean;
     }
   | {
       input: "number";


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
Supports displaying the time when a topic appears, making it easy to locate the time when a specific event occurs and start playing from the time of occurrence. ( same as RVIZ. )

![rviz](https://github.com/foxglove/studio/assets/23401125/2887e591-41c2-449c-a172-5fb99c2fa421)

**After**
![image](https://github.com/foxglove/studio/assets/23401125/83822186-5b04-4744-bf02-1965caf7c324)



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
