### PR TITLE
Replace `__brand` with Opaque from ts-essentials

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/messageProcessing.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as _ from "lodash-es";
+import { Opaque } from "ts-essentials";
 
 import {
   Immutable,
@@ -14,8 +15,7 @@ import { Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
 import { ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
 
 // Branded string to ensure that users go through the `converterKey` function to compute a lookup key
-type Brand<K, T> = K & { __brand: T };
-type ConverterKey = Brand<string, "ConverterKey">;
+type ConverterKey = Opaque<string, "ConverterKey">;
 
 type MessageConverter = RegisterMessageConverterArgs<unknown> & {
   extensionNamespace?: ExtensionNamespace;

--- a/packages/studio-base/src/context/PerformanceContext.ts
+++ b/packages/studio-base/src/context/PerformanceContext.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { createContext, useContext } from "react";
+import { Opaque } from "ts-essentials";
 
 // Ensure Symbol.dispose and Symbol.asyncDispose are defined
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html
@@ -11,7 +12,7 @@ import { createContext, useContext } from "react";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (Symbol as any).asyncDispose ??= Symbol("Symbol.asyncDispose");
 
-export type PerformanceMetricID = number & { __brand: "PerformanceMetricID" };
+export type PerformanceMetricID = Opaque<number, "PerformanceMetricID">;
 
 export type PerformanceMetric = {
   id: PerformanceMetricID;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -4,6 +4,7 @@
 
 import { t } from "i18next";
 import * as THREE from "three";
+import { Opaque } from "ts-essentials";
 
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas";
@@ -28,7 +29,7 @@ import { IMessageHandler, MessageRenderState } from "../MessageHandler";
 
 const MISSING_SYNCHRONIZED_ANNOTATION = "MISSING_SYNCHRONIZED_ANNOTATION";
 
-type TopicName = string & { __brand: "TopicName" };
+type TopicName = Opaque<string, "TopicName">;
 
 interface ImageAnnotationsContext {
   initialScale: number;


### PR DESCRIPTION
**User-facing changes**
None

**Description**
Replace home-grown `__brand` uses with the Opaque type from `ts-essentials`. It does the same thing, is documented, and is cleaner to write.