### PR TITLE
Avoid adding the same ID twice to subscriberIdsByTopic

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -239,7 +239,12 @@ function updateSubscriberAction(
       const topic = subscription.topic;
 
       const ids = subscriberIdsByTopic.get(topic) ?? [];
-      ids.push(id);
+      // If the id is already present in the array for the topic then we should not add it again.
+      // If we add it again it will be given frame messages again when bucketing incoming messages
+      // by subscriber id.
+      if (!ids.includes(id)) {
+        ids.push(id);
+      }
       subscriberIdsByTopic.set(topic, ids);
     }
   }

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -48,17 +48,19 @@ export type MessagePipelineInternalState = {
 
   /** used to keep track of whether we need to update public.startPlayback/playUntil/etc. */
   lastCapabilities: string[];
-  // Preserves reference equality of subscriptions to minimize player subscription churn.
+  /** Preserves reference equality of subscriptions to minimize player subscription churn. */
   subscriptionMemoizer: (sub: SubscribePayload) => SubscribePayload;
   subscriptionsById: Map<string, Immutable<SubscribePayload[]>>;
   publishersById: { [key: string]: AdvertiseOptions[] };
   allPublishers: AdvertiseOptions[];
-  // A map of topic name to the IDs that are subscribed to that topic. Incoming messages
-  // are bucketed by ID so only the messages a panel subscribed to are sent to it.
-  //
-  // Note: Even though we avoid storing the same ID twice in the array, we use an array rather than
-  //       a Set because iterating over array elements is faster than iterating a Set and the "hot"
-  //       path for dispatching messages needs to iterate over the array of IDs.
+  /**
+   * A map of topic name to the IDs that are subscribed to that topic. Incoming messages
+   * are bucketed by ID so only the messages a panel subscribed to are sent to it.
+   *
+   * Note: Even though we avoid storing the same ID twice in the array, we use an array rather than
+   * a Set because iterating over array elements is faster than iterating a Set and the "hot" path
+   * for dispatching messages needs to iterate over the array of IDs.
+   */
   subscriberIdsByTopic: Map<string, string[]>;
   newTopicsBySubscriberId: Map<string, Set<string>>;
   lastMessageEventByTopic: Map<string, MessageEvent>;
@@ -303,12 +305,12 @@ function updatePlayerStateAction(
       }
 
       for (const id of ids) {
-        let subscriberMessageEvents = messagesBySubscriberId.get(id);
+        const subscriberMessageEvents = messagesBySubscriberId.get(id);
         if (!subscriberMessageEvents) {
-          subscriberMessageEvents = [];
-          messagesBySubscriberId.set(id, subscriberMessageEvents);
+          messagesBySubscriberId.set(id, [messageEvent]);
+        } else {
+          subscriberMessageEvents.push(messageEvent);
         }
-        subscriberMessageEvents.push(messageEvent);
       }
     }
   }

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -53,6 +53,12 @@ export type MessagePipelineInternalState = {
   subscriptionsById: Map<string, Immutable<SubscribePayload[]>>;
   publishersById: { [key: string]: AdvertiseOptions[] };
   allPublishers: AdvertiseOptions[];
+  // A map of topic name to the IDs that are subscribed to that topic. Incoming messages
+  // are bucketed by ID so only the messages a panel subscribed to are sent to it.
+  //
+  // Note: Even though we avoid storing the same ID twice in the array, we use an array rather than
+  //       a Set because iterating over array elements is faster than iterating a Set and the "hot"
+  //       path for dispatching messages needs to iterate over the array of IDs.
   subscriberIdsByTopic: Map<string, string[]>;
   newTopicsBySubscriberId: Map<string, Set<string>>;
   lastMessageEventByTopic: Map<string, MessageEvent>;


### PR DESCRIPTION
**User-Facing Changes**
Fix duplicate messages being sent to a panel if it subscribed twice to the same topic.

**Description**
This change updates the `MessagePipeline` store `updateSubscriberAction` function to avoid adding a subscriber ID multiple times to the `subscriberIdsByTopic` array for a particular topic. Including the ID multiple times results in other logic in the store which handles message distribution to erroneously provide the message to the panel multiple times here: https://github.com/foxglove/studio/blob/main/packages/studio-base/src/components/MessagePipeline/store.ts#L289-L300

A panel might subscribe to the same topic multiple times if it an array of subscription requests and includes the same topic multiple times and does not itself de-duplicate the array entries based on topic name. A panel is not required to do such de-duplication.

This issue was uncovered by #6984  which created a situation where the 3d panel thought it could subscribe to the same topic twice because the original topic was a `foxglove.Grid` schema and there was a converter installed which provided a conversion from `foxglove.Grid` to `foxglove.PosesInFrame`. Both of these schemas are 3d renderable and the panel wanted to subscribe for both.

Fixes: #6984
