### PR TITLE
Fix plot story flakiness

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -284,8 +284,14 @@ function Chart(props: Props): JSX.Element {
         const { current: queued } = queuedUpdates;
         queuedUpdates.current = [];
         for (const queuedUpdate of queued) {
-          const newScales = await sendWrapperRef.current<RpcScales>("update", queuedUpdate);
-          maybeUpdateScales(newScales);
+          void (async () => {
+            const { current } = sendWrapperRef;
+            if (current == undefined) {
+              return;
+            }
+            const newScales = await current<RpcScales>("update", queuedUpdate);
+            maybeUpdateScales(newScales);
+          });
         }
 
         // once we are initialized, we can allow other handlers to send to the rpc endpoint

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -286,14 +286,7 @@ function Chart(props: Props): JSX.Element {
         for (const queuedUpdate of queued) {
           // We do not want to block the rest of this function on these calls,
           // which can take a while (particularly on weak devices)
-          void (async () => {
-            const { current } = sendWrapperRef;
-            if (current == undefined) {
-              return;
-            }
-            const newScales = await current<RpcScales>("update", queuedUpdate);
-            maybeUpdateScales(newScales);
-          })();
+          void sendWrapperRef.current<RpcScales>("update", queuedUpdate).then(maybeUpdateScales);
         }
 
         // once we are initialized, we can allow other handlers to send to the rpc endpoint

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -24,9 +24,18 @@ import Rpc, { createLinkedChannels } from "@foxglove/studio-base/util/Rpc";
 import WebWorkerManager from "@foxglove/studio-base/util/WebWorkerManager";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
+import { getTypedLength } from "@foxglove/studio-base/components/Chart/datasets";
+
 import { TypedChartData, ChartData, RpcElement, RpcScales } from "./types";
 
 const log = Logger.getLogger(__filename);
+
+const getSize = (data: TypedChartData | undefined) => {
+  if (data == undefined) {
+    return undefined;
+  }
+  return data.datasets.map((v) => getTypedLength(v.data));
+};
 
 function makeChartJSWorker() {
   // foxglove-depcheck-used: babel-plugin-transform-import-meta
@@ -96,8 +105,11 @@ const supportsOffscreenCanvas =
 
 function Chart(props: Props): JSX.Element {
   const [id] = useState(() => uuidv4());
+  const trace = (event: string, ...args: any[]) =>
+    console.log(`${id.slice(0, 5)}: ${event}`, ...args);
 
   const initialized = useRef(false);
+  const calledAgain = useRef(false);
   const canvasRef = useRef<HTMLCanvasElement>();
   const containerRef = useRef<HTMLDivElement>(ReactNull);
   const isMounted = useMountedState();
@@ -122,6 +134,7 @@ function Chart(props: Props): JSX.Element {
     onStartRender,
     onFinishRender,
   } = props;
+  trace(`prop`, getSize(typedData));
 
   const sendWrapperRef = useRef<RpcSend | undefined>();
   const rpcSendRef = useRef<RpcSend | undefined>();
@@ -198,6 +211,7 @@ function Chart(props: Props): JSX.Element {
   // The purpose of this mechanism is to avoid sending data/options/size to the worker
   // if they are unchanged from a previous initialization or update.
   const getNewUpdateMessage = useCallback(() => {
+    trace(`getNewUpdateMessage`);
     const prev = previousUpdateMessage.current;
     const out: Partial<ChartUpdateMessage> = {};
 
@@ -215,7 +229,10 @@ function Chart(props: Props): JSX.Element {
       prev.data = out.data = data;
     }
     if (prev.typedData !== typedData) {
+      trace(`new data`, getSize(typedData));
       prev.typedData = out.typedData = typedData;
+    } else {
+      trace("data unchanged", getSize(prev.typedData), getSize(typedData));
     }
     if (prev.options !== options) {
       prev.options = out.options = options;
@@ -240,6 +257,8 @@ function Chart(props: Props): JSX.Element {
   // Update the chart with a new set of data
   const updateChart = useCallback(
     async (update: Partial<ChartUpdateMessage>) => {
+      const t = performance.now();
+      trace("updateChart", initialized.current, t, update, getSize(update.typedData));
       // first time initialization
       if (!initialized.current) {
         assert(canvasRef.current == undefined, "Canvas has already been initialized");
@@ -284,7 +303,13 @@ function Chart(props: Props): JSX.Element {
         const { current: queued } = queuedUpdates;
         queuedUpdates.current = [];
         for (const queuedUpdate of queued) {
-          void sendWrapperRef.current<RpcScales>("update", queuedUpdate);
+          void (async () => {
+            trace(`update start`, t, getSize(queuedUpdate.typedData), queuedUpdate);
+            const scales = await sendWrapperRef.current<RpcScales>("update", queuedUpdate);
+            trace("scales", scales);
+            maybeUpdateScales(scales);
+            trace(`update end`, t, getSize(queuedUpdate.typedData), queuedUpdate);
+          })();
         }
 
         // once we are initialized, we can allow other handlers to send to the rpc endpoint
@@ -300,8 +325,11 @@ function Chart(props: Props): JSX.Element {
         return;
       }
 
+      calledAgain.current = true;
+
       onStartRender?.();
       const scales = await rpcSendRef.current<RpcScales>("update", update);
+      trace(`update b`, getSize(update.typedData), update);
       maybeUpdateScales(scales);
       onFinishRender?.();
     },

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -284,13 +284,15 @@ function Chart(props: Props): JSX.Element {
         const { current: queued } = queuedUpdates;
         queuedUpdates.current = [];
         for (const queuedUpdate of queued) {
+          // We do not want to block the rest of this function on these calls,
+          // which can take a while (particularly on weak devices)
           void (async () => {
-            const { current } = sendWrapperRef
+            const { current } = sendWrapperRef;
             if (current == undefined) {
-              return
+              return;
             }
-            const scales = await current<RpcScales>("update", queuedUpdate);
-            maybeUpdateScales(scales);
+            const newScales = await current<RpcScales>("update", queuedUpdate);
+            maybeUpdateScales(newScales);
           })();
         }
 

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -284,14 +284,7 @@ function Chart(props: Props): JSX.Element {
         const { current: queued } = queuedUpdates;
         queuedUpdates.current = [];
         for (const queuedUpdate of queued) {
-          void (async () => {
-            const { current } = sendWrapperRef;
-            if (current == undefined) {
-              return;
-            }
-            const newScales = await current<RpcScales>("update", queuedUpdate);
-            maybeUpdateScales(newScales);
-          });
+          void sendWrapperRef.current<RpcScales>("update", queuedUpdate);
         }
 
         // once we are initialized, we can allow other handlers to send to the rpc endpoint

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -24,18 +24,9 @@ import Rpc, { createLinkedChannels } from "@foxglove/studio-base/util/Rpc";
 import WebWorkerManager from "@foxglove/studio-base/util/WebWorkerManager";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
-import { getTypedLength } from "@foxglove/studio-base/components/Chart/datasets";
-
 import { TypedChartData, ChartData, RpcElement, RpcScales } from "./types";
 
 const log = Logger.getLogger(__filename);
-
-const getSize = (data: TypedChartData | undefined) => {
-  if (data == undefined) {
-    return undefined;
-  }
-  return data.datasets.map((v) => getTypedLength(v.data));
-};
 
 function makeChartJSWorker() {
   // foxglove-depcheck-used: babel-plugin-transform-import-meta
@@ -105,11 +96,8 @@ const supportsOffscreenCanvas =
 
 function Chart(props: Props): JSX.Element {
   const [id] = useState(() => uuidv4());
-  const trace = (event: string, ...args: any[]) =>
-    console.log(`${id.slice(0, 5)}: ${event}`, ...args);
 
   const initialized = useRef(false);
-  const calledAgain = useRef(false);
   const canvasRef = useRef<HTMLCanvasElement>();
   const containerRef = useRef<HTMLDivElement>(ReactNull);
   const isMounted = useMountedState();
@@ -134,7 +122,6 @@ function Chart(props: Props): JSX.Element {
     onStartRender,
     onFinishRender,
   } = props;
-  trace(`prop`, getSize(typedData));
 
   const sendWrapperRef = useRef<RpcSend | undefined>();
   const rpcSendRef = useRef<RpcSend | undefined>();
@@ -211,7 +198,6 @@ function Chart(props: Props): JSX.Element {
   // The purpose of this mechanism is to avoid sending data/options/size to the worker
   // if they are unchanged from a previous initialization or update.
   const getNewUpdateMessage = useCallback(() => {
-    trace(`getNewUpdateMessage`);
     const prev = previousUpdateMessage.current;
     const out: Partial<ChartUpdateMessage> = {};
 
@@ -229,10 +215,7 @@ function Chart(props: Props): JSX.Element {
       prev.data = out.data = data;
     }
     if (prev.typedData !== typedData) {
-      trace(`new data`, getSize(typedData));
       prev.typedData = out.typedData = typedData;
-    } else {
-      trace("data unchanged", getSize(prev.typedData), getSize(typedData));
     }
     if (prev.options !== options) {
       prev.options = out.options = options;
@@ -257,8 +240,6 @@ function Chart(props: Props): JSX.Element {
   // Update the chart with a new set of data
   const updateChart = useCallback(
     async (update: Partial<ChartUpdateMessage>) => {
-      const t = performance.now();
-      trace("updateChart", initialized.current, t, update, getSize(update.typedData));
       // first time initialization
       if (!initialized.current) {
         assert(canvasRef.current == undefined, "Canvas has already been initialized");
@@ -304,11 +285,12 @@ function Chart(props: Props): JSX.Element {
         queuedUpdates.current = [];
         for (const queuedUpdate of queued) {
           void (async () => {
-            trace(`update start`, t, getSize(queuedUpdate.typedData), queuedUpdate);
-            const scales = await sendWrapperRef.current<RpcScales>("update", queuedUpdate);
-            trace("scales", scales);
+            const { current } = sendWrapperRef
+            if (current == undefined) {
+              return
+            }
+            const scales = await current<RpcScales>("update", queuedUpdate);
             maybeUpdateScales(scales);
-            trace(`update end`, t, getSize(queuedUpdate.typedData), queuedUpdate);
           })();
         }
 
@@ -325,11 +307,8 @@ function Chart(props: Props): JSX.Element {
         return;
       }
 
-      calledAgain.current = true;
-
       onStartRender?.();
       const scales = await rpcSendRef.current<RpcScales>("update", update);
-      trace(`update b`, getSize(update.typedData), update);
       maybeUpdateScales(scales);
       onFinishRender?.();
     },

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -699,13 +699,7 @@ export const LineGraphAfterZoom: StoryObj = {
 export const TimestampMethodHeaderStamp: StoryObj = {
   render: function Story() {
     const readySignal = useDebouncedReadySignal();
-    const pauseFrame = useCallback(
-      () => () => {
-        console.log("pauseFrame");
-        readySignal();
-      },
-      [readySignal],
-    );
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
       <PlotWrapper

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -391,7 +391,7 @@ function useDebouncedReadySignal(): ReadySignal {
   const readySignal = useReadySignal();
   return React.useMemo(() => {
     return _.debounce(() => {
-      readySignal()
+      readySignal();
     }, 3000);
   }, [readySignal]);
 }
@@ -1198,10 +1198,9 @@ export const IndexBasedXAxisForArray: StoryObj = {
 export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   render: function Story() {
     const readySignal = useDebouncedReadySignal();
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     const [ourFixture, setOurFixture] = useState(structuredClone(fixture));
-
-    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     useEffect(() => {
       setOurFixture((oldValue) => {
@@ -1254,7 +1253,7 @@ export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   },
 
   play: async (ctx) => {
-    await waitFor(() => ctx.parameters.storyReady);
+    await waitFor(() => ctx.parameters.storyReady, { timeout: 10000 });
   },
 };
 

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -390,7 +390,9 @@ function PlotWrapper(props: {
 function useDebouncedReadySignal(): ReadySignal {
   const readySignal = useReadySignal();
   return React.useMemo(() => {
-    return _.debounce(readySignal, 1000);
+    return _.debounce(() => {
+      readySignal()
+    }, 3000);
   }, [readySignal]);
 }
 

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -23,7 +23,7 @@ import { fromSec } from "@foxglove/rostime";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
 import { BlockCache, MessageEvent } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture, triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
-import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+import { useReadySignal, ReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 const locationMessages = [
@@ -387,6 +387,13 @@ function PlotWrapper(props: {
   );
 }
 
+function useDebouncedReadySignal(): ReadySignal {
+  const readySignal = useReadySignal();
+  return React.useMemo(() => {
+    return _.debounce(readySignal, 1000);
+  }, [readySignal]);
+}
+
 export default {
   title: "panels/Plot",
   component: Plot,
@@ -405,7 +412,7 @@ export const Empty: StoryObj = {
 
 export const LineGraph: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
   },
@@ -423,7 +430,7 @@ export const LineGraph: StoryObj = {
 
 export const LineGraphWithValuesAndDisabledSeries: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     const config = produce(exampleConfig, (draft) => {
@@ -447,7 +454,7 @@ export const LineGraphWithValuesAndDisabledSeries: StoryObj = {
 
 export const LineGraphWithXMinMax: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
       <PlotWrapper
@@ -471,7 +478,7 @@ export const LineGraphWithXMinMax: StoryObj = {
 
 export const LineGraphWithXRange: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
       <PlotWrapper
@@ -496,7 +503,7 @@ export const LineGraphWithXRange: StoryObj = {
 
 export const LineGraphWithNoTitle: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, title: undefined }} />;
   },
@@ -514,7 +521,7 @@ export const LineGraphWithNoTitle: StoryObj = {
 
 export const LineGraphWithSettings: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 2 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return (
       <PlotWrapper
@@ -566,7 +573,7 @@ export const LineGraphWithSettingsJapanese: StoryObj = {
 
 export const LineGraphWithLegendsHidden: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     return <PlotWrapper pauseFrame={pauseFrame} config={{ ...exampleConfig, showLegend: false }} />;
   },
@@ -594,7 +601,7 @@ const useStyles = makeStyles()(() => ({
 
 export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 10 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
     const { classes } = useStyles();
 
@@ -691,8 +698,14 @@ export const LineGraphAfterZoom: StoryObj = {
 
 export const TimestampMethodHeaderStamp: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
-    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+    const readySignal = useDebouncedReadySignal();
+    const pauseFrame = useCallback(
+      () => () => {
+        console.log("pauseFrame");
+        readySignal();
+      },
+      [readySignal],
+    );
 
     return (
       <PlotWrapper
@@ -725,7 +738,7 @@ export const TimestampMethodHeaderStamp: StoryObj = {
 
 export const LongPath: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -759,7 +772,7 @@ export const LongPath: StoryObj = {
 
 export const DisabledPath: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -797,7 +810,7 @@ export const DisabledPath: StoryObj = {
 
 export const HiddenConnectingLines: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -837,7 +850,7 @@ export const HiddenConnectingLines: StoryObj = {
 
 export const ReferenceLine: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -871,7 +884,7 @@ export const ReferenceLine: StoryObj = {
 
 export const WithMinAndMaxYValues: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -910,7 +923,7 @@ export const WithMinAndMaxYValues: StoryObj = {
 
 export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 5 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -944,7 +957,7 @@ export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
 
 export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 5 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -978,7 +991,7 @@ export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
 
 export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 5 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1012,7 +1025,7 @@ export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
 
 export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 5 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1046,7 +1059,7 @@ export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
 
 export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1080,7 +1093,7 @@ export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
 
 export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1114,7 +1127,7 @@ export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
 
 export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1153,7 +1166,7 @@ export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
 
 export const IndexBasedXAxisForArray: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 1 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1188,7 +1201,7 @@ export const IndexBasedXAxisForArray: StoryObj = {
 
 export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 1 });
+    const readySignal = useDebouncedReadySignal();
 
     const [ourFixture, setOurFixture] = useState(structuredClone(fixture));
 
@@ -1251,7 +1264,7 @@ export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
 
 export const CustomXAxisTopic: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1286,7 +1299,7 @@ export const CustomXAxisTopic: StoryObj = {
 
 export const CustomXAxisTopicWithXLimits: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1324,7 +1337,7 @@ export const CustomXAxisTopicWithXLimits: StoryObj = {
 
 export const CurrentCustomXAxisTopic: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 1 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     // As above, but just shows a single point instead of the whole line.
@@ -1360,7 +1373,7 @@ export const CurrentCustomXAxisTopic: StoryObj = {
 
 export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1406,7 +1419,7 @@ export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
 
 export const SuperCloseValues: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 1 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1467,7 +1480,7 @@ export const SuperCloseValues: StoryObj = {
 
 export const TimeValues: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1502,7 +1515,7 @@ export const TimeValues: StoryObj = {
 
 export const PreloadedDataInBinaryBlocks: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1533,7 +1546,7 @@ export const PreloadedDataInBinaryBlocks: StoryObj = {
 
 export const MixedStreamedAndPreloadedData: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1568,7 +1581,7 @@ export const MixedStreamedAndPreloadedData: StoryObj = {
 
 export const PreloadedDataAndItsDerivative: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1603,7 +1616,7 @@ export const PreloadedDataAndItsDerivative: StoryObj = {
 
 export const PreloadedDataAndItsNegative: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1638,7 +1651,7 @@ export const PreloadedDataAndItsNegative: StoryObj = {
 
 export const PreloadedDataAndItsAbsoluteValue: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (
@@ -1673,7 +1686,7 @@ export const PreloadedDataAndItsAbsoluteValue: StoryObj = {
 
 export const DifferentLineSizes: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 3 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (

--- a/packages/studio-base/src/stories/ReadySignalContext.ts
+++ b/packages/studio-base/src/stories/ReadySignalContext.ts
@@ -4,7 +4,7 @@
 
 import { createContext, useCallback, useContext, useRef } from "react";
 
-type ReadySignal = () => void;
+export type ReadySignal = () => void;
 
 const ReadySignalContext = createContext<ReadySignal | undefined>(undefined);
 ReadySignalContext.displayName = "ReadySignalContext";


### PR DESCRIPTION
**User-Facing Changes**
None; this is just an improvement to developer experience.

**Description**
Our plot stories have been flaky for a while, even predating the changes I made to move data processing into a worker. This PR attempts to fix these issues.

There were two main causes for flaky stories:
1. The mechanism we were using to indicate that a story was ready was error-prone, particularly after moving plot data processing to a worker, which meant that differences in timing could cause us to render an inconsistent number of times. This broke the traditional `useReadySignal({ count: N })` strategy.
2. There were (and are) significant problems with timing in the `Chart` component, which sends rendering jobs to a Web Worker that uses ChartJS.

I fixed #1 by switching to a strategy where, instead of counting the number of rerenders, we wait a certain amount of time after the last time the Chart component renders before declaring the story "ready". This may not actually fix this problem definitively because Chromatic's workers are extremely weak, but it's less error-prone than hoping we get the same number of renders every time.

For #2 I added what can only be described as a hack because that component is woefully, woefully tangled. (I'm getting flashbacks to our layout bug.) We have several interacting layers of React state (mostly refs), `async` code that can complete at any time, and then, if that weren't enough, the whole `Rpc` layer that also seems to respond to requests whenever it feels like.

The core problem is that we were [waiting for a bunch of calls to finish](https://github.com/foxglove/studio/pull/7112/files#diff-c83b85fde0ce9eb98a2d3d36cc869873cad467fc1fb3aa3f4cc48a8fe73e6b8fR286) asynchronously and then setting some state on the component, which in a compute-constrained environment could mean that several seconds have already passed. In other words, the requests in flight elsewhere were being randomly overwritten.

In my opinion, we really just need to rewrite this whole section with `getNewUpdateMessage`, the queued updates stuff, and initialization. I swear, at least half of the problems we've had with rendering and timing have been because of this code block.