### PR TITLE
Skip Chart frames if we fall behind

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -187,6 +187,12 @@ export const AllowsClickingOnDatalabels: StoryObj = {
       }
     }, [clickedDatalabel, readySignal]);
 
+    const debouncedOnFinish = React.useMemo(() => {
+      return _.debounce(() => {
+        doClick();
+      }, 3000);
+    }, [doClick]);
+
     return (
       <div style={divStyle}>
         <div style={{ padding: 6, fontSize: 16 }}>
@@ -196,7 +202,11 @@ export const AllowsClickingOnDatalabels: StoryObj = {
               )}`
             : "Have not clicked datalabel"}
         </div>
-        <ChartComponent {...propsWithDatalabels} onFinishRender={doClick} onClick={onClick} />
+        <ChartComponent
+          {...propsWithDatalabels}
+          onFinishRender={debouncedOnFinish}
+          onClick={onClick}
+        />
       </div>
     );
   },


### PR DESCRIPTION
**User-Facing Changes**
Minor improvements to rendering performance for the Plot and State Transition panels.

**Description**
The Chart component, which is used by the State Transition and Plot panels, does not currently have a way to drop frames if it starts to fall behind. This PR adds that functionality by coalescing rendering jobs together if we're not keeping up.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
