### PR TITLE
Add avro schema and message encoding support

### DIFF
--- a/packages/@types/avro-js/index.d.ts
+++ b/packages/@types/avro-js/index.d.ts
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// https://github.com/apache/avro/blob/main/lang/js/doc/API.md
+
+declare module "avro-js" {
+  type AvroType =
+    | "array"
+    | "boolean"
+    | "bytes"
+    | "double"
+    | "enum"
+    | "error"
+    | "fixed"
+    | "float"
+    | "int"
+    | "long"
+    | "map"
+    | "null"
+    | "record"
+    | "request"
+    | "string"
+    | "union";
+
+  class Type {
+    public fromBuffer(buffer: Buffer): unknown;
+
+    /**
+     * Returns type's fully qualified name if it exists, undefined otherwise.
+     *
+     * @param noRef Return built-in names (e.g. 'record', 'map', 'boolean') rather than user-specified references.
+     */
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    public getName(noRef?: boolean): string | undefined;
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    public getName(noRef: true): AvroType;
+  }
+
+  class BooleanType extends Type {}
+  class BytesType extends Type {}
+  class DoubleType extends Type {}
+  class FloatType extends Type {}
+  class IntType extends Type {}
+  class LongType extends Type {}
+  class NullType extends Type {}
+  class StringType extends Type {}
+
+  class RecordType extends Type {
+    /** Returns a copy of the array of fields contained in this record. */
+    public getFields(): Field[];
+  }
+
+  class ArrayType extends Type {
+    /** The type of the array's items.*/
+    public getItemsType(): Type;
+  }
+
+  class MapType extends Type {}
+  class EnumType extends Type {}
+  class FixedType extends Type {}
+  class UnionType extends Type {}
+
+  type PrimitiveType =
+    | DoubleType
+    | BooleanType
+    | BytesType
+    | FloatType
+    | IntType
+    | LongType
+    | NullType
+    | StringType;
+  type ComplexType = RecordType | ArrayType | MapType | EnumType | FixedType | UnionType;
+
+  type Registry = Record<string, PrimitiveType | ComplexType>;
+
+  class Field {
+    public getName(): string;
+    public getType(): PrimitiveType | ComplexType;
+  }
+
+  export type ParseOptions = {
+    namespace?: string;
+    registry?: Registry;
+  };
+
+  export function parse(schema: unknown, options?: ParseOptions): void;
+
+  const types = {
+    BooleanType,
+    BytesType,
+    DoubleType,
+    FloatType,
+    IntType,
+    LongType,
+    NullType,
+    StringType,
+    RecordType,
+    ArrayType,
+    EnumType,
+    FixedType,
+    MapType,
+    UnionType,
+  };
+  export const types;
+}

--- a/packages/@types/avro-js/package.json
+++ b/packages/@types/avro-js/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@types/avro-js",
+  "types": "index.d.ts"
+}

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@foxglove/tsconfig": "2.0.0",
+    "@types/avro-js": "workspace:*",
     "@types/protobufjs": "workspace:*",
     "typescript": "5.2.2"
   },
@@ -39,6 +40,7 @@
     "@foxglove/wasm-zstd": "1.0.1",
     "@mcap/core": "1.3.0",
     "@protobufjs/base64": "1.1.2",
+    "avro-js": "1.11.3",
     "flatbuffers": "23.5.26",
     "flatbuffers_reflection": "0.0.7",
     "protobufjs": "patch:protobufjs@7.2.4#../../patches/protobufjs.patch"

--- a/packages/mcap-support/src/index.ts
+++ b/packages/mcap-support/src/index.ts
@@ -7,3 +7,5 @@ export * from "./protobufDefinitionsToDatatypes";
 export * from "./parseChannel";
 export * from "./decompressHandlers";
 export * from "./TempBuffer";
+
+export type { ParsedChannel } from "./types";

