### PR TITLE
Restore state transition panel downsampling

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -5,7 +5,7 @@
 import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets";
 import { RpcScales } from "@foxglove/studio-base/components/Chart/types";
 
-import { downsample } from "./downsample";
+import { downsample, MAX_POINTS } from "./downsample";
 import { ChartDatasets, PlotViewport } from "./types";
 
 type UpdateParams = {
@@ -36,28 +36,23 @@ export class Downsampler {
    */
   public downsample(): ChartDatasets | undefined {
     const width = this.#datasetBounds?.width;
-    const height = this.#datasetBounds?.width;
+    const height = this.#datasetBounds?.height;
 
     const currentScales = this.#scales;
-    let bounds:
-      | {
-          width: number;
-          height: number;
-          x: { min: number; max: number };
-          y: { min: number; max: number };
-        }
-      | undefined = undefined;
+    let view: PlotViewport | undefined = undefined;
     if (currentScales?.x && currentScales.y) {
-      bounds = {
+      view = {
         width: width ?? 0,
         height: height ?? 0,
-        x: {
-          min: currentScales.x.min,
-          max: currentScales.x.max,
-        },
-        y: {
-          min: currentScales.y.min,
-          max: currentScales.y.max,
+        bounds: {
+          x: {
+            min: currentScales.x.min,
+            max: currentScales.x.max,
+          },
+          y: {
+            min: currentScales.y.min,
+            max: currentScales.y.max,
+          },
         },
       };
     }
@@ -66,19 +61,13 @@ export class Downsampler {
       return undefined;
     }
 
-    const { bounds: dataBounds } = this.#datasetBounds;
-    const view: PlotViewport = {
-      width: 0,
-      height: 0,
-      bounds: dataBounds,
-    };
-
+    const numPoints = MAX_POINTS / Math.max(this.#datasets.length, 1);
     return this.#datasets.map((dataset) => {
-      if (!bounds) {
+      if (!view) {
         return dataset;
       }
 
-      const downsampled = downsample(dataset, iterateObjects(dataset.data), view);
+      const downsampled = downsample(dataset, iterateObjects(dataset.data), view, numPoints);
       const resolved = downsampled.map((i) => dataset.data[i]);
 
       // NaN item values create gaps in the line

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -207,7 +207,6 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   );
 
   const provided = useProvider(view, getBounds, mergeNormal, data, provider ?? downsampler);
-
   const typedProvided = useProvider(view, getTypedBounds, mergeTyped, typedData, typedProvider);
 
   React.useEffect(() => {

--- a/packages/studio-base/src/components/TimeBasedChart/useDownsampler.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/useDownsampler.tsx
@@ -85,7 +85,7 @@ export default function useDownsampler(datasets: ChartDataset[]): {
         // setSetter cannot take two arguments, so we can't just write
         // `register: setSetter`
         register: (newSetter) => {
-          setSetter(newSetter);
+          setSetter(() => newSetter);
         },
       },
       setScales,

--- a/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
@@ -202,5 +202,5 @@ export default function useProvider<T>(
       },
       data,
     };
-  }, [data, state, getDatasetBounds, mergeState]);
+  }, [data, provider, state, getDatasetBounds, mergeState]);
 }

--- a/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/useProvider.tsx
@@ -173,7 +173,7 @@ export default function useProvider<T>(
   }, [provider, view]);
 
   return useMemo(() => {
-    if (data == undefined) {
+    if (provider != undefined) {
       if (state == undefined) {
         return undefined;
       }
@@ -190,8 +190,11 @@ export default function useProvider<T>(
       return mergeState(full, partial);
     }
 
-    const bounds = getDatasetBounds(data.datasets);
+    if (data == undefined) {
+      return undefined;
+    }
 
+    const bounds = getDatasetBounds(data.datasets);
     return {
       bounds: bounds ?? {
         x: { min: 0, max: 0 },


### PR DESCRIPTION
**User-Facing Changes**
Marginally speed up the rendering performance of the state transition panel.

**Description**
This had broken at some point, certainly when I introduced `useProvider`. Honestly though, downsampling doesn't do very much for the state transition panel right now because distinct states are always represented by at least one point; the maximum number of points is not respected for some nuanced reasons. We will address this soon.

In the mean time though, this PR helps because when we zoom in, we will (correctly) cull points outside of the viewport. We are not doing that right now.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
