### PR TITLE
Do not assume 0 bytes for size of sliced messages

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -18,7 +18,7 @@ import {
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
 import {
   OBJECT_BASE_SIZE,
-  estimateMessageObjectSize,
+  estimateMessageFieldSizes,
 } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
@@ -35,7 +35,7 @@ export class McapIndexedIterableSource implements IIterableSource {
       schemaName: string | undefined;
       // Guesstimate of the memory size in bytes of a deserialized message object
       approxDeserializedMsgSize: number;
-      msgSizeByField: Map<string, number>;
+      msgSizeByField: Record<string, number>;
     }
   >();
   #start?: Time;
@@ -74,29 +74,21 @@ export class McapIndexedIterableSource implements IIterableSource {
         continue;
       }
 
-      let parsedChannel: ParsedChannel;
+      let parsedChannel;
       let approxDeserializedMsgSize;
-      const msgSizeByField = new Map<string, number>();
+      let msgSizeByField;
       try {
         parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
         // Determine the size of each schema sub-field. This is going to be used for estimating
         // the size of sliced messages.
-        parsedChannel.datatypes.get(schema?.name ?? "")?.definitions.forEach((field) => {
-          const fieldSchemaName = `${schema?.name}-${field.name}`;
-          const fieldSizeInBytes = estimateMessageObjectSize(
-            new Map([
-              [fieldSchemaName, { name: fieldSchemaName, definitions: [field] }],
-              ...parsedChannel.datatypes,
-            ]),
-            fieldSchemaName,
-            estimatedObjectSizeByType,
-          );
-          // Subtract the object base size here, it will be added only once per sliced message object.
-          msgSizeByField.set(field.name, fieldSizeInBytes - OBJECT_BASE_SIZE);
-        });
+        msgSizeByField = estimateMessageFieldSizes(
+          parsedChannel.datatypes,
+          schema?.name ?? "",
+          estimatedObjectSizeByType,
+        );
         // Since we know already the sizes of each individual sub-field, we just sum them up to get the
-        // total message size.
-        approxDeserializedMsgSize = [...msgSizeByField.values()].reduce(
+        // total message size. Note that the minimum size is OBJECT_BASE_SIZE.
+        approxDeserializedMsgSize = Object.values(msgSizeByField).reduce(
           (acc, fieldSize) => acc + fieldSize,
           OBJECT_BASE_SIZE,
         );
@@ -174,15 +166,15 @@ export class McapIndexedIterableSource implements IIterableSource {
 
     // Estimate memory size for sliced messages. We pre-calculate the total size here to avoid
     // multiple field-size lookups when iterating over messages.
-    const slicedMsgSizeByChannelId = new Map<number, number>();
+    const slicedMsgSizeByChannelId: Record<number, number> = {};
     for (const [channelId, channelInfo] of this.#channelInfoById.entries()) {
       const fields = args.topics.get(channelInfo.channel.topic)?.fields;
       if (fields != undefined) {
         const sizeInBytes = fields.reduce(
-          (acc, field) => acc + (channelInfo.msgSizeByField.get(field) ?? 0),
+          (acc, field) => acc + (channelInfo.msgSizeByField[field] ?? 0),
           OBJECT_BASE_SIZE,
         );
-        slicedMsgSizeByChannelId.set(channelId, sizeInBytes);
+        slicedMsgSizeByChannelId[channelId] = sizeInBytes;
       }
     }
 
@@ -211,7 +203,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         const sizeInBytes =
           spec?.fields == undefined
             ? Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize)
-            : slicedMsgSizeByChannelId.get(message.channelId) ?? OBJECT_BASE_SIZE;
+            : slicedMsgSizeByChannelId[message.channelId] ?? OBJECT_BASE_SIZE;
 
         yield {
           type: "message-event",

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -172,6 +172,20 @@ export class McapIndexedIterableSource implements IIterableSource {
 
     const topicNames = Array.from(topics.keys());
 
+    // Estimate memory size for sliced messages. We pre-calculate the total size here to avoid
+    // multiple field-size lookups when iterating over messages.
+    const slicedMsgSizeByChannelId = new Map<number, number>();
+    for (const [channelId, channelInfo] of this.#channelInfoById.entries()) {
+      const fields = args.topics.get(channelInfo.channel.topic)?.fields;
+      if (fields != undefined) {
+        const sizeInBytes = fields.reduce(
+          (acc, field) => acc + (channelInfo.msgSizeByField.get(field) ?? 0),
+          OBJECT_BASE_SIZE,
+        );
+        slicedMsgSizeByChannelId.set(channelId, sizeInBytes);
+      }
+    }
+
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
       endTime: toNanoSec(end),
@@ -197,10 +211,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         const sizeInBytes =
           spec?.fields == undefined
             ? Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize)
-            : spec.fields.reduce(
-                (acc, field) => acc + (channelInfo.msgSizeByField.get(field) ?? 0),
-                OBJECT_BASE_SIZE,
-              );
+            : slicedMsgSizeByChannelId.get(message.channelId) ?? OBJECT_BASE_SIZE;
 
         yield {
           type: "message-event",

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -17,7 +17,6 @@ import {
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
 import {
-  HEAP_NUMBER_SIZE,
   OBJECT_BASE_SIZE,
   estimateMessageObjectSize,
 } from "@foxglove/studio-base/players/messageMemoryEstimation";
@@ -157,6 +156,31 @@ export class McapIndexedIterableSource implements IIterableSource {
 
     const topicNames = Array.from(topics.keys());
 
+    // Estimate memory size of sliced schemas.
+    const slicedMessageMemSize = new Map<number, number>();
+    const estimatedObjectSizeByType = new Map<string, number>(); // For caching purposes
+    for (const [channelId, channelInfo] of this.#channelInfoById.entries()) {
+      const fields = args.topics.get(channelInfo.channel.topic)?.fields;
+      if (fields != undefined && channelInfo.schemaName != undefined) {
+        const rootDatatype = channelInfo.parsedChannel.datatypes.get(channelInfo.schemaName);
+        const pickedRootDatatype = {
+          name: channelInfo.schemaName,
+          definitions:
+            rootDatatype?.definitions.filter((definition) => fields.includes(definition.name)) ??
+            [],
+        };
+        const sizeInBytes = estimateMessageObjectSize(
+          new Map([
+            ...channelInfo.parsedChannel.datatypes,
+            [channelInfo.schemaName, pickedRootDatatype],
+          ]),
+          channelInfo.schemaName,
+          estimatedObjectSizeByType,
+        );
+        slicedMessageMemSize.set(channelId, sizeInBytes);
+      }
+    }
+
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
       endTime: toNanoSec(end),
@@ -182,7 +206,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         const sizeInBytes =
           spec?.fields == undefined
             ? Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize)
-            : OBJECT_BASE_SIZE + spec.fields.length * HEAP_NUMBER_SIZE; // Approximate object size by assuming fields to be floats
+            : slicedMessageMemSize.get(message.channelId) ?? OBJECT_BASE_SIZE;
 
         yield {
           type: "message-event",

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -16,7 +16,11 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
-import { estimateMessageObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
+import {
+  HEAP_NUMBER_SIZE,
+  OBJECT_BASE_SIZE,
+  estimateMessageObjectSize,
+} from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -175,10 +179,10 @@ export class McapIndexedIterableSource implements IIterableSource {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
         const spec = args.topics.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
-        const sizeInBytes = Math.max(
-          message.data.byteLength,
-          channelInfo.approxDeserializedMsgSize,
-        );
+        const sizeInBytes =
+          spec?.fields == undefined
+            ? Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize)
+            : OBJECT_BASE_SIZE + spec.fields.length * HEAP_NUMBER_SIZE; // Approximate object size by assuming fields to be floats
 
         yield {
           type: "message-event",
@@ -187,10 +191,7 @@ export class McapIndexedIterableSource implements IIterableSource {
             receiveTime: fromNanoSec(message.logTime),
             publishTime: fromNanoSec(message.publishTime),
             message: payload,
-            // Treat sliced messages as zero bytes. This is a rough approximation of course but the
-            // alternative is taking the performance hit of sizing the sliced fields for each
-            // message.
-            sizeInBytes: spec?.fields == undefined ? sizeInBytes : 0,
+            sizeInBytes,
             schemaName: channelInfo.schemaName ?? "",
           },
         };

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -35,6 +35,7 @@ export class McapIndexedIterableSource implements IIterableSource {
       schemaName: string | undefined;
       // Guesstimate of the memory size in bytes of a deserialized message object
       approxDeserializedMsgSize: number;
+      msgSizeByField: Map<string, number>;
     }
   >();
   #start?: Time;
@@ -73,18 +74,32 @@ export class McapIndexedIterableSource implements IIterableSource {
         continue;
       }
 
-      let parsedChannel;
+      let parsedChannel: ParsedChannel;
       let approxDeserializedMsgSize;
+      const msgSizeByField = new Map<string, number>();
       try {
         parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
-        approxDeserializedMsgSize =
-          schema?.name != undefined
-            ? estimateMessageObjectSize(
-                parsedChannel.datatypes,
-                schema.name,
-                estimatedObjectSizeByType,
-              )
-            : 0;
+        // Determine the size of each schema sub-field. This is going to be used for estimating
+        // the size of sliced messages.
+        parsedChannel.datatypes.get(schema?.name ?? "")?.definitions.forEach((field) => {
+          const fieldSchemaName = `${schema?.name}-${field.name}`;
+          const fieldSizeInBytes = estimateMessageObjectSize(
+            new Map([
+              [fieldSchemaName, { name: fieldSchemaName, definitions: [field] }],
+              ...parsedChannel.datatypes,
+            ]),
+            fieldSchemaName,
+            estimatedObjectSizeByType,
+          );
+          // Subtract the object base size here, it will be added only once per sliced message object.
+          msgSizeByField.set(field.name, fieldSizeInBytes - OBJECT_BASE_SIZE);
+        });
+        // Since we know already the sizes of each individual sub-field, we just sum them up to get the
+        // total message size.
+        approxDeserializedMsgSize = [...msgSizeByField.values()].reduce(
+          (acc, fieldSize) => acc + fieldSize,
+          OBJECT_BASE_SIZE,
+        );
       } catch (error) {
         problems.push({
           severity: "error",
@@ -98,6 +113,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         parsedChannel,
         schemaName: schema?.name,
         approxDeserializedMsgSize,
+        msgSizeByField,
       });
 
       let topic = topicsByName.get(channel.topic);
@@ -156,31 +172,6 @@ export class McapIndexedIterableSource implements IIterableSource {
 
     const topicNames = Array.from(topics.keys());
 
-    // Estimate memory size of sliced schemas.
-    const slicedMessageMemSize = new Map<number, number>();
-    const estimatedObjectSizeByType = new Map<string, number>(); // For caching purposes
-    for (const [channelId, channelInfo] of this.#channelInfoById.entries()) {
-      const fields = args.topics.get(channelInfo.channel.topic)?.fields;
-      if (fields != undefined && channelInfo.schemaName != undefined) {
-        const rootDatatype = channelInfo.parsedChannel.datatypes.get(channelInfo.schemaName);
-        const pickedRootDatatype = {
-          name: channelInfo.schemaName,
-          definitions:
-            rootDatatype?.definitions.filter((definition) => fields.includes(definition.name)) ??
-            [],
-        };
-        const sizeInBytes = estimateMessageObjectSize(
-          new Map([
-            ...channelInfo.parsedChannel.datatypes,
-            [channelInfo.schemaName, pickedRootDatatype],
-          ]),
-          channelInfo.schemaName,
-          estimatedObjectSizeByType,
-        );
-        slicedMessageMemSize.set(channelId, sizeInBytes);
-      }
-    }
-
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
       endTime: toNanoSec(end),
@@ -206,7 +197,10 @@ export class McapIndexedIterableSource implements IIterableSource {
         const sizeInBytes =
           spec?.fields == undefined
             ? Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize)
-            : slicedMessageMemSize.get(message.channelId) ?? OBJECT_BASE_SIZE;
+            : spec.fields.reduce(
+                (acc, field) => acc + (channelInfo.msgSizeByField.get(field) ?? 0),
+                OBJECT_BASE_SIZE,
+              );
 
         yield {
           type: "message-event",

--- a/packages/studio-base/src/players/messageMemoryEstimation.test.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.test.ts
@@ -2,7 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { estimateMessageObjectSize } from "./messageMemoryEstimation";
+import {
+  estimateMessageObjectSize,
+  estimateMessageFieldSizes,
+  OBJECT_BASE_SIZE,
+} from "./messageMemoryEstimation";
 
 describe("memoryEstimation", () => {
   it("size for empty schema is greater than 0", () => {
@@ -99,4 +103,26 @@ describe("memoryEstimation", () => {
       );
     },
   );
+
+  it("sum of field sizes matches total object size", () => {
+    const datatypes = new Map([
+      [
+        "ComplexType",
+        {
+          definitions: [
+            { type: "int32", name: "field1" },
+            { type: "bool", name: "field2" },
+          ],
+        },
+      ],
+    ]);
+
+    const fieldSizes = estimateMessageFieldSizes(datatypes, "ComplexType", new Map());
+    const msgSizeInBytes = estimateMessageObjectSize(datatypes, "ComplexType", new Map());
+    const fieldSizesSum = Object.values(fieldSizes).reduce(
+      (acc, fieldSize) => acc + fieldSize,
+      OBJECT_BASE_SIZE,
+    );
+    expect(fieldSizesSum).toEqual(msgSizeInBytes);
+  });
 });

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -11,7 +11,7 @@ const COMPRESSED_POINTER_SIZE = 4; // Pointers use 4 bytes (also on 64-bit syste
 export const OBJECT_BASE_SIZE = 3 * COMPRESSED_POINTER_SIZE; // 3 compressed pointers
 const TYPED_ARRAY_BASE_SIZE = 25 * COMPRESSED_POINTER_SIZE; // byteLength, byteOffset, ..., see https://stackoverflow.com/a/45808835
 const SMALL_INTEGER_SIZE = COMPRESSED_POINTER_SIZE; // Small integers (up to 31 bits), pointer tagging
-export const HEAP_NUMBER_SIZE = 8 + 2 * COMPRESSED_POINTER_SIZE; // 4-byte map pointer + 8-byte payload + property pointer
+const HEAP_NUMBER_SIZE = 8 + 2 * COMPRESSED_POINTER_SIZE; // 4-byte map pointer + 8-byte payload + property pointer
 const FIELD_SIZE_BY_PRIMITIVE: Record<string, number> = {
   bool: SMALL_INTEGER_SIZE,
   int8: SMALL_INTEGER_SIZE,

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -8,10 +8,10 @@ import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
  * Values of the contants below are a (more or less) informed guesses and not guaranteed to be accurate.
  */
 const COMPRESSED_POINTER_SIZE = 4; // Pointers use 4 bytes (also on 64-bit systems) due to pointer compression
-const OBJECT_BASE_SIZE = 3 * COMPRESSED_POINTER_SIZE; // 3 compressed pointers
+export const OBJECT_BASE_SIZE = 3 * COMPRESSED_POINTER_SIZE; // 3 compressed pointers
 const TYPED_ARRAY_BASE_SIZE = 25 * COMPRESSED_POINTER_SIZE; // byteLength, byteOffset, ..., see https://stackoverflow.com/a/45808835
 const SMALL_INTEGER_SIZE = COMPRESSED_POINTER_SIZE; // Small integers (up to 31 bits), pointer tagging
-const HEAP_NUMBER_SIZE = 8 + 2 * COMPRESSED_POINTER_SIZE; // 4-byte map pointer + 8-byte payload + property pointer
+export const HEAP_NUMBER_SIZE = 8 + 2 * COMPRESSED_POINTER_SIZE; // 4-byte map pointer + 8-byte payload + property pointer
 const FIELD_SIZE_BY_PRIMITIVE: Record<string, number> = {
   bool: SMALL_INTEGER_SIZE,
   int8: SMALL_INTEGER_SIZE,

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -156,3 +156,33 @@ export function estimateMessageObjectSize(
 
   return sizeInBytes;
 }
+
+/**
+ * Determine the size of each schema sub-field. This can be used for estimating
+ * the size of sliced messages.
+ *
+ * @param datatypes
+ * @param typeName
+ * @param knownTypeSizes
+ * @returns
+ */
+export function estimateMessageFieldSizes(
+  datatypes: MessageDefinitionMap,
+  typeName: string,
+  knownTypeSizes: Map<string, number>,
+): Record<string, number> {
+  const sizeByField: Record<string, number> = {};
+  datatypes.get(typeName)?.definitions.forEach((field) => {
+    const fieldSchemaName = `${typeName}-${field.name}`;
+    const fieldSizeInBytes = estimateMessageObjectSize(
+      new Map([[fieldSchemaName, { name: fieldSchemaName, definitions: [field] }], ...datatypes]),
+      fieldSchemaName,
+      knownTypeSizes,
+    );
+
+    // Subtract the object base size here, it will be added only once per sliced message object.
+    sizeByField[field.name] = fieldSizeInBytes - OBJECT_BASE_SIZE;
+  });
+
+  return sizeByField;
+}


### PR DESCRIPTION
**User-Facing Changes**
Not worth being called out

**Description**
Instead of assuming the size of sliced messages to be 0, we use an estimate that is closer to the actual memory usage. This makes OOM crashes slightly less likely. 

Resolves FG-5897