--- a/packages/mcap-support/src/parseAvroSchema.test.ts
+++ b/packages/mcap-support/src/parseAvroSchema.test.ts
@@ -1,0 +1,187 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// checkParse is a helper function that does the actual asserting
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["checkParse"] }] */
+
+import { MessageDefinition } from "@foxglove/message-definition";
+
+import { parseAvroSchema } from "./parseAvroSchema";
+
+function checkParse(
+  name: string,
+  inputSchema: unknown,
+  expectedRegistry: Record<string, MessageDefinition>,
+): void {
+  const result = parseAvroSchema(name, new TextEncoder().encode(JSON.stringify(inputSchema)));
+  expect(result.datatypes).toEqual(new Map(Object.entries(expectedRegistry)));
+}
+
+describe("parseAvroSchema", () => {
+  it("parses a valid single object schema", () => {
+    checkParse(
+      "AvroPrimitives",
+      {
+        name: "AvroPrimitives",
+        type: "record",
+        fields: [
+          { name: "str", type: "string" },
+          { name: "int", type: "int" },
+          { name: "long", type: "long" },
+          { name: "boolean", type: "boolean" },
+          { name: "float", type: "float" },
+          { name: "double", type: "double" },
+          { name: "bytes", type: "bytes" },
+        ],
+      },
+      {
+        AvroPrimitives: {
+          name: "AvroPrimitives",
+          definitions: [
+            { isComplex: false, name: "str", type: "string" },
+            { isComplex: false, name: "int", type: "int32" },
+            { isComplex: false, name: "long", type: "int64" },
+            { isComplex: false, name: "boolean", type: "bool" },
+            { isComplex: false, name: "float", type: "float32" },
+            { isComplex: false, name: "double", type: "float64" },
+            { isComplex: false, isArray: true, name: "bytes", type: "uint8" },
+          ],
+        },
+      },
+    );
+  });
+
+  it("parses an array of primitives", () => {
+    checkParse(
+      "AvroArrayPrimitives",
+      {
+        name: "AvroArrayPrimitives",
+        type: "record",
+        fields: [{ name: "strings", type: { type: "array", items: "string" } }],
+      },
+      {
+        AvroArrayPrimitives: {
+          name: "AvroArrayPrimitives",
+          definitions: [{ isComplex: false, isArray: true, name: "strings", type: "string" }],
+        },
+      },
+    );
+  });
+
+  it("parses an array of records", () => {
+    checkParse(
+      "AvroArrayComplex",
+      {
+        name: "AvroArrayComplex",
+        type: "record",
+        fields: [
+          {
+            name: "points",
+            type: {
+              type: "array",
+              items: {
+                type: "record",
+                name: "foxglove.Point2d",
+                fields: [
+                  { name: "x", type: "float" },
+                  { name: "y", type: "float" },
+                ],
+              },
+            },
+          },
+        ],
+      },
+      {
+        "foxglove.Point2d": {
+          name: "foxglove.Point2d",
+          definitions: [
+            { isComplex: false, name: "x", type: "float32" },
+            { isComplex: false, name: "y", type: "float32" },
+          ],
+        },
+        AvroArrayComplex: {
+          name: "AvroArrayComplex",
+          definitions: [
+            { isComplex: true, isArray: true, name: "points", type: "foxglove.Point2d" },
+          ],
+        },
+      },
+    );
+  });
+
+  it("parses nested records", () => {
+    checkParse(
+      "MyRecord",
+      {
+        name: "MyRecord",
+        type: "record",
+        fields: [
+          {
+            name: "point",
+            type: {
+              type: "record",
+              name: "foxglove.Point2d",
+              fields: [
+                { name: "x", type: "float" },
+                { name: "y", type: "float" },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        MyRecord: {
+          name: "MyRecord",
+          definitions: [{ isComplex: true, name: "point", type: "foxglove.Point2d" }],
+        },
+        "foxglove.Point2d": {
+          name: "foxglove.Point2d",
+          definitions: [
+            { isComplex: false, name: "x", type: "float32" },
+            { isComplex: false, name: "y", type: "float32" },
+          ],
+        },
+      },
+    );
+  });
+
+  it("parses array of schemas", () => {
+    checkParse(
+      "MyRecord",
+      [
+        {
+          type: "record",
+          name: "foxglove.Point2d",
+          fields: [
+            { name: "x", type: "float" },
+            { name: "y", type: "float" },
+          ],
+        },
+        {
+          name: "MyRecord",
+          type: "record",
+          fields: [
+            {
+              name: "point",
+              type: "foxglove.Point2d",
+            },
+          ],
+        },
+      ],
+      {
+        MyRecord: {
+          name: "MyRecord",
+          definitions: [{ isComplex: true, name: "point", type: "foxglove.Point2d" }],
+        },
+        "foxglove.Point2d": {
+          name: "foxglove.Point2d",
+          definitions: [
+            { isComplex: false, name: "x", type: "float32" },
+            { isComplex: false, name: "y", type: "float32" },
+          ],
+        },
+      },
+    );
+  });
+});

--- a/packages/mcap-support/src/parseAvroSchema.ts
+++ b/packages/mcap-support/src/parseAvroSchema.ts
@@ -1,0 +1,165 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import avro, { ParseOptions } from "avro-js";
+
+import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
+
+import { MessageDefinitionMap, ParsedChannel } from "./types";
+
+/**
+ * Parse a Avro schema and produce datatypes and a deserializer function.
+ */
+export function parseAvroSchema(schemaName: string, schemaData: Uint8Array): ParsedChannel {
+  const avroSchema = JSON.parse(new TextDecoder().decode(schemaData)) as unknown;
+
+  // Setup a shared registry to populate via avro.parse() calls
+  // We will populate the registry either from a single schema or from an array of schemas
+  const registry: ParseOptions["registry"] = {};
+
+  // Parse supports a single schema object or an array of objects. Technically in avro an array of
+  // schemas indicates a union type, but mcap defines arrays as separate record schemas.
+  avro.parse(avroSchema, { registry });
+
+  // Grab the entry schema from the registry to build the datatypes
+  const avroType = registry[schemaName];
+  if (!avroType) {
+    throw new Error(`Could not find type "${schemaName}" in types registry.`);
+  }
+
+  if (!(avroType instanceof avro.types.RecordType)) {
+    throw new Error(
+      `Type "${schemaName}" is not a record type. Only record types are supported at the top level.`,
+    );
+  }
+
+  const deserialize: ParsedChannel["deserialize"] = (data: ArrayBufferView) => {
+    return avroType.fromBuffer(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
+  };
+
+  const datatypes: MessageDefinitionMap = new Map();
+  registerRecordType(avroType, datatypes);
+
+  return { deserialize, datatypes };
+}
+
+/**
+ * Register a RecordType into the definition registry.
+ *
+ * This function will recursively register the provided record type and its fields into the
+ * definition registry.
+ */
+function registerRecordType(
+  record: avro.RecordType,
+  definitionRegistry: MessageDefinitionMap,
+): void {
+  // All records must have a full name so they can be entered into the registry
+  const fullName = record.getName();
+  if (!fullName) {
+    throw new Error("invariant: RecordType without a name");
+  }
+
+  // skip re-registering if the registry already has this name to support the
+  // recursive references avro feature
+  if (definitionRegistry.has(fullName)) {
+    return;
+  }
+
+  const definition: MessageDefinition = {
+    name: fullName,
+    definitions: [],
+  };
+
+  const fields = record.getFields();
+  for (const field of fields) {
+    const fieldName = field.getName();
+    const fieldType = field.getType();
+
+    const definitionField = typeToDefinitionField(fieldName, fieldType);
+    definition.definitions.push(definitionField);
+
+    // Fields may contain definitions for other records so we register those as well
+    if (fieldType instanceof avro.types.ArrayType) {
+      const itemType = fieldType.getItemsType();
+      if (itemType instanceof avro.types.RecordType) {
+        registerRecordType(itemType, definitionRegistry);
+      }
+    } else if (fieldType instanceof avro.types.RecordType) {
+      registerRecordType(fieldType, definitionRegistry);
+    }
+  }
+
+  definitionRegistry.set(fullName, definition);
+}
+
+function getStudioTypeForPrimitiveType(type: string): string {
+  switch (type) {
+    case "boolean":
+      return "bool";
+    case "int":
+      return "int32";
+    case "long":
+      return "int64";
+    case "float":
+      return "float32";
+    case "double":
+      return "float64";
+    case "bytes":
+      return "uint8";
+    case "string":
+      return "string";
+  }
+
+  throw new Error(`unknown primitive type: ${type}`);
+}
+
+function typeToDefinitionField(name: string, type: avro.Type): MessageDefinitionField {
+  // The avro type is the builtin set of avro types
+  const avroType = type.getName(true);
+
+  if (type instanceof avro.types.ArrayType) {
+    const itemType = type.getItemsType();
+    const itemDefinition = typeToDefinitionField("-", itemType);
+
+    return {
+      name,
+      type: itemDefinition.type,
+      isArray: true,
+      isComplex: itemDefinition.isComplex,
+    };
+  } else if (type instanceof avro.types.RecordType) {
+    const itemName = type.getName();
+    if (!itemName) {
+      throw new Error(`invariant: missing item name for field: ${name}`);
+    }
+
+    return {
+      name,
+      type: itemName,
+      isComplex: true,
+    };
+  } else if (type instanceof avro.types.UnionType) {
+    throw new Error("union type is not supported");
+  } else if (type instanceof avro.types.MapType) {
+    throw new Error("map type is not supported");
+  } else if (type instanceof avro.types.EnumType) {
+    throw new Error("enum type is not supported");
+  } else if (type instanceof avro.types.FixedType) {
+    throw new Error("fixed type is not supported");
+  } else if (type instanceof avro.types.BytesType) {
+    // bytes are represented as an array of uint8
+    return {
+      name,
+      type: "uint8",
+      isComplex: false,
+      isArray: true,
+    };
+  }
+
+  return {
+    name,
+    type: getStudioTypeForPrimitiveType(avroType),
+    isComplex: false,
+  };
+}

--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -7,7 +7,7 @@ import { BaseType, Schema, SchemaT, FieldT, Parser, Table } from "flatbuffers_re
 
 import { MessageDefinitionField } from "@foxglove/message-definition";
 
-import { MessageDefinitionMap } from "./types";
+import { MessageDefinitionMap, ParsedChannel } from "./types";
 
 function typeForSimpleField(type: BaseType): string {
   switch (type) {
@@ -152,13 +152,7 @@ function typeForField(schema: SchemaT, field: FieldT): MessageDefinitionField[] 
 /**
  * Parse a flatbuffer binary schema and produce datatypes and a deserializer function.
  */
-export function parseFlatbufferSchema(
-  schemaName: string,
-  schemaArray: Uint8Array,
-): {
-  datatypes: MessageDefinitionMap;
-  deserialize: (buffer: ArrayBufferView) => unknown;
-} {
+export function parseFlatbufferSchema(schemaName: string, schemaArray: Uint8Array): ParsedChannel {
   const datatypes: MessageDefinitionMap = new Map();
   const schemaBuffer = new ByteBuffer(schemaArray);
   const rawSchema = Schema.getRootAsSchema(schemaBuffer);

--- a/packages/mcap-support/src/parseProtobufSchema.ts
+++ b/packages/mcap-support/src/parseProtobufSchema.ts
@@ -6,19 +6,13 @@ import protobufjs from "protobufjs";
 import { FileDescriptorSet } from "protobufjs/ext/descriptor";
 
 import { protobufDefinitionsToDatatypes, stripLeadingDot } from "./protobufDefinitionsToDatatypes";
-import { MessageDefinitionMap } from "./types";
+import { MessageDefinitionMap, ParsedChannel } from "./types";
 
 /**
  * Parse a Protobuf binary schema (FileDescriptorSet) and produce datatypes and a deserializer
  * function.
  */
-export function parseProtobufSchema(
-  schemaName: string,
-  schemaData: Uint8Array,
-): {
-  datatypes: MessageDefinitionMap;
-  deserialize: (buffer: ArrayBufferView) => unknown;
-} {
+export function parseProtobufSchema(schemaName: string, schemaData: Uint8Array): ParsedChannel {
   const descriptorSet = FileDescriptorSet.decode(schemaData);
 
   const root = protobufjs.Root.fromDescriptor(descriptorSet);

--- a/packages/mcap-support/src/types.ts
+++ b/packages/mcap-support/src/types.ts
@@ -6,3 +6,8 @@ import { MessageDefinition } from "@foxglove/message-definition";
 
 /** A map of schema name to the schema message definition */
 export type MessageDefinitionMap = Map<string, MessageDefinition>;
+
+export type ParsedChannel = {
+  deserialize: (data: ArrayBufferView) => unknown;
+  datatypes: MessageDefinitionMap;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,7 +2479,9 @@ __metadata:
     "@foxglove/wasm-zstd": 1.0.1
     "@mcap/core": 1.3.0
     "@protobufjs/base64": 1.1.2
+    "@types/avro-js": "workspace:*"
     "@types/protobufjs": "workspace:*"
+    avro-js: 1.11.3
     flatbuffers: 23.5.26
     flatbuffers_reflection: 0.0.7
     protobufjs: "patch:protobufjs@7.2.4#../../patches/protobufjs.patch"
@@ -6036,6 +6038,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/avro-js@workspace:*, @types/avro-js@workspace:packages/@types/avro-js":
+  version: 0.0.0-use.local
+  resolution: "@types/avro-js@workspace:packages/@types/avro-js"
+  languageName: unknown
+  linkType: soft
+
 "@types/babel__core@npm:^7.0.0, @types/babel__core@npm:^7.1.14, @types/babel__core@npm:^7.20.2":
   version: 7.20.2
   resolution: "@types/babel__core@npm:7.20.2"
@@ -8211,6 +8219,15 @@ __metadata:
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
   checksum: 20eb47b3cefd7db027b9bbb993c658abd36d4edd3fe1060e83699a03ee275b0c9b216cc076ff3f2db29073225fb70e7613987af14269ac1fe2a19803ccc97f1a
+  languageName: node
+  linkType: hard
+
+"avro-js@npm:1.11.3":
+  version: 1.11.3
+  resolution: "avro-js@npm:1.11.3"
+  dependencies:
+    underscore: ^1.13.2
+  checksum: a52a94f4058f58b65a42297ac40cc96861d015d1bef45568368de36394852d35344e483463175b95988057021a1a360ef65a2ee5176db117102a8805c16695bf
   languageName: node
   linkType: hard
 
@@ -21149,6 +21166,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"underscore@npm:^1.13.2":
+  version: 1.13.6
+  resolution: "underscore@npm:1.13.6"
+  checksum: d5cedd14a9d0d91dd38c1ce6169e4455bb931f0aaf354108e47bd46d3f2da7464d49b2171a5cf786d61963204a42d01ea1332a903b7342ad428deaafaf70ec36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Add support for mcap files with "avro" message and schema encoding.

**Description**

This PR adds support for mcap files with avro messages as described in https://github.com/foxglove/mcap/pull/993.

Sample mcap: 
[avro.mcap.zip](https://github.com/foxglove/studio/files/13065671/avro.mcap.zip)



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
