### PR TITLE
Explicityly ignore situations where ctrl or meta keys are pressed for 3 shortcut

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -784,7 +784,7 @@ export function ThreeDeeRender(props: {
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key === "3") {
+      if (event.key === "3" && !(event.metaKey || event.ctrlKey)) {
         onTogglePerspective();
         event.stopPropagation();
         event.preventDefault();


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
3 key no longer iterferes with Tab selection

Resolves FG-5489
