### PR TITLE
Attempt to resolve `package://` asset URLs relative to URDF url

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -166,19 +166,6 @@ export function createMessagePipelineStore({
         const { protocol } = new URL(uri);
         const player = get().player;
 
-        const builtinFetch = async (url: string, opts?: { signal?: AbortSignal }) => {
-          const response = await fetch(url, opts);
-          if (!response.ok) {
-            const errMsg = response.statusText;
-            throw new Error(`Error ${response.status}${errMsg ? ` (${errMsg})` : ``}`);
-          }
-          return {
-            uri,
-            data: new Uint8Array(await response.arrayBuffer()),
-            mediaType: response.headers.get("content-type") ?? undefined,
-          };
-        };
-
         if (protocol === "package:") {
           // For the desktop app, package:// is registered as a supported schema for builtin _fetch_ calls.
           const canBuiltinFetchPkgUri = isDesktopApp();
@@ -439,4 +426,17 @@ export function reducer(
     action,
     `Unhandled message pipeline action type ${(action as MessagePipelineStateAction).type}`,
   );
+}
+
+async function builtinFetch(url: string, opts?: { signal?: AbortSignal }) {
+  const response = await fetch(url, opts);
+  if (!response.ok) {
+    const errMsg = response.statusText;
+    throw new Error(`Error ${response.status}${errMsg ? ` (${errMsg})` : ``}`);
+  }
+  return {
+    uri: url,
+    data: new Uint8Array(await response.arrayBuffer()),
+    mediaType: response.headers.get("content-type") ?? undefined,
+  };
 }

--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -186,9 +186,9 @@ export function createMessagePipelineStore({
             return await builtinFetch(uri, options);
           } else if (
             pkgName &&
-            options?.baseUrl != undefined &&
-            !options.baseUrl.startsWith("package://") &&
-            options.baseUrl.includes(pkgName)
+            options?.referenceUrl != undefined &&
+            !options.referenceUrl.startsWith("package://") &&
+            options.referenceUrl.includes(pkgName)
           ) {
             // As last resort to load the package://<pkgName>/<pkgPath> URL, we resolve the package URL to
             // be relative of the base URL (which contains <pkgName> and is not a package:// URL itself).
@@ -196,7 +196,7 @@ export function createMessagePipelineStore({
             //   base URL: https://example.com/<pkgName>/urdf/robot.urdf
             //   resolved: https://example.com/<pkgName>/<pkgPath>
             const resolvedUrl =
-              options.baseUrl.slice(0, options.baseUrl.lastIndexOf(pkgName)) + pkgPath;
+              options.referenceUrl.slice(0, options.referenceUrl.lastIndexOf(pkgName)) + pkgPath;
             return await builtinFetch(resolvedUrl, options);
           }
         }

--- a/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
@@ -63,11 +63,16 @@ export type BuiltinPanelExtensionContext = {
    * while other schemes may fall back to the data source.
    *
    * @param uri URI identifying the asset
-   * @param options Optional abort signal that allows to abort fetching of the asset. Note that this
-   * might not be supported by all fetching methods.
+   * @param options Addiotional options:
+   *  - Optional abort signal that allows to abort fetching of the asset. Note that this
+   *    might not be supported by all fetching methods.
+   *  - Optional baseUrl which may be used to resolve package:// URIs
    * @returns
    */
-  unstable_fetchAsset: (uri: string, options?: { signal: AbortSignal }) => Promise<Asset>;
+  unstable_fetchAsset: (
+    uri: string,
+    options?: { signal?: AbortSignal; baseUrl?: string },
+  ) => Promise<Asset>;
 
   /**
    * Updates the configuration for message path drag & drop support. A value of `undefined`

--- a/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
@@ -66,12 +66,12 @@ export type BuiltinPanelExtensionContext = {
    * @param options Addiotional options:
    *  - Optional abort signal that allows to abort fetching of the asset. Note that this
    *    might not be supported by all fetching methods.
-   *  - Optional baseUrl which may be used to resolve package:// URIs
+   *  - Optional referenceUrl URL which may be used to resolve package:// URIs
    * @returns
    */
   unstable_fetchAsset: (
     uri: string,
-    options?: { signal?: AbortSignal; baseUrl?: string },
+    options?: { signal?: AbortSignal; referenceUrl?: string },
   ) => Promise<Asset>;
 
   /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -29,6 +29,7 @@ export type ModelCacheOptions = {
 
 type LoadModelOptions = {
   overrideMediaType?: string;
+  baseUrl?: string;
 };
 
 export type LoadedModel = THREE.Group | THREE.Scene;
@@ -84,7 +85,7 @@ export class ModelCache {
   ): Promise<LoadedModel> {
     const GLB_MAGIC = 0x676c5446; // "glTF"
 
-    const asset = await this.#fetchAsset(url);
+    const asset = await this.#fetchAsset(url, { baseUrl: options.baseUrl });
 
     const buffer = asset.data;
     if (buffer.byteLength < 4) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -29,7 +29,8 @@ export type ModelCacheOptions = {
 
 type LoadModelOptions = {
   overrideMediaType?: string;
-  baseUrl?: string;
+  /** A URL to e.g. a URDf which may be used to resolve mesh package:// URLs */
+  referenceUrl?: string;
 };
 
 export type LoadedModel = THREE.Group | THREE.Scene;
@@ -85,7 +86,7 @@ export class ModelCache {
   ): Promise<LoadedModel> {
     const GLB_MAGIC = 0x676c5446; // "glTF"
 
-    const asset = await this.#fetchAsset(url, { baseUrl: options.baseUrl });
+    const asset = await this.#fetchAsset(url, { referenceUrl: options.referenceUrl });
 
     const buffer = asset.data;
     if (buffer.byteLength < 4) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -111,7 +111,7 @@ function createTFMessageEvent(
   };
 }
 
-const fetchAsset = async (uri: string, options?: { signal: AbortSignal }): Promise<Asset> => {
+const fetchAsset = async (uri: string, options?: { signal?: AbortSignal }): Promise<Asset> => {
   const response = await fetch(uri, options);
   return {
     uri,

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1056,7 +1056,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     this.followFrameId = frameId;
   }
 
-  public async fetchAsset(uri: string, options?: { signal: AbortSignal }): Promise<Asset> {
+  public async fetchAsset(
+    uri: string,
+    options?: { signal?: AbortSignal; baseUrl?: string },
+  ): Promise<Asset> {
     return await this.#fetchAsset(uri, options);
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -990,10 +990,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     }
   }
 
-  async #getFileFetch(url: string, baseUrl?: string): Promise<string> {
+  async #getFileFetch(url: string, referenceUrl?: string): Promise<string> {
     try {
       log.debug(`fetch(${url}) requested`);
-      const asset = await this.renderer.fetchAsset(url, { baseUrl });
+      const asset = await this.renderer.fetchAsset(url, { referenceUrl });
       return this.#textDecoder.decode(asset.data);
     } catch (err) {
       throw new Error(`Failed to fetch "${url}": ${err}`);
@@ -1088,7 +1088,9 @@ function createRenderable(args: {
       // Use embedded materials if the mesh is a Collada file
       const embedded = isCollada ? EmbeddedMaterialUsage.Use : EmbeddedMaterialUsage.Ignore;
       const marker = createMeshMarker(frameId, pose, embedded, visual.geometry, baseUrl, color);
-      return new RenderableMeshResource(name, marker, undefined, renderer, { baseUrl });
+      return new RenderableMeshResource(name, marker, undefined, renderer, {
+        referenceUrl: baseUrl,
+      });
     }
     default:
       throw new Error(`Unrecognized visual geometryType: ${type}`);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -19,6 +19,7 @@ const MESH_FETCH_FAILED = "MESH_FETCH_FAILED";
 export class RenderableMeshResource extends RenderableMarker {
   #mesh: THREE.Group | THREE.Scene | undefined;
   #material: THREE.MeshStandardMaterial;
+  #baseUrl: string | undefined;
 
   /** Track updates to avoid race conditions when asynchronously loading models */
   #updateId = 0;
@@ -28,10 +29,12 @@ export class RenderableMeshResource extends RenderableMarker {
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,
+    options?: { baseUrl?: string },
   ) {
     super(topic, marker, receiveTime, renderer);
 
     this.#material = makeStandardMaterial(marker.color);
+    this.#baseUrl = options?.baseUrl;
     this.update(marker, receiveTime, true);
   }
 
@@ -122,13 +125,17 @@ export class RenderableMeshResource extends RenderableMarker {
     url: string,
     opts: { useEmbeddedMaterials: boolean },
   ): Promise<THREE.Group | THREE.Scene | undefined> {
-    const cachedModel = await this.renderer.modelCache.load(url, {}, (err) => {
-      this.renderer.settings.errors.add(
-        this.userData.settingsPath,
-        MESH_FETCH_FAILED,
-        `Error loading mesh from "${url}": ${err.message}`,
-      );
-    });
+    const cachedModel = await this.renderer.modelCache.load(
+      url,
+      { baseUrl: this.#baseUrl },
+      (err) => {
+        this.renderer.settings.errors.add(
+          this.userData.settingsPath,
+          MESH_FETCH_FAILED,
+          `Error loading mesh from "${url}": ${err.message}`,
+        );
+      },
+    );
 
     if (!cachedModel) {
       if (!this.renderer.settings.errors.hasError(this.userData.settingsPath, MESH_FETCH_FAILED)) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -19,7 +19,7 @@ const MESH_FETCH_FAILED = "MESH_FETCH_FAILED";
 export class RenderableMeshResource extends RenderableMarker {
   #mesh: THREE.Group | THREE.Scene | undefined;
   #material: THREE.MeshStandardMaterial;
-  #baseUrl: string | undefined;
+  #referenceUrl: string | undefined;
 
   /** Track updates to avoid race conditions when asynchronously loading models */
   #updateId = 0;
@@ -29,12 +29,12 @@ export class RenderableMeshResource extends RenderableMarker {
     marker: Marker,
     receiveTime: bigint | undefined,
     renderer: IRenderer,
-    options?: { baseUrl?: string },
+    options?: { referenceUrl?: string },
   ) {
     super(topic, marker, receiveTime, renderer);
 
     this.#material = makeStandardMaterial(marker.color);
-    this.#baseUrl = options?.baseUrl;
+    this.#referenceUrl = options?.referenceUrl;
     this.update(marker, receiveTime, true);
   }
 
@@ -127,7 +127,7 @@ export class RenderableMeshResource extends RenderableMarker {
   ): Promise<THREE.Group | THREE.Scene | undefined> {
     const cachedModel = await this.renderer.modelCache.load(
       url,
-      { baseUrl: this.#baseUrl },
+      { referenceUrl: this.#referenceUrl },
       (err) => {
         this.renderer.settings.errors.add(
           this.userData.settingsPath,


### PR DESCRIPTION
**User-Facing Changes**
attempt to resolve `package://` asset URLs relative to URDF url

**Description**
Often, a URDF contains `package://` references to e.g. mesh files or xacro includes (converted to package:// URLs by [xacro-parser](https://www.npmjs.com/package/xacro-parser)). package:// resources can be loaded in 2 different ways:
- Through the player's fetchAsset method (if defined) - e.g. used for foxglove_websocket
- Through the Desktop app (if ROS_PACKAGE_PATH is defined)

This PR adds a third method in case the first two are not applicable: 

```
As last resort to load the package://<pkgName>/<pkgPath> URL, we resolve the package URL to
be relative of the base URL (which contains <pkgName> and is not a package:// URL itself).
Example:
   base URL: https://example.com/<pkgName>/urdf/robot.urdf
   resolved: https://example.com/<pkgName>/<pkgPath>
```

This allows loading entire URDFs from Github URLs, for instance:

- https://raw.githubusercontent.com/LeoRover/leo_common-ros2/humble/leo_description/urdf/leo.urdf.xacro
- https://raw.githubusercontent.com/LeoRover/leo_common-ros2/de35d0ee7/leo_description/urdf/leo.urdf.xacro
