### PR TITLE
Adjust block processing to support new user script output

### DIFF
--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -205,4 +205,18 @@ describe("processBlocks", () => {
       expect(newData).toEqual([block]);
     }
   });
+
+  it("should start from beginning when blocks before cursor are emptied", () => {
+    // ssss| -> s|eee
+    const { state } = processBlocks([block, block, block, block], subscriptions, initial);
+    const {
+      state: { messages, cursors },
+      resetTopics,
+      newData,
+    } = processBlocks([block, {}, {}, {}], subscriptions, state);
+    expect(messages[0]?.[FAKE_TOPIC]).toEqual(1);
+    expect(cursors[FAKE_TOPIC]).toEqual(1);
+    expect(resetTopics).toEqual([FAKE_TOPIC]);
+    expect(newData).toEqual([block]);
+  });
 });


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
Right now when a user script changes, it does not clear out the existing message state in the blocks as one might expect, it just overwrites blocks one at a time*. Soon the user script player will be updated to fix this. This PR adds support for the new behavior without breaking any existing behavior. It should be able to be safely merged into `main` without requiring the upstream change, since this scenario can't actually occur right now.

*I'm simplifying a lot
