### PR TITLE
Fix error message when preloading cache is full

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -318,9 +318,9 @@ export class BlockLoader {
           if (totalBlockSizeBytes > this.#maxCacheSize) {
             this.#problemManager.addProblem("cache-full", {
               severity: "error",
-              message: `Cache is full. Preloading for topics [${Array.from(topicsToFetch).join(
-                ", ",
-              )}] has stopped on block ${currentBlockId + 1}/${this.#blocks.length}.`,
+              message: `Cache is full. Preloading for topics [${Array.from(
+                topicsToFetch.keys(),
+              ).join(", ")}] has stopped on block ${currentBlockId + 1}/${this.#blocks.length}.`,
               tip: "Try reducing the number of topics that require preloading at a given time (e.g. in plots), or try to reduce the time range of the file.",
             });
             // We need to emit progress here so the player will emit a new state


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes the error message that is shown when preloading cache is full to include one or more `[object Object]`.