### PR TITLE
Clear data on path change in state transition panel and show error for array data

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -315,11 +315,7 @@ export default class ChartJSManager {
       }
     }
 
-    if (data == undefined && typedData == undefined) {
-      instance.data = {
-        datasets: [],
-      };
-    } else if (data != undefined) {
+    if (data != undefined) {
       instance.data = data;
     } else if (typedData != undefined) {
       instance.data = proxyTyped(typedData);

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -315,11 +315,13 @@ export default class ChartJSManager {
       }
     }
 
-    if (data != undefined) {
+    if (data == undefined && typedData == undefined) {
+      instance.data = {
+        datasets: [],
+      };
+    } else if (data != undefined) {
       instance.data = data;
-    }
-
-    if (typedData != undefined) {
+    } else if (typedData != undefined) {
       instance.data = proxyTyped(typedData);
     }
 

--- a/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
@@ -191,12 +191,12 @@ export default function useProvider<T>(
     }
 
     const bounds = getDatasetBounds(data.datasets);
-    if (bounds == undefined) {
-      return undefined;
-    }
 
     return {
-      bounds,
+      bounds: bounds ?? {
+        x: { min: 0, max: 0 },
+        y: { min: 0, max: 0 },
+      },
       data,
     };
   }, [data, state, getDatasetBounds, mergeState]);

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -15,6 +15,7 @@ import { Add16Filled, Edit16Filled } from "@fluentui/react-icons";
 import { Button, Typography } from "@mui/material";
 import { ChartOptions, ScaleOptions } from "chart.js";
 import * as _ from "lodash-es";
+import * as R from "ramda";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import tinycolor from "tinycolor2";
@@ -251,6 +252,17 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       // negative makes each path render below the previous
       const y = (pathIndex + 1) * 6 * -1;
       outMinY = Math.min(outMinY ?? y, y - 3);
+
+      const isEmpty = R.all(
+        (block) => R.all(({ queriedData }) => queriedData.length === 0, block[path.value] ?? []),
+        decodedBlocks,
+      );
+      if (isEmpty) {
+        outDatasets = outDatasets.concat({
+          data: [],
+        });
+        return;
+      }
 
       const blocksForPath = decodedBlocks.map((decodedBlock) => decodedBlock[path.value]);
 

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -27,6 +27,7 @@ import { add as addTimes, fromSec, subtract as subtractTimes, toSec } from "@fox
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import {
   MessageDataItemsByPath,
+  MessageAndData,
   useDecodeMessagePathsForMessagesByTopic,
 } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import useMessagesByPath from "@foxglove/studio-base/components/MessagePathSyntax/useMessagesByPath";
@@ -255,12 +256,31 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       const y = (pathIndex + 1) * 6 * -1;
       outMinY = Math.min(outMinY ?? y, y - 3);
 
+      const blocksForPath = decodedBlocks.map((decodedBlock) => decodedBlock[path.value]);
+
+      const newBlockDataSets = messagesToDatasets({
+        blocks: blocksForPath,
+        path,
+        pathIndex,
+        startTime,
+        y,
+      });
+
+      // We have already filtered out paths we can find in blocks so anything left here
+      // should be included in the dataset.
+      const items = newItemsByPath[path.value];
+
       const dataCounts = R.pipe(
-        R.chain((block: MessageDataItemsByPath) =>
-          (block[path.value] ?? []).map(({ queriedData }) => queriedData.length),
-        ),
+        R.chain((data: readonly MessageAndData[] | undefined): readonly MessageAndData[] => {
+          if (data == undefined) {
+            return [];
+          }
+
+          return data;
+        }),
+        R.map((data: MessageAndData) => data.queriedData.length),
         R.uniq,
-      )(decodedBlocks);
+      )([...blocksForPath, items]);
 
       outIsArrayData.push(R.all((numPoints) => numPoints > 1, dataCounts));
 
@@ -272,22 +292,8 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         return;
       }
 
-      const blocksForPath = decodedBlocks.map((decodedBlock) => decodedBlock[path.value]);
-
-      const newBlockDataSets = messagesToDatasets({
-        blocks: blocksForPath,
-        path,
-        pathIndex,
-        startTime,
-        y,
-      });
-
       outDatasets = outDatasets.concat(newBlockDataSets);
