### PR TITLE
Hide individual channel override in log settings for warn and error

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -110,7 +110,8 @@ export default function SettingsTreeEditor({
     [saveConfig],
   );
 
-  const showTitleField = filterText.length === 0 && panelInfo?.hasCustomToolbar !== true;
+  const showTitleField =
+    filterText.length === 0 && panelInfo?.hasCustomToolbar !== true && variant !== "log";
 
   return (
     <Stack fullHeight>

--- a/packages/studio-base/src/components/StudioLogsSettings/useStudioLogsSettingsTree.ts
+++ b/packages/studio-base/src/components/StudioLogsSettings/useStudioLogsSettingsTree.ts
@@ -54,7 +54,17 @@ function useStudioLogsSettingsTree(): SettingsTree {
       children: {},
     };
 
+    // When the global level is warn or error we don't allow suppressing individual files. This is
+    // to make sure you always see warning and errors go to console since they are also visible in
+    // prod.
+    const disableIndividualOverride =
+      logsConfig.globalLevel === "warn" || logsConfig.globalLevel === "error";
+
     for (const channel of logsConfig.channels) {
+      if (disableIndividualOverride) {
+        continue;
+      }
+
       const channelName = channel.name;
 
       const parts = channelName.split("/");
@@ -150,8 +160,10 @@ function useStudioLogsSettingsTree(): SettingsTree {
       }
     }
 
-    // Add misc nodes at the end of root
-    settingsRoot["misc"] = miscRoot;
+    if (!disableIndividualOverride) {
+      // Add misc nodes at the end of root
+      settingsRoot["misc"] = miscRoot;
+    }
 
     return {
       enableFilter: true,

--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/store.ts
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/store.ts
@@ -117,7 +117,7 @@ function createStudioLogsSettingsStore(
     disableChannel(name: string) {
       log.debug(`Disable channel: ${name}`);
 
-      // Enable the underlying log channels
+      // Disable the underlying log channels
       const logChannels = channelByName.get(name) ?? [];
       for (const channel of logChannels) {
         channel.setLevel("warn");


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When setting the studio log level to warn or error, the individual log file overrides (to hide a speciifc file's logs) does not work. This is by design so warning and error logs are always shown.

This change updates the log settings sidebar to hide the individual file names when "warn" or "error" log level is selected.