### PR TITLE
Update point clouds to default to `z` instead of first field

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -16,8 +16,7 @@ import {
   getColorConverter,
   NEEDS_MIN_MAX,
   FS_SRGB_TO_LINEAR,
-  RGBA_PACKED_FIELDS,
-  hasSeparateRgbaFields,
+  autoSelectColorSettings,
 } from "./colorMode";
 import { FieldReader, getReader } from "./pointClouds/fieldReaders";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
@@ -493,6 +492,15 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       return;
     }
 
+    let fields = this.#fieldsByTopic.get(topic);
+    let fieldsUpdated = false;
+    if (!fields || fields.length !== foxgloveGrid.fields.length) {
+      fields = foxgloveGrid.fields.map((field) => field.name);
+      this.#fieldsByTopic.set(topic, fields);
+      this.updateSettingsTree();
+      fieldsUpdated = true;
+    }
+
     if (renderable) {
       renderable.visible = true;
     } else {
@@ -502,8 +510,11 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       // only want to autoselect if it's in flatcolor mode (without colorfield) and previously didn't have fields
-      if (settings.colorField == undefined && this.#fieldsByTopic.get(topic) == undefined) {
-        autoSelectColorField(settings, foxgloveGrid.fields, { supportsPackedRgbModes: false });
+      if (settings.colorField == undefined && fieldsUpdated) {
+        autoSelectColorSettings(settings, fields, {
+          supportsPackedRgbModes: false,
+          supportsRgbaFieldsMode: true,
+        });
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {
           const updatedUserSettings = { ...userSettings };
@@ -543,13 +554,6 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
 
       this.add(renderable);
       this.renderables.set(topic, renderable);
-    }
-
-    let fields = this.#fieldsByTopic.get(topic);
-    if (!fields || fields.length !== foxgloveGrid.fields.length) {
-      fields = foxgloveGrid.fields.map((field) => field.name);
-      this.#fieldsByTopic.set(topic, fields);
-      this.updateSettingsTree();
     }
 
     this.#updateFoxgloveGridRenderable(
@@ -923,43 +927,3 @@ const NumericTypeMinMaxValueMap: Record<NumericType, [number, number]> = {
   [NumericType.FLOAT32]: [0, 1.0],
   [NumericType.FLOAT64]: [0, 1.0],
 };
-
-function autoSelectColorField<Settings extends ColorModeSettings>(
-  output: Settings,
-  fields: PackedElementField[],
-  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
-): void {
-  // Prefer color fields first
-  if (supportsPackedRgbModes) {
-    for (const field of fields) {
-      const fieldNameLower = field.name.toLowerCase();
-      if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
-        output.colorField = field.name;
-        switch (fieldNameLower) {
-          case "rgb":
-            output.colorMode = "rgb";
-            break;
-          default:
-          case "rgba":
-            output.colorMode = "rgba";
-            break;
-        }
-        return;
-      }
-    }
-  }
-
-  if (hasSeparateRgbaFields(fields.map((f) => f.name))) {
-    output.colorMode = "rgba-fields";
-    return;
-  }
-
-  // Fall back to using the first field
-  if (fields.length > 0) {
-    const firstField = fields[0]!;
-    output.colorField = firstField.name;
-    output.colorMode = "colormap";
-    output.colorMap = "turbo";
-    return;
-  }
-}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -523,6 +523,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
           updatedUserSettings.colorMap = settings.colorMap;
           draft.topics[topic] = updatedUserSettings;
         });
