### PR TITLE
Fix clearing of camera model while error image is active

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -306,7 +306,10 @@ export class ImageMode
         this.renderer.queueAnimationFrame();
       }, REMOVE_IMAGE_TIMEOUT_MS);
     }
-    this.#clearCameraModel();
+    // fallback camera model shouldn't ever be stale so we don't need to clear it
+    if (!this.#fallbackCameraModelActive()) {
+      this.#clearCameraModel();
+    }
     this.#annotations.removeAllRenderables();
     this.messageHandler.clear();
     super.removeAllRenderables();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -207,13 +207,16 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         }
         // avoid needing to recreate error image if it already shown
         if (!this.#showingErrorImage) {
-          void this.#setErrorImage(seq);
+          void this.#setErrorImage(seq, onDecoded);
         }
         this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding image: ${err.message}`);
       });
   }
 
-  async #setErrorImage(seq: number): Promise<void> {
+  async #setErrorImage(
+    seq: number,
+    onDecoded?: (image: { width: number; height: number }) => void,
+  ): Promise<void> {
     const errorBitmap = await getErrorImage(64, 64);
     if (this.isDisposed()) {
       return;
@@ -225,6 +228,8 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.#textureNeedsUpdate = true;
     this.update();
     this.#showingErrorImage = true;
+    // call ondecoded to display the error image when calibration is None
+    onDecoded?.(this.#decodedImage);
     this.renderer.queueAnimationFrame();
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -197,7 +197,7 @@ const ImageModeFoxgloveImage = ({
   minValue,
   maxValue,
 }: {
-  imageType?: "raw" | "png" | "raw_mono16" | "error";
+  imageType?: "raw" | "png" | "raw_mono16";
   rotation?: 0 | 90 | 180 | 270;
   flipHorizontal?: boolean;
   flipVertical?: boolean;
@@ -209,7 +209,6 @@ const ImageModeFoxgloveImage = ({
     { name: "/cam1/info", schemaName: "foxglove.CameraCalibration" },
     { name: "/cam2/info", schemaName: "foxglove.CameraCalibration" },
     { name: "/cam1/png", schemaName: "foxglove.CompressedImage" },
-    { name: "/cam2/error", schemaName: "foxglove.CompressedImage" },
     { name: "/cam2/raw", schemaName: "foxglove.RawImage" },
     { name: "/mono16/raw", schemaName: "foxglove.RawImage" },
   ];
@@ -267,19 +266,6 @@ const ImageModeFoxgloveImage = ({
       frame_id: SENSOR_FRAME_ID,
       format: "png",
       data: PNG_TEST_IMAGE,
-    },
-    schemaName: "foxglove.CompressedImage",
-    sizeInBytes: 0,
-  };
-
-  const cam1Error: MessageEvent<Partial<CompressedImage>> = {
-    topic: "/cam2/error",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      timestamp: { sec: 0, nsec: 0 },
-      frame_id: SENSOR_FRAME_ID,
-      format: "imaginary-format",
-      data: new Uint8Array(PNG_TEST_IMAGE).fill(255, 0),
     },
     schemaName: "foxglove.CompressedImage",
     sizeInBytes: 0,
@@ -353,7 +339,6 @@ const ImageModeFoxgloveImage = ({
       "/cam1/info": [cam1],
       "/cam2/info": [cam2],
       "/cam1/png": [cam1Png],
-      "/cam2/error": [cam1Error],
       "/cam2/raw": [cam2Raw],
       "/mono16/raw": [mono16Raw],
     },
@@ -376,10 +361,6 @@ const ImageModeFoxgloveImage = ({
       break;
     case "raw_mono16":
       imageTopic = "/mono16/raw";
-      break;
-    case "error":
-      imageTopic = "/cam2/error";
-      calibrationTopic = "/cam2/info";
       break;
   }
 
@@ -435,11 +416,6 @@ export const ImageModeFoxglovePngImage: StoryObj<
 > = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "png" },
-};
-
-export const ImageModeErrorImage: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
-  render: ImageModeFoxgloveImage,
-  args: { imageType: "error" },
 };
 
 export const DownloadRawImage: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
n/a

**Description**

While seeking to an image message that would produce an error image with `None` image calibration, it would clear the existing camera model causing a strange panning behavior in the image panel while the error image was displayed. Previously we would not show an image at all when erroring so this wasn't noticeable.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
