### PR TITLE
Move Playback Performance panel into the right sidebar

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -35,6 +35,7 @@ import {
 import PanelLayout from "@foxglove/studio-base/components/PanelLayout";
 import PanelSettings from "@foxglove/studio-base/components/PanelSettings";
 import PlaybackControls from "@foxglove/studio-base/components/PlaybackControls";
+import { PlaybackPerformance } from "@foxglove/studio-base/components/PlaybackPerformance";
 import { ProblemsList } from "@foxglove/studio-base/components/ProblemsList";
 import RemountOnValueChange from "@foxglove/studio-base/components/RemountOnValueChange";
 import { Sidebars, SidebarItem } from "@foxglove/studio-base/components/Sidebars";
@@ -150,9 +151,7 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
 
   useDefaultWebLaunchPreference();
 
-  const [enableStudioLogsSidebar = false] = useAppConfigurationValue<boolean>(
-    AppSetting.SHOW_DEBUG_PANELS,
-  );
+  const [enableDebugMode = false] = useAppConfigurationValue<boolean>(AppSetting.SHOW_DEBUG_PANELS);
 
   const { workspaceExtensions } = useAppContext();
 
@@ -356,14 +355,15 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
     const items = new Map<RightSidebarItemKey, SidebarItem>([
       ["variables", { title: t("variables"), component: VariablesList }],
     ]);
-    if (enableStudioLogsSidebar) {
+    if (enableDebugMode) {
       items.set("studio-logs-settings", { title: t("studioLogs"), component: StudioLogsSettings });
+      items.set("performance", { title: t("performance"), component: PlaybackPerformance });
     }
     if (showEventsTab) {
       items.set("events", { title: t("events"), component: EventsList });
     }
     return items;
-  }, [enableStudioLogsSidebar, showEventsTab, t]);
+  }, [enableDebugMode, showEventsTab, t]);
 
   const keyboardEventHasModifier = (event: KeyboardEvent) =>
     navigator.userAgent.includes("Mac") ? event.metaKey : event.ctrlKey;

--- a/packages/studio-base/src/components/PlaybackPerformance/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackPerformance/index.stories.tsx
@@ -13,11 +13,20 @@
 
 import { StoryObj } from "@storybook/react";
 
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
 import { PlaybackPerformance } from "./index";
 
 export default {
   title: "panels/PlaybackPerformance",
-  component: PlaybackPerformance,
 };
 
-export const SimpleExample: StoryObj = {};
+export const SimpleExample: StoryObj = {
+  render: () => {
+    return (
+      <PanelSetup>
+        <PlaybackPerformance />
+      </PanelSetup>
+    );
+  },
+};

--- a/packages/studio-base/src/components/PlaybackPerformance/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackPerformance/index.stories.tsx
@@ -13,20 +13,11 @@
 
 import { StoryObj } from "@storybook/react";
 
-import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
-
-import PlaybackPerformance from "./index";
+import { PlaybackPerformance } from "./index";
 
 export default {
   title: "panels/PlaybackPerformance",
+  component: PlaybackPerformance,
 };
 
-export const SimpleExample: StoryObj = {
-  render: () => {
-    return (
-      <PanelSetup>
-        <PlaybackPerformance />
-      </PanelSetup>
-    );
-  },
-};
+export const SimpleExample: StoryObj = {};

--- a/packages/studio-base/src/components/PlaybackPerformance/index.tsx
+++ b/packages/studio-base/src/components/PlaybackPerformance/index.tsx
@@ -18,8 +18,6 @@ import { ReactElement } from "react";
 import { subtract as subtractTimes, toSec } from "@foxglove/rostime";
 import { Immutable } from "@foxglove/studio";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
-import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { Sparkline, SparklinePoint } from "@foxglove/studio-base/components/Sparkline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { PlayerStateActiveData } from "@foxglove/studio-base/players/types";
@@ -56,15 +54,11 @@ function PlaybackPerformanceItem(props: PlaybackPerformanceItemProps): ReactElem
   );
 }
 
