### PR TITLE
Fix incorrect removal of unused topics from preload cache

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -340,6 +340,19 @@ export class BlockLoader {
         }
 
         const existingBlock = this.#blocks[currentBlockId];
+
+        // Calculate size of messages in the existing block that will be overridden.
+        // These have to be taken into account when calculating the size of the new block.
+        let overridenBlockMessagesSize = 0;
+        for (const topic of Object.keys(messagesByTopic)) {
+          const messages = existingBlock?.messagesByTopic[topic];
+          if (messages) {
+            overridenBlockMessagesSize += messages.reduce((acc, msg) => acc + msg.sizeInBytes, 0);
+          }
+        }
+        const newBlockSizeInBytes =
+          (existingBlock?.sizeInBytes ?? 0) - overridenBlockMessagesSize + sizeInBytes;
+
         this.#blocks[currentBlockId] = {
           needTopics: new Map(),
           messagesByTopic: {
@@ -347,8 +360,12 @@ export class BlockLoader {
             // Any new topics override the same previous topic
             ...messagesByTopic,
           },
-          sizeInBytes: (existingBlock?.sizeInBytes ?? 0) + sizeInBytes,
+          sizeInBytes: newBlockSizeInBytes,
         };
+
+        // Subtract the size of overridden messages from the the total size of all blocks.
+        // (The size of new messages is already added above).
+        totalBlockSizeBytes -= overridenBlockMessagesSize;
 
         progress(this.#calculateProgress(topics));
       }

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -113,7 +113,8 @@ export class BlockLoader {
   }
 
   /**
-   * Remove topics that are no longer requested to be preloaded from blocks to free up space
+   * Remove topics that are no longer requested to be preloaded or topics that will be re-loaded
+   * from blocks to free up space
    */
   #removeUnusedBlockTopics(): number {
     const topics = this.#topics;
@@ -127,8 +128,9 @@ export class BlockLoader {
         };
         const blockTopics = Object.keys(newMessagesByTopic);
         for (const topic of blockTopics) {
-          // remove topics that are no longer requested to be preloaded.
-          if (!topics.has(topic) && newMessagesByTopic[topic]) {
+          // remove topics that are no longer requested to be preloaded and topics that will
+          // be re-loaded (due to different subscription parameters)
+          if ((!topics.has(topic) || block.needTopics.has(topic)) && newMessagesByTopic[topic]) {
             for (const msg of newMessagesByTopic[topic]!) {
               blockBytesRemoved += msg.sizeInBytes;
             }


### PR DESCRIPTION
**User-Facing Changes**
Fix removal of unused topics of the preloaded topics cache 

**Description**
When the block loader cache exceeds its limit, we attempt to remove already preloaded topics that are not needed anymore from existing blocks. We were however only checking for topic name equality and did not take into account if the subscription payload (e.g. message slicing fields) are different. This PR fixes it.
