### PR TITLE
Adjust worker font loading to use ArrayBuffer instead of data url directly

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -59,7 +59,9 @@ type RpcUpdateEvent = {
 // crash in skia code related to DirectWrite font loading when the system display scaling is set
 // >100%. For more info on this crash, see util/waitForFonts.ts.
 async function loadDefaultFont(): Promise<FontFace> {
-  const fontFace = new FontFace("IBM Plex Mono", `url(${PlexMono}) format('woff2')`);
+  // Passing a `url(data:...) format('woff2')` string does not work in Safari, which complains it
+  // cannot load the data url due to it being cross-origin.
+  const fontFace = new FontFace("IBM Plex Mono", await (await fetch(PlexMono)).arrayBuffer());
   if (typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope) {
     (self as unknown as WorkerGlobalScope).fonts.add(fontFace);
   } else {

--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -61,6 +61,7 @@ type RpcUpdateEvent = {
 async function loadDefaultFont(): Promise<FontFace> {
   // Passing a `url(data:...) format('woff2')` string does not work in Safari, which complains it
   // cannot load the data url due to it being cross-origin.
+  // https://bugs.webkit.org/show_bug.cgi?id=265000
   const fontFace = new FontFace("IBM Plex Mono", await (await fetch(PlexMono)).arrayBuffer());
   if (typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope) {
     (self as unknown as WorkerGlobalScope).fonts.add(fontFace);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Workaround for Safari font loading issue (https://bugs.webkit.org/show_bug.cgi?id=265000). Fixes https://github.com/foxglove/studio/issues/7129, fixes FG-5790