### PR TITLE
Fix "<datatype> not found in definitions" error when loading db3 file

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -15,6 +15,7 @@ import {
   TopicStats,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+import { basicDatatypes } from "@foxglove/studio-base/util/basicDatatypes";
 
 import {
   IIterableSource,
@@ -95,7 +96,11 @@ export class RosDb3IterableSource implements IIterableSource {
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
       this.#approxDeserializedMsgSizeByType.set(
         topicDef.type,
-        estimateMessageObjectSize(datatypes, topicDef.type, estimatedObjectSizeByType),
+        estimateMessageObjectSize(
+          new Map([...basicDatatypes, ...datatypes]),
+          topicDef.type,
+          estimatedObjectSizeByType,
+        ),
       );
     }
 

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -66,7 +66,8 @@ export class RosDb3IterableSource implements IIterableSource {
     const problems: PlayerProblem[] = [];
     const topics: Topic[] = [];
     const topicStats = new Map<string, TopicStats>();
-    const datatypes: RosDatatypes = new Map();
+    // ROS 2 .db3 files do not contain message definitions, so we can only support well-known ROS types.
+    const datatypes: RosDatatypes = new Map([...ROS2_TO_DEFINITIONS, ...basicDatatypes]);
     const messageDefinitionsByTopic: MessageDefinitionsByTopic = {};
     const parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
     const estimatedObjectSizeByType = new Map<string, number>();
@@ -79,7 +80,7 @@ export class RosDb3IterableSource implements IIterableSource {
         topicStats.set(topicDef.name, { numMessages });
       }
 
-      const parsedMsgdef = ROS2_TO_DEFINITIONS.get(topicDef.type);
+      const parsedMsgdef = datatypes.get(topicDef.type);
       if (parsedMsgdef == undefined) {
         problems.push({
           severity: "warn",
@@ -96,11 +97,7 @@ export class RosDb3IterableSource implements IIterableSource {
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
       this.#approxDeserializedMsgSizeByType.set(
         topicDef.type,
-        estimateMessageObjectSize(
-          new Map([...basicDatatypes, ...datatypes]),
-          topicDef.type,
-          estimatedObjectSizeByType,
-        ),
+        estimateMessageObjectSize(datatypes, topicDef.type, estimatedObjectSizeByType),
       );
     }
 


### PR DESCRIPTION
**User-Facing Changes**
Fix "<datatype> not found in definitions" error when loading db3 file

**Description**
Use well-known message definitions for estimating object memory size as db3 files (ROS2 bags) do not contain schema information. These message definitions will also be emitted by the source (and subsequently by the player)