### PR TITLE
Avoid opening plot settings which deleting a plot series via the legend

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -10,7 +10,7 @@ import {
   Square12Regular,
 } from "@fluentui/react-icons";
 import { ButtonBase, Checkbox, Tooltip, Typography, buttonBaseClasses } from "@mui/material";
-import { useMemo, useState } from "react";
+import { MouseEventHandler, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
@@ -180,7 +180,13 @@ export function PlotLegendRow({
   // When there are no series configured we render an extra row to show an "add series" button.
   const isAddSeriesRow = paths.length === 0;
 
-  const handleDeletePath = () => {
+  const handleDeletePath: MouseEventHandler<HTMLButtonElement> = (ev) => {
+    // Deleting a path is a "quick action" and we want to avoid opening the settings sidebar
+    // so whatever sidebar the user is already viewing says active.
+    //
+    // This prevents the click event from going up to the entire row and showing the sidebar.
+    ev.stopPropagation();
+
     const newPaths = paths.slice();
     if (newPaths.length > 0) {
       newPaths.splice(index, 1);


### PR DESCRIPTION
**User-Facing Changes**
When clicking the "x" on a plot legend, the series is deleted without the plot settings opening.

**Description**
When searching a list of topics and using the drag & drop feature with the plot panel it is convenient to quickly add a signal and then remove it. When removing the signal using the legend "x" button, the panel settings would open and lose the topic search sidebar context.

This change updates the "x" button behavior on the legend to stop the click event from triggering the settings to open and leaves the sidebar state unchanged.
