### PR TITLE
Update @node/types, handle errors that follow

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "resolutions": {
-    "@types/node": "16.18.40",
+    "@types/node": "20.10.0",
     "react-use": "patch:react-use@17.4.0#./patches/react-use.patch",
     "react-dnd": "patch:react-dnd@npm:16.0.1#./patches/react-dnd.patch"
   },

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.test.ts
@@ -17,7 +17,14 @@ describe("McapIterableSource", () => {
     await writer.start({ library: "", profile: "" });
     await writer.end();
 
-    const source = new McapIterableSource({ type: "file", file: new Blob([tempBuffer.get()]) });
+    const source = new McapIterableSource({
+      type: "file",
+      // the global Blob definition exists in type definitions, but the constructor is
+      // not available at runtime. We use node:buffer's Blob to test here, but the
+      // type is technically not compatible with the global Blob type, so we cast
+      // to get around this.
+      file: new Blob([tempBuffer.get()]) as unknown as globalThis.Blob,
+    });
     const { problems } = await source.initialize();
     expect(problems).toEqual([
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6426,10 +6426,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:16.18.40":
-  version: 16.18.40
-  resolution: "@types/node@npm:16.18.40"
-  checksum: a683930491b4fd7cb2dc7684e32bbeedc4a83fb1949a7b15ea724fbfaa9988cec59091f169a3f1090cb91992caba8c1a7d50315b2c67c6e2579a3788bb09eec4
+"@types/node@npm:20.10.0":
+  version: 20.10.0
+  resolution: "@types/node@npm:20.10.0"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: face395140d6f2f1755b91fdd3b697cf56aeb9e2514529ce88d56e56f261ad65be7269d863520a9406d73c338699ea68b418e8677584de0c1efeed09539b6f97
   languageName: node
   linkType: hard
 
@@ -20002,6 +20004,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**


**Description**

Updates our @types/node dependency resolution to 20.10.* . This includes type definitions for `fetch`, which conflict for the `dom.d.ts` definitions for fetch, so some wrangling needs to be done in overwriteFetch.
