### PR TITLE
Fix collada textures not being loaded over websocket

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -233,6 +233,10 @@ export class ModelCache {
     const dae = daeLoader.parse(xmlText, baseUrl(url));
     manager.itemEnd(url);
 
+    for (const objectUrl of textureUrls.values()) {
+      URL.revokeObjectURL(objectUrl);
+    }
+
     // If the <up_axis> is Y_UP, rotate to the Studio convention of Z-up following
     // ROS [REP-0103](https://www.ros.org/reps/rep-0103.html)
     if (upAxis === "Y_UP") {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -203,8 +203,30 @@ export class ModelCache {
     });
     const xmlText = xml.documentElement.outerHTML;
 
+    // Preload textures. We do this here since we can't pass in an async function in LoadingManager.setURLModifier
+    // which is supposed to be used for overriding loading behavior. See also
+    // https://threejs.org/docs/index.html#api/en/loaders/managers/LoadingManager.setURLModifier
+    const textureUrls = new Map<string, string>();
+    for await (const node of xml.querySelectorAll("init_from")) {
+      if (!node.textContent) {
+        continue;
+      }
+
+      try {
+        const textureUrl = new URL(node.textContent, baseUrl(url)).toString();
+        const textureAsset = await this.#fetchAsset(textureUrl);
+        const objectUrl = URL.createObjectURL(
+          new Blob([textureAsset.data], { type: textureAsset.mediaType }),
+        );
+        textureUrls.set(textureUrl, objectUrl);
+      } catch (e) {
+        log.error(e);
+        onError(node.textContent);
+      }
+    }
+
     const manager = new THREE.LoadingManager(undefined, undefined, onError);
-    manager.setURLModifier(rewriteUrl);
+    manager.setURLModifier((u) => textureUrls.get(u) ?? rewriteUrl(u));
     const daeLoader = new ColladaLoader(manager);
 
     manager.itemStart(url);


### PR DESCRIPTION
**User-Facing Changes**
Fix collada textures not being loaded over websocket

**Description**
Studio loads collada meshes through the asset management layer which, in case of a foxglove-websocket connection, may fetch the asset over the websocket connection. However, this was not the case for texture assets that are referenced by the collada mesh, resulting in the entire collada mesh not being loaded.

This PR fixes this by also loading the referenced texture assets through Studio's asset management layer.

Resolves FG-5340
