### PR TITLE
Consistent labelling of event details in app sidebar

### DIFF
--- a/packages/studio-base/src/components/EventView.tsx
+++ b/packages/studio-base/src/components/EventView.tsx
@@ -112,7 +112,7 @@ function EventViewComponent(params: {
   const { classes, cx } = useStyles();
 
   const fields = _.compact([
-    ["timestamp", formattedTime],
+    ["start", formattedTime],
     Number(event.event.durationNanos) > 0 && ["duration", formatEventDuration(event.event)],
     ...Object.entries(event.event.metadata),
   ]);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- N/A

**Description**
- Consistent labelling of event details in app sidebar

Before:
![image](https://github.com/foxglove/studio/assets/6993359/1b76f9ff-256e-4969-9867-4c7eb82f334e)

After:
"timestamp" --> "start"
