### PR TITLE
Better downsampling for the State Transition panel

### DIFF
--- a/packages/studio-base/src/components/Chart/types.ts
+++ b/packages/studio-base/src/components/Chart/types.ts
@@ -18,6 +18,10 @@ type Datum = ScatterDataPoint & {
   value?: string | number | bigint | boolean;
   // Constant name for the datum (used by state transitions)
   constantName?: string | undefined;
+
+  // Contains all of the distinct states present in this line segment. Only for
+  // state transition data.
+  states?: string[];
 };
 export type ObjectData = (Datum | typeof ChartNull)[];
 export type ChartData = ChartJsChartData<"scatter", ObjectData>;

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -6,8 +6,8 @@ import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets"
 import { RpcScales } from "@foxglove/studio-base/components/Chart/types";
 import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 
-import { downsampleStates } from "./downsampleStates";
 import { MAX_POINTS } from "./downsample";
+import { downsampleStates } from "./downsampleStates";
 import { ChartDatasets, PlotViewport } from "./types";
 
 type UpdateParams = {

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -70,14 +70,14 @@ export class Downsampler {
       }
 
       const downsampled = downsampleStates(iterateObjects(dataset.data), view, numPoints);
-      const yValue = dataset.data[0]?.y ?? 0
+      const yValue = dataset.data[0]?.y ?? 0;
       const resolved = downsampled.map(({ x, index }) => {
         if (index == undefined) {
           return {
             x,
             y: yValue,
             labelColor: grey,
-            label: undefined,
+            label: "(multiple states)",
           };
         }
 

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -4,8 +4,9 @@
 
 import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets";
 import { RpcScales } from "@foxglove/studio-base/components/Chart/types";
+import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 
-import { downsample, MAX_POINTS } from "./downsample";
+import { downsampleStates, MAX_POINTS } from "./downsample";
 import { ChartDatasets, PlotViewport } from "./types";
 
 type UpdateParams = {
@@ -67,8 +68,19 @@ export class Downsampler {
         return dataset;
       }
 
-      const downsampled = downsample(dataset, iterateObjects(dataset.data), view, numPoints);
-      const resolved = downsampled.map((i) => dataset.data[i]);
+      const downsampled = downsampleStates(iterateObjects(dataset.data), view, numPoints);
+      const resolved = downsampled.map(([index, numStates]) => {
+        const point = dataset.data[index];
+        if (point == undefined || numStates === 1) {
+          return point;
+        }
+
+        return {
+          ...point,
+          labelColor: grey,
+          label: undefined,
+        };
+      });
 
       // NaN item values create gaps in the line
       const undefinedToNanData = resolved.map((item) => {

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -6,7 +6,8 @@ import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets"
 import { RpcScales } from "@foxglove/studio-base/components/Chart/types";
 import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 
-import { downsampleStates, MAX_POINTS } from "./downsample";
+import { downsampleStates } from "./downsampleStates";
+import { MAX_POINTS } from "./downsample";
 import { ChartDatasets, PlotViewport } from "./types";
 
 type UpdateParams = {
@@ -69,16 +70,25 @@ export class Downsampler {
       }
 
       const downsampled = downsampleStates(iterateObjects(dataset.data), view, numPoints);
-      const resolved = downsampled.map(([index, numStates]) => {
+      const yValue = dataset.data[0]?.y ?? 0
+      const resolved = downsampled.map(({ x, index }) => {
+        if (index == undefined) {
+          return {
+            x,
+            y: yValue,
+            labelColor: grey,
+            label: undefined,
+          };
+        }
+
         const point = dataset.data[index];
-        if (point == undefined || numStates === 1) {
+        if (point == undefined) {
           return point;
         }
 
         return {
           ...point,
-          labelColor: grey,
-          label: undefined,
+          x,
         };
       });
 

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -71,13 +71,14 @@ export class Downsampler {
 
       const downsampled = downsampleStates(iterateObjects(dataset.data), view, numPoints);
       const yValue = dataset.data[0]?.y ?? 0;
-      const resolved = downsampled.map(({ x, index }) => {
+      const resolved = downsampled.map(({ x, index, states }) => {
         if (index == undefined) {
           return {
             x,
             y: yValue,
             labelColor: grey,
             label: "[...]",
+            states,
           };
         }
 

--- a/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/Downsampler.ts
@@ -77,7 +77,7 @@ export class Downsampler {
             x,
             y: yValue,
             labelColor: grey,
-            label: "(multiple states)",
+            label: "[...]",
           };
         }
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -2,13 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import type { ChartDataset } from "chart.js";
-
 import { Point } from "@foxglove/studio-base/components/Chart/datasets";
 
 import type { PlotViewport } from "./types";
-
-type Dataset<T> = ChartDataset<"scatter", T>;
 
 // This is the desired number of data points for each plot across all signals
 // and data sources. Beyond this threshold, ChartJS can no longer render at
@@ -277,19 +273,4 @@ export function downsampleScatter(points: Iterable<Point>, view: PlotViewport): 
   }
 
   return indices;
-}
-
-/**
- * Given a dataset and a viewport, `downsample` chooses a list of
- * representative points that, when plotted, resemble the full dataset.
- */
-export function downsample<T>(
-  dataset: Dataset<T>,
-  points: Iterable<Point>,
-  view: PlotViewport,
-  numPoints?: number,
-): number[] {
-  return dataset.showLine !== true
-    ? downsampleScatter(points, view)
-    : downsampleTimeseries(points, view, numPoints);
 }

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -42,25 +42,44 @@ export type DownsampleState = {
 };
 
 /**
- * Initialize a stateful downsampling operation with a fixed viewport and
- * maximum number of points.
+ * Calculate the size of the intervals the downsampling operation should use,
+ * expressed as a ratio of pixels to units in the coordinate frame of the plot.
  */
-export function initDownsample(view: PlotViewport, maxPoints?: number): DownsampleState {
+export function calculateIntervals(
+  view: PlotViewport,
+  pointsPerInterval: number,
+  maxPoints?: number,
+): {
+  pixelPerXValue: number;
+  pixelPerYValue: number;
+} {
   const { bounds, width, height } = view;
-
   const numPixelIntervals = Math.trunc(width / MINIMUM_PIXEL_DISTANCE);
   // When maxPoints is provided, we should take either that constant or
   // the number of pixel-defined intervals, whichever is fewer
   const numPoints = Math.min(
-    maxPoints ?? numPixelIntervals * POINTS_PER_INTERVAL,
-    numPixelIntervals * POINTS_PER_INTERVAL,
+    maxPoints ?? numPixelIntervals * pointsPerInterval,
+    numPixelIntervals * pointsPerInterval,
   );
-
   // We then calculate the number of intervals based on the number of points we
   // decided on
-  const numIntervals = Math.trunc(numPoints / POINTS_PER_INTERVAL);
-  const pixelPerXValue = numIntervals / (bounds.x.max - bounds.x.min);
-  const pixelPerYValue = height / (bounds.y.max - bounds.y.min);
+  const numIntervals = Math.trunc(numPoints / pointsPerInterval);
+  return {
+    pixelPerXValue: numIntervals / (bounds.x.max - bounds.x.min),
+    pixelPerYValue: height / (bounds.y.max - bounds.y.min),
+  };
+}
+
+/**
+ * Initialize a stateful downsampling operation with a fixed viewport and
+ * maximum number of points.
+ */
+export function initDownsample(view: PlotViewport, maxPoints?: number): DownsampleState {
+  const { pixelPerXValue, pixelPerYValue } = calculateIntervals(
+    view,
+    POINTS_PER_INTERVAL,
+    maxPoints,
+  );
 
   return {
     pixelPerXValue,

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -80,4 +80,28 @@ describe("downsampleStates", () => {
       ]),
     );
   });
+
+  it("does not consolidate interval with same state as before", () => {
+    // in:  A--|-AA|--A
+    // out: A--|-A-|--A
+    const result = downsampleStates(
+      iterateObjects(
+        createData([
+          [0, A],
+          [50, A],
+          [51, A],
+          [100, A],
+        ]),
+      ),
+      bounds,
+      numPoints,
+    );
+    expect(result).toEqual(
+      createResult([
+        [0, 0],
+        [50, 1],
+        [100, 3],
+      ]),
+    );
+  });
 });

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets";
+
+import { downsampleStates, StatePoint } from "./downsampleStates";
+import { ChartDatum as Datum } from "./types";
+
+const createData = (refs: [x: number, label: string][]): Datum[] =>
+  refs.map(([x, label]) => ({
+    x,
+    y: 0,
+    label,
+  }));
+
+const createResult = (refs: [x: number, index: number | undefined][]): StatePoint[] =>
+  refs.map(([x, index]) => ({
+    x,
+    index,
+  }));
+
+const A = "a";
+const B = "b";
+
+describe("downsampleStates", () => {
+  const bounds = {
+    width: 100,
+    height: 100,
+    bounds: { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } },
+  };
+  const numPoints = 6; // 3 intervals
+
+  const secondInterval = (100 / 3) * 2;
+
+  it("leaves one center point intact", () => {
+    // in:  A--|-B-|--A
+    // out: A--|-B-|--A
+    const result = downsampleStates(
+      iterateObjects(
+        createData([
+          [0, A],
+          [50, B],
+          [100, A],
+        ]),
+      ),
+      bounds,
+      numPoints,
+    );
+    expect(result).toEqual(
+      createResult([
+        [0, 0],
+        [50, 1],
+        [100, 2],
+      ]),
+    );
+  });
+
+  it("consolidates interval with more than one state", () => {
+    // in:  A--|-BA|--A
+    // out: A--|-##|--A
+    const result = downsampleStates(
+      iterateObjects(
+        createData([
+          [0, A],
+          [50, B],
+          [51, A],
+          [100, A],
+        ]),
+      ),
+      bounds,
+      numPoints,
+    );
+    expect(result).toEqual(
+      createResult([
+        [0, 0],
+        [50, undefined],
+        [secondInterval, 2],
+        [100, 3],
+      ]),
+    );
+  });
+});

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -82,12 +82,13 @@ describe("downsampleStates", () => {
   });
 
   it("does not consolidate interval with same state as before", () => {
-    // in:  A--|-AA|--A
-    // out: A--|-A-|--A
+    // in:  A--|AAA|--A
+    // out: A--|A--|--A
     const result = downsampleStates(
       iterateObjects(
         createData([
           [0, A],
+          [49, A],
           [50, A],
           [51, A],
           [100, A],
@@ -99,8 +100,8 @@ describe("downsampleStates", () => {
     expect(result).toEqual(
       createResult([
         [0, 0],
-        [50, 1],
-        [100, 3],
+        [49, 1],
+        [100, 4],
       ]),
     );
   });

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.test.ts
@@ -4,7 +4,7 @@
 
 import { iterateObjects } from "@foxglove/studio-base/components/Chart/datasets";
 
-import { downsampleStates, StatePoint } from "./downsampleStates";
+import { downsampleStates } from "./downsampleStates";
 import { ChartDatum as Datum } from "./types";
 
 const createData = (refs: [x: number, label: string][]): Datum[] =>
@@ -12,12 +12,6 @@ const createData = (refs: [x: number, label: string][]): Datum[] =>
     x,
     y: 0,
     label,
-  }));
-
-const createResult = (refs: [x: number, index: number | undefined][]): StatePoint[] =>
-  refs.map(([x, index]) => ({
-    x,
-    index,
   }));
 
 const A = "a";
@@ -47,13 +41,11 @@ describe("downsampleStates", () => {
       bounds,
       numPoints,
     );
-    expect(result).toEqual(
-      createResult([
-        [0, 0],
-        [50, 1],
-        [100, 2],
-      ]),
-    );
+    expect(result).toEqual([
+      { x: 0, index: 0 },
+      { x: 50, index: 1 },
+      { x: 100, index: 2 },
+    ]);
   });
 
   it("consolidates interval with more than one state", () => {
@@ -71,14 +63,12 @@ describe("downsampleStates", () => {
       bounds,
       numPoints,
     );
-    expect(result).toEqual(
-      createResult([
-        [0, 0],
-        [50, undefined],
-        [secondInterval, 2],
-        [100, 3],
-      ]),
-    );
+    expect(result).toEqual([
+      { x: 0, index: 0 },
+      { x: 50, index: undefined, states: ["b", "a"] },
+      { x: secondInterval, index: 2 },
+      { x: 100, index: 3 },
+    ]);
   });
 
   it("does not consolidate interval with same state as before", () => {
@@ -97,12 +87,10 @@ describe("downsampleStates", () => {
       bounds,
       numPoints,
     );
-    expect(result).toEqual(
-      createResult([
-        [0, 0],
-        [49, 1],
-        [100, 4],
-      ]),
-    );
+    expect(result).toEqual([
+      { x: 0, index: 0 },
+      { x: 49, index: 1 },
+      { x: 100, index: 4 },
+    ]);
   });
 });

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -1,0 +1,148 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Point } from "@foxglove/studio-base/components/Chart/datasets";
+
+import type { PlotViewport } from "./types";
+
+import { MINIMUM_PIXEL_DISTANCE } from "./downsample";
+
+type StatePoint = {
+  x: number;
+  index: number | undefined;
+};
+
+type Label = {
+  index: number;
+  value: string;
+};
+
+function addLabel(label: Label, labels: Label[]): Label[] {
+  const last = labels.at(-1);
+  if (last != undefined && label.value === last.value) {
+    return labels;
+  }
+
+  return [...labels, label];
+}
+
+type Interval = { x: number; xPixel: number; labels: Label[]; index: number };
+
+// get:    o--|--o-oo-|-o
+// return: o-----|-oo-|-o
+
+export function downsampleStates(
+  points: Iterable<Point>,
+  view: PlotViewport,
+  maxPoints?: number,
+): StatePoint[] {
+  const { bounds, width } = view;
+
+  const numPixelIntervals = Math.trunc(width / MINIMUM_PIXEL_DISTANCE);
+  // When maxPoints is provided, we should take either that constant or
+  // the number of pixel-defined intervals, whichever is fewer
+  const numPoints = Math.min(maxPoints ?? numPixelIntervals, numPixelIntervals);
+  // We then calculate the number of intervals based on the number of points we
+  // decided on
+  const numIntervals = Math.trunc(numPoints);
+  const pixelPerXValue = numIntervals / (bounds.x.max - bounds.x.min);
+  const xValuePerPixel = 1 / pixelPerXValue;
+
+  const indices: StatePoint[] = [];
+  let interval: Interval | undefined;
+
+  // We keep points within a buffer window around the bounds so points near the bounds are
+  // connected to their peers and available for pan/zoom.
+  // Points outside this buffer window are dropped.
+  const xRange = bounds.x.max - bounds.x.min;
+  const minX = bounds.x.min - xRange * 0.5;
+  const maxX = bounds.x.max + xRange * 0.5;
+
+  let firstPastBounds: number | undefined = undefined;
+
+  for (const datum of points) {
+    const { index, label, x } = datum;
+
+    // track the first point before our bounds
+    if (datum.x < minX) {
+      const point = {
+        index,
+        x,
+      };
+      if (indices.length === 0) {
+        indices.push(point);
+      } else {
+        indices[0] = point;
+      }
+      continue;
+    }
+
+    // track the first point outside of our bounds
+    if (datum.x > maxX) {
+      firstPastBounds = index;
+      continue;
+    }
+
+    if (label == undefined) {
+      continue;
+    }
+
+    const xPixel = Math.trunc(datum.x * pixelPerXValue);
+    const isNew = interval?.xPixel !== xPixel;
+
+    if (interval != undefined && isNew) {
+      const { labels } = interval;
+      const [first] = labels;
+      const last = labels.at(-1);
+      const haveMultiple = labels.length > 1;
+
+      if (first != undefined && last != undefined) {
+        indices.push({
+          x: interval.x,
+          index: haveMultiple ? undefined : first.index,
+        });
+
+        if (haveMultiple) {
+          indices.push({
+            x: interval.x + xValuePerPixel,
+            index: last.index,
+          });
+        }
+      }
+    }
+
+    if (interval == undefined || isNew) {
+      interval = {
+        x,
+        xPixel,
+        index,
+        labels: [
+          {
+            index,
+            value: label,
+          },
+        ],
+      };
+      continue;
+    }
+
+    interval.labels = addLabel(
+      {
+        index,
+        value: label,
+      },
+      interval.labels,
+    );
+  }
+
+  if (interval != undefined) {
+    //indices.push([interval.index, new Set(interval.labels).size]);
+  }
+
+  if (firstPastBounds != undefined) {
+    //indices.push([firstPastBounds, 1]);
+  }
+
+  return indices;
+}

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -4,9 +4,9 @@
 
 import { Point } from "@foxglove/studio-base/components/Chart/datasets";
 
+import { calculateIntervals } from "./downsample";
 import type { PlotViewport } from "./types";
 
-import { calculateIntervals } from "./downsample";
 
 export type StatePoint = {
   x: number;

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -124,7 +124,7 @@ export function downsampleStates(
     indices.push({
       x: interval.x,
       index: haveMultiple ? undefined : first.index,
-      states: R.uniq(labels.map(({ value }) => value)),
+      ...(haveMultiple ? { states: R.uniq(labels.map(({ value }) => value)) } : undefined),
     });
 
     if (!haveMultiple) {

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -137,7 +137,7 @@ export function downsampleStates(
     if (interval == undefined || isNew) {
       interval = {
         x,
-        endX: bounds.x.min + xPixel * xValuePerPixel + xValuePerPixel,
+        endX: xPixel * xValuePerPixel + xValuePerPixel,
         xPixel,
         index,
         labels: [

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -6,9 +6,9 @@ import { Point } from "@foxglove/studio-base/components/Chart/datasets";
 
 import type { PlotViewport } from "./types";
 
-import { MINIMUM_PIXEL_DISTANCE } from "./downsample";
+import { calculateIntervals } from "./downsample";
 
-type StatePoint = {
+export type StatePoint = {
   x: number;
   index: number | undefined;
 };
@@ -27,26 +27,26 @@ function addLabel(label: Label, labels: Label[]): Label[] {
   return [...labels, label];
 }
 
-type Interval = { x: number; xPixel: number; labels: Label[]; index: number };
-
-// get:    o--|--o-oo-|-o
-// return: o-----|-oo-|-o
+type Interval = {
+  // The x coordinate of the beginning of the interval
+  x: number;
+  // The pixel coordinate of the beginning of the interval
+  xPixel: number;
+  // The x coordinate of the end of the interval
+  endX: number;
+  // All of the labels that appeared in this interval
+  labels: Immutable<Label[]>;
+  // The index of the point that started the interval
+  index: number;
+};
 
 export function downsampleStates(
   points: Iterable<Point>,
   view: PlotViewport,
   maxPoints?: number,
 ): StatePoint[] {
-  const { bounds, width } = view;
-
-  const numPixelIntervals = Math.trunc(width / MINIMUM_PIXEL_DISTANCE);
-  // When maxPoints is provided, we should take either that constant or
-  // the number of pixel-defined intervals, whichever is fewer
-  const numPoints = Math.min(maxPoints ?? numPixelIntervals, numPixelIntervals);
-  // We then calculate the number of intervals based on the number of points we
-  // decided on
-  const numIntervals = Math.trunc(numPoints);
-  const pixelPerXValue = numIntervals / (bounds.x.max - bounds.x.min);
+  const { bounds } = view;
+  const { pixelPerXValue } = calculateIntervals(view, 2, maxPoints);
   const xValuePerPixel = 1 / pixelPerXValue;
 
   const indices: StatePoint[] = [];
@@ -60,6 +60,46 @@ export function downsampleStates(
   const maxX = bounds.x.max + xRange * 0.5;
 
   let firstPastBounds: number | undefined = undefined;
+
+  /**
+   * Conclude the current interval, producing one or more StatePoint.
+   *
+   * If the interval contained just one state, we leave the original point in
+   * place.
+   *
+   * If the interval contained multiple states, we produce two points:
+   * * One at the x-value of the first point in the interval
+   * * One at the x-value of the end of the interval (which is not a real point)
+   * This allows the renderer to draw a gray line segment between these two points.
+   */
+  const finishInterval = () => {
+    if (interval == undefined) {
+      return;
+    }
+
+    const { labels, endX } = interval;
+    const [first] = labels;
+    const last = labels.at(-1);
+    const haveMultiple = labels.length > 1;
+
+    if (first == undefined || last == undefined) {
+      return;
+    }
+
+    indices.push({
+      x: interval.x,
+      index: haveMultiple ? undefined : first.index,
+    });
+
+    if (!haveMultiple) {
+      return;
+    }
+
+    indices.push({
+      x: endX,
+      index: last.index,
+    });
+  };
 
   for (const datum of points) {
     const { index, label, x } = datum;
@@ -88,33 +128,16 @@ export function downsampleStates(
       continue;
     }
 
-    const xPixel = Math.trunc(datum.x * pixelPerXValue);
+    const xPixel = Math.trunc(x * pixelPerXValue);
     const isNew = interval?.xPixel !== xPixel;
-
     if (interval != undefined && isNew) {
-      const { labels } = interval;
-      const [first] = labels;
-      const last = labels.at(-1);
-      const haveMultiple = labels.length > 1;
-
-      if (first != undefined && last != undefined) {
-        indices.push({
-          x: interval.x,
-          index: haveMultiple ? undefined : first.index,
-        });
-
-        if (haveMultiple) {
-          indices.push({
-            x: interval.x + xValuePerPixel,
-            index: last.index,
-          });
-        }
-      }
+      finishInterval();
     }
 
     if (interval == undefined || isNew) {
       interval = {
         x,
+        endX: bounds.x.min + xPixel * xValuePerPixel + xValuePerPixel,
         xPixel,
         index,
         labels: [
@@ -137,11 +160,14 @@ export function downsampleStates(
   }
 
   if (interval != undefined) {
-    //indices.push([interval.index, new Set(interval.labels).size]);
+    finishInterval();
   }
 
   if (firstPastBounds != undefined) {
-    //indices.push([firstPastBounds, 1]);
+    indices.push({
+      x: maxX,
+      index: firstPastBounds,
+    });
   }
 
   return indices;

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -18,7 +18,9 @@ export type StatePoint = {
 };
 
 type Label = {
+  // The index at which this label first appeared
   index: number;
+  // The value of the label
   value: string;
 };
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -160,7 +160,13 @@ export function downsampleStates(
       continue;
     }
 
+    // This only seems to occur when we've inserted a dummy final point, which
+    // we need to add
     if (label == undefined) {
+      indices.push({
+        x,
+        index,
+      });
       continue;
     }
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -7,9 +7,13 @@ import { Point } from "@foxglove/studio-base/components/Chart/datasets";
 import { calculateIntervals } from "./downsample";
 import type { PlotViewport } from "./types";
 
-
+// Represents a point corresponding to a State Transition segment.
 export type StatePoint = {
+  // The x-coordinate of the point in the coordinate frame of the plot
   x: number;
+  // The index of a point in the original dataset whose properties this segment
+  // should include. If this is undefined, this segment consists of more than
+  // one states and it should be rendered as such.
   index: number | undefined;
 };
 
@@ -18,7 +22,11 @@ type Label = {
   value: string;
 };
 
-function addLabel(label: Label, labels: Label[]): Label[] {
+/**
+ * Add a Label to a list of Labels, but not if the top of the new Label's value
+ * matches the value of the Label at the top of the stack.
+ */
+function addLabel(label: Label, labels: Immutable<Label[]>): Immutable<Label[]> {
   const last = labels.at(-1);
   if (last != undefined && label.value === last.value) {
     return labels;
@@ -27,6 +35,7 @@ function addLabel(label: Label, labels: Label[]): Label[] {
   return [...labels, label];
 }
 
+// Contains all of the state we need to keep track of for each interval.
 type Interval = {
   // The x coordinate of the beginning of the interval
   x: number;
@@ -40,6 +49,26 @@ type Interval = {
   index: number;
 };
 
+/**
+ * Downsample state transition data by breaking the visible bounds into a set
+ * of evenly-sized intervals and making a note of the number of state
+ * transitions (between distinct states) that occur in each.
+ *
+ * If just one occurs, we return a StatePoint with x == the x-coordinate of the
+ * single state transition point and index == the index of that point.
+ *
+ * If more than one does, it's represented in the output as two StatePoints:
+ * one that matches the first point found in the interval (except with index ==
+ * undefined) and another that matches the _last_ point in the interval, with x
+ * == the end of the interval in the coordinate frame of the plot.
+ *
+ * This allows the caller to render intervals that contain more state
+ * transitions than we can safely render in a different way to make it obvious
+ * to the user that there is more detail.
+ *
+ * The `maxPoints` parameter works identically to the way it does in
+ * `downsampleTimeseries`.
+ */
 export function downsampleStates(
   points: Iterable<Point>,
   view: PlotViewport,
@@ -134,6 +163,7 @@ export function downsampleStates(
       finishInterval();
     }
 
+    // Start a new interval if this point falls in a new one
     if (interval == undefined || isNew) {
       interval = {
         x,
@@ -150,6 +180,7 @@ export function downsampleStates(
       continue;
     }
 
+    // If we haven't yet moved on, add this point's label
     interval.labels = addLabel(
       {
         index,

--- a/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsampleStates.ts
@@ -2,6 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import * as R from "ramda";
+
+import { Immutable } from "@foxglove/studio";
 import { Point } from "@foxglove/studio-base/components/Chart/datasets";
 
 import { calculateIntervals } from "./downsample";
@@ -15,6 +18,7 @@ export type StatePoint = {
   // should include. If this is undefined, this segment consists of more than
   // one states and it should be rendered as such.
   index: number | undefined;
+  states?: string[];
 };
 
 type Label = {
@@ -120,6 +124,7 @@ export function downsampleStates(
     indices.push({
       x: interval.x,
       index: haveMultiple ? undefined : first.index,
+      states: R.uniq(labels.map(({ value }) => value)),
     });
 
     if (!haveMultiple) {

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -346,20 +346,21 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     const tooltipItems: { item: TimeBasedChartTooltipData; element: RpcElement }[] = [];
 
     for (const element of elements) {
-      if (!element.data) {
+      const { data: datum } = element;
+      if (datum == undefined) {
         continue;
       }
 
-      const datum = element.data;
-      if (datum.value == undefined) {
+      const { value, constantName, states } = datum;
+      if (value == undefined && states == undefined) {
         continue;
       }
 
       tooltipItems.push({
         item: {
           datasetIndex: element.datasetIndex,
-          value: datum.value,
-          constantName: datum.constantName,
+          value: value ?? (states ?? []).join(", "),
+          constantName,
         },
         element,
       });

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDataset.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDataset.ts
@@ -14,7 +14,7 @@ import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 import positiveModulo from "./positiveModulo";
 import { StateTransitionPath } from "./types";
 
-const baseColors = [grey, ...expandedLineColors];
+const baseColors = [...expandedLineColors];
 const baseColorsLength = Object.values(baseColors).length;
 
 type Args = {
@@ -82,7 +82,7 @@ export function messagesToDataset(args: Args): ChartDataset {
 
       const valueForColor =
         typeof value === "string" ? stringHash(value) : Math.round(Number(value));
-      const color = baseColors[positiveModulo(valueForColor, baseColorsLength)] ?? "grey";
+      const color = baseColors[positiveModulo(valueForColor, baseColorsLength)] ?? grey;
 
       const x = toSec(subtractTimes(timestamp, startTime));
 

--- a/packages/studio-base/src/util/toolsColorScheme.ts
+++ b/packages/studio-base/src/util/toolsColorScheme.ts
@@ -61,4 +61,4 @@ export const toolsColorScheme = {
   },
 };
 
-export const grey = tinycolor(`hsv(0, 0%, 75%)`).toHexString();
+export const grey = tinycolor(`hsv(0, 0%, 60%)`).toHexString();


### PR DESCRIPTION
**User-Facing Changes**
Introduce a new downsampling algorithm for the State Transition panel to greatly improve its performance.

**Description**
This PR introduces a downsampling algorithm specifically for state transition data called `downsampleStates`. It is conceptually similar to our existing `downsampleTimeseries` algorithm, which divides the viewport into a set of equally-sized intervals.

The nature of state transitions lets us do something a bit more sophisticated: when an interval contains more points than are in our "budget" (put differently: it contains more than one distinct state transition), we render it in gray. We can work on the UX of this, but it does work, includes a suite of tests, and resolves the high-level issue with the panel's rendering performance.

Here is an example from nuScenes. This scenario intentionally contains a lot of state transitions, more than might actually occur in everyday use; it's just a good way of demonstrating how this might work.

https://github.com/foxglove/studio/assets/4588553/a9b3e86b-b673-4529-bd8d-c126a8eb34c4

When the user mouses over a segment with multiple states, we render them in the tooltip:
<img width="917" alt="image" src="https://github.com/foxglove/studio/assets/4588553/bca84d9f-7b7a-4ddf-a99e-2fd7ac4cc36f">
