### PR TITLE
Fix error with undefined interaction items

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -99,6 +99,7 @@ const lastX: InteractionModeFunction = (chart, event, _options, useFinalPosition
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
   const position = getRelativePosition(event, chart as any);
 
+  // Create a sparse array to track the last datum for each dataset
   const datasetIndexToLastItem: InteractionItem[] = [];
   Interaction.evaluateInteractionItems(chart, "x", position, (element, datasetIndex, index) => {
     const center = element.getCenterPoint(useFinalPosition);
@@ -106,7 +107,8 @@ const lastX: InteractionModeFunction = (chart, event, _options, useFinalPosition
       datasetIndexToLastItem[datasetIndex] = { element, datasetIndex, index };
     }
   });
-  return datasetIndexToLastItem;
+  // Filter unused entries from the sparse array
+  return datasetIndexToLastItem.filter(Boolean);
 };
 
 Interaction.modes.lastX = lastX;


### PR DESCRIPTION
https://github.com/foxglove/studio/pull/7086 introduced a new interaction mode for identifying the last datum across datasets. It uses a sparse array to track the items for datasets by index. This sparse array can sometimes have holes which cause downstream logic with handing the returned items to fail. The returned array should not have holes so this change filters our missing values.

**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
