### PR TITLE
Fix Tab layout getting replaced when dropping a panel in the wrong place

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -77,12 +77,15 @@ function TabMosaicWrapper({ tabId, children }: PropsWithChildren<{ tabId?: strin
     accept: MosaicDragType.WINDOW,
     drop: (_item, monitor) => {
       const nestedDropResult = monitor.getDropResult<MosaicDropResult>();
-      if (nestedDropResult) {
-        // The drop result may already have a tabId if it was dropped in a more deeply-nested Tab
-        // mosaic. Provide our tabId only if there wasn't one already.
-        return { tabId, ...nestedDropResult };
+      // MosaicWindow has a top-level drop target which can fire if something is dropped onto the
+      // tab bar or elsewhere inside the tab that doesn't correspond to one of the other mosaic drop
+      // targets. In this case we don't want to replace the tab's existing layout so we do nothing.
+      if (nestedDropResult?.path == undefined) {
+        return undefined;
       }
-      return undefined;
+      // The drop result may already have a tabId if it was dropped in a more deeply-nested Tab
+      // mosaic. Provide our tabId only if there wasn't one already.
+      return { tabId, ...nestedDropResult };
     },
   });
   return (

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -10,8 +10,8 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-
 import { useTheme } from "@mui/material";
+import { expect } from "@storybook/jest";
 import { StoryObj, Meta } from "@storybook/react";
 import { fireEvent, within } from "@storybook/testing-library";
 
@@ -398,5 +398,55 @@ export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = {
     const target = targetTab.querySelector(".drop-target.left");
 
     dragAndDrop(dragHandle[0]!, target!);
+  },
+};
+
+export const DraggingOntoTabRootDoesNotReplaceTabContents: Story = {
+  render: () => <PanelLayout />,
+  args: {
+    fixture: {
+      topics: [],
+      datatypes: new Map(),
+      frame: {},
+      layout: {
+        direction: "row",
+        splitPercentage: 50,
+        first: "Tab!a",
+        second: "Sample1!2xqjjqw",
+      },
+      savedProps: {
+        "Tab!a": {
+          activeTabIdx: 0,
+          tabs: [
+            {
+              title: "First",
+              layout: {
+                direction: "row",
+                splitPercentage: 50,
+                first: "unknown!inner1",
+                second: "unknown!inner2",
+              },
+            },
+          ],
+        },
+      },
+    } satisfies Fixture,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sample1 = await canvas.findByTestId("panel-mouseenter-container Sample1!2xqjjqw");
+    const targetTab = await canvas.findByTestId("panel-mouseenter-container Tab!a");
+
+    const dragHandle = await within(sample1).findAllByTestId("panel-menu");
+
+    dragAndDrop(dragHandle[0]!, targetTab);
+
+    // Drag & drop should not have replaced existing tab contents
+    await expect(
+      await canvas.findByTestId("panel-mouseenter-container unknown!inner1"),
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByTestId("panel-mouseenter-container unknown!inner2"),
+    ).toBeInTheDocument();
   },
 };


### PR DESCRIPTION
**User-Facing Changes**
- Fixed a bug where tab layouts would sometimes be unexpectedly replaced when dragging & dropping panels.

**Description**
Fixes FG-5686