### PR TITLE
Fix inconsistent shadow and min height on plot legend

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -52,14 +52,14 @@ const useStyles = makeStyles<void, "container" | "toggleButton" | "toggleButtonF
     rootFloating: {
       padding: spacing(0.75), // pad the container to prevent shadow from being clipped
       pointerEvents: "none",
-      gap: spacing(0.75),
+      // gap: spacing(0.75),
       position: "absolute",
       top: spacing(4.5),
       left: spacing(4),
       zIndex: 1000,
       backgroundColor: "transparent",
       alignItems: "flex-start",
-      height: `calc(100% - ${PANEL_TOOLBAR_MIN_HEIGHT}px - ${spacing(5.25)})`,
+      height: `calc(100% - ${PANEL_TOOLBAR_MIN_HEIGHT}px - ${spacing(3.5)})`,
       overflow: "hidden",
       minWidth: 200,
 
@@ -153,7 +153,7 @@ function PlotLegendComponent(props: Props): JSX.Element {
     showPlotValuesInLegend,
     sidebarDimension,
   } = props;
-  const { classes, cx } = useStyles();
+  const { classes, cx, theme } = useStyles();
 
   const dragStart = useRef({ x: 0, y: 0, sidebarDimension: 0 });
 
@@ -236,6 +236,7 @@ function PlotLegendComponent(props: Props): JSX.Element {
           style={{
             height: legendDisplay === "top" ? Math.round(sidebarDimension) : undefined,
             width: legendDisplay === "left" ? Math.round(sidebarDimension) : undefined,
+            marginTop: legendDisplay === "floating" ? theme.spacing(-0.75) : undefined,
           }}
         >
           <Stack
@@ -243,6 +244,7 @@ function PlotLegendComponent(props: Props): JSX.Element {
             fullWidth
             fullHeight={legendDisplay !== "top"}
             overflow={legendDisplay === "floating" ? "auto" : undefined}
+            padding={legendDisplay === "floating" ? 0.75 : undefined}
           >
             <div className={classes.container}>
               {(paths.length === 0 ? [DEFAULT_PATH] : paths).map((path, index) => (

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -120,14 +120,7 @@ const useStyles = makeStyles<void, "container" | "toggleButton" | "toggleButtonF
         borderColor: palette.action.selected,
       },
     },
-    toggleButton: {
-      fontSize: "1rem",
-      padding: spacing(0.75),
-
-      "svg:not(.MuiSvgIcon-root)": {
-        fontSize: "1em",
-      },
-    },
+    toggleButton: {},
     toggleButtonFloating: {
       backdropFilter: "blur(3px)",
       pointerEvents: "auto",

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -52,7 +52,6 @@ const useStyles = makeStyles<void, "container" | "toggleButton" | "toggleButtonF
     rootFloating: {
       padding: spacing(0.75), // pad the container to prevent shadow from being clipped
       pointerEvents: "none",
-      // gap: spacing(0.75),
       position: "absolute",
       top: spacing(4.5),
       left: spacing(4),

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -38,7 +38,7 @@ type PlotLegendRowProps = Immutable<{
   showPlotValuesInLegend: boolean;
 }>;
 
-const ROW_HEIGHT = 28;
+const ROW_HEIGHT = 30;
 
 const useStyles = makeStyles<void, "plotName" | "removeButton">()((theme, _params, classes) => ({
   root: {
@@ -75,13 +75,10 @@ const useStyles = makeStyles<void, "plotName" | "removeButton">()((theme, _param
     left: 0,
   },
   checkbox: {
-    fontSize: "1em",
-    padding: theme.spacing(0.975),
+    height: ROW_HEIGHT,
+    width: ROW_HEIGHT,
     borderRadius: 0,
 
-    "svg:not(.MuiSvgIcon-root)": {
-      fontSize: "1em",
-    },
     ":hover": {
       backgroundColor: theme.palette.action.hover,
     },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
<img width="274" alt="Screen Shot 2023-10-26 at 9 34 40 am" src="https://github.com/foxglove/studio/assets/924528/b1157aaf-f8ca-4502-9dee-dd291dea18d8">

Floating legend is now consistent with other floating buttons and the rows.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
