### PR TITLE
Fix SceneEntity primitives from disappearing / only showing outlines after seeking

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
@@ -25,6 +25,7 @@ export class DynamicInstancedMesh<
     super(geometry, material, 0);
 
     this.#capacity = initialCapacity;
+    this.frustumCulled = false;
     this.#resize();
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Axis.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Axis.ts
@@ -42,6 +42,7 @@ export class Axis extends THREE.Object3D {
       () => createShaftGeometry(this.#renderer.maxLod),
     );
     this.#shaftMesh = new THREE.InstancedMesh(shaftGeometry, standardMaterial(COLOR_WHITE), 3);
+    this.#shaftMesh.frustumCulled = false;
     this.#shaftMesh.castShadow = true;
     this.#shaftMesh.receiveShadow = true;
 
@@ -52,6 +53,7 @@ export class Axis extends THREE.Object3D {
     );
 
     this.#headMesh = new THREE.InstancedMesh(headGeometry, standardMaterial(COLOR_WHITE), 3);
+    this.#headMesh.frustumCulled = false;
     this.#headMesh.castShadow = true;
     this.#headMesh.receiveShadow = true;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/PrimitivePool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/PrimitivePool.ts
@@ -38,7 +38,9 @@ export class PrimitivePool {
     if (this.#disposed) {
       throw new Error(`Attempt to acquire PrimitiveType.${type} after PrimitivePool was disposed`);
     }
-    const primitive = this.#primitivesByType.get(type)?.pop();
+    // Using shift allows renderables to be reused for the same entities after a seek
+    // This avoids unnecessary `ensureCapacity` calls for instanced renderables
+    const primitive = this.#primitivesByType.get(type)?.shift();
     if (primitive) {
       primitive.prepareForReuse();
       return primitive as InstanceType<(typeof CONSTRUCTORS)[T]>;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -64,6 +64,7 @@ export class RenderableArrows extends RenderablePrimitive {
       this.#material,
       this.#maxInstances,
     );
+    this.#shaftMesh.frustumCulled = false;
     this.#shaftMesh.count = 0;
     this.add(this.#shaftMesh);
 
@@ -76,6 +77,7 @@ export class RenderableArrows extends RenderablePrimitive {
       this.#material,
       this.#maxInstances,
     );
+    this.#headMesh.frustumCulled = false;
     this.#headMesh.count = 0;
     this.add(this.#headMesh);
 
@@ -127,6 +129,7 @@ export class RenderableArrows extends RenderablePrimitive {
         this.#material,
         this.#maxInstances,
       );
+      this.#shaftMesh.frustumCulled = false;
       this.#shaftGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
       this.add(this.#shaftMesh);
 
@@ -137,6 +140,7 @@ export class RenderableArrows extends RenderablePrimitive {
         this.#material,
         this.#maxInstances,
       );
+      this.#headMesh.frustumCulled = false;
       this.#headGeometry.setAttribute("instanceOpacity", this.#instanceOpacity);
       this.add(this.#headMesh);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
@@ -53,6 +53,7 @@ export class RenderableCubes extends RenderablePrimitive {
 
     this.#maxInstances = 16;
     this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+    this.#mesh.frustumCulled = false;
     this.#instanceOpacity = new THREE.InstancedBufferAttribute(
       new Float32Array(this.#maxInstances),
       1,
@@ -86,6 +87,7 @@ export class RenderableCubes extends RenderablePrimitive {
       this.#mesh.removeFromParent();
       this.#mesh.dispose();
       this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+      this.#mesh.frustumCulled = false;
       this.#instanceOpacity = new THREE.InstancedBufferAttribute(
         new Float32Array(this.#maxInstances),
         1,
@@ -159,6 +161,7 @@ export class RenderableCubes extends RenderablePrimitive {
   }
 
   public override dispose(): void {
+    this.clear();
     this.#mesh.dispose();
     this.#geometry.dispose();
     this.#material.dispose();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -51,6 +51,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       .clone();
     this.#maxInstances = 16;
     this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+    this.#mesh.frustumCulled = false;
     this.#mesh.userData.pickingMaterial = this.#pickingMaterial;
     this.#instanceOpacity = new THREE.InstancedBufferAttribute(
       new Float32Array(this.#maxInstances),
@@ -114,6 +115,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       this.#mesh.removeFromParent();
       this.#mesh.dispose();
       this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+      this.#mesh.frustumCulled = false;
       this.#mesh.userData.pickingMaterial = this.#pickingMaterial;
       this.add(this.#mesh);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -45,6 +45,7 @@ export class RenderableSpheres extends RenderablePrimitive {
       .clone();
     this.#maxInstances = 16;
     this.#mesh = new THREE.InstancedMesh(this.#geometry, this.#material, this.#maxInstances);
+    this.#mesh.frustumCulled = false;
     this.#instanceOpacity = new THREE.InstancedBufferAttribute(
       new Float32Array(this.#maxInstances),
       1,
@@ -62,6 +63,7 @@ export class RenderableSpheres extends RenderablePrimitive {
       this.#mesh.removeFromParent();
       this.#mesh.dispose();
       this.#mesh = new THREE.InstancedMesh(this.#mesh.geometry, this.#material, this.#maxInstances);
+      this.#mesh.frustumCulled = false;
       this.#instanceOpacity = new THREE.InstancedBufferAttribute(
         new Float32Array(this.#maxInstances),
         1,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -45,6 +45,253 @@ const icospherePointsAndIndices = {
     11, 6, 11, 9, 6, 9, 8, 6, 8, 10, 6, 10, 7, 6, 2, 11, 7, 4, 9, 11, 1, 8, 9, 5, 10, 8, 3, 7, 10,
   ],
 };
+const teapotMesh = new THREE.Mesh(new TeapotGeometry(1));
+const teapotSTL = new STLExporter().parse(teapotMesh);
+
+/** Reorder points for testing `indices` */
+function rearrange<T>(arr: T[]): T[] {
+  for (let i = 0; i + 1 < arr.length; i += 2) {
+    [arr[i], arr[i + 1]] = [arr[i + 1]!, arr[i]!];
+  }
+  return arr;
+}
+const primitives = {
+  arrows: [
+    {
+      pose: xyzrpyToPose([0, 4, 0], [0, 0, 0]),
+      shaft_diameter: 0.5,
+      shaft_length: 0.5,
+      head_diameter: 1,
+      head_length: 0.3,
+      color: makeColor("#f4b136", 0.5),
+    },
+    {
+      pose: xyzrpyToPose([1, 4, 0], [0, 0, 30]),
+      shaft_diameter: 0.5,
+      shaft_length: 0.5,
+      head_diameter: 1,
+      head_length: 0.3,
+      color: makeColor("#afe663", 0.9),
+    },
+  ],
+
+  cubes: [
+    {
+      pose: xyzrpyToPose([0, 0, 0], [0, 0, 0]),
+      size: { x: 0.8, y: 0.5, z: 1 },
+      color: makeColor("#f4b136", 0.5),
+    },
+    {
+      pose: xyzrpyToPose([1, 0, 0], [0, 0, 30]),
+      size: { x: 0.4, y: 0.2, z: 1 },
+      color: makeColor("#afe663", 0.9),
+    },
+  ],
+
+  spheres: [
+    {
+      pose: xyzrpyToPose([0, 6, 0], [0, 0, 0]),
+      size: { x: 0.8, y: 0.5, z: 1 },
+      color: makeColor("#ff6136", 0.5),
+    },
+    {
+      pose: xyzrpyToPose([1, 6, 0], [0, 0, 30]),
+      size: { x: 0.4, y: 0.2, z: 1 },
+      color: makeColor("#afe6c3", 0.9),
+    },
+  ],
+
+  cylinders: [
+    {
+      pose: xyzrpyToPose([0, 5, 0], [0, 0, 0]),
+      size: { x: 0.8, y: 0.5, z: 1 },
+      color: makeColor("#f4b136", 0.5),
+      top_scale: 1,
+      bottom_scale: 0,
+    },
+    {
+      pose: xyzrpyToPose([1, 5, 0], [0, 0, 30]),
+      size: { x: 0.4, y: 0.2, z: 1 },
+      color: makeColor("#afe663", 0.9),
+      top_scale: 0.25,
+      bottom_scale: 0.75,
+    },
+  ],
+
+  lines: [LineType.LINE_STRIP, LineType.LINE_LOOP, LineType.LINE_LIST].flatMap(
+    (type, typeIndex) => [
+      {
+        // non-indexed, single color
+        type,
+        pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+        thickness: 0.05,
+        scale_invariant: false,
+        points: new Array(10).fill(0).map((_, i, { length }) => ({
+          x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+          y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+          z: 0,
+        })),
+        color: makeColor("#7995fb", 0.8),
+        colors: [],
+        indices: [],
+      },
+      {
+        // indexed, single color
+        type,
+        pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+        thickness: 0.05,
+        scale_invariant: false,
+        points: rearrange(
+          new Array(10).fill(0).map((_, i, { length }) => ({
+            x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+            y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+            z: 0,
+          })),
+        ),
+        color: makeColor("#7995fb", 0.8),
+        colors: [],
+        // Should make a flat-pointed star, LINE_LOOP should have a line across it
+        indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
+      },
+      {
+        // non-indexed, vertex colors
+        type,
+        pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+        thickness: 5,
+        scale_invariant: true,
+        points: new Array(10).fill(0).map((_, i, { length }) => ({
+          x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+          y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+          z: 0,
+        })),
+        color: makeColor("#7995fb", 0.8),
+        colors: new Array(10).fill(0).map((_, i, { length }) => {
+          const { r, g, b, a } = tinycolor.fromRatio({ h: i / (length - 1), s: 1, v: 1 }).toRgb();
+          return { r: r / 255, g: g / 255, b: b / 255, a };
+        }),
+        indices: [],
+      },
+      {
+        // indexed, vertex colors
+        type,
+        pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+        thickness: 4,
+        scale_invariant: true,
+        points: rearrange(
+          new Array(10).fill(0).map((_, i, { length }) => ({
+            x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+            y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+            z: 0,
+          })),
+        ),
+        color: makeColor("#7995fb", 0.8),
+        colors: rearrange(
+          new Array(10).fill(0).map((_, i, { length }) => {
+            const { r, g, b, a } = tinycolor.fromRatio({ h: i / (length - 1), s: 1, v: 1 }).toRgb();
+            return { r: r / 255, g: g / 255, b: b / 255, a };
+          }),
+        ),
+        // Should make a flat-pointed star, LINE_LOOP should have a line across it
+        indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
+      },
+      {
+        // empty points
+        type,
+        pose: xyzrpyToPose([1, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+        thickness: 5,
+        scale_invariant: true,
+        points: [],
+        color: makeColor("#7995fb", 0.8),
+        colors: [],
+        indices: [],
+      },
+    ],
+  ),
+
+  triangles: [
+    {
+      ...icospherePointsAndIndices,
+      pose: xyzrpyToPose([0, 9, 0], [0.5685618507342682, 0, 0]),
+      color: makeColor("#ff0048", 1.0),
+      colors: [],
+    },
+    {
+      ...icospherePointsAndIndices,
+      pose: xyzrpyToPose([1, 9, 0], [0.5685618507342682, 0, 0]),
+      color: makeColor("#ff0048", 0.5),
+      colors: [
+        { r: 1, g: 0, b: 0, a: 0 },
+        { r: 1, g: 0.6000000000000001, b: 0, a: 0.1 },
+        { r: 0.7999999999999998, g: 1, b: 0, a: 0.2 },
+        { r: 0.20000000000000018, g: 1, b: 0, a: 0.3 },
+        { r: 0, g: 1, b: 0.40000000000000036, a: 0.4 },
+        { r: 0, g: 1, b: 1, a: 0.5 },
+        { r: 0, g: 0.40000000000000036, b: 1, a: 0.6 },
+        { r: 0.1999999999999993, g: 0, b: 1, a: 0.7 },
+        { r: 0.8000000000000007, g: 0, b: 1, a: 0.8 },
+        { r: 1, g: 0, b: 0.5999999999999996, a: 0.9 },
+        { r: 1, g: 0, b: 0, a: 1 },
+        { r: 1, g: 0.6000000000000005, b: 0, a: 1.1 },
+      ] as ColorRGBA[],
+    },
+  ],
+
+  texts: [
+    {
+      pose: xyzrpyToPose([0, 7, 0], [0, 0, 0]),
+      color: makeColor("#f6f136", 0.5),
+      font_size: 0.2,
+      text: "3d size",
+      scale_invariant: false,
+      billboard: true,
+    },
+    {
+      pose: xyzrpyToPose([1, 7, 0], [0, 0, 30]),
+      color: makeColor("#ae6fc3", 0.9),
+      font_size: 10,
+      text: "pixel size",
+      scale_invariant: true,
+      billboard: true,
+    },
+    {
+      pose: xyzrpyToPose([0, 8, 0], [0, 0, 0]),
+      color: makeColor("#f6f136", 0.5),
+      font_size: 0.2,
+      text: "scale invariant false",
+      scale_invariant: false,
+      billboard: false,
+    },
+    {
+      pose: xyzrpyToPose([1, 8, 0], [0, 0, 30]),
+      color: makeColor("#ae6fc3", 0.9),
+      font_size: 0.2,
+      text: "scale invariant true",
+      scale_invariant: true,
+      billboard: false,
+    },
+  ],
+
+  models: [
+    {
+      pose: xyzrpyToPose([0, 3, 0], [0, 0, 0]),
+      scale: { x: 0.3, y: 0.2, z: 0.2 },
+      color: makeColor("#59e860", 0.8),
+      override_color: false,
+      url: "",
+      media_type: "model/stl",
+      data: new TextEncoder().encode(teapotSTL),
+    },
+    {
+      pose: xyzrpyToPose([1, 3, 0], [0, 0, 30]),
+      scale: { x: 0.3, y: 0.2, z: 0.2 },
+      color: makeColor("#59e860", 0.8),
+      override_color: true,
+      url: encodeURI(`data:model/stl;utf8,${teapotSTL}`),
+      media_type: "",
+      data: new Uint8Array(),
+    },
+  ],
+};
 
 function makeStoryScene({
   topic,
@@ -53,16 +300,6 @@ function makeStoryScene({
   topic: string;
   frameId: string;
 }): MessageEvent<SceneUpdate> {
-  const teapotMesh = new THREE.Mesh(new TeapotGeometry(1));
-  const teapotSTL = new STLExporter().parse(teapotMesh);
-
-  /** Reorder points for testing `indices` */
-  function rearrange<T>(arr: T[]): T[] {
-    for (let i = 0; i + 1 < arr.length; i += 2) {
-      [arr[i], arr[i + 1]] = [arr[i + 1]!, arr[i]!];
-    }
-    return arr;
-  }
   return {
     topic,
     receiveTime: { sec: 10, nsec: 0 },
@@ -76,246 +313,7 @@ function makeStoryScene({
           lifetime: { sec: 0, nsec: 0 },
           frame_locked: true,
           metadata: [],
-
-          arrows: [
-            {
-              pose: xyzrpyToPose([0, 4, 0], [0, 0, 0]),
-              shaft_diameter: 0.5,
-              shaft_length: 0.5,
-              head_diameter: 1,
-              head_length: 0.3,
-              color: makeColor("#f4b136", 0.5),
-            },
-            {
-              pose: xyzrpyToPose([1, 4, 0], [0, 0, 30]),
-              shaft_diameter: 0.5,
-              shaft_length: 0.5,
-              head_diameter: 1,
-              head_length: 0.3,
-              color: makeColor("#afe663", 0.9),
-            },
-          ],
-
-          cubes: [
-            {
-              pose: xyzrpyToPose([0, 0, 0], [0, 0, 0]),
-              size: { x: 0.8, y: 0.5, z: 1 },
-              color: makeColor("#f4b136", 0.5),
-            },
-            {
-              pose: xyzrpyToPose([1, 0, 0], [0, 0, 30]),
-              size: { x: 0.4, y: 0.2, z: 1 },
-              color: makeColor("#afe663", 0.9),
-            },
-          ],
-
-          spheres: [
-            {
-              pose: xyzrpyToPose([0, 6, 0], [0, 0, 0]),
-              size: { x: 0.8, y: 0.5, z: 1 },
-              color: makeColor("#ff6136", 0.5),
-            },
-            {
-              pose: xyzrpyToPose([1, 6, 0], [0, 0, 30]),
-              size: { x: 0.4, y: 0.2, z: 1 },
-              color: makeColor("#afe6c3", 0.9),
-            },
-          ],
-
-          cylinders: [
-            {
-              pose: xyzrpyToPose([0, 5, 0], [0, 0, 0]),
-              size: { x: 0.8, y: 0.5, z: 1 },
-              color: makeColor("#f4b136", 0.5),
-              top_scale: 1,
-              bottom_scale: 0,
-            },
-            {
-              pose: xyzrpyToPose([1, 5, 0], [0, 0, 30]),
-              size: { x: 0.4, y: 0.2, z: 1 },
-              color: makeColor("#afe663", 0.9),
-              top_scale: 0.25,
-              bottom_scale: 0.75,
-            },
-          ],
-
-          lines: [LineType.LINE_STRIP, LineType.LINE_LOOP, LineType.LINE_LIST].flatMap(
-            (type, typeIndex) => [
-              {
-                // non-indexed, single color
-                type,
-                pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-                thickness: 0.05,
-                scale_invariant: false,
-                points: new Array(10).fill(0).map((_, i, { length }) => ({
-                  x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-                  y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-                  z: 0,
-                })),
-                color: makeColor("#7995fb", 0.8),
-                colors: [],
-                indices: [],
-              },
-              {
-                // indexed, single color
-                type,
-                pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-                thickness: 0.05,
-                scale_invariant: false,
-                points: rearrange(
-                  new Array(10).fill(0).map((_, i, { length }) => ({
-                    x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-                    y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-                    z: 0,
-                  })),
-                ),
-                color: makeColor("#7995fb", 0.8),
-                colors: [],
-                // Should make a flat-pointed star, LINE_LOOP should have a line across it
-                indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
-              },
-              {
-                // non-indexed, vertex colors
-                type,
-                pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-                thickness: 5,
-                scale_invariant: true,
-                points: new Array(10).fill(0).map((_, i, { length }) => ({
-                  x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-                  y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-                  z: 0,
-                })),
-                color: makeColor("#7995fb", 0.8),
-                colors: new Array(10).fill(0).map((_, i, { length }) => {
-                  const { r, g, b, a } = tinycolor
-                    .fromRatio({ h: i / (length - 1), s: 1, v: 1 })
-                    .toRgb();
-                  return { r: r / 255, g: g / 255, b: b / 255, a };
-                }),
-                indices: [],
-              },
-              {
-                // indexed, vertex colors
-                type,
-                pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-                thickness: 4,
-                scale_invariant: true,
-                points: rearrange(
-                  new Array(10).fill(0).map((_, i, { length }) => ({
-                    x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-                    y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-                    z: 0,
-                  })),
-                ),
-                color: makeColor("#7995fb", 0.8),
-                colors: rearrange(
-                  new Array(10).fill(0).map((_, i, { length }) => {
-                    const { r, g, b, a } = tinycolor
-                      .fromRatio({ h: i / (length - 1), s: 1, v: 1 })
-                      .toRgb();
-                    return { r: r / 255, g: g / 255, b: b / 255, a };
-                  }),
-                ),
-                // Should make a flat-pointed star, LINE_LOOP should have a line across it
-                indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
-              },
-              {
-                // empty points
-                type,
-                pose: xyzrpyToPose([1, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-                thickness: 5,
-                scale_invariant: true,
-                points: [],
-                color: makeColor("#7995fb", 0.8),
-                colors: [],
-                indices: [],
-              },
-            ],
-          ),
-
-          triangles: [
-            {
-              ...icospherePointsAndIndices,
-              pose: xyzrpyToPose([0, 9, 0], [0.5685618507342682, 0, 0]),
-              color: makeColor("#ff0048", 1.0),
-              colors: [],
-            },
-            {
-              ...icospherePointsAndIndices,
-              pose: xyzrpyToPose([1, 9, 0], [0.5685618507342682, 0, 0]),
-              color: makeColor("#ff0048", 0.5),
-              colors: [
-                { r: 1, g: 0, b: 0, a: 0 },
-                { r: 1, g: 0.6000000000000001, b: 0, a: 0.1 },
-                { r: 0.7999999999999998, g: 1, b: 0, a: 0.2 },
-                { r: 0.20000000000000018, g: 1, b: 0, a: 0.3 },
-                { r: 0, g: 1, b: 0.40000000000000036, a: 0.4 },
-                { r: 0, g: 1, b: 1, a: 0.5 },
-                { r: 0, g: 0.40000000000000036, b: 1, a: 0.6 },
-                { r: 0.1999999999999993, g: 0, b: 1, a: 0.7 },
-                { r: 0.8000000000000007, g: 0, b: 1, a: 0.8 },
-                { r: 1, g: 0, b: 0.5999999999999996, a: 0.9 },
-                { r: 1, g: 0, b: 0, a: 1 },
-                { r: 1, g: 0.6000000000000005, b: 0, a: 1.1 },
-              ] as ColorRGBA[],
-            },
-          ],
-
-          texts: [
-            {
-              pose: xyzrpyToPose([0, 7, 0], [0, 0, 0]),
-              color: makeColor("#f6f136", 0.5),
-              font_size: 0.2,
-              text: "3d size",
-              scale_invariant: false,
-              billboard: true,
-            },
-            {
-              pose: xyzrpyToPose([1, 7, 0], [0, 0, 30]),
-              color: makeColor("#ae6fc3", 0.9),
-              font_size: 10,
-              text: "pixel size",
-              scale_invariant: true,
-              billboard: true,
-            },
-            {
-              pose: xyzrpyToPose([0, 8, 0], [0, 0, 0]),
-              color: makeColor("#f6f136", 0.5),
-              font_size: 0.2,
-              text: "scale invariant false",
-              scale_invariant: false,
-              billboard: false,
-            },
-            {
-              pose: xyzrpyToPose([1, 8, 0], [0, 0, 30]),
-              color: makeColor("#ae6fc3", 0.9),
-              font_size: 0.2,
-              text: "scale invariant true",
-              scale_invariant: true,
-              billboard: false,
-            },
-          ],
-
-          models: [
-            {
-              pose: xyzrpyToPose([0, 3, 0], [0, 0, 0]),
-              scale: { x: 0.3, y: 0.2, z: 0.2 },
-              color: makeColor("#59e860", 0.8),
-              override_color: false,
-              url: "",
-              media_type: "model/stl",
-              data: new TextEncoder().encode(teapotSTL),
-            },
-            {
-              pose: xyzrpyToPose([1, 3, 0], [0, 0, 30]),
-              scale: { x: 0.3, y: 0.2, z: 0.2 },
-              color: makeColor("#59e860", 0.8),
-              override_color: true,
-              url: encodeURI(`data:model/stl;utf8,${teapotSTL}`),
-              media_type: "",
-              data: new Uint8Array(),
-            },
-          ],
+          ...primitives,
         },
       ],
     },
@@ -879,16 +877,6 @@ function makeMultiEntityScene({
   topic: string;
   frameId: string;
 }): MessageEvent<SceneUpdate> {
-  const teapotMesh = new THREE.Mesh(new TeapotGeometry(1));
-  const teapotSTL = new STLExporter().parse(teapotMesh);
-
-  /** Reorder points for testing `indices` */
-  function rearrange<T>(arr: T[]): T[] {
-    for (let i = 0; i + 1 < arr.length; i += 2) {
-      [arr[i], arr[i + 1]] = [arr[i + 1]!, arr[i]!];
-    }
-    return arr;
-  }
   const entityData = {
     timestamp: { sec: 0, nsec: 0 },
     frame_id: frameId,
@@ -896,245 +884,7 @@ function makeMultiEntityScene({
     frame_locked: true,
     metadata: [],
   };
-  const primitives = {
-    arrows: [
-      {
-        pose: xyzrpyToPose([0, 4, 0], [0, 0, 0]),
-        shaft_diameter: 0.5,
-        shaft_length: 0.5,
-        head_diameter: 1,
-        head_length: 0.3,
-        color: makeColor("#f4b136", 0.5),
-      },
-      {
-        pose: xyzrpyToPose([1, 4, 0], [0, 0, 30]),
-        shaft_diameter: 0.5,
-        shaft_length: 0.5,
-        head_diameter: 1,
-        head_length: 0.3,
-        color: makeColor("#afe663", 0.9),
-      },
-    ],
 
-    cubes: [
-      {
-        pose: xyzrpyToPose([0, 0, 0], [0, 0, 0]),
-        size: { x: 0.8, y: 0.5, z: 1 },
-        color: makeColor("#f4b136", 0.5),
-      },
-      {
-        pose: xyzrpyToPose([1, 0, 0], [0, 0, 30]),
-        size: { x: 0.4, y: 0.2, z: 1 },
-        color: makeColor("#afe663", 0.9),
-      },
-    ],
-
-    spheres: [
-      {
-        pose: xyzrpyToPose([0, 6, 0], [0, 0, 0]),
-        size: { x: 0.8, y: 0.5, z: 1 },
-        color: makeColor("#ff6136", 0.5),
-      },
-      {
-        pose: xyzrpyToPose([1, 6, 0], [0, 0, 30]),
-        size: { x: 0.4, y: 0.2, z: 1 },
-        color: makeColor("#afe6c3", 0.9),
-      },
-    ],
-
-    cylinders: [
-      {
-        pose: xyzrpyToPose([0, 5, 0], [0, 0, 0]),
-        size: { x: 0.8, y: 0.5, z: 1 },
-        color: makeColor("#f4b136", 0.5),
-        top_scale: 1,
-        bottom_scale: 0,
-      },
-      {
-        pose: xyzrpyToPose([1, 5, 0], [0, 0, 30]),
-        size: { x: 0.4, y: 0.2, z: 1 },
-        color: makeColor("#afe663", 0.9),
-        top_scale: 0.25,
-        bottom_scale: 0.75,
-      },
-    ],
-
-    lines: [LineType.LINE_STRIP, LineType.LINE_LOOP, LineType.LINE_LIST].flatMap(
-      (type, typeIndex) => [
-        {
-          // non-indexed, single color
-          type,
-          pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-          thickness: 0.05,
-          scale_invariant: false,
-          points: new Array(10).fill(0).map((_, i, { length }) => ({
-            x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-            y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-            z: 0,
-          })),
-          color: makeColor("#7995fb", 0.8),
-          colors: [],
-          indices: [],
-        },
-        {
-          // indexed, single color
-          type,
-          pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-          thickness: 0.05,
-          scale_invariant: false,
-          points: rearrange(
-            new Array(10).fill(0).map((_, i, { length }) => ({
-              x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-              y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-              z: 0,
-            })),
-          ),
-          color: makeColor("#7995fb", 0.8),
-          colors: [],
-          // Should make a flat-pointed star, LINE_LOOP should have a line across it
-          indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
-        },
-        {
-          // non-indexed, vertex colors
-          type,
-          pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-          thickness: 5,
-          scale_invariant: true,
-          points: new Array(10).fill(0).map((_, i, { length }) => ({
-            x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-            y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-            z: 0,
-          })),
-          color: makeColor("#7995fb", 0.8),
-          colors: new Array(10).fill(0).map((_, i, { length }) => {
-            const { r, g, b, a } = tinycolor.fromRatio({ h: i / (length - 1), s: 1, v: 1 }).toRgb();
-            return { r: r / 255, g: g / 255, b: b / 255, a };
-          }),
-          indices: [],
-        },
-        {
-          // indexed, vertex colors
-          type,
-          pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-          thickness: 4,
-          scale_invariant: true,
-          points: rearrange(
-            new Array(10).fill(0).map((_, i, { length }) => ({
-              x: 0.25 * Math.cos((2 * Math.PI * i) / length),
-              y: 0.25 * Math.sin((2 * Math.PI * i) / length),
-              z: 0,
-            })),
-          ),
-          color: makeColor("#7995fb", 0.8),
-          colors: rearrange(
-            new Array(10).fill(0).map((_, i, { length }) => {
-              const { r, g, b, a } = tinycolor
-                .fromRatio({ h: i / (length - 1), s: 1, v: 1 })
-                .toRgb();
-              return { r: r / 255, g: g / 255, b: b / 255, a };
-            }),
-          ),
-          // Should make a flat-pointed star, LINE_LOOP should have a line across it
-          indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
-        },
-        {
-          // empty points
-          type,
-          pose: xyzrpyToPose([1, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
-          thickness: 5,
-          scale_invariant: true,
-          points: [],
-          color: makeColor("#7995fb", 0.8),
-          colors: [],
-          indices: [],
-        },
-      ],
-    ),
-
-    triangles: [
-      {
-        ...icospherePointsAndIndices,
-        pose: xyzrpyToPose([0, 9, 0], [0.5685618507342682, 0, 0]),
-        color: makeColor("#ff0048", 1.0),
-        colors: [],
-      },
-      {
-        ...icospherePointsAndIndices,
-        pose: xyzrpyToPose([1, 9, 0], [0.5685618507342682, 0, 0]),
-        color: makeColor("#ff0048", 0.5),
-        colors: [
-          { r: 1, g: 0, b: 0, a: 0 },
-          { r: 1, g: 0.6000000000000001, b: 0, a: 0.1 },
-          { r: 0.7999999999999998, g: 1, b: 0, a: 0.2 },
-          { r: 0.20000000000000018, g: 1, b: 0, a: 0.3 },
-          { r: 0, g: 1, b: 0.40000000000000036, a: 0.4 },
-          { r: 0, g: 1, b: 1, a: 0.5 },
-          { r: 0, g: 0.40000000000000036, b: 1, a: 0.6 },
-          { r: 0.1999999999999993, g: 0, b: 1, a: 0.7 },
-          { r: 0.8000000000000007, g: 0, b: 1, a: 0.8 },
-          { r: 1, g: 0, b: 0.5999999999999996, a: 0.9 },
-          { r: 1, g: 0, b: 0, a: 1 },
-          { r: 1, g: 0.6000000000000005, b: 0, a: 1.1 },
-        ] as ColorRGBA[],
-      },
-    ],
-
-    texts: [
-      {
-        pose: xyzrpyToPose([0, 7, 0], [0, 0, 0]),
-        color: makeColor("#f6f136", 0.5),
-        font_size: 0.2,
-        text: "3d size",
-        scale_invariant: false,
-        billboard: true,
-      },
-      {
-        pose: xyzrpyToPose([1, 7, 0], [0, 0, 30]),
-        color: makeColor("#ae6fc3", 0.9),
-        font_size: 10,
-        text: "pixel size",
-        scale_invariant: true,
-        billboard: true,
-      },
-      {
-        pose: xyzrpyToPose([0, 8, 0], [0, 0, 0]),
-        color: makeColor("#f6f136", 0.5),
-        font_size: 0.2,
-        text: "scale invariant false",
-        scale_invariant: false,
-        billboard: false,
-      },
-      {
-        pose: xyzrpyToPose([1, 8, 0], [0, 0, 30]),
-        color: makeColor("#ae6fc3", 0.9),
-        font_size: 0.2,
-        text: "scale invariant true",
-        scale_invariant: true,
-        billboard: false,
-      },
-    ],
-
-    models: [
-      {
-        pose: xyzrpyToPose([0, 3, 0], [0, 0, 0]),
-        scale: { x: 0.3, y: 0.2, z: 0.2 },
-        color: makeColor("#59e860", 0.8),
-        override_color: false,
-        url: "",
-        media_type: "model/stl",
-        data: new TextEncoder().encode(teapotSTL),
-      },
-      {
-        pose: xyzrpyToPose([1, 3, 0], [0, 0, 30]),
-        scale: { x: 0.3, y: 0.2, z: 0.2 },
-        color: makeColor("#59e860", 0.8),
-        override_color: true,
-        url: encodeURI(`data:model/stl;utf8,${teapotSTL}`),
-        media_type: "",
-        data: new Uint8Array(),
-      },
-    ],
-  };
   const entities: SceneEntity[] = [];
   const allPrimitivesAsEmpty = Object.keys(primitives).reduce(
     (acc, primitiveType) => ({ ...acc, [primitiveType]: [] }),
@@ -1144,6 +894,10 @@ function makeMultiEntityScene({
     const primitiveArray = primitives[primitiveType as keyof typeof primitives]!;
     let i = 0;
     for (const primitive of primitiveArray) {
+      // Each primitive has it's own entity
+      // This is important because entities will use other entities' primitives from the
+      // PrimitivePool after seeking because primitives are `push`ed when `released`
+      // and `pop`ed when `acquired`
       entities.push({
         ...entityData,
         id: `${primitiveType}-entity-${i}`,
@@ -1169,14 +923,9 @@ function makeMultiEntityScene({
 function CheckVisibleAfterSeek(): JSX.Element {
   const readySignal = useReadySignal();
 
-  // We're testing a Line loop using a position buffer bigger than it needs from a previous frame
-  // So we need to test across multiple frames
   const frames = useMemo(() => {
-    const frame1 = makeMultiEntityScene({ topic: "/markers/annotations", frameId: "map" });
-    const frame2 = makeMultiEntityScene({ topic: "/markers/annotations", frameId: "map" });
-    // const frame1 = msgs[0];
-    // const frame2 = msgs[0];
-
+    const frame1 = makeMultiEntityScene({ topic: "/markers/annotations", frameId: "root" });
+    const frame2 = makeMultiEntityScene({ topic: "/markers/annotations", frameId: "root" });
     return [frame1, frame2];
   }, []);
 
@@ -1206,6 +955,7 @@ function CheckVisibleAfterSeek(): JSX.Element {
         newFixture.activeData = {
           currentTime: { sec: 11, nsec: 0 },
           isPlaying: true,
+          // Make Renderer handle seek to clear renderables
           lastSeekTime: 11,
         };
         return newFixture;
@@ -1222,7 +972,7 @@ function CheckVisibleAfterSeek(): JSX.Element {
   }, [readySignal, frames]);
 
   return (
-    <PanelSetup fixture={fixture} includeSettings={true}>
+    <PanelSetup fixture={fixture}>
       <ThreeDeePanel
         overrideConfig={{
           ...ThreeDeePanel.defaultConfig,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -9,12 +9,12 @@ import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
 import { TeapotGeometry } from "three/examples/jsm/geometries/TeapotGeometry";
 import tinycolor from "tinycolor2";
 
-import { FrameTransform, LineType, SceneUpdate } from "@foxglove/schemas";
+import { FrameTransform, LineType, SceneEntity, SceneUpdate } from "@foxglove/schemas";
 import { MessageEvent } from "@foxglove/studio";
 import { ColorRGBA } from "@foxglove/studio-base/panels/ThreeDeeRender/ros";
 import { xyzrpyToPose } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
-import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 
 import { makeColor, QUAT_IDENTITY, rad2deg } from "./common";
@@ -867,6 +867,398 @@ export const UpdatedLineLoopsDontHaveExtraLines: StoryObj = {
     colorScheme: "dark",
   },
   render: LineLoops,
+  play: async (ctx) => {
+    await ctx.parameters.storyReady;
+  },
+};
+
+function makeMultiEntityScene({
+  topic,
+  frameId,
+}: {
+  topic: string;
+  frameId: string;
+}): MessageEvent<SceneUpdate> {
+  const teapotMesh = new THREE.Mesh(new TeapotGeometry(1));
+  const teapotSTL = new STLExporter().parse(teapotMesh);
+
+  /** Reorder points for testing `indices` */
+  function rearrange<T>(arr: T[]): T[] {
+    for (let i = 0; i + 1 < arr.length; i += 2) {
+      [arr[i], arr[i + 1]] = [arr[i + 1]!, arr[i]!];
+    }
+    return arr;
+  }
+  const entityData = {
+    timestamp: { sec: 0, nsec: 0 },
+    frame_id: frameId,
+    lifetime: { sec: 0, nsec: 0 },
+    frame_locked: true,
+    metadata: [],
+  };
+  const primitives = {
+    arrows: [
+      {
+        pose: xyzrpyToPose([0, 4, 0], [0, 0, 0]),
+        shaft_diameter: 0.5,
+        shaft_length: 0.5,
+        head_diameter: 1,
+        head_length: 0.3,
+        color: makeColor("#f4b136", 0.5),
+      },
+      {
+        pose: xyzrpyToPose([1, 4, 0], [0, 0, 30]),
+        shaft_diameter: 0.5,
+        shaft_length: 0.5,
+        head_diameter: 1,
+        head_length: 0.3,
+        color: makeColor("#afe663", 0.9),
+      },
+    ],
+
+    cubes: [
+      {
+        pose: xyzrpyToPose([0, 0, 0], [0, 0, 0]),
+        size: { x: 0.8, y: 0.5, z: 1 },
+        color: makeColor("#f4b136", 0.5),
+      },
+      {
+        pose: xyzrpyToPose([1, 0, 0], [0, 0, 30]),
+        size: { x: 0.4, y: 0.2, z: 1 },
+        color: makeColor("#afe663", 0.9),
+      },
+    ],
+
+    spheres: [
+      {
+        pose: xyzrpyToPose([0, 6, 0], [0, 0, 0]),
+        size: { x: 0.8, y: 0.5, z: 1 },
+        color: makeColor("#ff6136", 0.5),
+      },
+      {
+        pose: xyzrpyToPose([1, 6, 0], [0, 0, 30]),
+        size: { x: 0.4, y: 0.2, z: 1 },
+        color: makeColor("#afe6c3", 0.9),
+      },
+    ],
+
+    cylinders: [
+      {
+        pose: xyzrpyToPose([0, 5, 0], [0, 0, 0]),
+        size: { x: 0.8, y: 0.5, z: 1 },
+        color: makeColor("#f4b136", 0.5),
+        top_scale: 1,
+        bottom_scale: 0,
+      },
+      {
+        pose: xyzrpyToPose([1, 5, 0], [0, 0, 30]),
+        size: { x: 0.4, y: 0.2, z: 1 },
+        color: makeColor("#afe663", 0.9),
+        top_scale: 0.25,
+        bottom_scale: 0.75,
+      },
+    ],
+
+    lines: [LineType.LINE_STRIP, LineType.LINE_LOOP, LineType.LINE_LIST].flatMap(
+      (type, typeIndex) => [
+        {
+          // non-indexed, single color
+          type,
+          pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+          thickness: 0.05,
+          scale_invariant: false,
+          points: new Array(10).fill(0).map((_, i, { length }) => ({
+            x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+            y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+            z: 0,
+          })),
+          color: makeColor("#7995fb", 0.8),
+          colors: [],
+          indices: [],
+        },
+        {
+          // indexed, single color
+          type,
+          pose: xyzrpyToPose([-0.2 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+          thickness: 0.05,
+          scale_invariant: false,
+          points: rearrange(
+            new Array(10).fill(0).map((_, i, { length }) => ({
+              x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+              y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+              z: 0,
+            })),
+          ),
+          color: makeColor("#7995fb", 0.8),
+          colors: [],
+          // Should make a flat-pointed star, LINE_LOOP should have a line across it
+          indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
+        },
+        {
+          // non-indexed, vertex colors
+          type,
+          pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 0.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+          thickness: 5,
+          scale_invariant: true,
+          points: new Array(10).fill(0).map((_, i, { length }) => ({
+            x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+            y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+            z: 0,
+          })),
+          color: makeColor("#7995fb", 0.8),
+          colors: new Array(10).fill(0).map((_, i, { length }) => {
+            const { r, g, b, a } = tinycolor.fromRatio({ h: i / (length - 1), s: 1, v: 1 }).toRgb();
+            return { r: r / 255, g: g / 255, b: b / 255, a };
+          }),
+          indices: [],
+        },
+        {
+          // indexed, vertex colors
+          type,
+          pose: xyzrpyToPose([0.8 + typeIndex * 0.2, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+          thickness: 4,
+          scale_invariant: true,
+          points: rearrange(
+            new Array(10).fill(0).map((_, i, { length }) => ({
+              x: 0.25 * Math.cos((2 * Math.PI * i) / length),
+              y: 0.25 * Math.sin((2 * Math.PI * i) / length),
+              z: 0,
+            })),
+          ),
+          color: makeColor("#7995fb", 0.8),
+          colors: rearrange(
+            new Array(10).fill(0).map((_, i, { length }) => {
+              const { r, g, b, a } = tinycolor
+                .fromRatio({ h: i / (length - 1), s: 1, v: 1 })
+                .toRgb();
+              return { r: r / 255, g: g / 255, b: b / 255, a };
+            }),
+          ),
+          // Should make a flat-pointed star, LINE_LOOP should have a line across it
+          indices: rearrange(new Array(14).fill(0).map((_, i) => (i * 3) % 10)),
+        },
+        {
+          // empty points
+          type,
+          pose: xyzrpyToPose([1, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+          thickness: 5,
+          scale_invariant: true,
+          points: [],
+          color: makeColor("#7995fb", 0.8),
+          colors: [],
+          indices: [],
+        },
+      ],
+    ),
+
+    triangles: [
+      {
+        ...icospherePointsAndIndices,
+        pose: xyzrpyToPose([0, 9, 0], [0.5685618507342682, 0, 0]),
+        color: makeColor("#ff0048", 1.0),
+        colors: [],
+      },
+      {
+        ...icospherePointsAndIndices,
+        pose: xyzrpyToPose([1, 9, 0], [0.5685618507342682, 0, 0]),
+        color: makeColor("#ff0048", 0.5),
+        colors: [
+          { r: 1, g: 0, b: 0, a: 0 },
+          { r: 1, g: 0.6000000000000001, b: 0, a: 0.1 },
+          { r: 0.7999999999999998, g: 1, b: 0, a: 0.2 },
+          { r: 0.20000000000000018, g: 1, b: 0, a: 0.3 },
+          { r: 0, g: 1, b: 0.40000000000000036, a: 0.4 },
+          { r: 0, g: 1, b: 1, a: 0.5 },
+          { r: 0, g: 0.40000000000000036, b: 1, a: 0.6 },
+          { r: 0.1999999999999993, g: 0, b: 1, a: 0.7 },
+          { r: 0.8000000000000007, g: 0, b: 1, a: 0.8 },
+          { r: 1, g: 0, b: 0.5999999999999996, a: 0.9 },
+          { r: 1, g: 0, b: 0, a: 1 },
+          { r: 1, g: 0.6000000000000005, b: 0, a: 1.1 },
+        ] as ColorRGBA[],
+      },
+    ],
+
+    texts: [
+      {
+        pose: xyzrpyToPose([0, 7, 0], [0, 0, 0]),
+        color: makeColor("#f6f136", 0.5),
+        font_size: 0.2,
+        text: "3d size",
+        scale_invariant: false,
+        billboard: true,
+      },
+      {
+        pose: xyzrpyToPose([1, 7, 0], [0, 0, 30]),
+        color: makeColor("#ae6fc3", 0.9),
+        font_size: 10,
+        text: "pixel size",
+        scale_invariant: true,
+        billboard: true,
+      },
+      {
+        pose: xyzrpyToPose([0, 8, 0], [0, 0, 0]),
+        color: makeColor("#f6f136", 0.5),
+        font_size: 0.2,
+        text: "scale invariant false",
+        scale_invariant: false,
+        billboard: false,
+      },
+      {
+        pose: xyzrpyToPose([1, 8, 0], [0, 0, 30]),
+        color: makeColor("#ae6fc3", 0.9),
+        font_size: 0.2,
+        text: "scale invariant true",
+        scale_invariant: true,
+        billboard: false,
+      },
+    ],
+
+    models: [
+      {
+        pose: xyzrpyToPose([0, 3, 0], [0, 0, 0]),
+        scale: { x: 0.3, y: 0.2, z: 0.2 },
+        color: makeColor("#59e860", 0.8),
+        override_color: false,
+        url: "",
+        media_type: "model/stl",
+        data: new TextEncoder().encode(teapotSTL),
+      },
+      {
+        pose: xyzrpyToPose([1, 3, 0], [0, 0, 30]),
+        scale: { x: 0.3, y: 0.2, z: 0.2 },
+        color: makeColor("#59e860", 0.8),
+        override_color: true,
+        url: encodeURI(`data:model/stl;utf8,${teapotSTL}`),
+        media_type: "",
+        data: new Uint8Array(),
+      },
+    ],
+  };
+  const entities: SceneEntity[] = [];
+  const allPrimitivesAsEmpty = Object.keys(primitives).reduce(
+    (acc, primitiveType) => ({ ...acc, [primitiveType]: [] }),
+    {},
+  ) as Record<keyof typeof primitives, any[]>;
+  for (const primitiveType of Object.keys(primitives)) {
+    const primitiveArray = primitives[primitiveType as keyof typeof primitives]!;
+    let i = 0;
+    for (const primitive of primitiveArray) {
+      entities.push({
+        ...entityData,
+        id: `${primitiveType}-entity-${i}`,
+        ...allPrimitivesAsEmpty,
+        [primitiveType]: [primitive],
+      });
+      i++;
+    }
+  }
+
+  return {
+    topic,
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      deletions: [],
+      entities,
+    },
+    schemaName: "foxglove.SceneUpdate",
+    sizeInBytes: 0,
+  };
+}
+
+function CheckVisibleAfterSeek(): JSX.Element {
+  const readySignal = useReadySignal();
+
+  // We're testing a Line loop using a position buffer bigger than it needs from a previous frame
+  // So we need to test across multiple frames
+  const frames = useMemo(() => {
+    const frame1 = makeMultiEntityScene({ topic: "/markers/annotations", frameId: "map" });
+    const frame2 = makeMultiEntityScene({ topic: "/markers/annotations", frameId: "map" });
+    // const frame1 = msgs[0];
+    // const frame2 = msgs[0];
+
+    return [frame1, frame2];
+  }, []);
+
+  const [fixture, setFixture] = useState<Fixture>({
+    topics: [{ name: "/markers/annotations", schemaName: "foxglove.SceneUpdate" }],
+    frame: {
+      "/markers/annotations": [frames[0]!],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 10, nsec: 0 },
+      isPlaying: true,
+    },
+  });
+
+  useEffect(() => {
+    let timeOutID2: NodeJS.Timeout;
+
+    const timeOutID = setTimeout(() => {
+      setFixture((oldFixture) => {
+        const newFixture = {
+          ...oldFixture,
+        };
+        newFixture.frame = {
+          "/markers/annotations": [frames[1]!],
+        };
+        newFixture.activeData = {
+          currentTime: { sec: 11, nsec: 0 },
+          isPlaying: true,
+          lastSeekTime: 11,
+        };
+        return newFixture;
+      });
+      timeOutID2 = setTimeout(() => {
+        readySignal();
+      }, 100);
+    }, 500);
+
+    return () => {
+      clearTimeout(timeOutID);
+      clearTimeout(timeOutID2);
+    };
+  }, [readySignal, frames]);
+
+  return (
+    <PanelSetup fixture={fixture} includeSettings={true}>
+      <ThreeDeePanel
+        overrideConfig={{
+          ...ThreeDeePanel.defaultConfig,
+          followTf: "root",
+          layers: {
+            grid: { layerId: "foxglove.Grid" },
+          },
+          cameraState: {
+            distance: 5.84,
+            perspective: true,
+            phi: 0.2,
+            targetOffset: [-2.348, 3.351, 0],
+            thetaOffset: -89.5,
+            fovy: 45,
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+          topics: {
+            "/markers/annotations": { visible: true },
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+// Tests `LinePrimitives` reusing of larger `#positionBuffers`. These squares move across frames and test
+// that we correctly handle the case where the `#positionBuffer` in `RenderableLines/LinePrimitiveRenderable` is bigger than
+// the number of points after a `SceneUpdate`
+export const ProcessesSameSceneTwice: StoryObj = {
+  parameters: {
+    useReadySignal: true,
+    colorScheme: "dark",
+  },
+  render: CheckVisibleAfterSeek,
   play: async (ctx) => {
     await ctx.parameters.storyReady;
   },


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix SceneEntity primitives from disappearing / only showing outlines after seeking

**Description**

The issue here is that the primitive Renderables are using outdated/incorrect bounding volumes, which is causing them to be culled when they shouldn't be. 

In more detail, after seeking primitive renderables are released to the `PrimitivePool`, and then re-acquired on the next message. These renderables are `acquired` in reverse of the order that they were `released` from the pool. This caused entities to get renderables that were formerly part of other entities, which isn't inherently wrong except for the fact that we don't recalculate the bounding sphere on the mesh being used by the primitive, so it is being culled based off of an old bounding sphere. This PR sets `frustumCulled` on `InstancedMesh` to be false. 
This issue came from a change that happened in threejs between v150 and v151 that makes the `InstancedMesh.frustumCulled` default to true. 



<!-- link relevant GitHub issues -->
Fixes: FG-5211
Fixes: FG-5460
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
