### PR TITLE
Fix URDF url field not being shown when source is undefined

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -351,7 +351,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
             ],
           },
           url:
-            config.sourceType === "url"
+            (config.sourceType ?? DEFAULT_CUSTOM_SETTINGS.sourceType) === "url"
               ? {
                   label: "URL",
                   input: "string",


### PR DESCRIPTION
**User-Facing Changes**
Fix rare case of URDF url field not being shown

**Description**
Fixes that the custom layer URDF url field was not shown when the source type (default is `url`) was undefined.
