### PR TITLE
Set maximum byte size on messages in current frame in websocket player

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -78,7 +78,14 @@ type ResolvedService = {
 };
 type MessageDefinitionMap = Map<string, MessageDefinition>;
 
-// 1500MB
+/**
+ * When the tab is inactive setTimeout's are throttled to at most once per second.
+ * Because the MessagePipeline listener uses timeouts to resolve its promises, it throttles our ability to
+ * emit a frame more than once per second. In the websocket player this was causing
+ * an accumulation of messages that were waiting to be emitted, this could keep growing
+ * indefinitely if the rate at which we emit a frame is low enough.
+ * 1500MB
+ */
 const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 15e8;
 
 export default class FoxgloveWebSocketPlayer implements Player {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -78,8 +78,8 @@ type ResolvedService = {
 };
 type MessageDefinitionMap = Map<string, MessageDefinition>;
 
-// 500MB
-const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 5.0e8;
+// 1500MB
+const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 15e8;
 
 export default class FoxgloveWebSocketPlayer implements Player {
   readonly #sourceId: string;

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -78,6 +78,9 @@ type ResolvedService = {
 };
 type MessageDefinitionMap = Map<string, MessageDefinition>;
 
+// 500MB
+const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 5.0e8;
+
 export default class FoxgloveWebSocketPlayer implements Player {
   readonly #sourceId: string;
 
@@ -94,6 +97,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   #topicsStats = new Map<string, TopicStats>(); // Topic names to topic statistics.
   #datatypes: MessageDefinitionMap = new Map(); // Datatypes as published by the WebSocket.
   #parsedMessages: MessageEvent[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #parsedMessagesBytes: number = 0;
   #receivedBytes: number = 0;
   #metricsCollector: PlayerMetricsCollectorInterface;
   #hasReceivedMessage = false;
@@ -524,6 +528,28 @@ export default class FoxgloveWebSocketPlayer implements Player {
           sizeInBytes: data.byteLength,
           schemaName: chanInfo.channel.schemaName,
         });
+        this.#parsedMessagesBytes += data.byteLength;
+        if (this.#parsedMessagesBytes > CURRENT_FRAME_MAXIMUM_SIZE_BYTES) {
+          this.#problems.addProblem(`webSocketPlayer:parsedMessageCacheFull`, {
+            severity: "error",
+            message: `WebSocketPlayer maximum frame size (${(
+              CURRENT_FRAME_MAXIMUM_SIZE_BYTES / 1_000_000
+            ).toFixed(
+              2,
+            )}MB) reached. Dropping old messages. This accumulation can occur if the browser tab has been inactive.`,
+          });
+          // Amortize cost of dropping messages by dropping parsedMessages size to
+          // 80% so that it doesn't happen for every message after reaching the limit
+          const evictUntilSize = 0.8 * CURRENT_FRAME_MAXIMUM_SIZE_BYTES;
+          let droppedBytes = 0;
+          let indexToCutBefore = 0;
+          while (this.#parsedMessagesBytes - droppedBytes > evictUntilSize) {
+            droppedBytes += this.#parsedMessages[indexToCutBefore]!.sizeInBytes;
+            indexToCutBefore++;
+          }
+          this.#parsedMessages.splice(0, indexToCutBefore);
+          this.#parsedMessagesBytes -= droppedBytes;
+        }
 
         // Update the message count for this topic
         const topicStats = new Map(this.#topicsStats);
@@ -553,6 +579,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (this.#clockTime != undefined && isLessThan(time, this.#clockTime)) {
         this.#numTimeSeeks++;
         this.#parsedMessages = [];
+        this.#parsedMessagesBytes = 0;
       }
 
       this.#clockTime = time;
@@ -796,6 +823,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     const messages = this.#parsedMessages;
     this.#parsedMessages = [];
+    this.#parsedMessagesBytes = 0;
     return this.#listener({
       name: this.#name,
       presence: this.#presence,


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Mitigates crashing on returning to inactive tabs that were viewing live data by dropping messages after a certain size limit

**Description**

When the tab is inactive `setTimeout`'s are throttled to at most once per second. Because the MessagePipeline listener uses timeouts to resolve its promises, it throttles our ability to emit a frame more than once per second. In the websocket player this was causing an accumulation of messages that were waiting to be emitted, this could keep growing indefinitely if the rate at which we emit a frame is low enough for inactive tabs. To mitigate this, I've incorporated a maximum cache size for single frames in the WebSocketPlayer. Once it reaches this limit it will drop the oldest messages until it comes down to 80% cache capacity.


Here is an example of the number of messages that can appear in a single player emit while the tab is inactive. Normally while this is running in an active tab it is 1 message per frame (this is a single pointcloud topic at ~30hz)
![image](https://github.com/foxglove/studio/assets/10187776/3175e70a-d54a-49fd-906c-a0f5a138ea5f)




<!-- link relevant GitHub issues -->
Fixes: FG-4666
Fixes: FG-4578
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
