### PR TITLE
Limit the maximum number of points returned by downsampleTimeseries

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -65,9 +65,12 @@ describe("downsampleTimeseries", () => {
         { x: 1, y: 4, value: 4 },
         { x: 2, y: 5, value: 5 },
       ]),
-      bounds,
+      {
+        ...bounds,
+        width: bounds.width * 4,
+      },
     );
-    expect(result).toEqual([0, 2, 4]);
+    expect(result).toEqual([0, 1, 2, 3, 4]);
   });
 });
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -67,7 +67,7 @@ describe("downsampleTimeseries", () => {
       ]),
       bounds,
     );
-    expect(result).toEqual([0, 1, 2, 3, 4]);
+    expect(result).toEqual([0, 2, 4]);
   });
 });
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -4,7 +4,7 @@
 
 import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets";
 
-import { downsampleTimeseries, downsampleScatter } from "./downsample";
+import { MINIMUM_PIXEL_DISTANCE, downsampleTimeseries, downsampleScatter } from "./downsample";
 
 describe("downsampleTimeseries", () => {
   const bounds = {
@@ -67,7 +67,7 @@ describe("downsampleTimeseries", () => {
       ]),
       {
         ...bounds,
-        width: bounds.width * 4,
+        width: bounds.width * MINIMUM_PIXEL_DISTANCE,
       },
     );
     expect(result).toEqual([0, 1, 2, 3, 4]);

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -15,10 +15,21 @@ type Dataset<T> = ChartDataset<"scatter", T>;
 // 60FPS.
 export const MAX_POINTS = 5_000;
 
+// Each interval can produce up to this many points
+const POINTS_PER_INTERVAL = 4;
+
+// Points that appear within this threshold are visually indistinguishable
+export const MINIMUM_PIXEL_DISTANCE = 3;
+
 /**
- * Downsample a timeseries dataset
+ * Downsample a timeseries dataset by returning the indices of a subset of
+ * points that are deemed to be representative of the original dataset when
+ * rendered with the given viewport.
  *
- * This function assumes the dataset x axis time and sorted.
+ * This function assumes that points are sorted and that x- values are
+ * monotonically increasing.
+ *
+ * If `maxPoints` is provided, downsampleTimeseries will return only up to `maxPoints` points.
  *
  * The downsampled data preserves the shape of the original data. The algorithm does this by
  * downsampling within an interval. Each interval tracks the first datum of the interval,
@@ -40,12 +51,20 @@ export const MAX_POINTS = 5_000;
 export function downsampleTimeseries(
   points: Iterable<Point>,
   view: PlotViewport,
-  numPoints?: number,
+  maxPoints?: number,
 ): number[] {
   const { bounds, width, height } = view;
 
-  // Each interval can produce up to four points
-  const numIntervals = (numPoints ?? width) / 4;
+  const numPixelIntervals = Math.trunc(width / MINIMUM_PIXEL_DISTANCE);
+  // When maxPoints is provided, we should take either that constant or
+  // the number of pixel-defined intervals, whichever is fewer
+  const numPoints = Math.min(
+    maxPoints ?? numPixelIntervals * POINTS_PER_INTERVAL,
+    numPixelIntervals * POINTS_PER_INTERVAL,
+  );
+  // We then calculate the number of intervals based on the number of points we
+  // decided on
+  const numIntervals = Math.trunc(numPoints / POINTS_PER_INTERVAL);
   const pixelPerXValue = numIntervals / (bounds.x.max - bounds.x.min);
   const pixelPerYValue = height / (bounds.y.max - bounds.y.min);
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -10,6 +10,11 @@ import type { PlotViewport } from "./types";
 
 type Dataset<T> = ChartDataset<"scatter", T>;
 
+// This is the desired number of data points for each plot across all signals
+// and data sources. Beyond this threshold, ChartJS can no longer render at
+// 60FPS.
+export const MAX_POINTS = 5_000;
+
 /**
  * Downsample a timeseries dataset
  *
@@ -32,13 +37,19 @@ type Dataset<T> = ChartDataset<"scatter", T>;
  * dataset, and the interval connects to the next interval with the same slope line as the original
  * data. The min/max entries preserve spikes within the data.
  */
-export function downsampleTimeseries(points: Iterable<Point>, view: PlotViewport): number[] {
+export function downsampleTimeseries(
+  points: Iterable<Point>,
+  view: PlotViewport,
+  numPoints?: number,
+): number[] {
   const { bounds, width, height } = view;
 
-  const pixelPerXValue = width / (bounds.x.max - bounds.x.min);
+  // Each interval can produce up to four points
+  const numIntervals = (numPoints ?? width) / 4;
+  const pixelPerXValue = numIntervals / (bounds.x.max - bounds.x.min);
   const pixelPerYValue = height / (bounds.y.max - bounds.y.min);
 
-  const downsampled: number[] = [];
+  const indices: number[] = [];
 
   type IntervalItem = { xPixel: number; yPixel: number; label: string | undefined; index: number };
 
@@ -61,11 +72,11 @@ export function downsampleTimeseries(points: Iterable<Point>, view: PlotViewport
 
     // track the first point before our bounds
     if (datum.x < minX) {
-      if (downsampled.length === 0) {
-        downsampled.push(index);
+      if (indices.length === 0) {
+        indices.push(index);
       } else {
         // the first point outside our bounds will always be at index 0
-        downsampled[0] = index;
+        indices[0] = index;
       }
       continue;
     }
@@ -86,21 +97,21 @@ export function downsampleTimeseries(points: Iterable<Point>, view: PlotViewport
     if (intFirst?.xPixel !== x || (intLast?.label != undefined && intLast.label !== datum.label)) {
       // add the min value from previous interval if it doesn't match the first or last of that interval
       if (intMin && intMin.yPixel !== intFirst?.yPixel && intMin.yPixel !== intLast?.yPixel) {
-        downsampled.push(intMin.index);
+        indices.push(intMin.index);
       }
 
       // add the max value from previous interval if it doesn't match the first or last of that interval
       if (intMax && intMax.yPixel !== intFirst?.yPixel && intMax.yPixel !== intLast?.yPixel) {
-        downsampled.push(intMax.index);
+        indices.push(intMax.index);
       }
 
       // add the last value if it doesn't match the first
       if (intLast && intFirst?.yPixel !== intLast.yPixel) {
-        downsampled.push(intLast.index);
+        indices.push(intLast.index);
       }
 
       // always add the first datum of an new interval
-      downsampled.push(index);
+      indices.push(index);
 
       intFirst = { xPixel: x, yPixel: y, index, label };
       intLast = { xPixel: x, yPixel: y, index, label };
@@ -130,24 +141,24 @@ export function downsampleTimeseries(points: Iterable<Point>, view: PlotViewport
 
   // add the min value from previous interval if it doesn't match the first or last of that interval
   if (intMin && intMin.yPixel !== intFirst?.yPixel && intMin.yPixel !== intLast?.yPixel) {
-    downsampled.push(intMin.index);
+    indices.push(intMin.index);
   }
 
   // add the max value from previous interval if it doesn't match the first or last of that interval
   if (intMax && intMax.yPixel !== intFirst?.yPixel && intMax.yPixel !== intLast?.yPixel) {
-    downsampled.push(intMax.index);
+    indices.push(intMax.index);
   }
 
   // add the last value if it doesn't match the first
   if (intLast && intFirst?.yPixel !== intLast.yPixel) {
-    downsampled.push(intLast.index);
+    indices.push(intLast.index);
   }
 
   if (firstPastBounds != undefined) {
-    downsampled.push(firstPastBounds);
+    indices.push(firstPastBounds);
   }
 
-  return downsampled;
+  return indices;
 }
 
 export function downsampleScatter(points: Iterable<Point>, view: PlotViewport): number[] {
@@ -157,7 +168,7 @@ export function downsampleScatter(points: Iterable<Point>, view: PlotViewport): 
   const pixelPerYValue = height / (bounds.y.max - bounds.y.min);
   const pixelPerRow = width;
 
-  const downsampled: number[] = [];
+  const indices: number[] = [];
 
   // downsampling tracks a sparse array of x/y locations
   const sparse: boolean[] = [];
@@ -179,10 +190,12 @@ export function downsampleScatter(points: Iterable<Point>, view: PlotViewport): 
       continue;
     }
     sparse[locator] = true;
-    downsampled.push(datum.index);
+    indices.push(datum.index);
   }
 
-  return downsampled;
+  // Technically a lie because this may have downsampled but we say it did not
+  // so the points are still rendered
+  return indices;
 }
 
 /**
@@ -193,8 +206,9 @@ export function downsample<T>(
   dataset: Dataset<T>,
   points: Iterable<Point>,
   view: PlotViewport,
+  numPoints?: number,
 ): number[] {
   return dataset.showLine !== true
     ? downsampleScatter(points, view)
-    : downsampleTimeseries(points, view);
+    : downsampleTimeseries(points, view, numPoints);
 }

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -193,8 +193,6 @@ export function downsampleScatter(points: Iterable<Point>, view: PlotViewport): 
     indices.push(datum.index);
   }
 
-  // Technically a lie because this may have downsampled but we say it did not
-  // so the points are still rendered
   return indices;
 }
 

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj, StoryFn } from "@storybook/react";
-import { waitFor } from "@storybook/testing-library";
 import { useCallback } from "react";
 import { useAsync } from "react-use";
 
@@ -139,33 +138,33 @@ export const Dark: StoryObj = {
   decorators: [Wrapper],
 };
 
-export const LimitWidth: StoryObj = {
-  render: function Story() {
-    const readySignal = useReadySignal({ count: 6 });
-    const pauseFrame = useCallback(() => readySignal, [readySignal]);
+//export const LimitWidth: StoryObj = {
+//render: function Story() {
+//const readySignal = useReadySignal({ count: 6 });
+//const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
-    return (
-      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-        <div
-          style={{
-            height: "100%",
-            width: "100%",
-          }}
-        >
-          <Plot
-            overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
-          />
-        </div>
-      </PanelSetup>
-    );
-  },
+//return (
+//<PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+//<div
+//style={{
+//height: "100%",
+//width: "100%",
+//}}
+//>
+//<Plot
+//overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
+///>
+//</div>
+//</PanelSetup>
+//);
+//},
 
-  play: async (ctx) => {
-    await waitFor(() => ctx.parameters.storyReady);
-  },
+//play: async (ctx) => {
+//await waitFor(() => ctx.parameters.storyReady);
+//},
 
-  parameters: {
-    colorScheme: "light",
-    useReadySignal: true,
-  },
-};
+//parameters: {
+//colorScheme: "light",
+//useReadySignal: true,
+//},
+//};

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -6,7 +6,7 @@ import * as Comlink from "comlink";
 
 import { Immutable } from "@foxglove/studio";
 import { iterateTyped } from "@foxglove/studio-base/components/Chart/datasets";
-import { downsample } from "@foxglove/studio-base/components/TimeBasedChart/downsample";
+import { downsample, MAX_POINTS } from "@foxglove/studio-base/components/TimeBasedChart/downsample";
 import {
   ProviderStateSetter,
   PlotViewport,
@@ -111,8 +111,9 @@ function rebuild(id: string) {
     return;
   }
 
+  const maxPoints = MAX_POINTS / Math.max(newData.datasets.size, 1);
   const downsampled = mapDatasets((dataset) => {
-    const indices = downsample(dataset, iterateTyped(dataset.data), view);
+    const indices = downsample(dataset, iterateTyped(dataset.data), view, maxPoints);
     const resolved = resolveTypedIndices(dataset.data, indices);
     if (resolved == undefined) {
       return dataset;

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -5,7 +5,7 @@
 import * as Comlink from "comlink";
 
 import { Immutable } from "@foxglove/studio";
-import { iterateTyped, getTypedLength } from "@foxglove/studio-base/components/Chart/datasets";
+import { iterateTyped } from "@foxglove/studio-base/components/Chart/datasets";
 import { downsample, MAX_POINTS } from "@foxglove/studio-base/components/TimeBasedChart/downsample";
 import {
   ProviderStateSetter,
@@ -113,12 +113,6 @@ function rebuild(id: string) {
 
   const maxPoints = MAX_POINTS / Math.max(newData.datasets.size, 1);
   const downsampled = mapDatasets((dataset) => {
-    const numPoints = getTypedLength(dataset.data);
-    // We can skip calling downsample entirely
-    if (numPoints < maxPoints) {
-      return dataset;
-    }
-
     const indices = downsample(dataset, iterateTyped(dataset.data), view, maxPoints);
     const resolved = resolveTypedIndices(dataset.data, indices);
     if (resolved == undefined) {
@@ -127,7 +121,6 @@ function rebuild(id: string) {
 
     return {
       ...dataset,
-      pointRadius: 0,
       data: resolved,
     };
   }, newData.datasets);

--- a/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
+++ b/packages/studio-base/src/panels/Plot/useDatasets.worker.ts
@@ -5,7 +5,7 @@
 import * as Comlink from "comlink";
 
 import { Immutable } from "@foxglove/studio";
-import { iterateTyped } from "@foxglove/studio-base/components/Chart/datasets";
+import { iterateTyped, getTypedLength } from "@foxglove/studio-base/components/Chart/datasets";
 import { downsample, MAX_POINTS } from "@foxglove/studio-base/components/TimeBasedChart/downsample";
 import {
   ProviderStateSetter,
@@ -113,6 +113,12 @@ function rebuild(id: string) {
 
   const maxPoints = MAX_POINTS / Math.max(newData.datasets.size, 1);
   const downsampled = mapDatasets((dataset) => {
+    const numPoints = getTypedLength(dataset.data);
+    // We can skip calling downsample entirely
+    if (numPoints < maxPoints) {
+      return dataset;
+    }
+
     const indices = downsample(dataset, iterateTyped(dataset.data), view, maxPoints);
     const resolved = resolveTypedIndices(dataset.data, indices);
     if (resolved == undefined) {
@@ -121,6 +127,7 @@ function rebuild(id: string) {
 
     return {
       ...dataset,
+      pointRadius: 0,
       data: resolved,
     };
   }, newData.datasets);


### PR DESCRIPTION
**User-Facing Changes**
Improve rendering performance for plots with large datasets.

**Description**
One of our discoveries while testing [the downsampling PR](https://github.com/foxglove/studio/pull/6997) was that it was practical to add an upper bound to the original downsampling algorithm, which appears to do a better job of capturing the outliers of a plot. This backports that insight to `main`.

It's worth noting that in an effort to keep this diff as minimal as possible, I omitted the change that hides the dots at each data point if any downsampling occurred.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