-
-      // We have already filtered out paths we can find in blocks so anything left here
-      // should be included in the dataset.
-      const items = newItemsByPath[path.value];
-      if (items) {
+      if (items != undefined) {
         const newPathDataSets = messagesToDatasets({
           blocks: [items],
           path,

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -274,7 +274,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
           if (data == undefined) {
             return [];
           }
-          return R.map((data: MessageAndData) => data.queriedData.length, data);
+          return data.map((message: MessageAndData) => message.queriedData.length);
         }),
         R.uniq,
       )([...blocksForPath, items]);

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -269,6 +269,9 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       // We have already filtered out paths we can find in blocks so anything left here
       // should be included in the dataset.
       const items = newItemsByPath[path.value];
+
+      // We need to detect when the path produces more than one data point,
+      // since that is invalid input
       const dataCounts = R.pipe(
         R.chain((data: readonly MessageAndData[] | undefined): number[] => {
           if (data == undefined) {
@@ -279,6 +282,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         R.uniq,
       )([...blocksForPath, items]);
       const isArray = dataCounts.length > 0 && R.all((numPoints) => numPoints > 1, dataCounts);
+
       outPathState.push({
         path,
         isArray,

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -271,18 +271,15 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       const items = newItemsByPath[path.value];
 
       const dataCounts = R.pipe(
-        R.chain((data: readonly MessageAndData[] | undefined): readonly MessageAndData[] => {
+        R.chain((data: readonly MessageAndData[] | undefined): number[] => {
           if (data == undefined) {
             return [];
           }
-
-          return data;
+          return R.map((data: MessageAndData) => data.queriedData.length, data);
         }),
-        R.map((data: MessageAndData) => data.queriedData.length),
         R.uniq,
       )([...blocksForPath, items]);
-
-      outIsArrayData.push(R.all((numPoints) => numPoints > 1, dataCounts));
+      outIsArrayData.push(dataCounts.length > 0 && R.all((numPoints) => numPoints > 1, dataCounts));
 
       const isEmpty = dataCounts.length === 0;
       if (isEmpty) {

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -235,17 +235,19 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     return _.isEmpty(newItemsNotInBlocks) ? EMPTY_ITEMS_BY_PATH : newItemsNotInBlocks;
   }, [decodedBlocks, itemsByPath]);
 
-  const { datasets, minY } = useMemo(() => {
+  const { isArrayData, datasets, minY } = useMemo(() => {
     // ignore all data when we don't have a start time
     if (!startTime) {
       return {
         datasets: [],
         minY: undefined,
+        isArrayData: [],
       };
     }
 
     let outMinY: number | undefined;
     let outDatasets: ChartDatasets = [];
+    const outIsArrayData: boolean[] = [];
 
     paths.forEach((path, pathIndex) => {
       // y axis values are set based on the path we are rendering
@@ -253,10 +255,16 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       const y = (pathIndex + 1) * 6 * -1;
       outMinY = Math.min(outMinY ?? y, y - 3);
 
-      const isEmpty = R.all(
-        (block) => R.all(({ queriedData }) => queriedData.length === 0, block[path.value] ?? []),
-        decodedBlocks,
-      );
+      const dataCounts = R.pipe(
+        R.chain((block: MessageDataItemsByPath) =>
+          (block[path.value] ?? []).map(({ queriedData }) => queriedData.length),
+        ),
+        R.uniq,
+      )(decodedBlocks);
+
+      outIsArrayData.push(R.all((numPoints) => numPoints > 1, dataCounts));
+
+      const isEmpty = dataCounts.length === 0;
       if (isEmpty) {
         outDatasets = outDatasets.concat({
           data: [],
@@ -294,6 +302,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     return {
       datasets: outDatasets,
       minY: outMinY,
+      isArrayData: outIsArrayData,
     };
   }, [decodedBlocks, newItemsByPath, paths, startTime]);
 
@@ -406,7 +415,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   const data: ChartData = useShallowMemo({ datasets });
 
-  useStateTransitionsPanelSettings(config, saveConfig, focusedPath);
+  useStateTransitionsPanelSettings(config, saveConfig, isArrayData, focusedPath);
 
   return (
     <Stack flexGrow={1} overflow="hidden" style={{ zIndex: 0 }}>

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -269,7 +269,6 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       // We have already filtered out paths we can find in blocks so anything left here
       // should be included in the dataset.
       const items = newItemsByPath[path.value];
-
       const dataCounts = R.pipe(
         R.chain((data: readonly MessageAndData[] | undefined): number[] => {
           if (data == undefined) {
@@ -280,26 +279,19 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         R.uniq,
       )([...blocksForPath, items]);
       outIsArrayData.push(dataCounts.length > 0 && R.all((numPoints) => numPoints > 1, dataCounts));
+      outDatasets = outDatasets.concat(newBlockDataSets);
 
-      const isEmpty = dataCounts.length === 0;
-      if (isEmpty) {
-        outDatasets = outDatasets.concat({
-          data: [],
-        });
+      if (items == undefined) {
         return;
       }
-
-      outDatasets = outDatasets.concat(newBlockDataSets);
-      if (items != undefined) {
-        const newPathDataSets = messagesToDatasets({
-          blocks: [items],
-          path,
-          pathIndex,
-          startTime,
-          y,
-        });
-        outDatasets = outDatasets.concat(newPathDataSets);
-      }
+      const newPathDataSets = messagesToDatasets({
+        blocks: [items],
+        path,
+        pathIndex,
+        startTime,
+        y,
+      });
+      outDatasets = outDatasets.concat(newPathDataSets);
     });
 
     return {

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -52,7 +52,7 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fontMonospace } from "@foxglove/theme";
 
 import messagesToDatasets from "./messagesToDatasets";
-import { useStateTransitionsPanelSettings } from "./settings";
+import { PathState, useStateTransitionsPanelSettings } from "./settings";
 import { DEFAULT_PATH, stateTransitionPathDisplayName } from "./shared";
 import { StateTransitionConfig } from "./types";
 
@@ -236,19 +236,19 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     return _.isEmpty(newItemsNotInBlocks) ? EMPTY_ITEMS_BY_PATH : newItemsNotInBlocks;
   }, [decodedBlocks, itemsByPath]);
 
-  const { isArrayData, datasets, minY } = useMemo(() => {
+  const { pathState, datasets, minY } = useMemo(() => {
     // ignore all data when we don't have a start time
     if (!startTime) {
       return {
         datasets: [],
         minY: undefined,
-        isArrayData: [],
+        pathState: [],
       };
     }
 
     let outMinY: number | undefined;
     let outDatasets: ChartDatasets = [];
-    const outIsArrayData: boolean[] = [];
+    const outPathState: PathState[] = [];
 
     paths.forEach((path, pathIndex) => {
       // y axis values are set based on the path we are rendering
@@ -278,7 +278,11 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         }),
         R.uniq,
       )([...blocksForPath, items]);
-      outIsArrayData.push(dataCounts.length > 0 && R.all((numPoints) => numPoints > 1, dataCounts));
+      const isArray = dataCounts.length > 0 && R.all((numPoints) => numPoints > 1, dataCounts);
+      outPathState.push({
+        path,
+        isArray,
+      });
       outDatasets = outDatasets.concat(newBlockDataSets);
 
       if (items == undefined) {
@@ -297,7 +301,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     return {
       datasets: outDatasets,
       minY: outMinY,
-      isArrayData: outIsArrayData,
+      pathState: outPathState,
     };
   }, [decodedBlocks, newItemsByPath, paths, startTime]);
 
@@ -410,7 +414,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   const data: ChartData = useShallowMemo({ datasets });
 
-  useStateTransitionsPanelSettings(config, saveConfig, isArrayData, focusedPath);
+  useStateTransitionsPanelSettings(config, saveConfig, pathState, focusedPath);
 
   return (
     <Stack flexGrow={1} overflow="hidden" style={{ zIndex: 0 }}>

--- a/packages/studio-base/src/panels/StateTransitions/settings.ts
+++ b/packages/studio-base/src/panels/StateTransitions/settings.ts
@@ -21,15 +21,15 @@ import { StateTransitionConfig, StateTransitionPath } from "./types";
 // at the level of individual nodes in our tree. This keeps our DOM updates small since
 // the NodeEditor component is wrapped in a React.memo.
 
-type SeriesOptions = {
+export type PathState = {
+  path: StateTransitionPath;
+  // Whether the data the path refers to resolves to more than one value
   isArray: boolean;
-  canDelete: boolean;
 };
 const makeSeriesNode = memoizeWeak(
   (
-    path: StateTransitionPath,
     index: number,
-    { canDelete, isArray }: SeriesOptions,
+    { path, canDelete, isArray }: PathState & { canDelete: boolean },
   ): SettingsTreeNode => {
     return {
       actions: canDelete
@@ -71,38 +71,37 @@ const makeSeriesNode = memoizeWeak(
   },
 );
 
-const makeRootSeriesNode = memoizeWeak(
-  (paths: StateTransitionPath[], isArrayData: boolean[]): SettingsTreeNode => {
-    const children = Object.fromEntries(
-      paths.length === 0
-        ? [["0", makeSeriesNode(DEFAULT_PATH, 0, { isArray: false, canDelete: false })]]
-        : paths.map((path, index) => [
-            `${index}`,
-            makeSeriesNode(path, index, {
-              isArray: isArrayData[index] ?? false,
-              canDelete: true,
-            }),
-          ]),
-    );
-    return {
-      label: "Series",
-      children,
-      actions: [
-        {
-          type: "action",
-          id: "add-series",
-          label: "Add series",
-          display: "inline",
-          icon: "Addchart",
-        },
-      ],
-    };
-  },
-);
+const makeRootSeriesNode = memoizeWeak((paths: PathState[]): SettingsTreeNode => {
+  const children = Object.fromEntries(
+    paths.length === 0
+      ? [["0", makeSeriesNode(0, { path: DEFAULT_PATH, isArray: false, canDelete: false })]]
+      : paths.map(({ path, isArray }, index) => [
+          `${index}`,
+          makeSeriesNode(index, {
+            path,
+            isArray,
+            canDelete: true,
+          }),
+        ]),
+  );
+  return {
+    label: "Series",
+    children,
+    actions: [
+      {
+        type: "action",
+        id: "add-series",
+        label: "Add series",
+        display: "inline",
+        icon: "Addchart",
+      },
+    ],
+  };
+});
 
 function buildSettingsTree(
   config: StateTransitionConfig,
-  isArrayData: boolean[],
+  paths: PathState[],
   t: TFunction<"stateTransitions">,
 ): SettingsTreeNodes {
   const maxXError =
@@ -143,14 +142,14 @@ function buildSettingsTree(
         },
       },
     },
-    paths: makeRootSeriesNode(config.paths, isArrayData),
+    paths: makeRootSeriesNode(paths),
   };
 }
 
 export function useStateTransitionsPanelSettings(
   config: StateTransitionConfig,
   saveConfig: SaveConfig<StateTransitionConfig>,
-  isArrayData: boolean[],
+  paths: PathState[],
   focusedPath?: readonly string[],
 ): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
@@ -215,7 +214,7 @@ export function useStateTransitionsPanelSettings(
     updatePanelSettingsTree({
       actionHandler,
       focusedPath,
-      nodes: buildSettingsTree(config, isArrayData, t),
+      nodes: buildSettingsTree(config, paths, t),
     });
-  }, [actionHandler, config, focusedPath, t, updatePanelSettingsTree, isArrayData]);
+  }, [actionHandler, paths, config, focusedPath, t, updatePanelSettingsTree]);
 }

--- a/packages/studio-base/src/panels/StateTransitions/settings.ts
+++ b/packages/studio-base/src/panels/StateTransitions/settings.ts
@@ -21,14 +21,15 @@ import { StateTransitionConfig, StateTransitionPath } from "./types";
 // at the level of individual nodes in our tree. This keeps our DOM updates small since
 // the NodeEditor component is wrapped in a React.memo.
 
+type SeriesOptions = {
+  isArray: boolean;
+  canDelete: boolean;
+};
 const makeSeriesNode = memoizeWeak(
   (
     path: StateTransitionPath,
     index: number,
-    // eslint-disable-next-line @foxglove/no-boolean-parameters
-    isArray: boolean,
-    // eslint-disable-next-line @foxglove/no-boolean-parameters
-    canDelete: boolean,
+    { canDelete, isArray }: SeriesOptions,
   ): SettingsTreeNode => {
     return {
       actions: canDelete
@@ -74,15 +75,13 @@ const makeRootSeriesNode = memoizeWeak(
   (paths: StateTransitionPath[], isArrayData: boolean[]): SettingsTreeNode => {
     const children = Object.fromEntries(
       paths.length === 0
-        ? [["0", makeSeriesNode(DEFAULT_PATH, 0, /*isArray=*/ false, /*canDelete=*/ false)]]
+        ? [["0", makeSeriesNode(DEFAULT_PATH, 0, { isArray: false, canDelete: false })]]
         : paths.map((path, index) => [
             `${index}`,
-            makeSeriesNode(
-              path,
-              index,
-              /*isArray=*/ isArrayData[index] ?? false,
-              /*canDelete=*/ true,
-            ),
+            makeSeriesNode(path, index, {
+              isArray: isArrayData[index] ?? false,
+              canDelete: true,
+            }),
           ]),
     );
     return {

--- a/packages/studio-base/src/panels/StateTransitions/settings.ts
+++ b/packages/studio-base/src/panels/StateTransitions/settings.ts
@@ -22,8 +22,14 @@ import { StateTransitionConfig, StateTransitionPath } from "./types";
 // the NodeEditor component is wrapped in a React.memo.
 
 const makeSeriesNode = memoizeWeak(
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  (path: StateTransitionPath, index: number, canDelete: boolean): SettingsTreeNode => {
+  (
+    path: StateTransitionPath,
+    index: number,
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    isArray: boolean,
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    canDelete: boolean,
+  ): SettingsTreeNode => {
     return {
       actions: canDelete
         ? [
@@ -43,6 +49,7 @@ const makeSeriesNode = memoizeWeak(
           input: "messagepath",
           value: path.value,
           validTypes: plotableRosTypes,
+          ...(isArray ? { error: "This path resolves to more than one value" } : {}),
         },
         label: {
           input: "string",
@@ -63,29 +70,40 @@ const makeSeriesNode = memoizeWeak(
   },
 );
 
-const makeRootSeriesNode = memoizeWeak((paths: StateTransitionPath[]): SettingsTreeNode => {
-  const children = Object.fromEntries(
-    paths.length === 0
-      ? [["0", makeSeriesNode(DEFAULT_PATH, 0, /*canDelete=*/ false)]]
-      : paths.map((path, index) => [`${index}`, makeSeriesNode(path, index, /*canDelete=*/ true)]),
-  );
-  return {
-    label: "Series",
-    children,
-    actions: [
-      {
-        type: "action",
-        id: "add-series",
-        label: "Add series",
-        display: "inline",
-        icon: "Addchart",
-      },
-    ],
-  };
-});
+const makeRootSeriesNode = memoizeWeak(
+  (paths: StateTransitionPath[], isArrayData: boolean[]): SettingsTreeNode => {
+    const children = Object.fromEntries(
+      paths.length === 0
+        ? [["0", makeSeriesNode(DEFAULT_PATH, 0, /*isArray=*/ false, /*canDelete=*/ false)]]
+        : paths.map((path, index) => [
+            `${index}`,
+            makeSeriesNode(
+              path,
+              index,
+              /*isArray=*/ isArrayData[index] ?? false,
+              /*canDelete=*/ true,
+            ),
+          ]),
+    );
+    return {
+      label: "Series",
+      children,
+      actions: [
+        {
+          type: "action",
+          id: "add-series",
+          label: "Add series",
+          display: "inline",
+          icon: "Addchart",
+        },
+      ],
+    };
+  },
+);
 
 function buildSettingsTree(
   config: StateTransitionConfig,
+  isArrayData: boolean[],
   t: TFunction<"stateTransitions">,
 ): SettingsTreeNodes {
   const maxXError =
@@ -126,13 +144,14 @@ function buildSettingsTree(
         },
       },
     },
-    paths: makeRootSeriesNode(config.paths),
+    paths: makeRootSeriesNode(config.paths, isArrayData),
   };
 }
 
 export function useStateTransitionsPanelSettings(
   config: StateTransitionConfig,
   saveConfig: SaveConfig<StateTransitionConfig>,
+  isArrayData: boolean[],
   focusedPath?: readonly string[],
 ): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
@@ -197,7 +216,7 @@ export function useStateTransitionsPanelSettings(
     updatePanelSettingsTree({
       actionHandler,
       focusedPath,
-      nodes: buildSettingsTree(config, t),
+      nodes: buildSettingsTree(config, isArrayData, t),
     });
-  }, [actionHandler, config, focusedPath, t, updatePanelSettingsTree]);
+  }, [actionHandler, config, focusedPath, t, updatePanelSettingsTree, isArrayData]);
 }


### PR DESCRIPTION
**User-Facing Changes**
In the state transition panel, changing a path to an invalid one will correctly remove the existing data.
We also now show an error when the user's path refers to array data.

**Description**
These tasks were very similar, so I combined them.

<img width="496" alt="image" src="https://github.com/foxglove/studio/assets/4588553/950567f9-3ba6-4dcd-aa54-7de768b59487">


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
