### PR TITLE
Move reset zoom button so it only overlaps StateTransition chart when it has to.

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -76,6 +76,9 @@ const useStyles = makeStyles()((theme) => ({
       pointerEvents: "auto",
     },
   },
+  stateTransition: {
+    padding: theme.spacing(0, 1, 2),
+  },
   tooltip: {
     maxWidth: "none",
   },
@@ -116,6 +119,7 @@ export type Props = {
   xAxes?: ScaleOptions<"linear">;
   yAxes: ScaleOptions<"linear">;
   annotations?: AnnotationOptions[];
+  isStateTransition?: boolean;
   isSynced?: boolean;
   linesToHide?: {
     [key: string]: boolean;
@@ -148,6 +152,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     datasetId,
     defaultView,
     height,
+    isStateTransition = false,
     isSynced = false,
     showXAxisLabels,
     type,
@@ -808,7 +813,11 @@ export default function TimeBasedChart(props: Props): JSX.Element {
             </div>
 
             {showReset && (
-              <div className={classes.resetZoomButton}>
+              <div
+                className={cx(classes.resetZoomButton, {
+                  [classes.stateTransition]: isStateTransition,
+                })}
+              >
                 <Button
                   variant="contained"
                   color="inherit"

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Button, Fade, Tooltip, buttonClasses, useTheme } from "@mui/material";
+import { Button, Fade, Tooltip, buttonClasses } from "@mui/material";
 import { ChartOptions, InteractionMode, ScaleOptions } from "chart.js";
 import { AnnotationOptions } from "chartjs-plugin-annotation";
 import * as _ from "lodash-es";
@@ -66,7 +66,7 @@ const useStyles = makeStyles()((theme) => ({
     position: "sticky",
     display: "flex",
     justifyContent: "flex-end",
-    padding: theme.spacing(0, 1, 4),
+    paddingInline: theme.spacing(1),
     right: 0,
     left: 0,
     bottom: 0,
@@ -75,9 +75,6 @@ const useStyles = makeStyles()((theme) => ({
     [`.${buttonClasses.root}`]: {
       pointerEvents: "auto",
     },
-  },
-  stateTransition: {
-    padding: theme.spacing(0, 1, 2),
   },
   tooltip: {
     maxWidth: "none",
@@ -119,7 +116,7 @@ export type Props = {
   xAxes?: ScaleOptions<"linear">;
   yAxes: ScaleOptions<"linear">;
   annotations?: AnnotationOptions[];
-  isStateTransition?: boolean;
+  resetButtonPaddingBottom?: number;
   isSynced?: boolean;
   linesToHide?: {
     [key: string]: boolean;
@@ -152,8 +149,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     datasetId,
     defaultView,
     height,
-    isStateTransition = false,
     isSynced = false,
+    resetButtonPaddingBottom = 4,
     showXAxisLabels,
     type,
     width,
@@ -229,8 +226,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
   const bounds = dataBounds ?? datasetBounds;
 
-  const theme = useTheme();
-  const { classes, cx } = useStyles();
+  const { classes, cx, theme } = useStyles();
   const componentId = useMemo(() => uuidv4(), []);
   const isMounted = useMountedState();
   const canvasContainer = useRef<HTMLDivElement>(ReactNull);
@@ -814,9 +810,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
             {showReset && (
               <div
-                className={cx(classes.resetZoomButton, {
-                  [classes.stateTransition]: isStateTransition,
-                })}
+                className={classes.resetZoomButton}
+                style={{ paddingBottom: theme.spacing(resetButtonPaddingBottom) }}
               >
                 <Button
                   variant="contained"

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Button, Fade, Tooltip, useTheme } from "@mui/material";
+import { Button, Fade, Tooltip, buttonClasses, useTheme } from "@mui/material";
 import { ChartOptions, InteractionMode, ScaleOptions } from "chart.js";
 import { AnnotationOptions } from "chartjs-plugin-annotation";
 import * as _ from "lodash-es";
@@ -62,11 +62,19 @@ const useStyles = makeStyles()((theme) => ({
     position: "relative",
   },
   resetZoomButton: {
-    position: "absolute",
-    bottom: 0,
+    pointerEvents: "none",
+    position: "sticky",
+    display: "flex",
+    justifyContent: "flex-end",
+    padding: theme.spacing(0, 1, 4),
     right: 0,
-    marginBottom: theme.spacing(4),
-    marginRight: theme.spacing(1),
+    left: 0,
+    bottom: 0,
+    width: "100%",
+
+    [`.${buttonClasses.root}`]: {
+      pointerEvents: "auto",
+    },
   },
   tooltip: {
     maxWidth: "none",
@@ -761,7 +769,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   }
 
   return (
-    <Stack direction="row" fullWidth>
+    <Stack direction="row" fullWidth fullHeight>
       <Tooltip
         arrow={false}
         classes={{ tooltip: classes.tooltip }}
@@ -800,15 +808,16 @@ export default function TimeBasedChart(props: Props): JSX.Element {
             </div>
 
             {showReset && (
-              <Button
-                className={classes.resetZoomButton}
-                variant="contained"
-                color="inherit"
-                title="(shortcut: double-click)"
-                onClick={onResetZoom}
-              >
-                Reset view
-              </Button>
+              <div className={classes.resetZoomButton}>
+                <Button
+                  variant="contained"
+                  color="inherit"
+                  title="(shortcut: double-click)"
+                  onClick={onResetZoom}
+                >
+                  Reset view
+                </Button>
+              </div>
             )}
             <KeyListener global keyDownHandlers={keyDownHandlers} keyUpHandlers={keyUphandlers} />
           </div>

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -62,6 +62,7 @@ const useStyles = makeStyles()((theme) => ({
   chartWrapper: {
     position: "relative",
     marginTop: theme.spacing(0.5),
+    height: "100%",
   },
   chartOverlay: {
     top: 0,
@@ -399,8 +400,8 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   return (
     <Stack flexGrow={1} overflow="hidden" style={{ zIndex: 0 }}>
       <PanelToolbar />
-      <Stack fullWidth flex="auto" overflowX="hidden" overflowY="auto">
-        <div className={classes.chartWrapper} style={{ height }} ref={sizeRef}>
+      <Stack fullWidth fullHeight flex="auto" overflowX="hidden" overflowY="auto">
+        <div className={classes.chartWrapper} ref={sizeRef}>
           <TimeBasedChart
             zoom
             isSynced={config.isSynced}

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -404,13 +404,13 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         <div className={classes.chartWrapper} ref={sizeRef}>
           <TimeBasedChart
             zoom
-            isStateTransition
             isSynced={config.isSynced}
             showXAxisLabels
             width={width ?? 0}
             height={height}
             data={data}
             dataBounds={databounds}
+            resetButtonPaddingBottom={2}
             type="scatter"
             xAxes={xScale}
             xAxisIsPlaybackTime

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -404,6 +404,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         <div className={classes.chartWrapper} ref={sizeRef}>
           <TimeBasedChart
             zoom
+            isStateTransition
             isSynced={config.isSynced}
             showXAxisLabels
             width={width ?? 0}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Move reset zoom button so it only overlaps StateTransition chart when it has to.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