+        this.updateSettingsTree();
       }
 
       // Check color

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -24,8 +24,7 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/pointExtensionUtils";
 import type { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 
-import { autoSelectColorSettings } from "./colorMode";
-import { colorHasTransparency, getColorConverter } from "./colorMode";
+import { autoSelectColorSettings, colorHasTransparency, getColorConverter } from "./colorMode";
 import { FieldReader, getReader, isSupportedField } from "./pointClouds/fieldReaders";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
 import { BaseUserData, Renderable } from "../Renderable";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -5,13 +5,11 @@
 import * as _ from "lodash-es";
 import * as THREE from "three";
 
-import { filterMap } from "@foxglove/den/collection";
 import { Time, toNanoSec } from "@foxglove/rostime";
 import { NumericType, PackedElementField, PointCloud } from "@foxglove/schemas";
 import { SettingsTreeAction, MessageEvent } from "@foxglove/studio";
 import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRender/DynamicBufferGeometry";
 import {
-  autoSelectColorField,
   createGeometry,
   createInstancePickingMaterial,
   createPickingMaterial,
@@ -26,6 +24,7 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/pointExtensionUtils";
 import type { RosObject, RosValue } from "@foxglove/studio-base/players/types";
 
+import { autoSelectColorSettings } from "./colorMode";
 import { colorHasTransparency, getColorConverter } from "./colorMode";
 import { FieldReader, getReader, isSupportedField } from "./pointClouds/fieldReaders";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
@@ -824,21 +823,15 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
   };
 
   #handleFoxglovePointCloud = (messageEvent: PartialMessageEvent<PointCloud>): void => {
-    const topic = messageEvent.topic;
+    const { topic, schemaName } = messageEvent;
     const pointCloud = normalizePointCloud(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const messageTime = toNanoSec(pointCloud.timestamp);
     const frameId = pointCloud.frame_id;
 
-    // Update the mapping of topic to point cloud field names if necessary
-    let fields = this.#fieldsByTopic.get(topic);
-    if (!fields || fields.length !== pointCloud.fields.length) {
-      fields = pointCloud.fields.map((field) => field.name);
-      this.#fieldsByTopic.set(topic, fields);
-      this.updateSettingsTree();
-    }
     this.#handlePointCloud(
       topic,
+      schemaName,
       pointCloud,
       receiveTime,
       messageTime,
@@ -848,29 +841,15 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
   };
 
   #handleRosPointCloud = (messageEvent: PartialMessageEvent<PointCloud2>): void => {
-    const topic = messageEvent.topic;
+    const { topic, schemaName } = messageEvent;
     const pointCloud = normalizePointCloud2(messageEvent.message);
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const messageTime = toNanoSec(pointCloud.header.stamp);
     const frameId = pointCloud.header.frame_id;
 
-    // Update the mapping of topic to point cloud field names if necessary
-    let fields = this.#fieldsByTopic.get(topic);
-    // filter count to compare only supported fields
-    const numSupportedFields = pointCloud.fields.reduce((numSupported, field) => {
-      return numSupported + (isSupportedField(field) ? 1 : 0);
-    }, 0);
-    if (!fields || fields.length !== numSupportedFields) {
-      // Omit fields with count != 1
-      fields = filterMap(pointCloud.fields, (field) =>
-        isSupportedField(field) ? field.name : undefined,
-      );
-      this.#fieldsByTopic.set(topic, fields);
-      this.updateSettingsTree();
-    }
-
     this.#handlePointCloud(
       topic,
+      schemaName,
       pointCloud,
       receiveTime,
       messageTime,
@@ -881,12 +860,29 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
 
   #handlePointCloud(
     topic: string,
+    schemaName: string,
     pointCloud: PointCloud | PointCloud2,
     receiveTime: bigint,
     messageTime: bigint,
     originalMessage: RosObject,
     frameId: string,
   ): void {
+    // Update the mapping of topic to point cloud field names if necessary
+    let fields = this.#fieldsByTopic.get(topic);
+    // filter count to compare only supported fields
+    const numSupportedFields = pointCloud.fields.reduce((numSupported, field) => {
+      return numSupported + (isSupportedField(field) ? 1 : 0);
+    }, 0);
+    let fieldsForTopicUpdated = false;
+    if (!fields || fields.length !== numSupportedFields) {
+      // Omit fields with count != 1 (only applies to ros pointclouds)
+      // can't use filterMap here because of incompatible types
+      fields = pointCloud.fields.filter(isSupportedField).map((field) => field.name);
+      this.#fieldsByTopic.set(topic, fields);
+      fieldsForTopicUpdated = true;
+      this.updateSettingsTree();
+    }
+
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
@@ -894,8 +890,13 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
         | Partial<LayerSettingsPointClouds>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
-      if (settings.colorField == undefined) {
-        autoSelectColorField(settings, pointCloud, { supportsPackedRgbModes: true });
+
+      // want to avoid setting this if fields didn't update
+      if (settings.colorField == undefined && fieldsForTopicUpdated) {
+        autoSelectColorSettings(settings, fields, {
+          supportsPackedRgbModes: ROS_POINTCLOUD_DATATYPES.has(schemaName),
+          supportsRgbaFieldsMode: FOXGLOVE_POINTCLOUD_DATATYPES.has(schemaName),
+        });
 
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/colorMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/colorMode.ts
@@ -181,11 +181,10 @@ export const RGBA_PACKED_FIELDS = new Set<string>(["rgb", "rgba"]);
 export const INTENSITY_FIELDS = new Set<string>(["intensity", "i"]);
 
 /**
- * Selects optimal color field for settings given a list of fields
+ * Mutates output to select optimal color settings given a list of fields
  * @param output - settings object to apply auto selection of colorfield to
  * @param fields - array of string field names. PointField names should already have been checked for support
  * @param { supportsPackedRgbModes, supportsRgbaFieldsMode } - whether or not the message supports packed rgb modes or rgba fields mode
- * @returns - changes output object to have desired color field selected
  */
 
 export function autoSelectColorSettings<Settings extends ColorModeSettings>(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/colorMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/colorMode.ts
@@ -180,26 +180,74 @@ function turboLinearCached(output: ColorRGBA, pct: number): void {
 export const RGBA_PACKED_FIELDS = new Set<string>(["rgb", "rgba"]);
 export const INTENSITY_FIELDS = new Set<string>(["intensity", "i"]);
 
+/**
+ * Selects optimal color field for settings given a list of fields
+ * @param output - settings object to apply auto selection of colorfield to
+ * @param fields - array of string field names. PointField names should already have been checked for support
+ * @param { supportsPackedRgbModes, supportsRgbaFieldsMode } - whether or not the message supports packed rgb modes or rgba fields mode
+ * @returns - changes output object to have desired color field selected
+ */
+
+export function autoSelectColorSettings<Settings extends ColorModeSettings>(
+  output: Settings,
+  fields: string[],
+  {
+    supportsPackedRgbModes,
+    supportsRgbaFieldsMode,
+  }: { supportsPackedRgbModes: boolean; supportsRgbaFieldsMode?: boolean },
+): void {
+  const bestField = bestColorByField(fields, { supportsPackedRgbModes });
+
+  if (!bestField) {
+    return;
+  }
+
+  output.colorField = bestField;
+  switch (bestField.toLowerCase()) {
+    case "rgb":
+      output.colorMode = "rgb";
+      break;
+    case "rgba":
+      output.colorMode = "rgba";
+      break;
+    default: // intensity, z, etc
+      output.colorMode = "colormap";
+      output.colorMap = "turbo";
+      break;
+  }
+
+  if (supportsRgbaFieldsMode === true) {
+    // does not depend on color field, so it's fine to leave as last was
+    if (hasSeparateRgbaFields(fields)) {
+      output.colorMode = "rgba-fields";
+      return;
+    }
+  }
+}
+
 function bestColorByField(
   fields: string[],
   { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
-): string {
+): string | undefined {
   if (supportsPackedRgbModes) {
+    // first priority is color fields
     for (const field of fields) {
-      if (RGBA_PACKED_FIELDS.has(field)) {
+      if (RGBA_PACKED_FIELDS.has(field.toLowerCase())) {
         return field;
       }
     }
   }
+  // second priority is intensity fields
   for (const field of fields) {
-    if (INTENSITY_FIELDS.has(field)) {
+    if (INTENSITY_FIELDS.has(field.toLowerCase())) {
       return field;
     }
   }
-  return fields.find((field) => field === "x") ?? fields[0] ?? "";
+  // third is 'z', then the first field
+  return fields.find((field) => field === "z") ?? fields[0];
 }
 
-export function hasSeparateRgbaFields(fields: string[]): boolean {
+function hasSeparateRgbaFields(fields: string[]): boolean {
   let r = false;
   let g = false;
   let b = false;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -5,7 +5,7 @@
 import { t } from "i18next";
 import * as THREE from "three";
 
-import { PackedElementField, PointCloud } from "@foxglove/schemas";
+import { PointCloud } from "@foxglove/schemas";
 import { SettingsTreeNode, Topic } from "@foxglove/studio";
 import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRender/DynamicBufferGeometry";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
@@ -30,7 +30,7 @@ import {
   RGBA_PACKED_FIELDS,
 } from "./colorMode";
 import { POINTCLOUD_DATATYPES as FOXGLOVE_POINTCLOUD_DATATYPES } from "../foxglove";
-import { PointCloud2, POINTCLOUD_DATATYPES as ROS_POINTCLOUD_DATATYPES, PointField } from "../ros";
+import { PointCloud2, POINTCLOUD_DATATYPES as ROS_POINTCLOUD_DATATYPES } from "../ros";
 
 export type LayerSettingsPointExtension = BaseSettings &
   ColorModeSettings & {
@@ -144,11 +144,9 @@ export function autoSelectColorField(
   { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
 ): void {
   // Prefer color fields first
+  const supportedFields = pointCloud.fields.filter(isSupportedField);
   if (supportsPackedRgbModes) {
-    for (const field of pointCloud.fields) {
-      if (!isSupportedField(field)) {
-        continue;
-      }
+    for (const field of supportedFields) {
       const fieldNameLower = field.name.toLowerCase();
       if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
         output.colorField = field.name;
@@ -167,10 +165,7 @@ export function autoSelectColorField(
   }
 
   // Intensity fields are second priority
-  for (const field of pointCloud.fields) {
-    if (!isSupportedField(field)) {
-      continue;
-    }
+  for (const field of supportedFields) {
     if (INTENSITY_FIELDS.has(field.name)) {
       output.colorField = field.name;
       output.colorMode = "colormap";
@@ -179,10 +174,18 @@ export function autoSelectColorField(
     }
   }
 
+  // Next check to see if there is a `z` field
+  for (const field of supportedFields) {
+    if (field.name === "z") {
+      output.colorField = field.name;
+      output.colorMode = "colormap";
+      output.colorMap = "turbo";
+      return;
+    }
+  }
+
   // Fall back to using the first point cloud field
-  const firstField = (pointCloud.fields as readonly (PackedElementField | PointField)[]).find(
-    (field) => isSupportedField(field),
-  );
+  const firstField = supportedFields[0];
   if (firstField != undefined) {
     output.colorField = firstField.name;
     output.colorMode = "colormap";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -5,13 +5,11 @@
 import { t } from "i18next";
 import * as THREE from "three";
 
-import { PointCloud } from "@foxglove/schemas";
 import { SettingsTreeNode, Topic } from "@foxglove/studio";
 import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRender/DynamicBufferGeometry";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { BaseUserData, Renderable } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderable";
 import { rgbaToCssString } from "@foxglove/studio-base/panels/ThreeDeeRender/color";
-import { isSupportedField } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders";
 import {
   missingTransformMessage,
   MISSING_TRANSFORM,
@@ -26,11 +24,9 @@ import {
   colorHasTransparency,
   ColorModeSettings,
   FS_SRGB_TO_LINEAR,
-  INTENSITY_FIELDS,
-  RGBA_PACKED_FIELDS,
 } from "./colorMode";
 import { POINTCLOUD_DATATYPES as FOXGLOVE_POINTCLOUD_DATATYPES } from "../foxglove";
-import { PointCloud2, POINTCLOUD_DATATYPES as ROS_POINTCLOUD_DATATYPES } from "../ros";
+import { POINTCLOUD_DATATYPES as ROS_POINTCLOUD_DATATYPES } from "../ros";
 
 export type LayerSettingsPointExtension = BaseSettings &
   ColorModeSettings & {
@@ -131,68 +127,6 @@ export function pointSettingsNode(
   return node;
 }
 
-/**
- * Selects optimal color field for settings given point cloud message
- * @param output - settings object to apply auto selection of colorfield to
- * @param pointCloud - point cloud message
- * @param { supportsPackedRgbModes } - whether or not the point cloud message supports packed rgb modes
- * @returns - changes output object to have desired color field selected
- */
-export function autoSelectColorField(
-  output: LayerSettingsPointExtension,
-  pointCloud: PointCloud | PointCloud2,
-  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
-): void {
-  // Prefer color fields first
-  const supportedFields = pointCloud.fields.filter(isSupportedField);
-  if (supportsPackedRgbModes) {
-    for (const field of supportedFields) {
-      const fieldNameLower = field.name.toLowerCase();
-      if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
-        output.colorField = field.name;
-        switch (fieldNameLower) {
-          case "rgb":
-            output.colorMode = "rgb";
-            break;
-          default:
-          case "rgba":
-            output.colorMode = "rgba";
-            break;
-        }
-        return;
-      }
-    }
-  }
-
-  // Intensity fields are second priority
-  for (const field of supportedFields) {
-    if (INTENSITY_FIELDS.has(field.name)) {
-      output.colorField = field.name;
-      output.colorMode = "colormap";
-      output.colorMap = "turbo";
-      return;
-    }
-  }
-
-  // Next check to see if there is a `z` field
-  for (const field of supportedFields) {
-    if (field.name === "z") {
-      output.colorField = field.name;
-      output.colorMode = "colormap";
-      output.colorMap = "turbo";
-      return;
-    }
-  }
-
-  // Fall back to using the first point cloud field
-  const firstField = supportedFields[0];
-  if (firstField != undefined) {
-    output.colorField = firstField.name;
-    output.colorMode = "colormap";
-    output.colorMap = "turbo";
-    return;
-  }
-}
 /**
  * Creates a THREE.Points object for a point cloud and scan messages
  * @param topic - topic name string for naming geometry


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Point clouds will default to color by `z` when intensity and rgb fields aren't present

**Description**

Updated to color by `z` as a fallback for all colorMode applicable renderables. Also in this I consolidated the autoselecting of color settings, and updated all renderables to use the same method. I also consolidated the setting of fields for pointlcouds since `isSupported` would run on both foxglove and ros pointclouds, and we should be using it as a flag to determine whether to update the autoselection of color settings aside from the colorField being `undefined` because the colorField can be undefined for `rgba-fields`.

We're also defaulting to `x` in `colorMode.ts` [here](https://github.com/foxglove/studio/blob/main/packages/studio-base/src/panels/ThreeDeeRender/renderables/colorMode.ts#L199), which we use for FoxgloveGrid, and Images. ~~Should I update that to use `z` as well?~~ updated. 


<!-- link relevant GitHub issues -->
Fixes: FG-5831
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
