### PR TITLE
Relax width on nested menus to prevent clipping

### DIFF
--- a/packages/studio-base/src/components/AppBar/NestedMenuItem.tsx
+++ b/packages/studio-base/src/components/AppBar/NestedMenuItem.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles<void, "endIcon">()((theme, _params, classes) => ({
   },
   menuList: {
     minWidth: 180,
-    maxWidth: 220,
+    maxWidth: 280,
   },
   endIcon: {
     marginRight: theme.spacing(-0.75),


### PR DESCRIPTION
**User-Facing Changes**
Bug fix

**Description**
[Bug reported in storybook](https://www.chromatic.com/test?appId=603ec8bf7908b500231841e2&id=6564e09e2f132656d829b88a)

<img width="451" alt="Screen Shot 2023-12-06 at 1 00 37 pm" src="https://github.com/foxglove/studio/assets/924528/c823b340-9126-4ffe-ad26-fcaa1b9053d7">

Resolves FG-5917

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
