### PR TITLE
add support for ws protocol's status message supplying tips

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -389,9 +389,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
         log.error(msg);
       }
 
+      
       const problem: PlayerProblem = {
         message: event.message,
         severity: statusLevelToProblemSeverity(event.level),
+        tip: event.tip
       };
 
       if (event.message === "Send buffer limit reached") {


### PR DESCRIPTION
**User-Facing Changes**
Adds support for an optional 'tip' feature that websocket servers can send alongside status broadcasts

**Description**
I use the status type message from foxglove ws-protocol to send server status information. sometimes I want to send tips when the server errors, but the client doesn't support it even if the Problem type fully does. I have 0 clue how typescript's optional?s work but hopefully this should make it so that if the event supplies a tips field in json, that field is given to the problem, so that it renders.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
