### PR TITLE
Convert UserScriptStateContext to zustand store

### DIFF
--- a/packages/studio-base/src/StudioApp.tsx
+++ b/packages/studio-base/src/StudioApp.tsx
@@ -55,10 +55,10 @@ export function StudioApp(): JSX.Element {
   const providers = [
     /* eslint-disable react/jsx-key */
     <TimelineInteractionStateProvider />,
-    <UserScriptStateProvider />,
     <CurrentLayoutProvider />,
     <ExtensionMarketplaceProvider />,
     <ExtensionCatalogProvider loaders={extensionLoaders} />,
+    <UserScriptStateProvider />,
     <PlayerManager playerSources={dataSources} />,
     <EventsProvider />,
     /* eslint-enable react/jsx-key */

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -22,7 +22,7 @@ import {
 } from "react";
 import { useLatest, useMountedState } from "react-use";
 
-import { useShallowMemo, useWarnImmediateReRender } from "@foxglove/hooks";
+import { useWarnImmediateReRender } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
 import { MessagePipelineProvider } from "@foxglove/studio-base/components/MessagePipeline";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
@@ -40,7 +40,10 @@ import PlayerSelectionContext, {
   IDataSourceFactory,
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import { useUserScriptState } from "@foxglove/studio-base/context/UserScriptStateContext";
+import {
+  UserScriptStore,
+  useUserScriptState,
+} from "@foxglove/studio-base/context/UserScriptStateContext";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import useIndexedDbRecents, { RecentRecord } from "@foxglove/studio-base/hooks/useIndexedDbRecents";
 import AnalyticsMetricsCollector from "@foxglove/studio-base/players/AnalyticsMetricsCollector";
@@ -65,23 +68,14 @@ const globalVariablesSelector = (state: LayoutState) =>
 const selectTopicAliasFunctions = (catalog: ExtensionCatalog) =>
   catalog.installedTopicAliasFunctions;
 
+const selectUserScriptActions = (store: UserScriptStore) => store.actions;
+
 export default function PlayerManager(props: PropsWithChildren<PlayerManagerProps>): JSX.Element {
   const { children, playerSources } = props;
 
   useWarnImmediateReRender();
 
-  const {
-    setUserScriptDiagnostics,
-    addUserScriptLogs,
-    setUserScriptRosLib,
-    setUserScriptTypesLib,
-  } = useUserScriptState();
-  const userScriptActions = useShallowMemo({
-    setUserScriptDiagnostics,
-    addUserScriptLogs,
-    setUserScriptRosLib,
-    setUserScriptTypesLib,
-  });
+  const userScriptActions = useUserScriptState(selectUserScriptActions);
 
   const nativeWindow = useNativeWindow();
 

--- a/packages/studio-base/src/context/UserScriptStateContext.tsx
+++ b/packages/studio-base/src/context/UserScriptStateContext.tsx
@@ -2,9 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createContext, useCallback, useState } from "react";
+import { createContext, useState } from "react";
+import { StoreApi, createStore, useStore } from "zustand";
 
-import { useShallowMemo, useGuaranteedContext } from "@foxglove/hooks";
+import { useGuaranteedContext } from "@foxglove/hooks";
 import { generateEmptyTypesLib } from "@foxglove/studio-base/players/UserScriptPlayer/transformerWorker/generateTypesLib";
 import { ros_lib_dts } from "@foxglove/studio-base/players/UserScriptPlayer/transformerWorker/typescript/ros";
 import { Diagnostic, UserScriptLog } from "@foxglove/studio-base/players/UserScriptPlayer/types";
@@ -20,94 +21,94 @@ type UserScriptState = {
   };
 };
 
-const UserScriptStateContext = createContext<
-  | {
-      state: UserScriptState;
-      setUserScriptDiagnostics: (scriptId: string, diagnostics: readonly Diagnostic[]) => void;
-      addUserScriptLogs: (scriptId: string, logs: readonly UserScriptLog[]) => void;
-      clearUserScriptLogs: (scriptId: string) => void;
-      setUserScriptRosLib: (rosLib: string) => void;
-      setUserScriptTypesLib: (lib: string) => void;
-    }
-  | undefined
->(undefined);
+export type UserScriptStore = {
+  state: UserScriptState;
+  actions: {
+    setUserScriptDiagnostics: (scriptId: string, diagnostics: readonly Diagnostic[]) => void;
+    addUserScriptLogs: (scriptId: string, logs: readonly UserScriptLog[]) => void;
+    clearUserScriptLogs: (scriptId: string) => void;
+    setUserScriptRosLib: (rosLib: string) => void;
+    setUserScriptTypesLib: (lib: string) => void;
+  };
+};
+
+const UserScriptStateContext = createContext<StoreApi<UserScriptStore> | undefined>(undefined);
 UserScriptStateContext.displayName = "UserScriptStateContext";
 
+function create() {
+  return createStore<UserScriptStore>((set) => {
+    return {
+      state: {
+        rosLib: ros_lib_dts,
+        typesLib: generateEmptyTypesLib(),
+        scriptStates: {},
+      },
+      actions: {
+        setUserScriptDiagnostics: (scriptId: string, diagnostics: readonly Diagnostic[]) => {
+          set((prevState) => ({
+            state: {
+              ...prevState.state,
+              scriptStates: {
+                ...prevState.state.scriptStates,
+                [scriptId]: {
+                  logs: [],
+                  ...prevState.state.scriptStates[scriptId],
+                  diagnostics, // replace diagnostics
+                },
+              },
+            },
+          }));
+        },
+        addUserScriptLogs(scriptId: string, logs: readonly UserScriptLog[]) {
+          set((prevState) => ({
+            state: {
+              ...prevState.state,
+              scriptStates: {
+                ...prevState.state.scriptStates,
+                [scriptId]: {
+                  diagnostics: [],
+                  ...prevState.state.scriptStates[scriptId],
+                  logs: (prevState.state.scriptStates[scriptId]?.logs ?? []).concat(logs), // add logs
+                },
+              },
+            },
+          }));
+        },
+        clearUserScriptLogs(scriptId: string) {
+          set((prevState) => ({
+            state: {
+              ...prevState.state,
+              scriptStates: {
+                ...prevState.state.scriptStates,
+                [scriptId]: {
+                  diagnostics: [],
+                  ...prevState.state.scriptStates[scriptId],
+                  logs: [], // clear logs
+                },
+              },
+            },
+          }));
+        },
+        setUserScriptRosLib(rosLib: string) {
+          set((prevState) => ({ state: { ...prevState.state, rosLib } }));
+        },
+        setUserScriptTypesLib(typesLib: string) {
+          set((prevState) => ({ state: { ...prevState.state, typesLib } }));
+        },
+      },
+    };
+  });
+}
+
 export function UserScriptStateProvider({ children }: React.PropsWithChildren): JSX.Element {
-  const [state, setState] = useState<UserScriptState>({
-    rosLib: ros_lib_dts,
-    typesLib: generateEmptyTypesLib(),
-    scriptStates: {},
-  });
-
-  const setUserScriptDiagnostics = useCallback(
-    (scriptId: string, diagnostics: readonly Diagnostic[]) => {
-      setState((prevState) => ({
-        ...prevState,
-        scriptStates: {
-          ...prevState.scriptStates,
-          [scriptId]: {
-            logs: [],
-            ...prevState.scriptStates[scriptId],
-            diagnostics, // replace diagnostics
-          },
-        },
-      }));
-    },
-    [],
-  );
-
-  const addUserScriptLogs = useCallback((scriptId: string, logs: readonly UserScriptLog[]) => {
-    setState((prevState) => ({
-      ...prevState,
-      scriptStates: {
-        ...prevState.scriptStates,
-        [scriptId]: {
-          diagnostics: [],
-          ...prevState.scriptStates[scriptId],
-          logs: (prevState.scriptStates[scriptId]?.logs ?? []).concat(logs), // add logs
-        },
-      },
-    }));
-  }, []);
-
-  const clearUserScriptLogs = useCallback((scriptId: string) => {
-    setState((prevState) => ({
-      ...prevState,
-      scriptStates: {
-        ...prevState.scriptStates,
-        [scriptId]: {
-          diagnostics: [],
-          ...prevState.scriptStates[scriptId],
-          logs: [], // clear logs
-        },
-      },
-    }));
-  }, []);
-
-  const setUserScriptRosLib = useCallback((rosLib: string) => {
-    setState((prevState) => ({ ...prevState, rosLib }));
-  }, []);
-
-  const setUserScriptTypesLib = useCallback((typesLib: string) => {
-    setState((prevState) => ({ ...prevState, typesLib }));
-  }, []);
-
-  const value = useShallowMemo({
-    state,
-    setUserScriptDiagnostics,
-    addUserScriptLogs,
-    clearUserScriptLogs,
-    setUserScriptRosLib,
-    setUserScriptTypesLib,
-  });
+  const [value] = useState(() => create());
 
   return (
     <UserScriptStateContext.Provider value={value}>{children}</UserScriptStateContext.Provider>
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function useUserScriptState() {
-  return useGuaranteedContext(UserScriptStateContext, "UserScriptStateContext");
+export function useUserScriptState<T>(selector: (arg: UserScriptStore) => T): T {
+  const store = useGuaranteedContext(UserScriptStateContext, "UserScriptStateContext");
+  return useStore(store, selector);
 }

--- a/packages/studio-base/src/panels/UserScriptEditor/BottomBar/index.tsx
+++ b/packages/studio-base/src/panels/UserScriptEditor/BottomBar/index.tsx
@@ -17,7 +17,10 @@ import { ReactElement, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
-import { useUserScriptState } from "@foxglove/studio-base/context/UserScriptStateContext";
+import {
+  UserScriptStore,
+  useUserScriptState,
+} from "@foxglove/studio-base/context/UserScriptStateContext";
 import DiagnosticsSection from "@foxglove/studio-base/panels/UserScriptEditor/BottomBar/DiagnosticsSection";
 import LogsSection from "@foxglove/studio-base/panels/UserScriptEditor/BottomBar/LogsSection";
 import { Diagnostic, UserScriptLog } from "@foxglove/studio-base/players/UserScriptPlayer/types";
@@ -73,6 +76,8 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
+const selectUserScriptActions = (store: UserScriptStore) => store.actions;
+
 const BottomBar = ({
   diagnostics,
   isSaved,
@@ -84,7 +89,7 @@ const BottomBar = ({
   const { classes } = useStyles();
   const [bottomBarDisplay, setBottomBarDisplay] = useState<BottomBarModes>("diagnostics");
 
-  const { clearUserScriptLogs } = useUserScriptState();
+  const { clearUserScriptLogs } = useUserScriptState(selectUserScriptActions);
 
   const handleChange = (_event: React.SyntheticEvent, value: BottomBarModes) => {
     setBottomBarDisplay(value);

--- a/packages/studio-base/src/panels/UserScriptEditor/index.tsx
+++ b/packages/studio-base/src/panels/UserScriptEditor/index.tsx
@@ -43,7 +43,10 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useUserScriptState } from "@foxglove/studio-base/context/UserScriptStateContext";
+import {
+  UserScriptStore,
+  useUserScriptState,
+} from "@foxglove/studio-base/context/UserScriptStateContext";
 import BottomBar from "@foxglove/studio-base/panels/UserScriptEditor/BottomBar";
 import { Sidebar } from "@foxglove/studio-base/panels/UserScriptEditor/Sidebar";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
@@ -179,6 +182,8 @@ const EMPTY_USER_NODES: UserScripts = Object.freeze({});
 const selectUserScripts = (state: LayoutState) =>
   state.selectedLayout?.data?.userNodes ?? EMPTY_USER_NODES;
 
+const selectState = (store: UserScriptStore) => store.state;
+
 function UserScriptEditor(props: Props) {
   const { config, saveConfig } = props;
   const { classes, theme } = useStyles();
@@ -186,9 +191,7 @@ function UserScriptEditor(props: Props) {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const userScripts = useCurrentLayoutSelector(selectUserScripts);
-  const {
-    state: { scriptStates: userScriptStates, rosLib, typesLib },
-  } = useUserScriptState();
+  const { scriptStates: userScriptStates, rosLib, typesLib } = useUserScriptState(selectState);
 
   const { setUserScripts } = useCurrentLayoutActions();
 

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -41,6 +41,7 @@ import {
 } from "@foxglove/studio-base/context/PanelStateContext";
 import {
   UserScriptStateProvider,
+  UserScriptStore,
   useUserScriptState,
 } from "@foxglove/studio-base/context/UserScriptStateContext";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
@@ -194,6 +195,8 @@ const defaultFetchAsset: ComponentProps<typeof MockMessagePipelineProvider>["fet
   };
 };
 
+const selectUserScriptActions = (store: UserScriptStore) => store.actions;
+
 function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull {
   const { t } = useTranslation("panels");
   const mockPanelCatalog = useMemo(
@@ -210,7 +213,8 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
   }));
 
   const actions = useCurrentLayoutActions();
-  const { setUserScriptDiagnostics, addUserScriptLogs, setUserScriptRosLib } = useUserScriptState();
+  const { setUserScriptDiagnostics, addUserScriptLogs, setUserScriptRosLib } =
+    useUserScriptState(selectUserScriptActions);
   const userScriptActions = useShallowMemo({
     setUserScriptDiagnostics,
     addUserScriptLogs,


### PR DESCRIPTION
**User-Facing Changes**
Performance improvements when scrubbing or seeking and user scripts are present.

**Description**
When scrubbing or seeking, the user scripts are reset which causes the `UserScriptStateContext` _state_ to get updated. Because the entire context is not selectable this invalidates the _value_ of the context which causes it to render and any downstream users of the context to re-render. This re-renders a lot of things downstream that don't need to render because they only need the stable actions functions and not the state.

This change updates the context to use zustand and allow for separately selecting the actions and the state.

---

Here is a before and after showing scrubbing behavior with a layout that has some user scripts. In this recording I did not have sidebars open. The effect is even more dramatic if I open sidebars.

Before:

https://github.com/foxglove/studio/assets/84792/771c070f-ecbc-44ec-98a9-8fcafa9d8165



After:


https://github.com/foxglove/studio/assets/84792/200e7d3a-339d-4547-9f02-6e0d2fcaa451


---
I think there's a poor behavior here where a user script that _logs_ could eat up memory if no one is viewing the logs but have not confirmed that.

