### PR TITLE
Update comment for BlockLoader early bail

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -4,7 +4,6 @@
 
 import { simplify } from "intervals-fn";
 import * as _ from "lodash-es";
-import * as R from "ramda";
 
 import { Condvar } from "@foxglove/den/async";
 import { filterMap } from "@foxglove/den/collection";
@@ -264,9 +263,10 @@ export class BlockLoader {
           return;
         }
 
-        // When topics change while loading, we need to wait for the next
-        // iteration
-        if (!R.equals(topics, this.#topics)) {
+        // While we were waiting for cursor data the topics we need to be loading may have changed.
+        // Check whether the topics are changed and abort this loading instance because the results
+        // may no longer be valid for the data we should be loading.
+        if (!_.isEqual(topics, this.#topics)) {
           return;
         }
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Updated the comment in BlockLoader to be more clear on what the logic is trying to do. Reference: https://github.com/foxglove/studio/pull/7041/files#r1380461856

I've updated the equality to `isEqual` from lodash because we were already using that in this file.

---
What I don't understand reading the original issue is why this logic needed to be added. Block loader #topics are only set via `setTopics` which also invokes an abort controller. This abort controller _should_ be triggering this bail logic a few lines above the newly introduced logic:

```
// No results means cursor aborted or eof
if (!results) {
  await cursor.end();
  return;
}
```

Seems like that was not happening? I'd like to understand what specifically was violated.
