### PR TITLE
Update subscriptions on topic alias changes

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -66,9 +66,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const [basePlayer, setBasePlayer] = useState<Player | undefined>();
 
-  // fixme - not good to rerender the player manager when global variables are changing
-  // the player manager is not a component we should be re-running often because of how high up the stack it is
-  // this doesn't need to be here - we can get the latest global variables
   const globalVariables = useCurrentLayoutSelector(globalVariablesSelector);
 
   const topicAliasFunctions = useExtensionCatalog(selectTopicAliasFunctions);

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -66,6 +66,9 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const [basePlayer, setBasePlayer] = useState<Player | undefined>();
 
+  // fixme - not good to rerender the player manager when global variables are changing
+  // the player manager is not a component we should be re-running often because of how high up the stack it is
+  // this doesn't need to be here - we can get the latest global variables
   const globalVariables = useCurrentLayoutSelector(globalVariablesSelector);
 
   const topicAliasFunctions = useExtensionCatalog(selectTopicAliasFunctions);

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -91,8 +91,7 @@ export class BlockLoader {
 
     this.#abortController.abort();
     this.#activeChangeCondvar.notifyAll();
-    // fixme - this join has [object Object] - this is no longer an array of topics...?
-    log.debug(`Preloaded topics: ${[...topics].join(", ")}`);
+    log.debug(`Preloaded topics: ${Array.from(topics.keys()).join(", ")}`);
 
     // Update all the blocks with any missing topics
     for (const block of this.#blocks) {

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -91,6 +91,7 @@ export class BlockLoader {
 
     this.#abortController.abort();
     this.#activeChangeCondvar.notifyAll();
+    // fixme - this join has [object Object] - this is no longer an array of topics...?
     log.debug(`Preloaded topics: ${[...topics].join(", ")}`);
 
     // Update all the blocks with any missing topics

--- a/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
@@ -300,4 +300,53 @@ describe("TopicAliasingPlayer", () => {
       }),
     );
   });
+
+  it("updates subscriptions when global variable changes update aliases", async () => {
+    const fakePlayer = new FakePlayer();
+    const mappers: TopicAliasFunctions = [
+      {
+        extensionId: "some-id",
+        aliasFunction: (opt) => {
+          // This function skips returning aliases until doMap is set
+          if (opt.globalVariables["doMap"] !== true) {
+            return [];
+          }
+
+          return [{ sourceTopicName: "/original_topic_1", name: "/renamed_topic_1" }];
+        },
+      },
+    ];
+    const player = new TopicAliasingPlayer(fakePlayer, mappers, {});
+    player.setListener(async () => {});
+    player.setSubscriptions([{ topic: "/renamed_topic_1" }, { topic: "/topic_2" }]);
+
+    await fakePlayer.emit(
+      mockPlayerState(undefined, {
+        topics: [{ name: "/original_topic_1", schemaName: "any.schema" }],
+      }),
+    );
+
+    // After an emit the set of subscriptions is updated since we have a list of topics
+    expect(fakePlayer.subscriptions).toEqual([
+      { topic: "/renamed_topic_1" },
+      { topic: "/topic_2" },
+    ]);
+
+    // update the global variables to create an alias
+    player.setGlobalVariables({ doMap: true });
+
+    // Wait for listener update
+    await Promise.resolve();
+
+    // fixme - why two resolves?
+    // because the subs are set post listener?
+    await Promise.resolve();
+
+    // The set of subscriptions should be updated to remove the aliased-out subscription and
+    // include the original topic subscription
+    expect(fakePlayer.subscriptions).toEqual([
+      { topic: "/original_topic_1" },
+      { topic: "/topic_2" },
+    ]);
+  });
 });

