### PR TITLE
Fix log panel auto scroll is failed when message is too long

### DIFF
--- a/packages/studio-base/src/panels/Log/LogMessage.tsx
+++ b/packages/studio-base/src/panels/Log/LogMessage.tsx
@@ -32,6 +32,7 @@ const useStyles = makeStyles()((theme) => ({
     paddingBottom: 1,
     lineHeight: 1,
     fontFamily: theme.typography.fontMonospace,
+    wordBreak: "break-word",
   },
 }));
 


### PR DESCRIPTION
**User-Facing Changes**
Bug fix

**Description**
Due to the lengthy message and the absence of break points (such as spaces and hyphens), a horizontal scrollbar appears. The functionality of automatic scrolling to the bottom is not working.

![2023-12-07_16h48_22](https://github.com/foxglove/studio/assets/22169974/c0714c4d-77b4-4257-9d2e-5afc0887f3a0)

