### PR TITLE
Improve estimation of per message memory usage

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -19,10 +19,13 @@ type Channel = {
   messageEncoding: string;
   schema: { name: string; encoding: string; data: Uint8Array } | undefined;
 };
+type FieldCount = Map<string, number>;
 
 export type ParsedChannel = {
   deserialize: (data: ArrayBufferView) => unknown;
   datatypes: MessageDefinitionMap;
+  // Guesstimate of the memory size in bytes of a deserialized message object
+  approxDeserializedMsgSize: number;
 };
 
 function parseIDLDefinitionsToDatatypes(
@@ -69,6 +72,83 @@ function parsedDefinitionsToDatatypes(
 }
 
 /**
+ * Calculate the expected occurence of primitive field for a given schema.
+ */
+function getFieldCount(datatypes: MessageDefinitionMap, typeName: string): FieldCount {
+  const fieldCount: FieldCount = new Map();
+  getFieldCountRecursive(datatypes, typeName, fieldCount);
+  return fieldCount;
+}
+
+function getFieldCountRecursive(
+  datatypes: MessageDefinitionMap,
+  typeName: string,
+  fieldCount: FieldCount,
+): void {
+  if (datatypes.size === 0) {
+    return; // Empty schema.
+  }
+
+  const definition = datatypes.get(typeName);
+  if (!definition) {
+    throw new Error(`Type '${typeName}' not found in definitions`);
+  }
+
+  for (const field of definition.definitions) {
+    const expectedArrayLength = field.arrayLength ?? field.arrayUpperBound ?? 1;
+    if (field.isComplex ?? false) {
+      for (let i = 0; i < expectedArrayLength; i++) {
+        getFieldCountRecursive(datatypes, field.type, fieldCount);
+      }
+    } else if (field.isArray ?? false) {
+      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + expectedArrayLength);
+    } else if (!(field.isConstant ?? false)) {
+      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + 1);
+    }
+  }
+}
+
+/**
+ * Guesstimate the size in bytes of a deserialized message object with the estimated amount of
+ * primitive fields.
+ */
+function guesstimateDeserializedMsgSize(fieldCount: FieldCount): number {
+  const totalFieldCount = [...fieldCount.values()].reduce((a, b) => a + b, 0);
+  let sizeInBytes = totalFieldCount * 16; // Object properties take up space as well
+  for (const [fieldName, count] of fieldCount.entries()) {
+    switch (fieldName) {
+      case "bool":
+      case "int8":
+      case "uint8":
+      case "int16":
+      case "uint16":
+        sizeInBytes += 8 * count; // small integer
+        break;
+      case "int32":
+      case "uint32":
+      case "float32":
+      case "float64":
+        sizeInBytes += 12 * count; // heapnumber
+        break;
+      case "int64":
+      case "uint64":
+        sizeInBytes += 16 * count; // bigint
+        break;
+      case "string":
+        sizeInBytes += 64 * count; // can't predict the string size, assume a certain length
+        break;
+      case "time":
+      case "duration":
+        sizeInBytes += 2 * 12 * count; // 2 x heapnumber
+        break;
+      default:
+        throw new Error(`Unknown primitive type ${fieldName}`);
+    }
+  }
+  return sizeInBytes;
+}
+
+/**
  * Process a channel/schema and extract information that can be used to deserialize messages on the
  * channel, and schemas in the format expected by Studio's RosDatatypes.
  *
@@ -104,7 +184,9 @@ export function parseChannel(channel: Channel): ParsedChannel {
           postprocessValue(JSON.parse(textDecoder.decode(data)) as Record<string, unknown>);
       }
     }
-    return { deserialize, datatypes };
+    const fieldCount = getFieldCount(datatypes, channel.schema?.name ?? "");
+    const approxDeserializedMsgSize = guesstimateDeserializedMsgSize(fieldCount);
+    return { deserialize, datatypes, approxDeserializedMsgSize };
   }
 
   if (channel.messageEncoding === "flatbuffer") {
@@ -117,7 +199,16 @@ export function parseChannel(channel: Channel): ParsedChannel {
         } is not supported (expected flatbuffer)`,
       );
     }
-    return parseFlatbufferSchema(channel.schema.name, channel.schema.data);
+    const { datatypes, deserialize } = parseFlatbufferSchema(
+      channel.schema.name,
+      channel.schema.data,
+    );
+    const fieldCount = getFieldCount(datatypes, channel.schema.name);
+    return {
+      datatypes,
+      deserialize,
+      approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
+    };
   }
 
   if (channel.messageEncoding === "protobuf") {
@@ -130,7 +221,16 @@ export function parseChannel(channel: Channel): ParsedChannel {
         } is not supported (expected protobuf)`,
       );
     }
-    return parseProtobufSchema(channel.schema.name, channel.schema.data);
+    const { datatypes, deserialize } = parseProtobufSchema(
+      channel.schema.name,
+      channel.schema.data,
+    );
+    const fieldCount = getFieldCount(datatypes, channel.schema.name);
+    return {
+      datatypes,
+      deserialize,
+      approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
+    };
   }
 
   if (channel.messageEncoding === "ros1") {
@@ -146,9 +246,12 @@ export function parseChannel(channel: Channel): ParsedChannel {
     const schema = new TextDecoder().decode(channel.schema.data);
     const parsedDefinitions = parseMessageDefinition(schema);
     const reader = new MessageReader(parsedDefinitions);
+    const datatypes = parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name);
+    const fieldCount = getFieldCount(datatypes, channel.schema.name);
     return {
       datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),
       deserialize: (data) => reader.readMessage(data),
+      approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
     };
   }
 
@@ -171,9 +274,11 @@ export function parseChannel(channel: Channel): ParsedChannel {
       const parsedDefinitions = parseIDL(schema);
       const reader = new OmgidlMessageReader(channel.schema.name, parsedDefinitions);
       const datatypes = parseIDLDefinitionsToDatatypes(parsedDefinitions);
+      const fieldCount = getFieldCount(datatypes, channel.schema.name);
       return {
         datatypes,
         deserialize: (data) => reader.readMessage(data),
+        approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
       };
     } else {
       const isIdl = channel.schema.encoding === "ros2idl";
@@ -183,10 +288,12 @@ export function parseChannel(channel: Channel): ParsedChannel {
         : parseMessageDefinition(schema, { ros2: true });
 
       const reader = new ROS2MessageReader(parsedDefinitions);
-
+      const datatypes = parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name);
+      const fieldCount = getFieldCount(datatypes, channel.schema.name);
       return {
-        datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),
+        datatypes,
         deserialize: (data) => reader.readMessage(data),
+        approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
       };
     }
   }

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -76,7 +76,7 @@ function parsedDefinitionsToDatatypes(
  */
 function getFieldCount(datatypes: MessageDefinitionMap, typeName: string): FieldCount {
   const fieldCount: FieldCount = new Map();
-  getFieldCountRecursive(datatypes, typeName, fieldCount);
+  getFieldCountRecursive(datatypes, typeName, fieldCount, []);
   return fieldCount;
 }
 
