### PR TITLE
Use a fixed fallback window for state transition

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -230,8 +230,8 @@ export const WithXAxisMinMax: StoryObj = {
       <PanelSetup fixture={fixture} pauseFrame={pauseFrame} includeSettings>
         <StateTransitions
           overrideConfig={{
-            xAxisMinValue: 11,
-            xAxisMaxValue: 15,
+            xAxisMinValue: 1,
+            xAxisMaxValue: 3,
             paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
             isSynced: true,
           }}

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -85,8 +85,8 @@ const fixture: Fixture = {
     { name: "/blocks", schemaName: "msgs/SystemState" },
   ],
   activeData: {
-    startTime: { sec: 1526191527, nsec: 202050 },
-    endTime: { sec: 1526191551, nsec: 999997069 },
+    startTime: { sec: 1526191539, nsec: 202050 },
+    endTime: { sec: 1526191542, nsec: 999997069 },
     isPlaying: false,
     speed: 0.2,
   },

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -326,9 +326,18 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         x: { min: currentTimeSinceStart - config.xAxisRange, max: currentTimeSinceStart },
         y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
       };
-    } else {
-      return undefined;
+    } else if (endTimeSinceStart != undefined) {
+      // If we have no configured xAxis min/max or range, then we set the x axis max to end time
+      // This will mirror the plot behavior of showing the full x-axis for data time range rather
+      // than constantly adjusting the end time to the latest loaded state transition while data
+      // is loading.
+      return {
+        x: { min: 0, max: endTimeSinceStart },
+        y: { min: Number.MIN_SAFE_INTEGER, max: Number.MAX_SAFE_INTEGER },
+      };
     }
+
+    return undefined;
   }, [
     config.xAxisMaxValue,
     config.xAxisMinValue,


### PR DESCRIPTION
**User-Facing Changes**
When loading a pre-recorded data-source, the state transition panel no longer "scrolls" the end position on the chart and instead uses the data source end time. This keeps the chart end position stable similar to the plot panel and the transition data loads from the start.

Before:

https://github.com/foxglove/studio/assets/84792/910986eb-55cd-4567-8943-b494f9591cf3

After:

https://github.com/foxglove/studio/assets/84792/3e67df09-3a3a-4c63-889d-93a78a540ab4


**Description**
If there is no configured range or min/max for the x-axis, set the x-axis bounds to `0, end-time`. This avoids the chart constantly re-computing the end time when new data arrives.

I think this behavior is also ok for live data sources since the end time constantly updates. Having some tire kicking on that would be nice.
