### PR TITLE
Move `EXPERIMENTAL_setMessagePathDropConfig` to internal types

### DIFF
--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -6,10 +6,10 @@ import { StoryObj } from "@storybook/react";
 import { fireEvent, screen, waitFor } from "@storybook/testing-library";
 import { useEffect, useState } from "react";
 
-import { DraggedMessagePath } from "@foxglove/studio";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import PanelCatalogContext, {

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { MessagePathDropConfig } from "@foxglove/studio";
+import { MessagePathDropConfig } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { SaveConfig, PanelConfig, OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
 
 export type PanelContextType<T> = {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -508,7 +508,7 @@ function PanelExtensionAdapter(
         setDefaultPanelTitle(title);
       },
 
-      EXPERIMENTAL_setMessagePathDropConfig(dropConfig) {
+      unstable_setMessagePathDropConfig(dropConfig) {
         setMessagePathDropConfig(dropConfig);
       },
     };

--- a/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
@@ -16,6 +16,39 @@ export type Asset = {
   mediaType?: string;
 };
 
+export type DraggedMessagePath = {
+  /** The full message path */
+  path: string;
+  /** The schema name of the top-level topic being dragged */
+  rootSchemaName: string | undefined;
+  /** True if the path represents a whole topic (no message path component). */
+  isTopic: boolean;
+  /** True if the path represents a primitive value inside a message. */
+  isLeaf: boolean;
+};
+
+export type MessagePathDropStatus = {
+  /** True if the panel would be able to accept this dragged message path. */
+  canDrop: boolean;
+  /**
+   * Indicate the type of operation that would occur if this path were dropped. Used to change the
+   * mouse cursor.
+   */
+  effect?: "replace" | "add";
+  /**
+   * A message to display to the user indicating what will happen when the path is dropped.
+   */
+  message?: string;
+};
+
+export type MessagePathDropConfig = {
+  /** Called when the user drags message paths over the panel. */
+  getDropStatus: (paths: readonly DraggedMessagePath[]) => MessagePathDropStatus;
+
+  /** Called when the user drops message paths on the panel. */
+  handleDrop: (paths: readonly DraggedMessagePath[]) => void;
+};
+
 /**
  * BuiltinPanelExtensionContext adds additional built-in only functionality to the PanelExtensionContext.
  *
@@ -35,4 +68,10 @@ export type BuiltinPanelExtensionContext = {
    * @returns
    */
   unstable_fetchAsset: (uri: string, options?: { signal: AbortSignal }) => Promise<Asset>;
+
+  /**
+   * Updates the configuration for message path drag & drop support. A value of `undefined`
+   * indicates that the panel does not accept any dragged message paths.
+   */
+  unstable_setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
 } & PanelExtensionContext;

--- a/packages/studio-base/src/components/TopicList/ContextMenu.tsx
+++ b/packages/studio-base/src/components/TopicList/ContextMenu.tsx
@@ -7,7 +7,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useCopyToClipboard } from "react-use";
 
-import { DraggedMessagePath } from "@foxglove/studio";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 
 export function ContextMenu(props: {
   messagePaths: DraggedMessagePath[];

--- a/packages/studio-base/src/components/TopicList/MessagePathRow.tsx
+++ b/packages/studio-base/src/components/TopicList/MessagePathRow.tsx
@@ -7,8 +7,8 @@ import { Badge, Typography } from "@mui/material";
 import { FzfResultItem } from "fzf";
 import { useCallback, useMemo } from "react";
 
-import { DraggedMessagePath } from "@foxglove/studio";
 import { HighlightChars } from "@foxglove/studio-base/components/HighlightChars";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useMessagePathDrag } from "@foxglove/studio-base/services/messagePathDragging";
 

--- a/packages/studio-base/src/components/TopicList/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList/TopicList.tsx
@@ -22,7 +22,6 @@ import { makeStyles } from "tss-react/mui";
 import { useDebounce } from "use-debounce";
 
 import { filterMap } from "@foxglove/den/collection";
-import { DraggedMessagePath } from "@foxglove/studio";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import { DirectTopicStatsUpdater } from "@foxglove/studio-base/components/DirectTopicStatsUpdater";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
@@ -30,6 +29,7 @@ import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { ContextMenu } from "@foxglove/studio-base/components/TopicList/ContextMenu";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { MessagePathSelectionProvider } from "@foxglove/studio-base/services/messagePathDragging/MessagePathSelectionProvider";

--- a/packages/studio-base/src/components/TopicList/TopicRow.tsx
+++ b/packages/studio-base/src/components/TopicList/TopicRow.tsx
@@ -7,8 +7,8 @@ import { Badge, Typography } from "@mui/material";
 import { FzfResultItem } from "fzf";
 import { useCallback, useMemo } from "react";
 
-import { DraggedMessagePath } from "@foxglove/studio";
 import { HighlightChars } from "@foxglove/studio-base/components/HighlightChars";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { useMessagePathDrag } from "@foxglove/studio-base/services/messagePathDragging";

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -6,17 +6,19 @@ import EventEmitter from "eventemitter3";
 import * as THREE from "three";
 
 import {
-  DraggedMessagePath,
   Immutable,
   MessageEvent,
-  MessagePathDropStatus,
   ParameterValue,
   SettingsIcon,
   Topic,
   VariableValue,
 } from "@foxglove/studio";
 import { PanelContextMenuItem } from "@foxglove/studio-base/components/PanelContextMenu";
-import { BuiltinPanelExtensionContext } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import {
+  BuiltinPanelExtensionContext,
+  DraggedMessagePath,
+  MessagePathDropStatus,
+} from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";
 import IAnalytics from "@foxglove/studio-base/services/IAnalytics";
 import { LabelPool } from "@foxglove/three-text";

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -13,10 +13,8 @@ import Logger from "@foxglove/log";
 import { Time, fromNanoSec, isLessThan, toNanoSec } from "@foxglove/rostime";
 import type { FrameTransform, FrameTransforms, SceneUpdate } from "@foxglove/schemas";
 import {
-  DraggedMessagePath,
   Immutable,
   MessageEvent,
-  MessagePathDropStatus,
   ParameterValue,
   SettingsIcon,
   SettingsTreeAction,
@@ -29,6 +27,8 @@ import { PanelContextMenuItem } from "@foxglove/studio-base/components/PanelCont
 import {
   Asset,
   BuiltinPanelExtensionContext,
+  DraggedMessagePath,
+  MessagePathDropStatus,
 } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { LayerErrors } from "@foxglove/studio-base/panels/ThreeDeeRender/LayerErrors";
 import { ICameraHandler } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ICameraHandler";

--- a/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
@@ -6,8 +6,9 @@ import * as _ from "lodash-es";
 import * as THREE from "three";
 import { DeepPartial, Writable } from "ts-essentials";
 
-import { DraggedMessagePath, MessageEvent, SettingsTreeAction } from "@foxglove/studio";
+import { MessageEvent, SettingsTreeAction } from "@foxglove/studio";
 import { PanelContextMenuItem } from "@foxglove/studio-base/components/PanelContextMenu";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 
 import type { AnyRendererSubscription, IRenderer, RendererConfig } from "./IRenderer";
 import { Path } from "./LayerErrors";

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -109,7 +109,12 @@ export function ThreeDeeRender(props: {
   customSceneExtensions?: DeepPartial<SceneExtensionConfig>;
 }): JSX.Element {
   const { context, interfaceMode, testOptions, customSceneExtensions } = props;
-  const { initialState, saveState, unstable_fetchAsset: fetchAsset } = context;
+  const {
+    initialState,
+    saveState,
+    unstable_fetchAsset: fetchAsset,
+    unstable_setMessagePathDropConfig: setMessagePathDropConfig,
+  } = context;
   const analytics = useAnalytics();
 
   // Load and save the persisted panel configuration
@@ -199,7 +204,7 @@ export function ThreeDeeRender(props: {
   }, [renderer, analytics]);
 
   useEffect(() => {
-    context.EXPERIMENTAL_setMessagePathDropConfig(
+    setMessagePathDropConfig(
       renderer
         ? {
             getDropStatus: renderer.getDropStatus,
@@ -207,7 +212,7 @@ export function ThreeDeeRender(props: {
           }
         : undefined,
     );
-  }, [context, renderer]);
+  }, [setMessagePathDropConfig, renderer]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
   const [timezone, setTimezone] = useState<string | undefined>();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -10,14 +10,9 @@ import { filterMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
-import {
-  DraggedMessagePath,
-  Immutable,
-  SettingsTreeAction,
-  SettingsTreeFields,
-  Topic,
-} from "@foxglove/studio";
+import { Immutable, SettingsTreeAction, SettingsTreeFields, Topic } from "@foxglove/studio";
 import { PanelContextMenuItem } from "@foxglove/studio-base/components/PanelContextMenu";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { Path } from "@foxglove/studio-base/panels/ThreeDeeRender/LayerErrors";
 import { IMAGE_TOPIC_PATH } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/ImageMode/constants";
 import {

--- a/packages/studio-base/src/services/messagePathDragging/MessagePathSelectionProvider.tsx
+++ b/packages/studio-base/src/services/messagePathDragging/MessagePathSelectionProvider.tsx
@@ -4,7 +4,7 @@
 
 import { createContext, useMemo } from "react";
 
-import { DraggedMessagePath } from "@foxglove/studio";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 
 type MessagePathSelectionContext = {
   getSelectedItems: () => DraggedMessagePath[];

--- a/packages/studio-base/src/services/messagePathDragging/index.ts
+++ b/packages/studio-base/src/services/messagePathDragging/index.ts
@@ -13,7 +13,11 @@ import {
 } from "react-dnd";
 
 import Logger from "@foxglove/log";
-import { DraggedMessagePath, MessagePathDropConfig, MessagePathDropStatus } from "@foxglove/studio";
+import {
+  DraggedMessagePath,
+  MessagePathDropConfig,
+  MessagePathDropStatus,
+} from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { MessagePathSelectionContextInternal } from "@foxglove/studio-base/services/messagePathDragging/MessagePathSelectionProvider";
 
 import { MessagePathDragParams } from "./types";

--- a/packages/studio-base/src/services/messagePathDragging/types.ts
+++ b/packages/studio-base/src/services/messagePathDragging/types.ts
@@ -2,9 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { DraggedMessagePath } from "@foxglove/studio";
+import { DraggedMessagePath } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 
 export type MessagePathDragParams = {
+  /**
+   * The item represented by the component that is using `useMessagePathDrag`. If no items are
+   * selected and a drag begins on this component, this will be used as the drag item.
+   */
   item: DraggedMessagePath;
+  /**
+   * Whether this item is currently selected.
+   */
   selected: boolean;
 };

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -238,39 +238,6 @@ export type RenderState = {
   appSettings?: Map<string, AppSettingValue>;
 };
 
-export type DraggedMessagePath = {
-  /** The full message path */
-  path: string;
-  /** The schema name of the top-level topic being dragged */
-  rootSchemaName: string | undefined;
-  /** True if the path represents a whole topic (no message path component). */
-  isTopic: boolean;
-  /** True if the path represents a primitive value inside a message. */
-  isLeaf: boolean;
-};
-
-export type MessagePathDropStatus = {
-  /** True if the panel would be able to accept this dragged message path. */
-  canDrop: boolean;
-  /**
-   * Indicate the type of operation that would occur if this path were dropped. Used to change the
-   * mouse cursor.
-   */
-  effect?: "replace" | "add";
-  /**
-   * A message to display to the user indicating what will happen when the path is dropped.
-   */
-  message?: string;
-};
-
-export type MessagePathDropConfig = {
-  /** Called when the user drags message paths over the panel. */
-  getDropStatus: (paths: readonly DraggedMessagePath[]) => MessagePathDropStatus;
-
-  /** Called when the user drops message paths on the panel. */
-  handleDrop: (paths: readonly DraggedMessagePath[]) => void;
-};
-
 export type PanelExtensionContext = {
   /**
    * The root element for the panel. Add your panel elements as children under this element.
@@ -427,12 +394,6 @@ export type PanelExtensionContext = {
    * manually. A value of `undefined` will display the panel's name in the title bar.
    */
   setDefaultPanelTitle(defaultTitle: string | undefined): void;
-
-  /**
-   * Updates the configuration for message path drag & drop support. A value of `undefined`
-   * indicates that the panel does not accept any dragged message paths.
-   */
-  EXPERIMENTAL_setMessagePathDropConfig: (config: MessagePathDropConfig | undefined) => void;
 };
 
 export type ExtensionPanelRegistration = {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When I added this function I forgot that `BuiltinPanelExtensionContext` was a thing. It is more appropriate for this function to live there until the API is reviewed and shipped.