### PR TITLE
Raise error if channel schema is empty

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -25,6 +25,8 @@ export type ParsedChannel = {
   datatypes: MessageDefinitionMap;
 };
 
+const KNOWN_EMPTY_SCHEMA_NAMES = ["std_msgs/Empty", "std_msgs/msg/Empty"];
+
 function parseIDLDefinitionsToDatatypes(
   parsedDefinitions: IDLMessageDefinition[],
   rootName?: string,
@@ -77,6 +79,14 @@ function parsedDefinitionsToDatatypes(
  * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-encodings.md
  */
 export function parseChannel(channel: Channel): ParsedChannel {
+  // We expect the schema to be non-empty unless the schema name is one of the well-known empty schema names.
+  if (
+    channel.schema?.data.length === 0 &&
+    !KNOWN_EMPTY_SCHEMA_NAMES.includes(channel.schema.name)
+  ) {
+    throw new Error(`Schema for ${channel.schema.name} is empty`);
+  }
+
   if (channel.messageEncoding === "json") {
     if (channel.schema != undefined && channel.schema.encoding !== "jsonschema") {
       throw new Error(

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -79,8 +79,10 @@ function parsedDefinitionsToDatatypes(
  * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-encodings.md
  */
 export function parseChannel(channel: Channel): ParsedChannel {
-  // We expect the schema to be non-empty unless the schema name is one of the well-known empty schema names.
+  // For ROS schemas, we expect the schema to be non-empty unless the
+  // schema name is one of the well-known empty schema names.
   if (
+    ["ros1msg", "ros2msg", "ros2idl"].includes(channel.schema?.encoding ?? "") &&
     channel.schema?.data.length === 0 &&
     !KNOWN_EMPTY_SCHEMA_NAMES.includes(channel.schema.name)
   ) {


### PR DESCRIPTION
**User-Facing Changes**
Raise error if channel schema is empty for a ROS channel.

**Description**
Raises an error if the channel schema data is empty and the schema name is not one of the well-known empty schemas ( `std_msgs/Empty` or `std_msgs/msg/Empty`). An empty schema is often a sign that something went wrong when recording messages (e.g. message definition could not be found). This change makes sure that this problem is surfaced to the user.

Resolves FG-5451