### PR TITLE
Flaky plots IV: A New Hope

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -241,8 +241,8 @@ function Chart(props: Props): JSX.Element {
     return out;
   }, [data, typedData, height, options, isBoundsReset, width]);
 
-  // Flush all new to the worker, coalescing them together if there is more
-  // than one.
+  // Flush all new updates to the worker, coalescing them together if there is
+  // more than one.
   const flushUpdates = useCallback(
     async (send: RpcSend | undefined) => {
       if (send == undefined || isSending.current) {

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -241,10 +241,10 @@ function Chart(props: Props): JSX.Element {
     return out;
   }, [data, typedData, height, options, isBoundsReset, width]);
 
-  // Queue an update to the chart and process any outstanding requests.
-  const queueUpdate = useCallback(
-    async (send: RpcSend | undefined, update: PartialUpdate) => {
-      queuedUpdates.current = [...queuedUpdates.current, update];
+  // Flush all new to the worker, coalescing them together if there is more
+  // than one.
+  const flushUpdates = useCallback(
+    async (send: RpcSend | undefined) => {
       if (send == undefined || isSending.current) {
         return;
       }
@@ -276,7 +276,8 @@ function Chart(props: Props): JSX.Element {
   const updateChart = useCallback(
     async (update: PartialUpdate) => {
       if (initialized.current) {
-        await queueUpdate(rpcSendRef.current, update);
+        queuedUpdates.current = [...queuedUpdates.current, update];
+        await flushUpdates(rpcSendRef.current);
         return;
       }
 
@@ -321,11 +322,20 @@ function Chart(props: Props): JSX.Element {
       maybeUpdateScales(scales);
       onFinishRender?.();
 
+      // We cannot rely solely on the call to `initialize`, since it doesn't
+      // actually produce the first frame. However, if we append this update to
+      // the end, it will overwrite updates that have been queued _since we
+      // started initializing_. This is incorrect behavior and can set the
+      // scales incorrectly on weak devices.
+      //
+      // To prevent this from happening, we put this update at the beginning of
+      // the queue so that it gets coalesced properly.
+      queuedUpdates.current = [update, ...queuedUpdates.current];
+      await flushUpdates(sendWrapperRef.current);
       // once we are initialized, we can allow other handlers to send to the rpc endpoint
-      await queueUpdate(sendWrapperRef.current, update);
       rpcSendRef.current = sendWrapperRef.current;
     },
-    [maybeUpdateScales, onFinishRender, onStartRender, type, queueUpdate],
+    [maybeUpdateScales, onFinishRender, onStartRender, type, flushUpdates],
   );
 
   const [updateError, setUpdateError] = useState<Error | undefined>();

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj, StoryFn } from "@storybook/react";
+import { waitFor } from "@storybook/testing-library";
 import { useCallback } from "react";
 import { useAsync } from "react-use";
 
@@ -138,33 +139,33 @@ export const Dark: StoryObj = {
   decorators: [Wrapper],
 };
 
-//export const LimitWidth: StoryObj = {
-//render: function Story() {
-//const readySignal = useReadySignal({ count: 6 });
-//const pauseFrame = useCallback(() => readySignal, [readySignal]);
+export const LimitWidth: StoryObj = {
+  render: function Story() {
+    const readySignal = useReadySignal({ count: 6 });
+    const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
-//return (
-//<PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-//<div
-//style={{
-//height: "100%",
-//width: "100%",
-//}}
-//>
-//<Plot
-//overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
-///>
-//</div>
-//</PanelSetup>
-//);
-//},
+    return (
+      <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+          }}
+        >
+          <Plot
+            overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }}
+          />
+        </div>
+      </PanelSetup>
+    );
+  },
 
-//play: async (ctx) => {
-//await waitFor(() => ctx.parameters.storyReady);
-//},
+  play: async (ctx) => {
+    await waitFor(() => ctx.parameters.storyReady);
+  },
 
-//parameters: {
-//colorScheme: "light",
-//useReadySignal: true,
-//},
-//};
+  parameters: {
+    colorScheme: "light",
+    useReadySignal: true,
+  },
+};

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -6,12 +6,13 @@ import { StoryObj, StoryFn } from "@storybook/react";
 import { waitFor } from "@storybook/testing-library";
 import { useCallback } from "react";
 import { useAsync } from "react-use";
+import * as _ from "lodash-es";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
 import { fixture, paths } from "@foxglove/studio-base/panels/Plot/index.stories";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
-import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+import { useReadySignal, ReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 
 export default {
   title: "panels/Plot/PlotLegend",
@@ -45,8 +46,17 @@ const exampleConfig: PlotConfig = {
   maxXValue: 3,
 };
 
+function useDebouncedReadySignal(): ReadySignal {
+  const readySignal = useReadySignal();
+  return React.useMemo(() => {
+    return _.debounce(() => {
+      readySignal();
+    }, 3000);
+  }, [readySignal]);
+}
+
 function Wrapper(Wrapped: StoryFn): JSX.Element {
-  const readySignal = useReadySignal({ count: 10 });
+  const readySignal = useDebouncedReadySignal();
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   const delayedFixture = useAsync(async () => fixture, []);
   return (
@@ -141,7 +151,7 @@ export const Dark: StoryObj = {
 
 export const LimitWidth: StoryObj = {
   render: function Story() {
-    const readySignal = useReadySignal({ count: 6 });
+    const readySignal = useDebouncedReadySignal();
     const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
     return (

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj, StoryFn } from "@storybook/react";
-import { waitFor } from "@storybook/testing-library";
 import * as _ from "lodash-es";
 import { useCallback } from "react";
 import { useAsync } from "react-use";
@@ -171,7 +170,7 @@ export const LimitWidth: StoryObj = {
   },
 
   play: async (ctx) => {
-    await waitFor(() => ctx.parameters.storyReady);
+    await ctx.parameters.storyReady;
   },
 
   parameters: {

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -4,9 +4,9 @@
 
 import { StoryObj, StoryFn } from "@storybook/react";
 import { waitFor } from "@storybook/testing-library";
+import * as _ from "lodash-es";
 import { useCallback } from "react";
 import { useAsync } from "react-use";
-import * as _ from "lodash-es";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -400,6 +400,7 @@ export default {
   title: "panels/Plot",
   component: Plot,
   parameters: {
+    colorScheme: "light",
     chromatic: { delay: 50 },
   },
   excludeStories: ["paths", "fixture"],
@@ -426,6 +427,7 @@ export const LineGraph: StoryObj = {
   name: "line graph",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 };
@@ -450,6 +452,7 @@ export const LineGraphWithValuesAndDisabledSeries: StoryObj = {
   name: "line graph with values and disabled series",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 };
@@ -517,6 +520,7 @@ export const LineGraphWithNoTitle: StoryObj = {
   name: "line graph with no title",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 };
@@ -561,6 +565,7 @@ export const LineGraphWithSettings: StoryObj = {
 export const LineGraphWithSettingsChinese: StoryObj = {
   ...LineGraphWithSettings,
   parameters: {
+    colorScheme: "light",
     ...LineGraphWithSettings.parameters,
     forceLanguage: "zh",
   },
@@ -568,6 +573,7 @@ export const LineGraphWithSettingsChinese: StoryObj = {
 export const LineGraphWithSettingsJapanese: StoryObj = {
   ...LineGraphWithSettings,
   parameters: {
+    colorScheme: "light",
     ...LineGraphWithSettings.parameters,
     forceLanguage: "ja",
   },
@@ -587,6 +593,7 @@ export const LineGraphWithLegendsHidden: StoryObj = {
   name: "line graph with legends hidden",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 };
@@ -641,6 +648,7 @@ export const InALineGraphWithMultiplePlotsXAxesAreSynced: StoryObj = {
   name: "in a line graph with multiple plots, x-axes are synced",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -689,8 +697,8 @@ export const LineGraphAfterZoom: StoryObj = {
   name: "line graph after zoom",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
-    colorScheme: "dark",
   },
 
   play: async (ctx) => {
@@ -724,6 +732,7 @@ export const TimestampMethodHeaderStamp: StoryObj = {
   name: "timestampMethod: headerStamp",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -758,6 +767,7 @@ export const LongPath: StoryObj = {
   name: "long path",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -796,6 +806,7 @@ export const DisabledPath: StoryObj = {
   name: "disabled path",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -836,6 +847,7 @@ export const HiddenConnectingLines: StoryObj = {
   name: "hidden connecting lines",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -870,6 +882,7 @@ export const ReferenceLine: StoryObj = {
   name: "reference line",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -943,6 +956,7 @@ export const WithJustMinYValueLessThanMinimumValue: StoryObj = {
   name: "with just min Y value less than minimum value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -977,6 +991,7 @@ export const WithJustMinYValueMoreThanMinimumValue: StoryObj = {
   name: "with just min Y value more than minimum value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1011,6 +1026,7 @@ export const WithJustMinYValueMoreThanMaximumValue: StoryObj = {
   name: "with just min Y value more than maximum value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1045,6 +1061,7 @@ export const WithJustMaxYValueLessThanMaximumValue: StoryObj = {
   name: "with just max Y value less than maximum value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1079,6 +1096,7 @@ export const WithJustMaxYValueMoreThanMaximumValue: StoryObj = {
   name: "with just max Y value more than maximum value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1113,6 +1131,7 @@ export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
   name: "with just max Y value less than minimum value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1152,6 +1171,7 @@ export const ScatterPlotPlusLineGraphPlusReferenceLine: StoryObj = {
   name: "scatter plot plus line graph plus reference line",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1187,6 +1207,7 @@ export const IndexBasedXAxisForArray: StoryObj = {
   name: "index-based x-axis for array",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1249,6 +1270,7 @@ export const IndexBasedXAxisForArrayWithUpdate: StoryObj = {
   name: "index-based x-axis for array with update",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1284,6 +1306,7 @@ export const CustomXAxisTopic: StoryObj = {
   name: "custom x-axis topic",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1358,6 +1381,7 @@ export const CurrentCustomXAxisTopic: StoryObj = {
   name: "current custom x-axis topic",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1404,6 +1428,7 @@ export const CustomXAxisTopicWithMismatchedDataLengths: StoryObj = {
   name: "custom x-axis topic with mismatched data lengths",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1465,6 +1490,7 @@ export const SuperCloseValues: StoryObj = {
   name: "super close values",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1500,6 +1526,7 @@ export const TimeValues: StoryObj = {
   name: "time values",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1531,6 +1558,7 @@ export const PreloadedDataInBinaryBlocks: StoryObj = {
   name: "preloaded data in binary blocks",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1566,6 +1594,7 @@ export const MixedStreamedAndPreloadedData: StoryObj = {
   name: "mixed streamed and preloaded data",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1601,6 +1630,7 @@ export const PreloadedDataAndItsDerivative: StoryObj = {
   name: "preloaded data and its derivative",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1636,6 +1666,7 @@ export const PreloadedDataAndItsNegative: StoryObj = {
   name: "preloaded data and its negative",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1671,6 +1702,7 @@ export const PreloadedDataAndItsAbsoluteValue: StoryObj = {
   name: "preloaded data and its absolute value",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 
@@ -1711,6 +1743,7 @@ export const DifferentLineSizes: StoryObj = {
   name: "different line sizes",
 
   parameters: {
+    colorScheme: "light",
     useReadySignal: true,
   },
 

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -116,6 +116,7 @@ export default {
   title: "panels/StateTransitions",
   component: StateTransitions,
   parameters: {
+    colorScheme: "light",
     chromatic: { delay: 100 },
   },
 };
@@ -134,7 +135,7 @@ export const Empty: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
 
 export const ColorPalette: StoryObj = {
@@ -218,7 +219,7 @@ export const OnePath: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
 
 export const WithXAxisMinMax: StoryObj = {
@@ -291,7 +292,7 @@ export const WithSettings: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
 
 export const MultiplePaths: StoryObj = {
@@ -316,7 +317,7 @@ export const MultiplePaths: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
 
 export const LongPath: StoryObj = {
@@ -338,7 +339,7 @@ export const LongPath: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
 
 export const ColorClash: StoryObj = {
@@ -362,7 +363,7 @@ export const ColorClash: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };
 
 const messageCache: BlockCache = {
@@ -436,5 +437,5 @@ export const Blocks: StoryObj = {
   play: async ({ parameters }) => {
     await parameters.storyReady;
   },
-  parameters: { useReadySignal: true },
+  parameters: { useReadySignal: true, colorScheme: "light" },
 };


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
I'm continuing my quest to fix our flaky stories. In this attempt I:
1. Changed all Plot and State Transition stories to just use single light mode plots (where applicable), since it seems that some of our problems stem from timing discrepancies between the two. In general it's nice to see both themes but in practice this seems to still cause us problems. This could just be temporary.
2. Fixed an ordering issue in the `Chart` component. It turns out that the previous `queueUpdate` logic was incorrect for specifically the first `update` call: if updates were queued while we were still initializing, we would incorrectly push the first `update` on top of them. Instead, we insert the first update at the _beginning_ of the queued updates.
