### PR TITLE
Fix a range of issues with user scripts and plots

### DIFF
--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -81,10 +81,10 @@ export function processBlocks(
       const currentCursor = cursors[topic] ?? 0;
 
       // 1. check for any new, non-empty unsent blocks
-      const lastNew = R.findLastIndex(
-        (block) => block[topic] != undefined,
-        blocks.slice(currentCursor),
-      );
+      const lastNew = R.findLastIndex((block) => {
+        const data = block[topic];
+        return data != undefined && data.length !== 0;
+      }, blocks.slice(currentCursor));
       const newCursor = lastNew === -1 ? currentCursor : lastNew + currentCursor + 1;
 
       // 2. check whether any blocks below the current cursor have changed

--- a/packages/studio-base/src/panels/Plot/processor/clients.ts
+++ b/packages/studio-base/src/panels/Plot/processor/clients.ts
@@ -18,7 +18,9 @@ import {
   mapClients,
   rebuildClient,
   keepEffects,
+  concatEffects,
   initClient,
+  getAllTopics,
 } from "./state";
 import { StateAndEffects, SideEffects, State, Client } from "./types";
 import { PlotParams } from "../internalTypes";
@@ -102,6 +104,33 @@ export function updateParams(id: string, params: PlotParams, state: State): Stat
       );
     }),
     keepEffects(evictCache),
+    concatEffects((newState: State): StateAndEffects => {
+      const { pending, blocks } = newState;
+
+      const allNewTopics = getAllTopics(newState);
+      const newData = R.pick(allNewTopics, pending);
+      if (R.isEmpty(newData)) {
+        return [newState, []];
+      }
+
+      const newTopics = R.keys(newData);
+      const migrated = {
+        ...newState,
+        pending: R.omit(allNewTopics, pending),
+        blocks: {
+          ...blocks,
+          ...newData,
+        },
+      };
+
+      return mapClients((client) => {
+        const { topics } = client;
+        if (R.intersection(newTopics, topics).length === 0) {
+          return noEffects(client);
+        }
+        return refreshClient(client, migrated);
+      })(migrated);
+    }),
   )(state);
 }
 

--- a/packages/studio-base/src/panels/Plot/processor/clients.ts
+++ b/packages/studio-base/src/panels/Plot/processor/clients.ts
@@ -114,6 +114,8 @@ export function updateParams(id: string, params: PlotParams, state: State): Stat
       }
 
       const newTopics = R.keys(newData);
+
+      // Move new data now used by at least one client into the real block data
       const migrated = {
         ...newState,
         pending: R.omit(allNewTopics, pending),
@@ -123,12 +125,12 @@ export function updateParams(id: string, params: PlotParams, state: State): Stat
         },
       };
 
-      return mapClients((client) => {
+      return mapClients((client, newState) => {
         const { topics } = client;
         if (R.intersection(newTopics, topics).length === 0) {
           return noEffects(client);
         }
-        return refreshClient(client, migrated);
+        return refreshClient(client, newState);
       })(migrated);
     }),
   )(state);

--- a/packages/studio-base/src/panels/Plot/processor/clients.ts
+++ b/packages/studio-base/src/panels/Plot/processor/clients.ts
@@ -125,12 +125,12 @@ export function updateParams(id: string, params: PlotParams, state: State): Stat
         },
       };
 
-      return mapClients((client, newState) => {
+      return mapClients((client, nextState) => {
         const { topics } = client;
         if (R.intersection(newTopics, topics).length === 0) {
           return noEffects(client);
         }
-        return refreshClient(client, newState);
+        return refreshClient(client, nextState);
       })(migrated);
     }),
   )(state);

--- a/packages/studio-base/src/panels/Plot/processor/messages.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/messages.test.ts
@@ -50,10 +50,15 @@ describe("addBlock", () => {
   });
   it("concatenates messages", () => {
     const [after] = addBlock(createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1), [], {
-      ...initProcessor(),
+      ...createState(FAKE_PATH),
       blocks: createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1),
     });
     expect(after.blocks[FAKE_TOPIC]?.length).toEqual(2);
