### PR TITLE
Use user-facing script name in user script errors

### DIFF
--- a/packages/studio-base/src/players/UserScriptPlayer/index.ts
+++ b/packages/studio-base/src/players/UserScriptPlayer/index.ts
@@ -529,7 +529,7 @@ export default class UserScriptPlayer implements Player {
         if (allDiagnostics.length > 0) {
           this.#problemStore.set(problemKey, {
             severity: "error",
-            message: `User Script ${scriptId} encountered an error.`,
+            message: `User Script ${scriptData.name} encountered an error.`,
             tip: "Open the User Scripts panel and check the Problems tab for errors.",
           });
 
@@ -540,7 +540,7 @@ export default class UserScriptPlayer implements Player {
         if (!result.message) {
           this.#problemStore.set(problemKey, {
             severity: "warn",
-            message: `User Script ${scriptId} did not produce a message.`,
+            message: `User Script ${scriptData.name} did not produce a message.`,
             tip: "Check that all code paths in the user script return a message.",
           });
           return;


### PR DESCRIPTION
**User-Facing Changes**
Use user-defined user script names in errors instead of the script's ID.

**Description**
This seems to have just been a mistake; as far as I'm aware we don't actually show this to the user anywhere else.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