@@ -84,6 +84,7 @@ function getFieldCountRecursive(
   datatypes: MessageDefinitionMap,
   typeName: string,
   fieldCount: FieldCount,
+  checkedTypes: string[],
 ): void {
   if (datatypes.size === 0) {
     return; // Empty schema.
@@ -97,8 +98,11 @@ function getFieldCountRecursive(
   for (const field of definition.definitions) {
     const expectedArrayLength = field.arrayLength ?? field.arrayUpperBound ?? 1;
     if (field.isComplex ?? false) {
+      if (checkedTypes.includes(field.type)) {
+        continue; // Bail out to avoid infinite loop
+      }
       for (let i = 0; i < expectedArrayLength; i++) {
-        getFieldCountRecursive(datatypes, field.type, fieldCount);
+        getFieldCountRecursive(datatypes, field.type, fieldCount, checkedTypes.concat(field.type));
       }
     } else if (field.isArray ?? false) {
       fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + expectedArrayLength);

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -19,13 +19,10 @@ type Channel = {
   messageEncoding: string;
   schema: { name: string; encoding: string; data: Uint8Array } | undefined;
 };
-type FieldCount = Map<string, number>;
 
 export type ParsedChannel = {
   deserialize: (data: ArrayBufferView) => unknown;
   datatypes: MessageDefinitionMap;
-  // Guesstimate of the memory size in bytes of a deserialized message object
-  approxDeserializedMsgSize: number;
 };
 
 function parseIDLDefinitionsToDatatypes(
@@ -72,87 +69,6 @@ function parsedDefinitionsToDatatypes(
 }
 
 /**
- * Calculate the expected occurence of primitive field for a given schema.
- */
-function getFieldCount(datatypes: MessageDefinitionMap, typeName: string): FieldCount {
-  const fieldCount: FieldCount = new Map();
-  getFieldCountRecursive(datatypes, typeName, fieldCount, []);
-  return fieldCount;
-}
-
-function getFieldCountRecursive(
-  datatypes: MessageDefinitionMap,
-  typeName: string,
-  fieldCount: FieldCount,
-  checkedTypes: string[],
-): void {
-  if (datatypes.size === 0) {
-    return; // Empty schema.
-  }
-
-  const definition = datatypes.get(typeName);
-  if (!definition) {
-    throw new Error(`Type '${typeName}' not found in definitions`);
-  }
-
-  for (const field of definition.definitions) {
-    const expectedArrayLength = field.arrayLength ?? field.arrayUpperBound ?? 1;
-    if (field.isComplex ?? false) {
-      if (checkedTypes.includes(field.type)) {
-        continue; // Bail out to avoid infinite loop
-      }
-      for (let i = 0; i < expectedArrayLength; i++) {
-        getFieldCountRecursive(datatypes, field.type, fieldCount, checkedTypes.concat(field.type));
-      }
-    } else if (field.isArray ?? false) {
-      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + expectedArrayLength);
-    } else if (!(field.isConstant ?? false)) {
-      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + 1);
-    }
-  }
-}
-
-/**
- * Guesstimate the size in bytes of a deserialized message object with the estimated amount of
- * primitive fields.
- */
-function guesstimateDeserializedMsgSize(fieldCount: FieldCount): number {
-  const totalFieldCount = [...fieldCount.values()].reduce((a, b) => a + b, 0);
-  let sizeInBytes = totalFieldCount * 16; // Object properties take up space as well
-  for (const [fieldName, count] of fieldCount.entries()) {
-    switch (fieldName) {
-      case "bool":
-      case "int8":
-      case "uint8":
-      case "int16":
-      case "uint16":
-        sizeInBytes += 8 * count; // small integer
-        break;
-      case "int32":
-      case "uint32":
-      case "float32":
-      case "float64":
-        sizeInBytes += 12 * count; // heapnumber
-        break;
-      case "int64":
-      case "uint64":
-        sizeInBytes += 16 * count; // bigint
-        break;
-      case "string":
-        sizeInBytes += 64 * count; // can't predict the string size, assume a certain length
-        break;
-      case "time":
-      case "duration":
-        sizeInBytes += 2 * 12 * count; // 2 x heapnumber
-        break;
-      default:
-        throw new Error(`Unknown primitive type ${fieldName}`);
-    }
-  }
-  return sizeInBytes;
-}
-
-/**
  * Process a channel/schema and extract information that can be used to deserialize messages on the
  * channel, and schemas in the format expected by Studio's RosDatatypes.
  *
@@ -188,9 +104,7 @@ export function parseChannel(channel: Channel): ParsedChannel {
           postprocessValue(JSON.parse(textDecoder.decode(data)) as Record<string, unknown>);
       }
     }
-    const fieldCount = getFieldCount(datatypes, channel.schema?.name ?? "");
-    const approxDeserializedMsgSize = guesstimateDeserializedMsgSize(fieldCount);
-    return { deserialize, datatypes, approxDeserializedMsgSize };
+    return { deserialize, datatypes };
   }
 
   if (channel.messageEncoding === "flatbuffer") {
@@ -203,16 +117,7 @@ export function parseChannel(channel: Channel): ParsedChannel {
         } is not supported (expected flatbuffer)`,
       );
     }
-    const { datatypes, deserialize } = parseFlatbufferSchema(
-      channel.schema.name,
-      channel.schema.data,
-    );
-    const fieldCount = getFieldCount(datatypes, channel.schema.name);
-    return {
-      datatypes,
-      deserialize,
-      approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
-    };
+    return parseFlatbufferSchema(channel.schema.name, channel.schema.data);
   }
 
   if (channel.messageEncoding === "protobuf") {
@@ -225,16 +130,7 @@ export function parseChannel(channel: Channel): ParsedChannel {
         } is not supported (expected protobuf)`,
       );
     }
-    const { datatypes, deserialize } = parseProtobufSchema(
-      channel.schema.name,
-      channel.schema.data,
-    );
-    const fieldCount = getFieldCount(datatypes, channel.schema.name);
-    return {
-      datatypes,
-      deserialize,
-      approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
-    };
+    return parseProtobufSchema(channel.schema.name, channel.schema.data);
   }
 
   if (channel.messageEncoding === "ros1") {
@@ -250,12 +146,9 @@ export function parseChannel(channel: Channel): ParsedChannel {
     const schema = new TextDecoder().decode(channel.schema.data);
     const parsedDefinitions = parseMessageDefinition(schema);
     const reader = new MessageReader(parsedDefinitions);
-    const datatypes = parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name);
-    const fieldCount = getFieldCount(datatypes, channel.schema.name);
     return {
       datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),
       deserialize: (data) => reader.readMessage(data),
-      approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
     };
   }
 
@@ -278,11 +171,9 @@ export function parseChannel(channel: Channel): ParsedChannel {
       const parsedDefinitions = parseIDL(schema);
       const reader = new OmgidlMessageReader(channel.schema.name, parsedDefinitions);
       const datatypes = parseIDLDefinitionsToDatatypes(parsedDefinitions);
-      const fieldCount = getFieldCount(datatypes, channel.schema.name);
       return {
         datatypes,
         deserialize: (data) => reader.readMessage(data),
-        approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
       };
     } else {
       const isIdl = channel.schema.encoding === "ros2idl";
@@ -292,12 +183,10 @@ export function parseChannel(channel: Channel): ParsedChannel {
         : parseMessageDefinition(schema, { ros2: true });
 
       const reader = new ROS2MessageReader(parsedDefinitions);
-      const datatypes = parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name);
-      const fieldCount = getFieldCount(datatypes, channel.schema.name);
+
       return {
-        datatypes,
+        datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),
         deserialize: (data) => reader.readMessage(data),
-        approxDeserializedMsgSize: guesstimateDeserializedMsgSize(fieldCount),
       };
     }
   }

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -7,6 +7,7 @@ import { BlobReader } from "@foxglove/rosbag/web";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { compare } from "@foxglove/rostime";
+import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import {
   PlayerProblem,
   MessageEvent,
@@ -35,7 +36,10 @@ export class BagIterableSource implements IIterableSource {
 
   #bag: Bag | undefined;
   #readersByConnectionId = new Map<number, MessageReader>();
-  #datatypesByConnectionId = new Map<number, string>();
+  #datatypesByConnectionId = new Map<
+    number,
+    { schemaName: string; approxDeserializedMsgSize: number }
+  >();
 
   public constructor(source: BagSource) {
     this.#source = source;
@@ -142,7 +146,6 @@ export class BagIterableSource implements IIterableSource {
       const parsedDefinition = parseMessageDefinition(connection.messageDefinition);
       const reader = new MessageReader(parsedDefinition);
       this.#readersByConnectionId.set(id, reader);
-      this.#datatypesByConnectionId.set(id, schemaName);
 
       for (const definition of parsedDefinition) {
         // In parsed definitions, the first definition (root) does not have a name as is meant to
@@ -153,6 +156,9 @@ export class BagIterableSource implements IIterableSource {
           datatypes.set(definition.name, definition);
         }
       }
+
+      const approxDeserializedMsgSize = guesstimateDeserializedMsgSize(datatypes, schemaName);
+      this.#datatypesByConnectionId.set(id, { schemaName, approxDeserializedMsgSize });
     }
 
     return {
@@ -197,8 +203,8 @@ export class BagIterableSource implements IIterableSource {
         return;
       }
 
-      const schemaName = this.#datatypesByConnectionId.get(connectionId);
-      if (!schemaName) {
+      const schemaNameAndApproxMsgSize = this.#datatypesByConnectionId.get(connectionId);
+      if (!schemaNameAndApproxMsgSize) {
         yield {
           type: "problem",
           connectionId,
@@ -224,9 +230,12 @@ export class BagIterableSource implements IIterableSource {
           msgEvent: {
             topic: bagMsgEvent.topic,
             receiveTime: bagMsgEvent.timestamp,
-            sizeInBytes: bagMsgEvent.data.byteLength,
+            sizeInBytes: Math.max(
+              bagMsgEvent.data.byteLength,
+              schemaNameAndApproxMsgSize.approxDeserializedMsgSize,
+            ),
             message: parsedMessage,
-            schemaName,
+            schemaName: schemaNameAndApproxMsgSize.schemaName,
           },
         };
       } else {

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -7,7 +7,7 @@ import { BlobReader } from "@foxglove/rosbag/web";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { compare } from "@foxglove/rostime";
-import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
+import { estimateMessageObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import {
   PlayerProblem,
   MessageEvent,
@@ -111,6 +111,7 @@ export class BagIterableSource implements IIterableSource {
     const topics = new Map<string, Topic>();
     const topicStats = new Map<string, TopicStats>();
     const publishersByTopic: Initalization["publishersByTopic"] = new Map();
+    const estimatedObjectSizeByType = new Map<string, number>();
     for (const [id, connection] of this.#bag.connections) {
       const schemaName = connection.type;
       if (!schemaName) {
@@ -157,7 +158,11 @@ export class BagIterableSource implements IIterableSource {
         }
       }
 
-      const approxDeserializedMsgSize = guesstimateDeserializedMsgSize(datatypes, schemaName);
+      const approxDeserializedMsgSize = estimateMessageObjectSize(
+        datatypes,
+        schemaName,
+        estimatedObjectSizeByType,
+      );
       this.#datatypesByConnectionId.set(id, { schemaName, approxDeserializedMsgSize });
     }
 

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -179,10 +179,6 @@ export class McapIndexedIterableSource implements IIterableSource {
           channelInfo.approxDeserializedMsgSize,
         );
 
-        log.info(
-          `${channelInfo.schemaName}, ${message.data.byteLength}, ${channelInfo.approxDeserializedMsgSize}`,
-        );
-
         yield {
           type: "message-event",
           msgEvent: {

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -16,6 +16,7 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -25,7 +26,13 @@ export class McapIndexedIterableSource implements IIterableSource {
   #reader: McapIndexedReader;
   #channelInfoById = new Map<
     number,
-    { channel: McapTypes.Channel; parsedChannel: ParsedChannel; schemaName: string | undefined }
+    {
+      channel: McapTypes.Channel;
+      parsedChannel: ParsedChannel;
+      schemaName: string | undefined;
+      // Guesstimate of the memory size in bytes of a deserialized message object
+      approxDeserializedMsgSize: number;
+    }
   >();
   #start?: Time;
   #end?: Time;
@@ -63,8 +70,13 @@ export class McapIndexedIterableSource implements IIterableSource {
       }
 
       let parsedChannel;
+      let approxDeserializedMsgSize;
       try {
         parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
+        approxDeserializedMsgSize =
+          schema?.name != undefined
+            ? guesstimateDeserializedMsgSize(parsedChannel.datatypes, schema.name)
+            : 0;
       } catch (error) {
         problems.push({
           severity: "error",
@@ -73,7 +85,12 @@ export class McapIndexedIterableSource implements IIterableSource {
         });
         continue;
       }
-      this.#channelInfoById.set(channel.id, { channel, parsedChannel, schemaName: schema?.name });
+      this.#channelInfoById.set(channel.id, {
+        channel,
+        parsedChannel,
+        schemaName: schema?.name,
+        approxDeserializedMsgSize,
+      });
 
       let topic = topicsByName.get(channel.topic);
       if (!topic) {
@@ -154,7 +171,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
         const sizeInBytes = Math.max(
           message.data.byteLength,
-          channelInfo.parsedChannel.approxDeserializedMsgSize,
+          channelInfo.approxDeserializedMsgSize,
         );
         yield {
           type: "message-event",
@@ -209,10 +226,7 @@ export class McapIndexedIterableSource implements IIterableSource {
             receiveTime: fromNanoSec(message.logTime),
             publishTime: fromNanoSec(message.publishTime),
             message: channelInfo.parsedChannel.deserialize(message.data),
-            sizeInBytes: Math.max(
-              message.data.byteLength,
-              channelInfo.parsedChannel.approxDeserializedMsgSize,
-            ),
+            sizeInBytes: Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize),
             schemaName: channelInfo.schemaName ?? "",
           });
         } catch (err) {

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -152,6 +152,10 @@ export class McapIndexedIterableSource implements IIterableSource {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
         const spec = args.topics.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
+        const sizeInBytes = Math.max(
+          message.data.byteLength,
+          channelInfo.parsedChannel.approxDeserializedMsgSize,
+        );
         yield {
           type: "message-event",
           msgEvent: {
@@ -162,7 +166,7 @@ export class McapIndexedIterableSource implements IIterableSource {
             // Treat sliced messages as zero bytes. This is a rough approximation of course but the
             // alternative is taking the performance hit of sizing the sliced fields for each
             // message.
-            sizeInBytes: spec?.fields == undefined ? message.data.byteLength : 0,
+            sizeInBytes: spec?.fields == undefined ? sizeInBytes : 0,
             schemaName: channelInfo.schemaName ?? "",
           },
         };
@@ -205,7 +209,10 @@ export class McapIndexedIterableSource implements IIterableSource {
             receiveTime: fromNanoSec(message.logTime),
             publishTime: fromNanoSec(message.publishTime),
             message: channelInfo.parsedChannel.deserialize(message.data),
-            sizeInBytes: message.data.byteLength,
+            sizeInBytes: Math.max(
+              message.data.byteLength,
+              channelInfo.parsedChannel.approxDeserializedMsgSize,
+            ),
             schemaName: channelInfo.schemaName ?? "",
           });
         } catch (err) {

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -16,7 +16,7 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
-import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
+import { estimateMessageObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -58,6 +58,7 @@ export class McapIndexedIterableSource implements IIterableSource {
     const datatypes: RosDatatypes = new Map();
     const problems: PlayerProblem[] = [];
     const publishersByTopic = new Map<string, Set<string>>();
+    const estimatedObjectSizeByType = new Map<string, number>();
 
     for (const channel of this.#reader.channelsById.values()) {
       const schema = this.#reader.schemasById.get(channel.schemaId);
@@ -75,7 +76,11 @@ export class McapIndexedIterableSource implements IIterableSource {
         parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
         approxDeserializedMsgSize =
           schema?.name != undefined
-            ? guesstimateDeserializedMsgSize(parsedChannel.datatypes, schema.name)
+            ? estimateMessageObjectSize(
+                parsedChannel.datatypes,
+                schema.name,
+                estimatedObjectSizeByType,
+              )
             : 0;
       } catch (error) {
         problems.push({
@@ -173,6 +178,11 @@ export class McapIndexedIterableSource implements IIterableSource {
           message.data.byteLength,
           channelInfo.approxDeserializedMsgSize,
         );
+
+        log.info(
+          `${channelInfo.schemaName}, ${message.data.byteLength}, ${channelInfo.approxDeserializedMsgSize}`,
+        );
+
         yield {
           type: "message-event",
           msgEvent: {

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -25,7 +25,7 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
-import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
+import { estimateMessageObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -70,6 +70,7 @@ export class McapUnindexedIterableSource implements IIterableSource {
         approxDeserializedMsgSize: number;
       }
     >();
+    const estimatedObjectSizeByType = new Map<string, number>();
 
     let startTime: Time | undefined;
     let endTime: Time | undefined;
@@ -117,7 +118,11 @@ export class McapUnindexedIterableSource implements IIterableSource {
             const parsedChannel = parseChannel({ messageEncoding: record.messageEncoding, schema });
             const approxDeserializedMsgSize =
               schema?.name != undefined
-                ? guesstimateDeserializedMsgSize(parsedChannel.datatypes, schema.name)
+                ? estimateMessageObjectSize(
+                    parsedChannel.datatypes,
+                    schema.name,
+                    estimatedObjectSizeByType,
+                  )
                 : 0;
             channelInfoById.set(record.id, {
               channel: record,

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -25,6 +25,7 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -61,7 +62,13 @@ export class McapUnindexedIterableSource implements IIterableSource {
     const schemasById = new Map<number, McapTypes.TypedMcapRecords["Schema"]>();
     const channelInfoById = new Map<
       number,
-      { channel: McapTypes.Channel; parsedChannel: ParsedChannel; schemaName: string | undefined }
+      {
+        channel: McapTypes.Channel;
+        parsedChannel: ParsedChannel;
+        schemaName: string | undefined;
+        // Guesstimate of the memory size in bytes of a deserialized message object
+        approxDeserializedMsgSize: number;
+      }
     >();
 
     let startTime: Time | undefined;
@@ -108,10 +115,15 @@ export class McapUnindexedIterableSource implements IIterableSource {
 
           try {
             const parsedChannel = parseChannel({ messageEncoding: record.messageEncoding, schema });
+            const approxDeserializedMsgSize =
+              schema?.name != undefined
+                ? guesstimateDeserializedMsgSize(parsedChannel.datatypes, schema.name)
+                : 0;
             channelInfoById.set(record.id, {
               channel: record,
               parsedChannel,
               schemaName: schema?.name,
+              approxDeserializedMsgSize,
             });
             messagesByChannel.set(record.id, []);
           } catch (error) {
@@ -149,7 +161,7 @@ export class McapUnindexedIterableSource implements IIterableSource {
             receiveTime,
             publishTime: fromNanoSec(record.publishTime),
             message: channelInfo.parsedChannel.deserialize(record.data),
-            sizeInBytes: record.data.byteLength,
+            sizeInBytes: Math.max(record.data.byteLength, channelInfo.approxDeserializedMsgSize),
             schemaName: channelInfo.schemaName ?? "",
           });
           break;

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -6,7 +6,7 @@ import { ROS2_TO_DEFINITIONS, Rosbag2, SqliteSqljs } from "@foxglove/rosbag2-web
 import { stringify } from "@foxglove/rosmsg";
 import { Time, add as addTime } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
-import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
+import { estimateMessageObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import {
   MessageDefinitionsByTopic,
   ParsedMessageDefinitionsByTopic,
@@ -68,6 +68,7 @@ export class RosDb3IterableSource implements IIterableSource {
     const datatypes: RosDatatypes = new Map();
     const messageDefinitionsByTopic: MessageDefinitionsByTopic = {};
     const parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
+    const estimatedObjectSizeByType = new Map<string, number>();
 
     for (const topicDef of topicDefs) {
       const numMessages = messageCounts.get(topicDef.name);
@@ -94,7 +95,7 @@ export class RosDb3IterableSource implements IIterableSource {
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
       this.#approxDeserializedMsgSizeByType.set(
         topicDef.type,
-        guesstimateDeserializedMsgSize(datatypes, topicDef.type),
+        estimateMessageObjectSize(datatypes, topicDef.type, estimatedObjectSizeByType),
       );
     }
 

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -6,6 +6,7 @@ import { ROS2_TO_DEFINITIONS, Rosbag2, SqliteSqljs } from "@foxglove/rosbag2-web
 import { stringify } from "@foxglove/rosmsg";
 import { Time, add as addTime } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
+import { guesstimateDeserializedMsgSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import {
   MessageDefinitionsByTopic,
   ParsedMessageDefinitionsByTopic,
@@ -28,6 +29,7 @@ export class RosDb3IterableSource implements IIterableSource {
   #bag?: Rosbag2;
   #start: Time = { sec: 0, nsec: 0 };
   #end: Time = { sec: 0, nsec: 0 };
+  #approxDeserializedMsgSizeByType = new Map<string, number>();
 
   public constructor(files: File[]) {
     this.#files = files;
@@ -90,6 +92,10 @@ export class RosDb3IterableSource implements IIterableSource {
       datatypes.set(topicDef.type, { name: topicDef.type, definitions: parsedMsgdef.definitions });
       messageDefinitionsByTopic[topicDef.name] = messageDefinition;
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
+      this.#approxDeserializedMsgSizeByType.set(
+        topicDef.type,
+        guesstimateDeserializedMsgSize(datatypes, topicDef.type),
+      );
     }
 
     this.#start = start;
@@ -131,13 +137,14 @@ export class RosDb3IterableSource implements IIterableSource {
       topics: Array.from(topics.keys()),
     });
     for await (const msg of msgIterator) {
+      const approxDeserializedMsgSize = this.#approxDeserializedMsgSizeByType.get(msg.topic.type);
       yield {
         type: "message-event",
         msgEvent: {
           topic: msg.topic.name,
           receiveTime: msg.timestamp,
           message: msg.value,
-          sizeInBytes: msg.data.byteLength,
+          sizeInBytes: Math.max(msg.data.byteLength, approxDeserializedMsgSize ?? 0),
           schemaName: msg.topic.type,
         },
       };

--- a/packages/studio-base/src/players/messageMemoryEstimation.test.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.test.ts
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { estimateMessageObjectSize } from "./messageMemoryEstimation";
+
+describe("memoryEstimation", () => {
+  it("size for empty schema is greater than 0", () => {
+    const sizeInBytes = estimateMessageObjectSize(new Map(), "", new Map());
+    expect(sizeInBytes).toBeGreaterThan(0);
+  });
+
+  it("throws an error for an unknown type", () => {
+    expect(() =>
+      estimateMessageObjectSize(new Map([["foo", { definitions: [] }]]), "UnknownType", new Map()),
+    ).toThrow("Type 'UnknownType' not found in definitions");
+  });
+
+  it("handles complex types with arrays of unknown primitive type", () => {
+    const datatypes = new Map([
+      [
+        "ComplexType",
+        {
+          definitions: [{ type: "unknownType", name: "field1", isArray: true, arrayLength: 2 }],
+        },
+      ],
+    ]);
+
+    expect(() => estimateMessageObjectSize(datatypes, "ComplexType", new Map())).toThrow(
+      "Unknown primitive type unknownType",
+    );
+  });
+
+  it("size for a complex schema is calculated correctly", () => {
+    const datatypes = new Map([
+      [
+        "ComplexType",
+        {
+          definitions: [
+            { type: "int32", name: "field1" },
+            { type: "string", name: "field2" },
+          ],
+        },
+      ],
+    ]);
+
+    const sizeInBytes = estimateMessageObjectSize(datatypes, "ComplexType", new Map());
+    expect(sizeInBytes).toBeGreaterThan(0);
+  });
+
+  it("handles complex types with arrays", () => {
+    const datatypes = new Map([
+      [
+        "ComplexType",
+        {
+          definitions: [
+            { type: "int32", name: "field1", isArray: true, arrayLength: 3 },
+            { type: "string", name: "field2" },
+          ],
+        },
+      ],
+    ]);
+
+    const sizeInBytes = estimateMessageObjectSize(datatypes, "ComplexType", new Map());
+    expect(sizeInBytes).toBeGreaterThan(0);
+  });
+
+  it.each([
+    { numFloats: 2, numInts: 2, measuredSize: 52, tolerancePercent: 5 },
+    { numFloats: 10, numInts: 10, measuredSize: 212, tolerancePercent: 5 },
+    { numFloats: 10, numInts: 10, measuredSize: 212, tolerancePercent: 5 },
+    { numFloats: 50, numInts: 50, measuredSize: 1012, tolerancePercent: 5 },
+    { numFloats: 100, numInts: 100, measuredSize: 2012, tolerancePercent: 5 },
+    { numFloats: 200, numInts: 200, measuredSize: 4028, tolerancePercent: 5 },
+    { numFloats: 400, numInts: 400, measuredSize: 8024, tolerancePercent: 5 },
+    { numFloats: 550, numInts: 550, measuredSize: 31220, tolerancePercent: 5 },
+    { numFloats: 1000, numInts: 1000, measuredSize: 61196, tolerancePercent: 5 },
+    { numFloats: 2000, numInts: 2000, measuredSize: 122348, tolerancePercent: 5 },
+  ])(
+    "matches the size of objects with int + double fields measured with chrome devtools",
+    ({ numFloats, numInts, measuredSize, tolerancePercent }) => {
+      const datatypes = new Map([
+        [
+          "SomeType",
+          {
+            definitions: [
+              ...new Array(numInts).fill({ type: "int16", name: "field" }),
+              ...new Array(numFloats).fill({ type: "float64", name: "field" }),
+            ],
+          },
+        ],
+      ]);
+      const sizeInBytes = estimateMessageObjectSize(datatypes, "SomeType", new Map());
+      expect(sizeInBytes).toBeGreaterThanOrEqual(measuredSize * ((100 - tolerancePercent) / 100));
+      expect(sizeInBytes).toBeLessThanOrEqual(measuredSize * ((100 + tolerancePercent) / 100));
+    },
+  );
+});

--- a/packages/studio-base/src/players/messageMemoryEstimation.test.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.test.ts
@@ -38,14 +38,15 @@ describe("memoryEstimation", () => {
         {
           definitions: [
             { type: "int32", name: "field1" },
-            { type: "string", name: "field2" },
+            { type: "bool", name: "field2" },
           ],
         },
       ],
     ]);
 
     const sizeInBytes = estimateMessageObjectSize(datatypes, "ComplexType", new Map());
-    expect(sizeInBytes).toBeGreaterThan(0);
+    const expectedSize = 30;
+    expect(Math.abs(expectedSize - sizeInBytes)).toBeLessThan(10);
   });
 
   it("handles complex types with arrays", () => {
@@ -54,15 +55,17 @@ describe("memoryEstimation", () => {
         "ComplexType",
         {
           definitions: [
-            { type: "int32", name: "field1", isArray: true, arrayLength: 3 },
-            { type: "string", name: "field2" },
+            { type: "int32", name: "field1" },
+            { type: "float64", name: "field2" },
+            { type: "bool", name: "field3", isArray: true, arrayLength: 10 },
           ],
         },
       ],
     ]);
 
     const sizeInBytes = estimateMessageObjectSize(datatypes, "ComplexType", new Map());
-    expect(sizeInBytes).toBeGreaterThan(0);
+    const expectedSize = 90;
+    expect(Math.abs(expectedSize - sizeInBytes)).toBeLessThan(10);
   });
 
   it.each([
@@ -91,8 +94,9 @@ describe("memoryEstimation", () => {
         ],
       ]);
       const sizeInBytes = estimateMessageObjectSize(datatypes, "SomeType", new Map());
-      expect(sizeInBytes).toBeGreaterThanOrEqual(measuredSize * ((100 - tolerancePercent) / 100));
-      expect(sizeInBytes).toBeLessThanOrEqual(measuredSize * ((100 + tolerancePercent) / 100));
+      expect(Math.abs(sizeInBytes - measuredSize)).toBeLessThanOrEqual(
+        measuredSize * (tolerancePercent / 100),
+      );
     },
   );
 });

--- a/packages/studio-base/src/players/messageMemoryEstimation.test.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.test.ts
@@ -45,7 +45,7 @@ describe("memoryEstimation", () => {
     ]);
 
     const sizeInBytes = estimateMessageObjectSize(datatypes, "ComplexType", new Map());
-    const expectedSize = 30;
+    const expectedSize = 20; // 3 x pointers + 1 x 4 byte smi + 1 x pointer to boolean
     expect(Math.abs(expectedSize - sizeInBytes)).toBeLessThan(10);
   });
 

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -4,24 +4,52 @@
 
 import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
 
-/**
- * Calculate the expected occurence of primitive field for a given schema.
- */
-function getFieldTypeCount(datatypes: MessageDefinitionMap, typeName: string): Map<string, number> {
-  const fieldTypeCount = new Map<string, number>();
-  getFieldTypeCountRecursive({ datatypes, typeName, fieldTypeCount, checkedTypes: [] });
-  return fieldTypeCount;
-}
+const OBJECT_BASE_SIZE = 12;
+const TYPED_ARRAY_BASE_SIZE = 64; // byteLenght, byteOffset, ...
+const MAX_NUM_FAST_PROPERTIES = 1020;
+const FIELD_SIZE_BY_PRIMITIVE: Record<string, number> = {
+  bool: 4,
+  int8: 4,
+  uint8: 4,
+  int16: 4,
+  uint16: 4,
+  int32: 8,
+  uint32: 8,
+  float32: 16,
+  float64: 16,
+  int64: 16,
+  uint64: 16,
+  string: 20, // we don't know the length upfront, assume a fixed length
+  time: 32,
+  duration: 32,
+};
 
-function getFieldTypeCountRecursive(args: {
-  datatypes: MessageDefinitionMap;
-  typeName: string;
-  fieldTypeCount: Map<string, number>;
-  checkedTypes: string[];
-}): void {
-  const { datatypes, typeName, fieldTypeCount, checkedTypes } = args;
+/**
+ * Estimates the memory size of a deserialized message object based on the schema definition.
+ *
+ * The estimation is by no means accurate but may in certain situations (especially when there are
+ * no dynamic fields such as arrays or strings) give a better estimation than the number of bytes
+ * of the serialized message. For estimating memory size, we assume a V8 JS engine (probably
+ * similar for other engines).
+ *
+ * @param datatypes Map of data types
+ * @param typeName Name of the data type
+ * @param knownTypeSizes Map of known type sizes (for caching purposes)
+ * @returns Estimated object size in bytes
+ */
+export function estimateMessageObjectSize(
+  datatypes: MessageDefinitionMap,
+  typeName: string,
+  knownTypeSizes: Map<string, number>,
+  checkedTypes?: string[],
+): number {
+  const knownSize = knownTypeSizes.get(typeName);
+  if (knownSize != undefined) {
+    return knownSize;
+  }
+
   if (datatypes.size === 0) {
-    return; // Empty schema.
+    return OBJECT_BASE_SIZE; // Empty schema -> Empty object.
   }
 
   const definition = datatypes.get(typeName);
@@ -29,68 +57,92 @@ function getFieldTypeCountRecursive(args: {
     throw new Error(`Type '${typeName}' not found in definitions`);
   }
 
-  for (const field of definition.definitions) {
-    const expectedArrayLength = field.arrayLength ?? field.arrayUpperBound ?? 1;
-    if (field.isComplex ?? false) {
-      if (checkedTypes.includes(field.type)) {
-        continue; // Bail out to avoid infinite loop
-      }
-      for (let i = 0; i < expectedArrayLength; i++) {
-        getFieldTypeCountRecursive({
-          datatypes,
-          typeName: field.type,
-          fieldTypeCount,
-          checkedTypes: checkedTypes.concat(field.type),
-        });
-      }
-    } else if (field.isArray ?? false) {
-      fieldTypeCount.set(field.type, (fieldTypeCount.get(field.type) ?? 0) + expectedArrayLength);
-    } else if (!(field.isConstant ?? false)) {
-      fieldTypeCount.set(field.type, (fieldTypeCount.get(field.type) ?? 0) + 1);
-    }
-  }
-}
+  let sizeInBytes = OBJECT_BASE_SIZE;
 
-/**
- * Guesstimate the size in bytes of a deserialized message object with the estimated amount of
- * primitive fields.
- */
-export function guesstimateDeserializedMsgSize(
-  datatypes: MessageDefinitionMap,
-  typeName: string,
-): number {
-  const fieldTypeCount = getFieldTypeCount(datatypes, typeName);
-  const numFields = [...fieldTypeCount.values()].reduce((a, b) => a + b, 0);
-  let sizeInBytes = numFields * 16; // Object properties take up space as well
-  for (const [fieldType, count] of fieldTypeCount.entries()) {
-    switch (fieldType) {
-      case "bool":
-      case "int8":
-      case "uint8":
-      case "int16":
-      case "uint16":
-        sizeInBytes += 8 * count; // small integer
-        break;
-      case "int32":
-      case "uint32":
-      case "float32":
-      case "float64":
-        sizeInBytes += 12 * count; // heapnumber
-        break;
-      case "int64":
-      case "uint64":
-        sizeInBytes += 16 * count; // bigint
-        break;
-      case "string":
-        sizeInBytes += 64 * count; // can't predict the string size, assume a certain length
-        break;
-      case "time":
-      case "duration":
-        sizeInBytes += 2 * 12 * count; // 2 x heapnumber
-        break;
-      default:
-        throw new Error(`Unknown primitive type ${fieldType}`);
+  const nonConstantFields = definition.definitions.filter((field) => !(field.isConstant ?? false));
+  if (nonConstantFields.length > MAX_NUM_FAST_PROPERTIES) {
+    // If there are too many properties, V8 stores Objects in dictionary mode (slow properties)
+    // with each object having a self-contained dictionary. This dictionary contains the key, value
+    // and details of properties. Below we estimate the size of this additional dictionary. Formula
+    // adapted from
+    // medium.com/@bpmxmqd/v8-engine-jsobject-structure-analysis-and-memory-optimization-ideas-be30cfcdcd16
+    const propertiesDictSize =
+      16 + 5 * 8 + 2 ** Math.ceil(Math.log2((nonConstantFields.length + 2) * 1.5)) * 3 * 4;
+    sizeInBytes += propertiesDictSize;
+
+    // In return, properties are no longer stored in the properties array
+    sizeInBytes -= 4 * nonConstantFields.length;
+  }
+
+  for (const field of nonConstantFields) {
+    if (field.isComplex ?? false) {
+      const count =
+        field.isArray === true
+          ? 0 // We are conservative and assume an empty array
+          : 1;
+
+      const knownFieldSize = knownTypeSizes.get(field.type);
+      if (knownFieldSize != undefined) {
+        sizeInBytes += count > 0 ? count * knownFieldSize : OBJECT_BASE_SIZE;
+        continue;
+      }
+
+      if (checkedTypes != undefined && checkedTypes.includes(field.type)) {
+        // E.g. protobuf allows types to reference itself.
+        // For that reason we bail out here to avoid an infinite loop.
+        continue;
+      }
+
+      const complexTypeObjectSize = estimateMessageObjectSize(
+        datatypes,
+        field.type,
+        knownTypeSizes,
+        (checkedTypes ?? []).concat(field.type),
+      );
+      sizeInBytes += count > 0 ? count * complexTypeObjectSize : OBJECT_BASE_SIZE;
+    } else if (field.isArray === true) {
+      const arrayLength = field.arrayLength ?? 0; // We are conservative and assume an empty array;
+      switch (field.type) {
+        // Assume that fields get deserialized as typed arrays
+        case "int8":
+        case "uint8":
+          sizeInBytes += TYPED_ARRAY_BASE_SIZE + arrayLength * 1;
+          break;
+        case "int16":
+        case "uint16":
+          sizeInBytes += TYPED_ARRAY_BASE_SIZE + arrayLength * 2;
+          break;
+        case "int32":
+        case "uint32":
+        case "float32":
+          sizeInBytes += TYPED_ARRAY_BASE_SIZE + arrayLength * 4;
+          break;
+        case "float64":
+        case "int64":
+        case "uint64":
+          sizeInBytes += TYPED_ARRAY_BASE_SIZE + arrayLength * 8;
+          break;
+        default:
+          {
+            const primitiveSize = FIELD_SIZE_BY_PRIMITIVE[field.type];
+            if (primitiveSize == undefined) {
+              throw new Error(`Unknown primitive type ${field.type}`);
+            }
+            // Assume Array<type> deserialization
+            sizeInBytes += arrayLength * primitiveSize + OBJECT_BASE_SIZE;
+          }
+          break;
+      }
+    } else {
+      const primitiveSize = FIELD_SIZE_BY_PRIMITIVE[field.type];
+      if (primitiveSize == undefined) {
+        throw new Error(`Unknown primitive type ${field.type}`);
+      }
+      sizeInBytes += primitiveSize;
     }
   }
+
+  knownTypeSizes.set(typeName, sizeInBytes);
+
   return sizeInBytes;
 }

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -4,25 +4,31 @@
 
 import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
 
-const OBJECT_BASE_SIZE = 12;
-const TYPED_ARRAY_BASE_SIZE = 64; // byteLength, byteOffset, ...
-const MAX_NUM_FAST_PROPERTIES = 1020;
+/**
+ * Values of the contants below are a (more or less) informed guesses and not guaranteed to be accurate.
+ */
+const COMPRESSED_POINTER_SIZE = 4; // Pointers use 4 bytes (also on 64-bit systems) due to pointer compression
+const OBJECT_BASE_SIZE = 3 * COMPRESSED_POINTER_SIZE; // 3 compressed pointers
+const TYPED_ARRAY_BASE_SIZE = 25 * COMPRESSED_POINTER_SIZE; // byteLength, byteOffset, ..., see https://stackoverflow.com/a/45808835
+const SMALL_INTEGER_SIZE = COMPRESSED_POINTER_SIZE; // Small integers (up to 31 bits), pointer tagging
+const HEAP_NUMBER_SIZE = 8 + 2 * COMPRESSED_POINTER_SIZE; // 4-byte map pointer + 8-byte payload + property pointer
 const FIELD_SIZE_BY_PRIMITIVE: Record<string, number> = {
-  bool: 4,
-  int8: 4,
-  uint8: 4,
-  int16: 4,
-  uint16: 4,
-  int32: 8,
-  uint32: 8,
-  float32: 16,
-  float64: 16,
-  int64: 16,
-  uint64: 16,
+  bool: SMALL_INTEGER_SIZE,
+  int8: SMALL_INTEGER_SIZE,
+  uint8: SMALL_INTEGER_SIZE,
+  int16: SMALL_INTEGER_SIZE,
+  uint16: SMALL_INTEGER_SIZE,
+  int32: SMALL_INTEGER_SIZE,
+  uint32: SMALL_INTEGER_SIZE,
+  float32: HEAP_NUMBER_SIZE,
+  float64: HEAP_NUMBER_SIZE,
+  int64: HEAP_NUMBER_SIZE,
+  uint64: HEAP_NUMBER_SIZE,
+  time: OBJECT_BASE_SIZE + 2 * HEAP_NUMBER_SIZE + COMPRESSED_POINTER_SIZE,
+  duration: OBJECT_BASE_SIZE + 2 * HEAP_NUMBER_SIZE + COMPRESSED_POINTER_SIZE,
   string: 20, // we don't know the length upfront, assume a fixed length
-  time: 32,
-  duration: 32,
 };
+const MAX_NUM_FAST_PROPERTIES = 1020;
 
 /**
  * Estimates the memory size of a deserialized message object based on the schema definition.
@@ -71,7 +77,7 @@ export function estimateMessageObjectSize(
     sizeInBytes += propertiesDictSize;
 
     // In return, properties are no longer stored in the properties array
-    sizeInBytes -= 4 * nonConstantFields.length;
+    sizeInBytes -= COMPRESSED_POINTER_SIZE * nonConstantFields.length;
   }
 
   for (const field of nonConstantFields) {
@@ -133,7 +139,7 @@ export function estimateMessageObjectSize(
               throw new Error(`Unknown primitive type ${field.type}`);
             }
             // Assume Array<type> deserialization
-            sizeInBytes += arrayLength * primitiveSize + OBJECT_BASE_SIZE;
+            sizeInBytes += arrayLength * primitiveSize + OBJECT_BASE_SIZE + COMPRESSED_POINTER_SIZE;
           }
           break;
       }

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -5,7 +5,7 @@
 import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
 
 const OBJECT_BASE_SIZE = 12;
-const TYPED_ARRAY_BASE_SIZE = 64; // byteLenght, byteOffset, ...
+const TYPED_ARRAY_BASE_SIZE = 64; // byteLength, byteOffset, ...
 const MAX_NUM_FAST_PROPERTIES = 1020;
 const FIELD_SIZE_BY_PRIMITIVE: Record<string, number> = {
   bool: 4,
@@ -78,7 +78,8 @@ export function estimateMessageObjectSize(
     if (field.isComplex ?? false) {
       const count =
         field.isArray === true
-          ? 0 // We are conservative and assume an empty array
+          ? // We are conservative and assume an empty array to avoid memory overestimation.
+            field.arrayLength ?? 0
           : 1;
 
       const knownFieldSize = knownTypeSizes.get(field.type);
@@ -101,7 +102,10 @@ export function estimateMessageObjectSize(
       );
       sizeInBytes += count > 0 ? count * complexTypeObjectSize : OBJECT_BASE_SIZE;
     } else if (field.isArray === true) {
-      const arrayLength = field.arrayLength ?? 0; // We are conservative and assume an empty array;
+      // We are conservative and assume an empty array to avoid memory overestimation.
+      // For dynamic messages it is better to use another estimator such as the serialized
+      // message size.
+      const arrayLength = field.arrayLength ?? 0;
       switch (field.type) {
         // Assume that fields get deserialized as typed arrays
         case "int8":

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -7,18 +7,19 @@ import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
 /**
  * Calculate the expected occurence of primitive field for a given schema.
  */
-function getFieldCount(datatypes: MessageDefinitionMap, typeName: string): Map<string, number> {
-  const fieldCount = new Map<string, number>();
-  getFieldCountRecursive(datatypes, typeName, fieldCount, []);
-  return fieldCount;
+function getFieldTypeCount(datatypes: MessageDefinitionMap, typeName: string): Map<string, number> {
+  const fieldTypeCount = new Map<string, number>();
+  getFieldTypeCountRecursive({ datatypes, typeName, fieldTypeCount, checkedTypes: [] });
+  return fieldTypeCount;
 }
 
-function getFieldCountRecursive(
-  datatypes: MessageDefinitionMap,
-  typeName: string,
-  fieldCount: Map<string, number>,
-  checkedTypes: string[],
-): void {
+function getFieldTypeCountRecursive(args: {
+  datatypes: MessageDefinitionMap;
+  typeName: string;
+  fieldTypeCount: Map<string, number>;
+  checkedTypes: string[];
+}): void {
+  const { datatypes, typeName, fieldTypeCount, checkedTypes } = args;
   if (datatypes.size === 0) {
     return; // Empty schema.
   }
@@ -35,12 +36,17 @@ function getFieldCountRecursive(
         continue; // Bail out to avoid infinite loop
       }
       for (let i = 0; i < expectedArrayLength; i++) {
-        getFieldCountRecursive(datatypes, field.type, fieldCount, checkedTypes.concat(field.type));
+        getFieldTypeCountRecursive({
+          datatypes,
+          typeName: field.type,
+          fieldTypeCount,
+          checkedTypes: checkedTypes.concat(field.type),
+        });
       }
     } else if (field.isArray ?? false) {
-      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + expectedArrayLength);
+      fieldTypeCount.set(field.type, (fieldTypeCount.get(field.type) ?? 0) + expectedArrayLength);
     } else if (!(field.isConstant ?? false)) {
-      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + 1);
+      fieldTypeCount.set(field.type, (fieldTypeCount.get(field.type) ?? 0) + 1);
     }
   }
 }
@@ -53,11 +59,11 @@ export function guesstimateDeserializedMsgSize(
   datatypes: MessageDefinitionMap,
   typeName: string,
 ): number {
-  const fieldCount = getFieldCount(datatypes, typeName);
-  const totalFieldCount = [...fieldCount.values()].reduce((a, b) => a + b, 0);
-  let sizeInBytes = totalFieldCount * 16; // Object properties take up space as well
-  for (const [fieldName, count] of fieldCount.entries()) {
-    switch (fieldName) {
+  const fieldTypeCount = getFieldTypeCount(datatypes, typeName);
+  const numFields = [...fieldTypeCount.values()].reduce((a, b) => a + b, 0);
+  let sizeInBytes = numFields * 16; // Object properties take up space as well
+  for (const [fieldType, count] of fieldTypeCount.entries()) {
+    switch (fieldType) {
       case "bool":
       case "int8":
       case "uint8":
@@ -83,7 +89,7 @@ export function guesstimateDeserializedMsgSize(
         sizeInBytes += 2 * 12 * count; // 2 x heapnumber
         break;
       default:
-        throw new Error(`Unknown primitive type ${fieldName}`);
+        throw new Error(`Unknown primitive type ${fieldType}`);
     }
   }
   return sizeInBytes;

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
+
+/**
+ * Calculate the expected occurence of primitive field for a given schema.
+ */
+function getFieldCount(datatypes: MessageDefinitionMap, typeName: string): Map<string, number> {
+  const fieldCount = new Map<string, number>();
+  getFieldCountRecursive(datatypes, typeName, fieldCount, []);
+  return fieldCount;
+}
+
+function getFieldCountRecursive(
+  datatypes: MessageDefinitionMap,
+  typeName: string,
+  fieldCount: Map<string, number>,
+  checkedTypes: string[],
+): void {
+  if (datatypes.size === 0) {
+    return; // Empty schema.
+  }
+
+  const definition = datatypes.get(typeName);
+  if (!definition) {
+    throw new Error(`Type '${typeName}' not found in definitions`);
+  }
+
+  for (const field of definition.definitions) {
+    const expectedArrayLength = field.arrayLength ?? field.arrayUpperBound ?? 1;
+    if (field.isComplex ?? false) {
+      if (checkedTypes.includes(field.type)) {
+        continue; // Bail out to avoid infinite loop
+      }
+      for (let i = 0; i < expectedArrayLength; i++) {
+        getFieldCountRecursive(datatypes, field.type, fieldCount, checkedTypes.concat(field.type));
+      }
+    } else if (field.isArray ?? false) {
+      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + expectedArrayLength);
+    } else if (!(field.isConstant ?? false)) {
+      fieldCount.set(field.type, (fieldCount.get(field.type) ?? 0) + 1);
+    }
+  }
+}
+
+/**
+ * Guesstimate the size in bytes of a deserialized message object with the estimated amount of
+ * primitive fields.
+ */
+export function guesstimateDeserializedMsgSize(
+  datatypes: MessageDefinitionMap,
+  typeName: string,
+): number {
+  const fieldCount = getFieldCount(datatypes, typeName);
+  const totalFieldCount = [...fieldCount.values()].reduce((a, b) => a + b, 0);
+  let sizeInBytes = totalFieldCount * 16; // Object properties take up space as well
+  for (const [fieldName, count] of fieldCount.entries()) {
+    switch (fieldName) {
+      case "bool":
+      case "int8":
+      case "uint8":
+      case "int16":
+      case "uint16":
+        sizeInBytes += 8 * count; // small integer
+        break;
+      case "int32":
+      case "uint32":
+      case "float32":
+      case "float64":
+        sizeInBytes += 12 * count; // heapnumber
+        break;
+      case "int64":
+      case "uint64":
+        sizeInBytes += 16 * count; // bigint
+        break;
+      case "string":
+        sizeInBytes += 64 * count; // can't predict the string size, assume a certain length
+        break;
+      case "time":
+      case "duration":
+        sizeInBytes += 2 * 12 * count; // 2 x heapnumber
+        break;
+      default:
+        throw new Error(`Unknown primitive type ${fieldName}`);
+    }
+  }
+  return sizeInBytes;
+}


### PR DESCRIPTION
**User-Facing Changes**
Improve estimation of per message memory usage

**Description**
When loading a recording, Studio attempts to buffer 10 seconds ahead (for a smoother playback experience) and preload messages used in plots or 3D panels (tf) for the entire recording duration. This is however not always possible, especially when dealing with larger messages. Studio will stop reading messages ahead if 1GB worth of messages have been read (both for preloading and playback buffer). 

For determining how many messages can still be read into the buffer, Studio uses the MessageEvent's [`sizeInBytes`](https://github.com/foxglove/studio/blob/b18467986cda61a73eb098da4c6a26cf59dd118a/packages/studio/src/index.ts#L116-L120) which is the size of the serialized message (and which obviously depends on the message encoding). Unfortunately, the deserialized message javascript object can take up a lot more space, especially when the message contains lots of fields. This underestimation of per-message memory size causes Studio to read ahead more messages than it should which might eventually lead to the app running out of memory :headstone: 

This PR attempts to improve the estimation of the memory a deserialized message will take up. The approach taken is rather simple: When parsing the schema, we count the number of primitive fields (e..g bool, int8, int32, ...) and use that to guesstimate the approximate memory size of a deserialized message object

