### PR TITLE
Don't touch TypedArrays in strPack

### DIFF
--- a/packages/studio-base/src/util/strPack.ts
+++ b/packages/studio-base/src/util/strPack.ts
@@ -25,8 +25,8 @@ const packValue = (value: unknown, map: Mapping): unknown => {
     return transformed;
   }
 
-  if (value instanceof Set) {
-    // we do not dedupe in sets for now
+  if (value instanceof Set || ArrayBuffer.isView(value)) {
+    // we do not dedupe in sets or Float32Array for now
     return value;
   }
 

--- a/packages/studio-base/src/util/strPack.ts
+++ b/packages/studio-base/src/util/strPack.ts
@@ -26,7 +26,7 @@ const packValue = (value: unknown, map: Mapping): unknown => {
   }
 
   if (value instanceof Set || ArrayBuffer.isView(value)) {
-    // we do not dedupe in sets or Float32Array for now
+    // we do not dedupe in sets or TypedArrays for now
     return value;
   }
 


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue where `TypedArray` message fields were not being plotted correctly.

**Description**
`strPack` did not handle `TypedArray`s. Ouch.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
