### PR TITLE
Update topic list search to include schema results when searching for topicname+'.'

### DIFF
--- a/packages/studio-base/src/components/TopicList/useTopicListSearch.test.ts
+++ b/packages/studio-base/src/components/TopicList/useTopicListSearch.test.ts
@@ -59,4 +59,20 @@ describe("useTopicListSearch", () => {
     );
     expect(result.current.map(itemToString)).toEqual(["xyz", "xyz.foobar", "footballer"]);
   });
+
+  it("includes topic matches when there's a trailing dot", () => {
+    const topics: UseTopicListSearchParams["topics"] = [
+      { name: "abc", schemaName: "ABCD" },
+      { name: "abc2", schemaName: "ABCD" },
+      { name: "xyz", schemaName: "XYZW" },
+    ];
+    const datatypes: UseTopicListSearchParams["datatypes"] = new Map([
+      ["ABCD", { definitions: [{ name: "xyz", type: "string" }] }],
+      ["XYZW", { definitions: [{ name: "abcd", type: "string" }] }],
+    ]);
+    const { result } = renderHook(() =>
+      useTopicListSearch({ topics, datatypes, filterText: "abc." }),
+    );
+    expect(result.current.map(itemToString)).toEqual(["abc", "abc.xyz", "abc2", "abc2.xyz"]);
+  });
 });

--- a/packages/studio-base/src/components/TopicList/useTopicListSearch.ts
+++ b/packages/studio-base/src/components/TopicList/useTopicListSearch.ts
@@ -62,8 +62,8 @@ export function useTopicListSearch(params: UseTopicListSearchParams): TopicListI
             [string],
             FzfResultItem<MessagePathSearchItem>[]
           >(this, query);
-          // `offset` denotes the beginning of the `suffix` +1 also excludes results that match only the `.`
-          return results.filter((result) => result.end > result.item.offset + 1);
+          // `offset` denotes the beginning of the `suffix`
+          return results.filter((result) => result.end > result.item.offset);
         },
       }),
     [messagePathSearchItems],


### PR DESCRIPTION
**User-Facing Changes**
Improved search matching algorithm in the Topics list.

**Description**

Originally I'd explicitly excluded field results from the search if the search string only matched `topic.` – I'm not totally sure why I did that; didn't have a test covering it, and it sounds like including the results in this case is more desirable.

Before | After
--- | ---
<img width="410" alt="image" src="https://github.com/foxglove/studio/assets/14237/608abb53-9ceb-41c7-9cd2-3fe039113304"><br><img width="411" alt="image" src="https://github.com/foxglove/studio/assets/14237/9f593532-772c-42da-bb73-09ec62fac5fe"> | <img width="465" alt="image" src="https://github.com/foxglove/studio/assets/14237/58e9a944-b7af-4323-b49e-b05daf3fe02c"><img width="460" alt="image" src="https://github.com/foxglove/studio/assets/14237/65e0bba6-c8d7-475b-8a4f-3cb000eb239b">

