### PR TITLE
Improve Log message normalization

### DIFF
--- a/packages/studio-base/src/panels/Log/filterMessages.ts
+++ b/packages/studio-base/src/panels/Log/filterMessages.ts
@@ -11,6 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
+
 import { getNormalizedMessage, getNormalizedLevel } from "./conversion";
 import { LogMessageEvent } from "./types";
 
@@ -41,7 +43,7 @@ export default function filterMessages(
       return false;
     }
 
-    const maybeName = logMessage.name;
+    const maybeName = mightActuallyBePartial(logMessage).name;
     if (maybeName != undefined && nameFilter[maybeName]?.visible === false) {
       return false;
     }
@@ -50,7 +52,7 @@ export default function filterMessages(
       return true;
     }
 
-    const lowerCaseName = logMessage.name?.toLowerCase() ?? "";
+    const lowerCaseName = mightActuallyBePartial(logMessage).name?.toLowerCase() ?? "";
     const lowerCaseMsg = getNormalizedMessage(logMessage).toLowerCase();
     return searchTermsInLowerCase.some(
       (term) => lowerCaseName.includes(term) || lowerCaseMsg.includes(term),

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -25,6 +25,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { FilterTagInput } from "@foxglove/studio-base/panels/Log/FilterTagInput";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
+import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
 import LogList from "./LogList";
 import { normalizedLogMessage } from "./conversion";
@@ -107,7 +108,7 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
 
   const seenNodeNames = useMemo(() => {
     for (const msgEvent of messages) {
-      const name = msgEvent.message.name;
+      const name = mightActuallyBePartial(msgEvent.message).name;
       if (name != undefined) {
         seenNodeNamesCache.current.add(name);
       }

--- a/packages/studio-base/src/panels/Log/types.ts
+++ b/packages/studio-base/src/panels/Log/types.ts
@@ -2,8 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Log as FoxgloveLog } from "@foxglove/schemas";
 import { Time, MessageEvent } from "@foxglove/studio";
-import { FoxgloveMessages } from "@foxglove/studio-base/types/FoxgloveMessages";
 import { Header } from "@foxglove/studio-base/types/Messages";
 
 export type Config = {
@@ -53,6 +53,6 @@ export type NormalizedLogMessage = {
 };
 
 export type LogMessageEvent =
-  | MessageEvent<FoxgloveMessages["foxglove.Log"]>
+  | MessageEvent<FoxgloveLog>
   | MessageEvent<Ros1RosgraphMsgs$Log>
   | MessageEvent<Ros2RosgraphMsgs$Log>;

--- a/packages/studio-base/src/types/FoxgloveMessages.ts
+++ b/packages/studio-base/src/types/FoxgloveMessages.ts
@@ -2,137 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export enum LogLevel {
-  UNKNOWN = 0,
-  DEBUG = 1,
-  INFO = 2,
-  WARN = 3,
-  ERROR = 4,
-  FATAL = 5,
-}
-
-export enum NumericType {
-  UINT8 = 1,
-  INT8 = 2,
-  UINT16 = 3,
-  INT16 = 4,
-  UINT32 = 5,
-  INT32 = 6,
-  FLOAT32 = 7,
-  FLOAT64 = 8,
-}
-
 export type FoxgloveMessages = {
-  "foxglove.CameraCalibration": {
-    timestamp: bigint | { sec: number; nsec: number };
-    width: number;
-    height: number;
-    distortion_model?: string;
-    D?: readonly number[];
-    K?: readonly number[];
-    P?: readonly number[];
-    R?: readonly number[];
-  };
-
-  "foxglove.Color": {
-    r: number;
-    g: number;
-    b: number;
-    a: number;
-  };
-
   "foxglove.GeoJSON": {
     geojson: string;
-  };
-
-  "foxglove.RawImage": {
-    timestamp: bigint | { sec: number; nsec: number };
-    width: number;
-    height: number;
-    encoding: string;
-    step: number;
-    data: Uint8Array;
-  };
-
-  "foxglove.CompressedImage": {
-    timestamp: bigint | { sec: number; nsec: number };
-    format: string;
-    data: Uint8Array;
-  };
-
-  "foxglove.Log": {
-    timestamp: bigint | { sec: number; nsec: number };
-    level: LogLevel;
-    message: string;
-    name?: string;
-    file?: string;
-    line?: number;
-  };
-
-  "foxglove.FrameTransform": {
-    timestamp: {
-      sec: number;
-      nsec: number;
-    };
-    parent_frame_id: string;
-    child_frame_id: string;
-    transform?: {
-      translation: { x: number; y: number; z: number };
-      rotation: { x: number; y: number; z: number; w: number };
-    };
-    translation?: { x: number; y: number; z: number };
-    rotation?: { x: number; y: number; z: number; w: number };
   };
 
   "foxglove.Pose": {
     position: { x: number; y: number; z: number };
     orientation: { x: number; y: number; z: number; w: number };
-  };
-
-  "foxglove.PoseInFrame": {
-    timestamp: { sec: number; nsec: number };
-    frame_id: string;
-    pose: FoxgloveMessages["foxglove.Pose"];
-  };
-
-  "foxglove.PosesInFrame": {
-    timestamp: { sec: number; nsec: number };
-    frame_id: string;
-    poses: Array<FoxgloveMessages["foxglove.Pose"]>;
-  };
-
-  "foxglove.Grid": {
-    timestamp: { sec: number; nsec: number };
-    frame_id: string;
-    pose: FoxgloveMessages["foxglove.Pose"];
-
-    column_count: number;
-    cell_size: { x: number; y: number };
-
-    row_stride: number;
-    cell_stride: number;
-    fields: Array<{ name: string; offset: number; type: NumericType }>;
-    data: Uint8Array;
-  };
-
-  "foxglove.PointCloud": {
-    timestamp: { sec: number; nsec: number };
-    frame_id: string;
-    pose: FoxgloveMessages["foxglove.Pose"];
-    point_stride: number;
-    fields: Array<{ name: string; offset: number; type: NumericType }>;
-    data: Uint8Array;
-  };
-
-  "foxglove.LaserScan": {
-    timestamp: { sec: number; nsec: number };
-    frame_id: string;
-    pose: FoxgloveMessages["foxglove.Pose"];
-
-    start_angle: number;
-    end_angle: number;
-
-    ranges: number[];
-    intensities: number[];
   };
 };


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The Log panel would crash if it received `timestamp: null`. Improved the normalization functions to catch this case (and some others).

I did not try to go overboard here with normalization because we could spend a ton of effort doing this in all our panels... some day it would be nice to have more centralized schema validation (see FG-4917)

Fixes FG-5578