### PR TITLE
Allow service request/response schemas to be empty

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -74,6 +74,9 @@ function parsedDefinitionsToDatatypes(
  * Process a channel/schema and extract information that can be used to deserialize messages on the
  * channel, and schemas in the format expected by Studio's RosDatatypes.
  *
+ * Empty ROS schemas (except std_msgs/[msg/]Empty) are treated as errors. If you want to allow empty
+ * schemas then use the `allowEmptySchema` option.
+ *
  * See:
  * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-message-encodings.md
  * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-encodings.md

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -78,10 +78,14 @@ function parsedDefinitionsToDatatypes(
  * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-message-encodings.md
  * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-encodings.md
  */
-export function parseChannel(channel: Channel): ParsedChannel {
+export function parseChannel(
+  channel: Channel,
+  options?: { allowEmptySchema: boolean },
+): ParsedChannel {
   // For ROS schemas, we expect the schema to be non-empty unless the
   // schema name is one of the well-known empty schema names.
   if (
+    options?.allowEmptySchema !== true &&
     ["ros1msg", "ros2msg", "ros2idl"].includes(channel.schema?.encoding ?? "") &&
     channel.schema?.data.length === 0 &&
     !KNOWN_EMPTY_SCHEMA_NAMES.includes(channel.schema.name)

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -686,22 +686,29 @@ export default class FoxgloveWebSocketPlayer implements Player {
             );
           }
 
-          const parsedRequest = parseChannel({
-            messageEncoding: requestMsgEncoding,
-            schema: {
-              name: requestType,
-              encoding: service.request?.schemaEncoding ?? defaultSchemaEncoding,
-              data: textEncoder.encode(service.request?.schema ?? service.requestSchema),
+          const parseChannelOptions = { allowEmptySchema: true };
+          const parsedRequest = parseChannel(
+            {
+              messageEncoding: requestMsgEncoding,
+              schema: {
+                name: requestType,
+                encoding: service.request?.schemaEncoding ?? defaultSchemaEncoding,
+                data: textEncoder.encode(service.request?.schema ?? service.requestSchema),
+              },
             },
-          });
-          const parsedResponse = parseChannel({
-            messageEncoding: responseMsgEncoding,
-            schema: {
-              name: responseType,
-              encoding: service.response?.schemaEncoding ?? defaultSchemaEncoding,
-              data: textEncoder.encode(service.response?.schema ?? service.responseSchema),
+            parseChannelOptions,
+          );
+          const parsedResponse = parseChannel(
+            {
+              messageEncoding: responseMsgEncoding,
+              schema: {
+                name: responseType,
+                encoding: service.response?.schemaEncoding ?? defaultSchemaEncoding,
+                data: textEncoder.encode(service.response?.schema ?? service.responseSchema),
+              },
             },
-          });
+            parseChannelOptions,
+          );
           const requestMsgDef = rosDatatypesToMessageDefinition(
             parsedRequest.datatypes,
             requestType,


### PR DESCRIPTION
**User-Facing Changes**
Not worth mentioning

**Description**
Fix falsely raising an error on empty ROS service request / response schemas. Since #7130 we are raising an error when a channel's schema is empty, but we shouldn't do this for service schemas as they can be often empty.
