### PR TITLE
Tolerate missing properties key in JSON schema

### DIFF
--- a/packages/mcap-support/src/parseJsonSchema.test.ts
+++ b/packages/mcap-support/src/parseJsonSchema.test.ts
@@ -285,4 +285,18 @@ describe("parseJsonSchema", () => {
   it.each(Object.values(foxgloveMessageSchemas))("handles Foxglove schema '$name'", (schema) => {
     expect(() => parseJsonSchema(generateJsonSchema(schema), schema.name)).not.toThrow();
   });
+
+  it("tolerates an 'any object' schema", () => {
+    const { datatypes } = parseJsonSchema({ type: "object" }, "Any object");
+    expect(datatypes).toEqual(
+      new Map([
+        [
+          "Any object",
+          {
+            definitions: [],
+          },
+        ],
+      ]),
+    );
+  });
 });

--- a/packages/mcap-support/src/parseJsonSchema.ts
+++ b/packages/mcap-support/src/parseJsonSchema.ts
@@ -37,9 +37,8 @@ export function parseJsonSchema(
         `Expected "type": "object" for schema ${typeName}, got ${JSON.stringify(schema.type)}`,
       );
     }
-    for (const [fieldName, fieldSchema] of Object.entries(
-      schema.properties as Record<string, Record<string, unknown>>,
-    )) {
+    const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+    for (const [fieldName, fieldSchema] of Object.entries(properties)) {
       if (Array.isArray(fieldSchema.oneOf)) {
         if (fieldSchema.oneOf.every((alternative) => typeof alternative.const === "number")) {
           for (const alternative of fieldSchema.oneOf) {


### PR DESCRIPTION
**User-Facing Changes**

Not significant.

**Description**

This allows a simpler representation of a JSON schema representing "any object".

When parsing a JSON schema, we assume the presence of `.properties`, but this is not a required field. Currently, if I open an mcap file with a JSON schema of `{"type":"object"}`, I see a confusing error. We could produce a better error message. However, I'd like to document this workaround for empty schemas, and accepting the above schema seems preferable to requiring `{"type": "object", "properties": {}}`.

<img width="595" alt="err" src="https://github.com/foxglove/studio/assets/39674/5a911aa6-6152-407b-bba1-04598abfc4c3">
