### PR TITLE
Control error clearing in ImageRenderable

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -76,6 +76,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
   #disposed = false;
 
+  // used by subclass
+  protected clearDecodeErrors = true;
+
   public constructor(topicName: string, renderer: IRenderer, userData: ImageUserData) {
     super(topicName, renderer, userData);
   }
@@ -200,7 +203,11 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         this.update();
 
         onDecoded?.(result);
-        this.removeError(DECODE_IMAGE_ERR_KEY);
+        if (this.clearDecodeErrors) {
+          this.removeError(DECODE_IMAGE_ERR_KEY);
+        }
+        // reset if changed
+        this.clearDecodeErrors = true;
         this.renderer.queueAnimationFrame();
       })
       .catch((err) => {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- n/a

**Description**

If an image sets an error while decoding but still resolves successfully in the promise, then we don't want to clear the errors set on the renderable.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
