### PR TITLE
Change selected panel visual

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -615,6 +615,7 @@ export default function Panel<
             id: childId,
             title,
             config: panelComponentConfig,
+            isSelected: isSelected || (isDragging && isValidTarget && isOver),
             saveConfig: saveConfig as SaveConfig<PanelConfig>,
             updatePanelConfigs,
             openSiblingPanel,
@@ -648,7 +649,6 @@ export default function Panel<
                 hasFullscreenDescendant={hasFullscreenDescendant}
                 fullscreenState={fullscreenState}
                 sourceRect={fullscreenSourceRect}
-                selected={isSelected || (isDragging && isValidTarget && isOver)}
                 data-testid={cx("panel-mouseenter-container", childId)}
                 ref={(el) => {
                   panelRootRef.current = el;

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -30,6 +30,7 @@ export type PanelContextType<T> = {
   enterFullscreen: () => void;
   exitFullscreen: () => void;
   isFullscreen: boolean;
+  isSelected: boolean;
 
   /** Used to adjust z-index settings on parent panels when children are fullscreen */
   // eslint-disable-next-line @foxglove/no-boolean-parameters

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { alpha } from "@mui/material";
 import { forwardRef, HTMLAttributes, PropsWithChildren } from "react";
 import { TransitionStatus } from "react-transition-group";
 import { makeStyles } from "tss-react/mui";
@@ -13,7 +12,6 @@ export const PANEL_ROOT_CLASS_NAME = "FoxglovePanelRoot-root";
 
 type PanelRootProps = {
   fullscreenState: TransitionStatus;
-  selected: boolean;
   sourceRect: DOMRectReadOnly | undefined;
   hasFullscreenDescendant: boolean;
 } & HTMLAttributes<HTMLDivElement>;
@@ -33,31 +31,6 @@ const useStyles = makeStyles<Omit<PanelRootProps, "fullscreenState" | "selected"
       flex: "1 1 auto",
       overflow: "hidden",
       backgroundColor: palette.background.default,
-      border: `0px solid ${alpha(palette.primary.main, 0.67)}`,
-      transition: transitions.create("border-width", {
-        duration, // match to timeout duration inside Panel component
-      }),
-
-      "::after": {
-        content: "''",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        inset: 1,
-        opacity: 0,
-        border: `1px solid ${palette.primary.main}`,
-        position: "absolute",
-        pointerEvents: "none",
-        transition: "opacity 0.05s ease-out",
-        zIndex: 10000 + 1,
-      },
-    },
-    rootSelected: {
-      "::after": {
-        opacity: 1,
-        transition: "opacity 0.125s ease-out",
-      },
     },
     entering: {
       position: "fixed",
@@ -107,8 +80,7 @@ const useStyles = makeStyles<Omit<PanelRootProps, "fullscreenState" | "selected"
 
 export const PanelRoot = forwardRef<HTMLDivElement, PropsWithChildren<PanelRootProps>>(
   function PanelRoot(props, ref): JSX.Element {
-    const { className, fullscreenState, hasFullscreenDescendant, selected, sourceRect, ...rest } =
-      props;
+    const { className, fullscreenState, hasFullscreenDescendant, sourceRect, ...rest } = props;
     const { classes, cx } = useStyles({ sourceRect, hasFullscreenDescendant });
 
     const classNames = cx(PANEL_ROOT_CLASS_NAME, className, classes.root, {
@@ -116,7 +88,6 @@ export const PanelRoot = forwardRef<HTMLDivElement, PropsWithChildren<PanelRootP
       [classes.entered]: fullscreenState === "entered",
       [classes.exiting]: fullscreenState === "exiting",
       [classes.exited]: fullscreenState === "exited",
-      [classes.rootSelected]: selected,
     });
 
     return (

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -13,6 +13,7 @@
 
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { Typography } from "@mui/material";
+import { alpha } from "@mui/material";
 import { useContext, useMemo, CSSProperties } from "react";
 import { makeStyles } from "tss-react/mui";
 
@@ -47,6 +48,9 @@ const useStyles = makeStyles()((theme) => ({
     width: "100%",
     left: 0,
     zIndex: theme.zIndex.appBar,
+  },
+  selected: {
+    backgroundColor: alpha(theme.palette.primary.main, 0.1),
   },
 }));
 
@@ -103,9 +107,14 @@ export default React.memo<Props>(function PanelToolbar({
       : defaultPanelTitle;
 
   const title = customPanelTitle ?? panelContext?.title;
+
+  const classNames = cx(classes.root, className, {
+    [classes.selected]: panelContext?.isSelected,
+  });
+
   return (
     <header
-      className={cx(classes.root, className)}
+      className={classNames}
       data-testid="mosaic-drag-handle"
       ref={rootDragRef}
       style={{ backgroundColor, cursor: rootDragRef != undefined ? "grab" : "auto" }}


### PR DESCRIPTION


**User-Facing Changes**
Highlight the toolbar for the selected panel.

Before:
<img width="914" alt="Screenshot 2023-11-08 at 8 19 58 AM" src="https://github.com/foxglove/studio/assets/84792/18612be7-e7c8-4c9d-a3bc-1f925129c67a">
<img width="919" alt="Screenshot 2023-11-08 at 8 19 51 AM" src="https://github.com/foxglove/studio/assets/84792/fd7d9968-66ca-4abb-bbea-5e9496de9598">

After:
<img width="918" alt="Screenshot 2023-11-08 at 8 18 50 AM" src="https://github.com/foxglove/studio/assets/84792/1d026d9b-9b25-416b-abb7-818ea90c1fc8">
<img width="917" alt="Screenshot 2023-11-08 at 8 18 42 AM" src="https://github.com/foxglove/studio/assets/84792/4c10fc9b-044f-46c6-9528-a069fd0a3030">


**Description**
This change alters the visual feedback for a selected panel. Prior to this change the visual feedback for a selected panel was a purple 1px border. This border went around the entire panel. This change updates the visual to highlight the panel toolbar instead of a border.

My opinion is that the toolbar highlight is less disruptive and maintains a cleaner appearence. The panel border would often result in a 1px boundary around some parts of the panel (possibly due to mosaic interactions) which has long been a visual annoyance for me.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
