### PR TITLE
Save Font Settings for Raw Messages Panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -302,6 +302,7 @@ export const DiffSameMessages: StoryObj = {
           diffTopicPath: "/foo",
           diffEnabled: true,
           showFullMessageForDiff: false,
+          fontSize: undefined,
         }}
       />
     </PanelSetup>
@@ -319,6 +320,7 @@ export const DiffConsecutiveMessages: StoryObj = {
           diffEnabled: true,
           showFullMessageForDiff: true,
           expansion: "all",
+          fontSize: undefined,
         }}
       />
     </PanelSetup>
@@ -336,6 +338,7 @@ export const DiffConsecutiveMessagesWithFilter: StoryObj = {
           diffEnabled: true,
           showFullMessageForDiff: true,
           expansion: "all",
+          fontSize: undefined,
         }}
       />
     </PanelSetup>
@@ -353,6 +356,7 @@ export const DiffConsecutiveMessagesWithBigint: StoryObj = {
           diffEnabled: true,
           showFullMessageForDiff: true,
           expansion: "all",
+          fontSize: undefined,
         }}
       />
     </PanelSetup>
@@ -370,6 +374,7 @@ export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet: 
           diffEnabled: false,
           showFullMessageForDiff: true,
           expansion: "all",
+          fontSize: undefined,
         }}
       />
     </PanelSetup>

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -96,7 +96,8 @@ function RawMessages(props: Props) {
   const jsonTreeTheme = useJsonTreeTheme();
   const { config, saveConfig } = props;
   const { openSiblingPanel } = usePanelContext();
-  const { topicPath, diffMethod, diffTopicPath, diffEnabled, showFullMessageForDiff } = config;
+  const { topicPath, diffMethod, diffTopicPath, diffEnabled, showFullMessageForDiff, fontSize } =
+    config;
   const { topics, datatypes } = useDataSourceInfo();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
   const { setMessagePathDropConfig } = usePanelContext();
@@ -145,7 +146,6 @@ function RawMessages(props: Props) {
   }, [structures, topic, topicRosPath]);
 
   const [expansion, setExpansion] = useState(config.expansion);
-  const [customFontSize, setCustomFontSize] = useState<number | undefined>();
 
   // Pass an empty path to useMessageDataItem if our path doesn't resolve to a valid topic to avoid
   // spamming the message pipeline with useless subscription requests.
@@ -424,7 +424,7 @@ function RawMessages(props: Props) {
         {shouldDisplaySingleVal ? (
           <Typography
             variant="h1"
-            fontSize={customFontSize}
+            fontSize={fontSize}
             whiteSpace="pre-wrap"
             style={{ wordWrap: "break-word" }}
           >
@@ -524,7 +524,7 @@ function RawMessages(props: Props) {
                 nestedNode: ({ style }, keyPath: any) => {
                   const baseStyle = {
                     ...style,
-                    fontSize: customFontSize,
+                    fontSize,
                     paddingTop: 2,
                     paddingBottom: 2,
                     marginTop: 2,
@@ -576,7 +576,7 @@ function RawMessages(props: Props) {
                 value: ({ style }, _nodeType, keyPath: any) => {
                   const baseStyle = {
                     ...style,
-                    fontSize: customFontSize,
+                    fontSize,
                     textDecoration: "inherit",
                   };
                   if (!diffEnabled) {
@@ -616,7 +616,7 @@ function RawMessages(props: Props) {
   }, [
     baseItem,
     classes.topic,
-    customFontSize,
+    fontSize,
     diffEnabled,
     diffItem,
     diffMethod,
@@ -635,17 +635,21 @@ function RawMessages(props: Props) {
     valueRenderer,
   ]);
 
-  const actionHandler = useCallback((action: SettingsTreeAction) => {
-    if (action.action === "update") {
-      if (action.payload.path[0] === "general") {
-        if (action.payload.path[1] === "fontSize") {
-          setCustomFontSize(
-            action.payload.value != undefined ? (action.payload.value as number) : undefined,
-          );
+  const actionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.action === "update") {
+        if (action.payload.path[0] === "general") {
+          if (action.payload.path[1] === "fontSize") {
+            saveConfig({
+              fontSize:
+                action.payload.value != undefined ? (action.payload.value as number) : undefined,
+            });
+          }
         }
       }
-    }
-  }, []);
+    },
+    [saveConfig],
+  );
 
   useEffect(() => {
     updatePanelSettingsTree({
@@ -664,13 +668,13 @@ function RawMessages(props: Props) {
                   value,
                 })),
               ],
-              value: customFontSize,
+              value: fontSize,
             },
           },
         },
       },
     });
-  }, [actionHandler, customFontSize, updatePanelSettingsTree]);
+  }, [actionHandler, fontSize, updatePanelSettingsTree]);
 
   return (
     <Stack flex="auto" overflow="hidden" position="relative">
@@ -697,6 +701,7 @@ const defaultConfig: RawMessagesPanelConfig = {
   diffTopicPath: "",
   showFullMessageForDiff: false,
   topicPath: "",
+  fontSize: undefined,
 };
 
 export default Panel(

--- a/packages/studio-base/src/panels/RawMessages/types.ts
+++ b/packages/studio-base/src/panels/RawMessages/types.ts
@@ -17,6 +17,7 @@ export type RawMessagesPanelConfig = {
   expansion?: NodeExpansion;
   showFullMessageForDiff: boolean;
   topicPath: string;
+  fontSize: number | undefined;
 };
 
 export const Constants = {


### PR DESCRIPTION
**User-Facing Changes**

Font settings of the RawMessage panel can be saved with the layout

**Description**

#6397 thoughtfully added the font setting function, but unfortunately, every time the data is switched or refreshed after the setting is completed, it will be reset to `auto` and needs to be set again.

I hope this setting can be remembered.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
