### PR TITLE
Restore download CSV button

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -309,7 +309,12 @@ function Plot(props: Props) {
     >
       <PanelToolbar
         additionalIcons={[
-          <ToolbarIconButton key="download-csv" title="Download as CSV" onClick={handleDownloadCSV}>
+          <ToolbarIconButton
+            disabled={yAxisPaths.length === 0}
+            key="download-csv"
+            title="Download as CSV"
+            onClick={handleDownloadCSV}
+          >
             <DownloadIcon />
           </ToolbarIconButton>,
         ]}


### PR DESCRIPTION
**User-Facing Changes**
<img width="620" alt="Screen Shot 2023-11-16 at 11 13 07 am" src="https://github.com/foxglove/studio/assets/924528/2945fe07-c251-440a-a2d6-3d6707a71b40">


**Description**
Allow user to download Plot Data as CSV

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