-type UnconnectedPlaybackPerformanceProps = Immutable<{
-  timestamp: number;
-  activeData?: PlayerStateActiveData;
-}>;
-
-function UnconnectedPlaybackPerformance({
-  timestamp,
-  activeData,
-}: UnconnectedPlaybackPerformanceProps): JSX.Element {
+export function PlaybackPerformance(): JSX.Element {
+  const timestamp = Date.now();
+  const activeData = useMessagePipeline(
+    React.useCallback(({ playerState }) => playerState.activeData, []),
+  );
   const playbackInfo =
     React.useRef<Immutable<{ timestamp: number; activeData: PlayerStateActiveData } | undefined>>();
   const lastPlaybackInfo = playbackInfo.current;
@@ -118,7 +112,6 @@ function UnconnectedPlaybackPerformance({
 
   return (
     <Stack flex="auto">
-      <PanelToolbar />
       <Stack flex="auto" justifyContent="center" gap={2} padding={1}>
         <PlaybackPerformanceItem
           points={perfPoints.current.speed}
@@ -148,16 +141,3 @@ function UnconnectedPlaybackPerformance({
     </Stack>
   );
 }
-
-function PlaybackPerformance() {
-  const timestamp = Date.now();
-  const activeData = useMessagePipeline(
-    React.useCallback(({ playerState }) => playerState.activeData, []),
-  );
-  return <UnconnectedPlaybackPerformance timestamp={timestamp} activeData={activeData} />;
-}
-
-PlaybackPerformance.panelType = "PlaybackPerformance";
-PlaybackPerformance.defaultConfig = {};
-
-export default Panel(PlaybackPerformance);

--- a/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/Workspace/WorkspaceContext.ts
@@ -15,7 +15,12 @@ import { IDataSourceFactory } from "@foxglove/studio-base/context/PlayerSelectio
 export const LeftSidebarItemKeys = ["panel-settings", "topics", "problems"] as const;
 export type LeftSidebarItemKey = (typeof LeftSidebarItemKeys)[number];
 
-export const RightSidebarItemKeys = ["events", "variables", "studio-logs-settings"] as const;
+export const RightSidebarItemKeys = [
+  "events",
+  "variables",
+  "studio-logs-settings",
+  "performance",
+] as const;
 export type RightSidebarItemKey = (typeof RightSidebarItemKeys)[number];
 
 export type WorkspaceContextStore = {

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -31,8 +31,8 @@ export const appSettings = {
   sendAnonymizedCrashReports: "Send anonymized crash reports",
   sendAnonymizedUsageData: "Send anonymized usage data to help us improve Foxglove Studio",
   settings: "Settings",
-  studioDebugPanels: "Studio debug panels",
-  studioDebugPanelsDescription: "Show Foxglove Studio debug panels in the “Add panel” list.",
+  studioDebugPanels: "Debug mode",
+  studioDebugPanelsDescription: "Enable panels and features for debugging Foxglove Studio.",
   timestampFormat: "Timestamp format",
   webApp: "Web app",
 };

--- a/packages/studio-base/src/i18n/en/panels.ts
+++ b/packages/studio-base/src/i18n/en/panels.ts
@@ -34,9 +34,6 @@ export const panels = {
   ROSDiagnosticSummaryDescription: "Display a summary of all ROS DiagnosticArray messages.",
   stateTransitions: "State Transitions",
   stateTransitionsDescription: "Track when values change over time.",
-  studioPlaybackPerformance: "Studio - Playback Performance",
-  studioPlaybackPerformanceDescription:
-    "Display playback and data-streaming performance statistics.",
   tab: "Tab",
   tabDescription: "Group panels together in a tabbed interface.",
   table: "Table",

--- a/packages/studio-base/src/i18n/en/workspace.ts
+++ b/packages/studio-base/src/i18n/en/workspace.ts
@@ -5,8 +5,9 @@
 export const workspace = {
   events: "Events",
   panel: "Panel",
+  performance: "Performance",
   problems: "Problems",
-  studioLogs: "Studio Logs",
+  studioLogs: "Logs",
   topics: "Topics",
   variables: "Variables",
 };

--- a/packages/studio-base/src/i18n/ja/appSettings.ts
+++ b/packages/studio-base/src/i18n/ja/appSettings.ts
@@ -32,8 +32,8 @@ export const appSettings: Partial<TypeOptions["resources"]["appSettings"]> = {
   sendAnonymizedCrashReports: "匿名化されたクラッシュレポートを送信",
   sendAnonymizedUsageData: "匿名化された使用データを送信して、Foxglove Studioの改善に役立てる",
   settings: "設定",
-  studioDebugPanels: "Studioデバッグパネル",
-  studioDebugPanelsDescription: "「パネルを追加」リストにFoxglove Studioデバッグパネルを表示する。",
+  studioDebugPanels: undefined,
+  studioDebugPanelsDescription: undefined,
   timestampFormat: "タイムスタンプ形式",
   webApp: "ウェブアプリ",
 };

--- a/packages/studio-base/src/i18n/ja/panels.ts
+++ b/packages/studio-base/src/i18n/ja/panels.ts
@@ -36,9 +36,6 @@ export const panels: Partial<TypeOptions["resources"]["panels"]> = {
   ROSDiagnosticSummaryDescription: "すべてのROS DiagnosticArrayメッセージの概要を表示します。",
   stateTransitions: "ステートトランジション",
   stateTransitionsDescription: "時間とともに値が変化するときを追跡します。",
-  studioPlaybackPerformance: "Studio - 再生パフォーマンス",
-  studioPlaybackPerformanceDescription:
-    "再生およびデータストリーミングのパフォーマンス統計情報を表示します。",
   tab: "タブ",
   tabDescription: "複数のパネルをタブでグループ化して表示します。",
   table: "テーブル",

--- a/packages/studio-base/src/i18n/ja/workspace.ts
+++ b/packages/studio-base/src/i18n/ja/workspace.ts
@@ -7,6 +7,7 @@ import { TypeOptions } from "i18next";
 export const workspace: Partial<TypeOptions["resources"]["workspace"]> = {
   events: undefined,
   panel: undefined,
+  performance: undefined,
   problems: undefined,
   studioLogs: undefined,
   topics: undefined,

--- a/packages/studio-base/src/i18n/zh/appSettings.ts
+++ b/packages/studio-base/src/i18n/zh/appSettings.ts
@@ -31,8 +31,8 @@ export const appSettings: Partial<TypeOptions["resources"]["appSettings"]> = {
   sendAnonymizedCrashReports: "发送匿名崩溃报告",
   sendAnonymizedUsageData: "发送匿名使用数据以帮助我们改进 Foxglove Studio",
   settings: "设置",
-  studioDebugPanels: "Studio 调试面板",
-  studioDebugPanelsDescription: "在“添加面板”列表中显示 Foxglove Studio 调试面板。",
+  studioDebugPanels: undefined,
+  studioDebugPanelsDescription: undefined,
   timestampFormat: "时间戳格式",
   webApp: "网页应用",
 };

--- a/packages/studio-base/src/i18n/zh/panels.ts
+++ b/packages/studio-base/src/i18n/zh/panels.ts
@@ -35,8 +35,6 @@ export const panels: Partial<TypeOptions["resources"]["panels"]> = {
   ROSDiagnosticSummaryDescription: "显示所有 ROS DiagnosticArray 消息的摘要。",
   stateTransitions: "状态转换",
   stateTransitionsDescription: "跟踪值随时间变化的情况。",
-  studioPlaybackPerformance: "Studio - 播放性能",
-  studioPlaybackPerformanceDescription: "显示回放和数据流式处理性能统计信息。",
   tab: "选项卡",
   tabDescription: "将面板分组在选项卡界面中。",
   table: "表格",

--- a/packages/studio-base/src/i18n/zh/workspace.ts
+++ b/packages/studio-base/src/i18n/zh/workspace.ts
@@ -7,8 +7,9 @@ import { TypeOptions } from "i18next";
 export const workspace: Partial<TypeOptions["resources"]["workspace"]> = {
   events: "事件",
   panel: "面板",
+  performance: undefined,
   problems: "问题",
-  studioLogs: "Studio 日志",
+  studioLogs: "日志",
   topics: "话题",
   variables: "变量",
 };

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -181,12 +181,3 @@ export const getBuiltin: (t: TFunction<"panels">) => PanelInfo[] = (t) => [
     hasCustomToolbar: true,
   },
 ];
-
-export const getDebug: (t: TFunction<"panels">) => PanelInfo[] = (t) => [
-  {
-    title: t("studioPlaybackPerformance"),
-    type: "PlaybackPerformance",
-    description: t("studioPlaybackPerformanceDescription"),
-    module: async () => await import("./PlaybackPerformance"),
-  },
-];

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -5,7 +5,6 @@
 import { PropsWithChildren, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
@@ -13,7 +12,6 @@ import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
-import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import * as panels from "@foxglove/studio-base/panels";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
@@ -23,7 +21,6 @@ type PanelProps = {
 };
 
 export default function PanelCatalogProvider(props: PropsWithChildren): React.ReactElement {
-  const [showDebugPanels = false] = useAppConfigurationValue<boolean>(AppSetting.SHOW_DEBUG_PANELS);
   const { t } = useTranslation("panels");
 
   const extensionPanels = useExtensionCatalog((state) => state.installedPanels);
@@ -58,22 +55,18 @@ export default function PanelCatalogProvider(props: PropsWithChildren): React.Re
   const allPanelsInfo = useMemo(() => {
     return {
       builtin: panels.getBuiltin(t),
-      debug: panels.getDebug(t),
     };
   }, [t]);
 
   const allPanels = useMemo(() => {
-    return [...allPanelsInfo.builtin, ...allPanelsInfo.debug, ...wrappedExtensionPanels];
+    return [...allPanelsInfo.builtin, ...wrappedExtensionPanels];
   }, [wrappedExtensionPanels, allPanelsInfo]);
 
   const visiblePanels = useMemo(() => {
     const panelList = [...allPanelsInfo.builtin];
-    if (showDebugPanels) {
-      panelList.push(...allPanelsInfo.debug);
-    }
     panelList.push(...wrappedExtensionPanels);
     return panelList;
-  }, [showDebugPanels, wrappedExtensionPanels, allPanelsInfo]);
+  }, [wrappedExtensionPanels, allPanelsInfo]);
 
   const panelsByType = useMemo(() => {
     const byType = new Map<string, PanelInfo>();

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -110,7 +110,7 @@ type UnconnectedProps = {
 };
 
 function makeMockPanelCatalog(t: TFunction<"panels">): PanelCatalog {
-  const allPanels = [...panels.getBuiltin(t), ...panels.getDebug(t)];
+  const allPanels = [...panels.getBuiltin(t)];
 
   const visiblePanels = [...panels.getBuiltin(t)];
 


### PR DESCRIPTION
**User-Facing Changes**
Moved the Playback Performance debugging panel into the right sidebar.

**Description**
- Renamed "Studio debug panels" experimental feature to "Debug mode"
- Renamed "Studio Logs" sidebar to "Logs"
- Added a "Performance" tab to the sidebar that contains the PlaybackPerformance component

<img width="292" alt="image" src="https://github.com/foxglove/studio/assets/14237/03f83247-1b96-4e0b-b955-61ce08765b4b">