--- a/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.test.ts
@@ -21,11 +21,21 @@ describe("TopicAliasingPlayer", () => {
     const player = new TopicAliasingPlayer(fakePlayer, mappers, {});
     player.setListener(async () => {});
     player.setSubscriptions([{ topic: "/renamed_topic_1" }, { topic: "/topic_2" }]);
+
+    // Until topics are set we can't run alias functions so "setSubscriptions" passes the original
+    // topics through.
+    expect(fakePlayer.subscriptions).toEqual([
+      { topic: "/renamed_topic_1" },
+      { topic: "/topic_2" },
+    ]);
+
     await fakePlayer.emit(
       mockPlayerState(undefined, {
         topics: [{ name: "/original_topic_1", schemaName: "any.schema" }],
       }),
     );
+
+    // After the state emit we have a set of topics and have re-calculated the aliases
     expect(fakePlayer.subscriptions).toEqual([
       { topic: "/original_topic_1" },
       { topic: "/topic_2" },
@@ -334,13 +344,6 @@ describe("TopicAliasingPlayer", () => {
 
     // update the global variables to create an alias
     player.setGlobalVariables({ doMap: true });
-
-    // Wait for listener update
-    await Promise.resolve();
-
-    // fixme - why two resolves?
-    // because the subs are set post listener?
-    await Promise.resolve();
 
     // The set of subscriptions should be updated to remove the aliased-out subscription and
     // include the original topic subscription

--- a/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import * as _ from "lodash-es";
+
 import { MutexLocked } from "@foxglove/den/async";
 import { Time } from "@foxglove/rostime";
 import { Immutable, ParameterValue } from "@foxglove/studio";
@@ -39,6 +41,7 @@ export class TopicAliasingPlayer implements Player {
 
   #inputs: Immutable<StateFactoryInput>;
   #pendingSubscriptions: undefined | SubscribePayload[];
+  #aliasedSubscriptions: undefined | SubscribePayload[];
   #subscriptions: SubscribePayload[] = [];
 
   // True if no aliases are active and we can pass calls directly through to the
@@ -90,6 +93,7 @@ export class TopicAliasingPlayer implements Player {
     this.#subscriptions = subscriptions;
 
     if (this.#skipAliasing) {
+      console.log("skip alias");
       this.#player.setSubscriptions(subscriptions);
       return;
     }
@@ -97,9 +101,12 @@ export class TopicAliasingPlayer implements Player {
     // If we have aliases but haven't recieved a topic list from an active state from
     // the wrapped player yet we have to delay setSubscriptions until we have the topic
     // list to set up the aliases.
+    // fixme - why? if the alias function outputs don't do anything then
+    // we will have delayed the subscriptions for no reason?
     if (this.#inputs.topics != undefined) {
-      const aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(subscriptions);
-      this.#player.setSubscriptions(aliasedSubscriptions);
+      this.#aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(subscriptions);
+      console.log("set subs", this.#aliasedSubscriptions);
+      this.#player.setSubscriptions(this.#aliasedSubscriptions);
       this.#pendingSubscriptions = undefined;
     } else {
       this.#pendingSubscriptions = subscriptions;
@@ -149,6 +156,8 @@ export class TopicAliasingPlayer implements Player {
   public setGlobalVariables(globalVariables: GlobalVariables): void {
     this.#player.setGlobalVariables(globalVariables);
 
+    // fixme - wait for topics to be set?
+
     // Set this before the lastPlayerstate skip below so we have global variables when
     // a player state is provided later.
     this.#inputs = { ...this.#inputs, variables: globalVariables };
@@ -166,6 +175,17 @@ export class TopicAliasingPlayer implements Player {
     // need to re-process the existing player state
     const shouldReprocess = stateProcessor !== this.#stateProcessor;
     this.#stateProcessor = stateProcessor;
+
+    // Generate a new set of subscription aliases if we have a new processor
+    // If this set is different than the current set of aliasedSubscriptions we need to update
+    // the pending subscriptions so they are set
+    // fixme - why wait to set the subscriptions?
+    if (shouldReprocess) {
+      const aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(this.#subscriptions);
+      if (!_.isEqual(this.#aliasedSubscriptions, aliasedSubscriptions)) {
+        this.#aliasedSubscriptions = this.#pendingSubscriptions = aliasedSubscriptions;
+      }
+    }
 
     // Re-process the last player state if the processor has changed since we might have new downstream topics
     // for panels to subscribe or get new re-mapped messages.
@@ -203,8 +223,25 @@ export class TopicAliasingPlayer implements Player {
       // are an input to the alias functions.
       if (playerState.activeData?.topics !== this.#inputs.topics) {
         this.#inputs = { ...this.#inputs, topics: playerState.activeData?.topics };
-        this.#stateProcessor = this.#stateProcessorFactory.buildStateProcessor(this.#inputs);
+        const stateProcessor = this.#stateProcessorFactory.buildStateProcessor(this.#inputs);
+
+        // if the state processor is changed, then we might need to re-process subscriptions since
+        // we might now be able to produce new subscriptions
+        if (this.#stateProcessor !== stateProcessor) {
+          const aliasedSubscriptions = stateProcessor.aliasSubscriptions(this.#subscriptions);
+          if (!_.isEqual(this.#aliasedSubscriptions, aliasedSubscriptions)) {
+            this.#aliasedSubscriptions = this.#pendingSubscriptions = aliasedSubscriptions;
+
+            // fixme - can I set subscriptions on the underlying player here?
+            // this logic is repeated in a few places now - maybe better to use a function?
+          }
+        }
+        this.#stateProcessor = stateProcessor;
       }
+
+      // fixme - what if state processor is different - what about subs?
+      // if the incoming this.#subscriptions have not changed
+      // in setSubscriptions we should handle this
 
       // remember the last player state so we can re-use it when global variables are set
       this.#lastPlayerState = playerState;
@@ -213,8 +250,12 @@ export class TopicAliasingPlayer implements Player {
       const newState = this.#stateProcessor.process(playerState, this.#subscriptions);
       await listener(newState);
 
-      if (this.#pendingSubscriptions && this.#inputs.topics) {
+      // We have new subscriptions to set on the underlying player, apply these and clear
+      // any pending subscriptions so we don't set them again
+      // fixme - why after listener fires?
+      if (this.#pendingSubscriptions) {
         this.setSubscriptions(this.#pendingSubscriptions);
+        this.#pendingSubscriptions = undefined;
       }
     });
   }

--- a/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/TopicAliasingPlayer.ts
@@ -40,7 +40,6 @@ export class TopicAliasingPlayer implements Player {
   readonly #player: Player;
 
   #inputs: Immutable<StateFactoryInput>;
-  #pendingSubscriptions: undefined | SubscribePayload[];
   #aliasedSubscriptions: undefined | SubscribePayload[];
   #subscriptions: SubscribePayload[] = [];
 
@@ -91,26 +90,8 @@ export class TopicAliasingPlayer implements Player {
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
     this.#subscriptions = subscriptions;
-
-    if (this.#skipAliasing) {
-      console.log("skip alias");
-      this.#player.setSubscriptions(subscriptions);
-      return;
-    }
-
-    // If we have aliases but haven't recieved a topic list from an active state from
-    // the wrapped player yet we have to delay setSubscriptions until we have the topic
-    // list to set up the aliases.
-    // fixme - why? if the alias function outputs don't do anything then
-    // we will have delayed the subscriptions for no reason?
-    if (this.#inputs.topics != undefined) {
-      this.#aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(subscriptions);
-      console.log("set subs", this.#aliasedSubscriptions);
-      this.#player.setSubscriptions(this.#aliasedSubscriptions);
-      this.#pendingSubscriptions = undefined;
-    } else {
-      this.#pendingSubscriptions = subscriptions;
-    }
+    this.#aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(subscriptions);
+    this.#player.setSubscriptions(this.#aliasedSubscriptions);
   }
 
   public setPublishers(publishers: AdvertiseOptions[]): void {
@@ -156,8 +137,6 @@ export class TopicAliasingPlayer implements Player {
   public setGlobalVariables(globalVariables: GlobalVariables): void {
     this.#player.setGlobalVariables(globalVariables);
 
-    // fixme - wait for topics to be set?
-
     // Set this before the lastPlayerstate skip below so we have global variables when
     // a player state is provided later.
     this.#inputs = { ...this.#inputs, variables: globalVariables };
@@ -165,7 +144,11 @@ export class TopicAliasingPlayer implements Player {
     // We can skip re-processing if we don't have any alias functions setup or we have not
     // had any player state provided yet. The player state handler onPlayerState will handle alias
     // function processing when it is called.
-    if (this.#skipAliasing || this.#lastPlayerState == undefined) {
+    if (
+      this.#skipAliasing ||
+      this.#lastPlayerState == undefined ||
+      this.#inputs.topics == undefined
+    ) {
       return;
     }
 
@@ -176,15 +159,9 @@ export class TopicAliasingPlayer implements Player {
     const shouldReprocess = stateProcessor !== this.#stateProcessor;
     this.#stateProcessor = stateProcessor;
 
-    // Generate a new set of subscription aliases if we have a new processor
-    // If this set is different than the current set of aliasedSubscriptions we need to update
-    // the pending subscriptions so they are set
-    // fixme - why wait to set the subscriptions?
+    // If we have a new processor we might also have new subscriptions for downstream
     if (shouldReprocess) {
-      const aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(this.#subscriptions);
-      if (!_.isEqual(this.#aliasedSubscriptions, aliasedSubscriptions)) {
-        this.#aliasedSubscriptions = this.#pendingSubscriptions = aliasedSubscriptions;
-      }
+      this.#resetSubscriptions();
     }
 
     // Re-process the last player state if the processor has changed since we might have new downstream topics
@@ -228,20 +205,10 @@ export class TopicAliasingPlayer implements Player {
         // if the state processor is changed, then we might need to re-process subscriptions since
         // we might now be able to produce new subscriptions
         if (this.#stateProcessor !== stateProcessor) {
-          const aliasedSubscriptions = stateProcessor.aliasSubscriptions(this.#subscriptions);
-          if (!_.isEqual(this.#aliasedSubscriptions, aliasedSubscriptions)) {
-            this.#aliasedSubscriptions = this.#pendingSubscriptions = aliasedSubscriptions;
-
-            // fixme - can I set subscriptions on the underlying player here?
-            // this logic is repeated in a few places now - maybe better to use a function?
-          }
+          this.#stateProcessor = stateProcessor;
+          this.#resetSubscriptions();
         }
-        this.#stateProcessor = stateProcessor;
       }
-
-      // fixme - what if state processor is different - what about subs?
-      // if the incoming this.#subscriptions have not changed
-      // in setSubscriptions we should handle this
 
       // remember the last player state so we can re-use it when global variables are set
       this.#lastPlayerState = playerState;
@@ -249,14 +216,18 @@ export class TopicAliasingPlayer implements Player {
       // Process the player state using the latest aliases
       const newState = this.#stateProcessor.process(playerState, this.#subscriptions);
       await listener(newState);
-
-      // We have new subscriptions to set on the underlying player, apply these and clear
-      // any pending subscriptions so we don't set them again
-      // fixme - why after listener fires?
-      if (this.#pendingSubscriptions) {
-        this.setSubscriptions(this.#pendingSubscriptions);
-        this.#pendingSubscriptions = undefined;
-      }
     });
+  }
+
+  /**
+   * Re-calculate the subscriptions using the latest state processor. If the subscriptions have
+   * changed then call setSubscriptions on the wrapped player.
+   */
+  #resetSubscriptions() {
+    const aliasedSubscriptions = this.#stateProcessor.aliasSubscriptions(this.#subscriptions);
+    if (!_.isEqual(this.#aliasedSubscriptions, aliasedSubscriptions)) {
+      this.#aliasedSubscriptions = aliasedSubscriptions;
+      this.#player.setSubscriptions(aliasedSubscriptions);
+    }
   }
 }


### PR DESCRIPTION
**User-facing changes**
Topic alias subscriptions are updated when changing global variables.

**Description**
This change fixes a behavior where changes to global variables would not cause updated subscriptions for the wrapped player. This would happen because aliased subscriptions were only updated in the `setSubscriptions` call. However, for some panel workflows they would not re-subscribe when the topics list changed because they were already subscribed to the topic they wanted (even though it was not yet present in the topic list). Plot panel is an example of such a panel. Because they had already specified their subscriptions there was no additional call to `setSubscriptions` and no re-calculating of aliased subscriptions for the original topic.

This change updates the `TopicAliasingPlayer` logic to re-process aliased subscriptions and call `setSubscriptions` on the wrapped player for all three workflows: setGlobalVariables, setSubscriptions, and player state updates. Now if a panel had previously subscribed that subscription will be properly aliased.

I've also changed the `setSubscriptions` behavior. Previously it would not set subscriptions until topics were received from the underlying player. I see no reason to keep this restriction since alias functions could be hard-coded and not require any input topics.