### PR TITLE
Fix deserialization errors hiding errors from other topics

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -220,7 +220,6 @@ export class BagIterableSource implements IIterableSource {
 
         yield {
           type: "message-event",
-          connectionId,
           msgEvent: {
             topic: bagMsgEvent.topic,
             receiveTime: bagMsgEvent.timestamp,

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -74,12 +74,15 @@ export type MessageIteratorArgs = {
 export type IteratorResult =
   | {
       type: "message-event";
-      connectionId?: number;
       msgEvent: MessageEvent;
     }
   | {
       type: "problem";
-      connectionId?: number;
+      /**
+       * An ID representing the channel/connection where this problem came from. The app may choose
+       * to display only a single problem from each connection to avoid overwhelming the user.
+       */
+      connectionId: number;
       problem: PlayerProblem;
     }
   | {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -398,7 +398,6 @@ describe("IterablePlayer", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        connectionId: undefined,
       };
     };
 
@@ -484,7 +483,6 @@ describe("IterablePlayer", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        connectionId: undefined,
       };
     };
 
@@ -691,7 +689,6 @@ describe("IterablePlayer", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        connectionId: undefined,
       };
     };
 
@@ -741,7 +738,6 @@ describe("IterablePlayer", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        connectionId: undefined,
       };
     };
 

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -141,6 +141,7 @@ export class McapIndexedIterableSource implements IIterableSource {
       if (!channelInfo) {
         yield {
           type: "problem",
+          connectionId: message.channelId,
           problem: {
             message: `Received message on channel ${message.channelId} without prior channel info`,
             severity: "error",
@@ -154,6 +155,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
         yield {
           type: "message-event",
+          connectionId: message.channelId,
           msgEvent: {
             topic: channelInfo.channel.topic,
             receiveTime: fromNanoSec(message.logTime),
@@ -169,6 +171,7 @@ export class McapIndexedIterableSource implements IIterableSource {
       } catch (error) {
         yield {
           type: "problem",
+          connectionId: message.channelId,
           problem: {
             message: `Error decoding message on ${channelInfo.channel.topic}`,
             error,

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -155,7 +155,6 @@ export class McapIndexedIterableSource implements IIterableSource {
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
         yield {
           type: "message-event",
-          connectionId: message.channelId,
           msgEvent: {
             topic: channelInfo.channel.topic,
             receiveTime: fromNanoSec(message.logTime),


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**

The IterablePlayer uses the `connectionId` as part of the key in the problem manager. The source was not sending any `connectionId`, so errors on multiple channels would override each other and only one was visible at a time. With this change, each channel's latest error is visible.

https://github.com/foxglove/studio/blob/3f87e3009acfb94020ad8270492225179ca6a5d3/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts#L652

Fixes FG-5631