### PR TITLE
overwriteFetch: remove type specifications to allow node/types and dom types to coexist

### DIFF
--- a/packages/studio-base/src/util/overwriteFetch.ts
+++ b/packages/studio-base/src/util/overwriteFetch.ts
@@ -15,15 +15,22 @@
 // in our logs and want the logs to more fully reflect the error message.
 export default function overwriteFetch(): void {
   const originalFetch = global.fetch;
-  global.fetch = async (url: RequestInfo | URL, init?: RequestInit) => {
+
+  // Do not specify types here, they will be inferred from context. See
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66824#issuecomment-1753778002
+  global.fetch = async (input, init) => {
     // Use this replacement error instead of the original one, because this one will have the correct stack trace.
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    const replacementError = new TypeError(`Failed to fetch: ${url}`);
-    return await originalFetch(url, init).catch((error) => {
-      if (error.message === "Failed to fetch") {
-        throw replacementError;
-      }
-      throw error;
-    });
+    const replacementError = new TypeError(`Failed to fetch: ${input}`);
+    // Since both node types and dom types are in scope here, the input types for `fetch` conflict.
+    // (FG-5919): get the node types out of scope, since this code is only meant to run in browser.
+    return await originalFetch(input as Parameters<typeof originalFetch>[0], init).catch(
+      (error) => {
+        if (error.message === "Failed to fetch") {
+          throw replacementError;
+        }
+        throw error;
+      },
+    );
   };
 }


### PR DESCRIPTION
This is one way for us to be able to update @types/node in the app repo.