### PR TITLE
Add `user-select: all` to TextMiddleTruncate

### DIFF
--- a/packages/studio-base/src/components/TextMiddleTruncate.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles()(() => ({
     display: "flex",
     justifyContent: "flex-start",
     overflow: "hidden",
+    userSelect: "all",
   },
   start: {
     overflow: "hidden",


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
In #6468 we changed the behavior of the "copy" command on TextMiddleTruncate components to copy the entire string. This was done to avoid issues where a [stray newline character](https://github.com/foxglove/studio/issues/6403) was copied. However, it introduced confusion because the user-selected text was no longer the text that is copied. This PR reduces confusion by adding `user-select: all` which makes it clear that the full string is implicitly selected and will be copied.

This is probably not an ideal user experience, but it's a trivial change to decrease confusion a bit, and we haven't come up with a good proposal for a more complete middle-truncation solution and copying experience that would be intuitive as well as consistent with the rest of the app.

Closes #6878