### PR TITLE
Avoid unnecessary rendering of app-bar & side-bars

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -156,7 +156,7 @@ const selectHasCurrentLayout = (state: LayoutState) => state.selectedLayout != u
 const selectLeftSidebarOpen = (store: WorkspaceContextStore) => store.sidebars.left.open;
 const selectRightSidebarOpen = (store: WorkspaceContextStore) => store.sidebars.right.open;
 
-export function AppBar(props: AppBarProps): JSX.Element {
+export const AppBar = React.memo(function AppBar(props: AppBarProps): JSX.Element {
   const {
     debugDragRegion,
     isMaximized,
@@ -326,4 +326,4 @@ export function AppBar(props: AppBarProps): JSX.Element {
       />
     </>
   );
-}
+});

--- a/packages/studio-base/src/components/Sidebars/Sidebars.tsx
+++ b/packages/studio-base/src/components/Sidebars/Sidebars.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PropsWithChildren, useCallback, useEffect, useState } from "react";
+import { PropsWithChildren, useCallback, useEffect, useMemo, useState } from "react";
 import { MosaicNode, MosaicWithoutDragDropContext } from "react-mosaic-component";
 import { makeStyles } from "tss-react/mui";
 
@@ -160,6 +160,45 @@ export function Sidebars<LeftKey extends string, RightKey extends string>(
     [setLeftSidebarSize, setRightSidebarSize],
   );
 
+  const childrenComponent = useMemo(
+    () => <ErrorBoundary>{children as JSX.Element}</ErrorBoundary>,
+    [children],
+  );
+
+  const leftSidebarComponent = useMemo(
+    () => (
+      <ErrorBoundary>
+        <Sidebar<LeftKey>
+          anchor="left"
+          onClose={() => {
+            onSelectLeftKey(undefined);
+          }}
+          items={leftItems}
+          activeTab={selectedLeftKey}
+          setActiveTab={onSelectLeftKey}
+        />
+      </ErrorBoundary>
+    ),
+    [leftItems, onSelectLeftKey, selectedLeftKey],
+  );
+
+  const rightSidebarComponent = useMemo(
+    () => (
+      <ErrorBoundary>
+        <Sidebar<RightKey>
+          anchor="right"
+          onClose={() => {
+            onSelectRightKey(undefined);
+          }}
+          items={rightItems}
+          activeTab={selectedRightKey}
+          setActiveTab={onSelectRightKey}
+        />
+      </ErrorBoundary>
+    ),
+    [onSelectRightKey, rightItems, selectedRightKey],
+  );
+
   return (
     <Stack direction="row" fullHeight overflow="hidden">
       {
@@ -174,35 +213,11 @@ export function Sidebars<LeftKey extends string, RightKey extends string>(
           renderTile={(id) => {
             switch (id) {
               case "children":
-                return <ErrorBoundary>{children as JSX.Element}</ErrorBoundary>;
+                return childrenComponent;
               case "leftbar":
-                return (
-                  <ErrorBoundary>
-                    <Sidebar<LeftKey>
-                      anchor="left"
-                      onClose={() => {
-                        onSelectLeftKey(undefined);
-                      }}
-                      items={leftItems}
-                      activeTab={selectedLeftKey}
-                      setActiveTab={onSelectLeftKey}
-                    />
-                  </ErrorBoundary>
-                );
+                return leftSidebarComponent;
               case "rightbar":
-                return (
-                  <ErrorBoundary>
-                    <Sidebar<RightKey>
-                      anchor="right"
-                      onClose={() => {
-                        onSelectRightKey(undefined);
-                      }}
-                      items={rightItems}
-                      activeTab={selectedRightKey}
-                      setActiveTab={onSelectRightKey}
-                    />
-                  </ErrorBoundary>
-                );
+                return rightSidebarComponent;
             }
           }}
           resize={{ minimumPaneSizePercentage: 10 }}


### PR DESCRIPTION
**User-Facing Changes**
Not worth being called out

**Description**
Memoizes components to avoid some unnecessary re-rendering when e.g. resizing the sidebars.

The effect can be seen in the screencast below, where the component renders are made visible using react dev tools. The current state (left) is compared against this PR (right)

[Screencast from 24.11.2023 12:24:43.webm](https://github.com/foxglove/studio/assets/9250155/aeec5338-1c9a-483b-b933-4e2efdd06acf)

Resolves FG-5746