### PR TITLE
Enable cross-origin isolation

### DIFF
--- a/benchmark/webpack.config.ts
+++ b/benchmark/webpack.config.ts
@@ -37,6 +37,11 @@ const devServerConfig: WebpackConfiguration = {
     //  "[WDS] Disconnected!"
     // Since we are only connecting to localhost, DNS rebinding attacks are not a concern during dev
     allowedHosts: "all",
+    headers: {
+      // Enable cross-origin isolation: https://resourcepolicy.fyi
+      "cross-origin-opener-policy": "same-origin",
+      "cross-origin-embedder-policy": "credentialless",
+    },
   },
 
   plugins: [new CleanWebpackPlugin()],

--- a/packages/studio-web/src/webpackConfigs.ts
+++ b/packages/studio-web/src/webpackConfigs.ts
@@ -59,6 +59,11 @@ export const devServerConfig = (params: ConfigParams): WebpackConfiguration => (
     //  "[WDS] Disconnected!"
     // Since we are only connecting to localhost, DNS rebinding attacks are not a concern during dev
     allowedHosts: "all",
+    headers: {
+      // Enable cross-origin isolation: https://resourcepolicy.fyi
+      "cross-origin-opener-policy": "same-origin",
+      "cross-origin-embedder-policy": "credentialless",
+    },
   },
 
   plugins: [new CleanWebpackPlugin()],

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,9 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "origin" },
         { "key": "Content-Security-Policy", "value": "base-uri 'self';" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "credentialless" }
       ]
     }
   ],


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This enables "cross-origin isolation" and thereby unlocks the [performance.measureUserAgentSpecificMemory()](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measureUserAgentSpecificMemory) and SharedArrayBuffer APIs.