### PR TITLE
Allow ability to toggle frame lock on more 3d topics

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -94,6 +94,7 @@ export type ImageModeConfig = Partial<ColorModeSettings> & {
   minValue?: number;
   /** Maximum (white) value for single-channel images */
   maxValue?: number;
+  frameLocked?: boolean;
 };
 
 export type RendererConfig = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
@@ -143,6 +143,11 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
           input: "rgba",
           value: config.color ?? DEFAULT_COLOR_STR,
         },
+        frameLocked: {
+          label: t("threeDee:frameLock"),
+          input: "boolean",
+          value: config.frameLocked ?? DEFAULT_SETTINGS.frameLocked,
+        },
       };
 
       entries.push({

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { t } from "i18next";
 import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
@@ -426,7 +427,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         fields: {
           ...colorModeFields,
           frameLocked: {
-            label: "Frame lock",
+            label: t("threeDee:frameLock"),
             input: "boolean",
             value: config.frameLocked ?? DEFAULT_SETTINGS.frameLocked,
           },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { t } from "i18next";
 import * as _ from "lodash-es";
 import * as THREE from "three";
 import { Writable } from "ts-essentials";
@@ -99,6 +100,7 @@ const ALL_SUPPORTED_CALIBRATION_SCHEMAS = new Set([
 ]);
 
 const DEFAULT_CONFIG = {
+  frameLocked: true,
   synchronize: false,
   flipHorizontal: false,
   flipVertical: false,
@@ -444,6 +446,11 @@ export class ImageMode
         { label: "270°", value: 270 },
       ],
     };
+    fields.frameLocked = {
+      label: t("threeDee:frameLock"),
+      input: "boolean",
+      value: settings.frameLocked,
+    };
 
     const colorModeFields = colorModeSettingsFields({
       config: settings as ImageModeConfig,
@@ -665,6 +672,7 @@ export class ImageMode
 
     const userSettings: ImageRenderableSettings = {
       ...IMAGE_RENDERABLE_DEFAULT_SETTINGS,
+      frameLocked: config.frameLocked,
       colorMode: config.colorMode,
       gradient: config.gradient as [string, string],
       colorMap: config.colorMap,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -167,6 +167,11 @@ export class Images extends SceneExtension<ImageRenderable> {
           options: cameraInfoOptions,
           value: config.cameraInfoTopic,
         },
+        frameLocked: {
+          label: t("threeDee:frameLock"),
+          input: "boolean",
+          value: config.frameLocked ?? IMAGE_RENDERABLE_DEFAULT_SETTINGS.frameLocked,
+        },
         distance: {
           label: t("threeDee:distance"),
           input: "number",

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/LaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/LaserScans.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { t } from "i18next";
 import * as THREE from "three";
 
 import { Time, toNanoSec } from "@foxglove/rostime";
@@ -351,6 +352,11 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
         messageFields,
         config,
       );
+      node.fields!.frameLocked = {
+        label: t("threeDee:frameLock"),
+        input: "boolean",
+        value: config.frameLocked ?? DEFAULT_SETTINGS.frameLocked,
+      };
       node.handler = handler;
       node.icon = "Radar";
       entries.push({ path: ["topics", topic.name], node });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { t } from "i18next";
 import * as THREE from "three";
 
 import { filterMap } from "@foxglove/den/collection";
@@ -737,6 +738,11 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
         label: "Stixel view",
         input: "boolean",
         value: config.stixelsEnabled ?? DEFAULT_SETTINGS.stixelsEnabled,
+      };
+      node.fields!.frameLocked = {
+        label: t("threeDee:frameLock"),
+        input: "boolean",
+        value: config.frameLocked ?? DEFAULT_SETTINGS.frameLocked,
       };
       node.handler = handler;
       node.icon = "Points";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { t } from "i18next";
+
 import { toNanoSec, toSec } from "@foxglove/rostime";
 import { NumericType, PointCloud as FoxglovePointCloud } from "@foxglove/schemas";
 import { MessageEvent, SettingsTreeAction } from "@foxglove/studio";
@@ -162,6 +164,11 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
         label: "Stixel view",
         input: "boolean",
         value: config.stixelsEnabled ?? DEFAULT_SETTINGS.stixelsEnabled,
+      };
+      node.fields!.frameLocked = {
+        label: t("threeDee:frameLock"),
+        input: "boolean",
+        value: config.frameLocked ?? DEFAULT_SETTINGS.frameLocked,
       };
       node.handler = handler;
       node.icon = "Points";


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
In draft for testing.
This would let things like images in the 3D scene to use their headerstamp to get transform data rather than the transform at the current time according to studio. When there is a mismatch of clocks between studio and the websocket server, this can cause issues becuase studio uses the transform at the currentTime (Date.now())  to access the corresponding transform with a headerstamp at that time. This can make it look like new messages are using old transforms if the studio clock is behind the websocket server clock that's writing the headerstamps


Potentially fixes this issue: FG-5229



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