+  });
+  it("adds messages to pending if no client matches", () => {
+    const [after] = addBlock(createMessages(FAKE_TOPIC, FAKE_SCHEMA, 1), [], initProcessor());
+    expect(after.blocks[FAKE_TOPIC]).toEqual(undefined);
+    expect(after.pending[FAKE_TOPIC]?.length).toEqual(1);
   });
   it("ignores client without params", () => {
     const before = {

--- a/packages/studio-base/src/panels/Plot/processor/state.ts
+++ b/packages/studio-base/src/panels/Plot/processor/state.ts
@@ -46,6 +46,7 @@ export function initProcessor(): State {
     globalVariables: {},
     blocks: {},
     current: {},
+    pending: {},
     metadata: {
       topics: [],
       datatypes: new Map(),
@@ -62,10 +63,23 @@ export function noEffects<T>(state: T): [T, SideEffects] {
 // eslint-disable-next-line @foxglove/no-boolean-parameters
 export const setLive = (isLive: boolean, state: State): State => ({ ...state, isLive });
 
+export const getAllTopics = (state: State): string[] =>
+  R.pipe(
+    R.chain(({ topics: clientTopics }: Client) => clientTopics),
+    R.uniq,
+  )(state.clients);
+
 export const keepEffects =
   (mutator: (state: State) => State) =>
   ([state, effects]: StateAndEffects): StateAndEffects => {
     return [mutator(state), effects];
+  };
+
+export const concatEffects =
+  (mutator: (state: State) => StateAndEffects) =>
+  ([state, effects]: StateAndEffects): StateAndEffects => {
+    const [newState, newEffects] = mutator(state);
+    return [newState, [...effects, ...newEffects]];
   };
 
 export const findClient = (state: State, id: string): Client | undefined =>

--- a/packages/studio-base/src/panels/Plot/processor/types.ts
+++ b/packages/studio-base/src/panels/Plot/processor/types.ts
@@ -23,6 +23,8 @@ export type State = {
   clients: Client[];
   globalVariables: GlobalVariables;
   blocks: Messages;
+  // all block data that was sent, but has not yet been used by a client
+  pending: Messages;
   current: Messages;
   metadata: MetadataEnums;
 };

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -217,6 +217,9 @@ function useData(id: string, params: PlotParams) {
 
   const blocks = useBlocks(blockSubscriptions);
   useEffect(() => {
+    if (blockSubscriptions.length === 0) {
+      return
+    }
     const {
       state: newState,
       resetTopics,

--- a/packages/studio-base/src/panels/Plot/useDatasets.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.ts
@@ -218,7 +218,7 @@ function useData(id: string, params: PlotParams) {
   const blocks = useBlocks(blockSubscriptions);
   useEffect(() => {
     if (blockSubscriptions.length === 0) {
-      return
+      return;
     }
     const {
       state: newState,

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -158,9 +158,6 @@ setInterval(() => {
 
 export const service = {
   addBlock(block: Messages, resetTopics: string[]): void {
-    if (resetTopics.length > 0) {
-    } else {
-    }
     handleEffects(addBlock(strPack(block), resetTopics, state));
   },
   addCurrent(events: readonly MessageEvent[]): void {

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -158,6 +158,9 @@ setInterval(() => {
 
 export const service = {
   addBlock(block: Messages, resetTopics: string[]): void {
+    if (resetTopics.length > 0) {
+    } else {
+    }
     handleEffects(addBlock(strPack(block), resetTopics, state));
   },
   addCurrent(events: readonly MessageEvent[]): void {

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -97,7 +97,16 @@ export class BlockLoader {
     // Update all the blocks with any missing topics
     for (const block of this.#blocks) {
       if (block) {
-        block.needTopics = new Map(topics);
+        const blockTopics = Object.keys(block.messagesByTopic);
+        const needTopics = new Map(topics);
+        for (const topic of blockTopics) {
+          // We need the topic unless the subscription is identical to the subscription for this
+          // topic at the time the block was loaded.
+          if (this.#topics.get(topic) === topics.get(topic)) {
+            needTopics.delete(topic);
+          }
+        }
+        block.needTopics = needTopics;
       }
     }
 
@@ -249,12 +258,15 @@ export class BlockLoader {
         const untilTime = clampTime(this.#blockIdToEndTime(currentBlockId), this.#start, this.#end);
 
         const results = await cursor.readUntil(untilTime);
-        if (!R.equals(topics, this.#topics)) {
-          return;
-        }
         // No results means cursor aborted or eof
         if (!results) {
           await cursor.end();
+          return;
+        }
+
+        // When topics change while loading, we need to wait for the next
+        // iteration
+        if (!R.equals(topics, this.#topics)) {
           return;
         }
 

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -4,6 +4,7 @@
 
 import { simplify } from "intervals-fn";
 import * as _ from "lodash-es";
+import * as R from "ramda";
 
 import { Condvar } from "@foxglove/den/async";
 import { filterMap } from "@foxglove/den/collection";
@@ -96,16 +97,7 @@ export class BlockLoader {
     // Update all the blocks with any missing topics
     for (const block of this.#blocks) {
       if (block) {
-        const blockTopics = Object.keys(block.messagesByTopic);
-        const needTopics = new Map(topics);
-        for (const topic of blockTopics) {
-          // We need the topic unless the subscription is identical to the subscription for this
-          // topic at the time the block was loaded.
-          if (this.#topics.get(topic) === topics.get(topic)) {
-            needTopics.delete(topic);
-          }
-        }
-        block.needTopics = needTopics;
+        block.needTopics = new Map(topics);
       }
     }
 
@@ -179,7 +171,7 @@ export class BlockLoader {
   }
 
   async #load(args: { progress: LoadArgs["progress"] }): Promise<void> {
-    const topics = this.#topics;
+    const topics = new Map(this.#topics);
 
     // Ignore changing the blocks if the topic list is empty
     if (topics.size === 0) {
@@ -257,6 +249,9 @@ export class BlockLoader {
         const untilTime = clampTime(this.#blockIdToEndTime(currentBlockId), this.#start, this.#end);
 
         const results = await cursor.readUntil(untilTime);
+        if (!R.equals(topics, this.#topics)) {
+          return;
+        }
         // No results means cursor aborted or eof
         if (!results) {
           await cursor.end();


### PR DESCRIPTION
**User-Facing Changes**
Fixed a handful of issues where plotting user script topics could lead to broken plots.

**Description**
This one is a doozy. It fixes three separate bugs that combined to create the poor experience described in [this GitHub ~issue~ discussion](https://github.com/orgs/foxglove/discussions/855):
1. If block data already exists on a topic a plot panel needs when it's mounted, the main thread delivers block data to the plot worker before the client is registered. The plot worker would drop the data.
  a. **Solution:** Now we hold on to incoming block data in anticipation of the registration of a client.
3. The plot panel block processor treated empty arrays on a topic as valid message data, not as being empty. This can occur if the `UserScriptPlayer` is partway through processing data when a subscription to a user script topic is cancelled.
  a. **Solution:** Empty message arrays now indicate an empty block.
5. The `BlockLoader` does not handle changes in subscriptions gracefully, particularly for user script topics.
  a. **Solution:** If topics change while we're loading data, we return from `load()` and wait until the next iteration to continue.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
