### PR TITLE
Disable ligatures in default datagrid styles

### DIFF
--- a/packages/theme/src/components/MuiDataGrid.ts
+++ b/packages/theme/src/components/MuiDataGrid.ts
@@ -32,6 +32,7 @@ export const MuiDataGrid: OverrideComponentReturn<"MuiDataGrid"> = {
   },
   styleOverrides: {
     root: {
+      fontVariantLigatures: "none",
       // Disable focus outline by default since most of our grids are used
       // as non-interactive display tables
       "& .MuiDataGrid-cell:focus": {


### PR DESCRIPTION
**User-Facing Changes**

None.

**Description**

This disables ligatures for type inside a data grid, which is intended for tabular data. We don't display any data grids in Studio today.

FG-5926