### PR TITLE
Add experimental memory saver option

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -20,6 +20,7 @@ export enum AppSetting {
 
   // Experimental features
   SHOW_DEBUG_PANELS = "showDebugPanels",
+  MEMORY_SAVER_ENABLED = "memorySaverEnabled",
 
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -45,6 +45,11 @@ function useFeatures(): Feature[] {
       name: t("newAppMenu"),
       description: <>{t("newAppMenuDescription")}</>,
     },
+    {
+      key: AppSetting.MEMORY_SAVER_ENABLED,
+      name: t("memorySaver"),
+      description: <>{t("memorySaverDescription")}</>,
+    },
   ];
 
   if (process.env.NODE_ENV === "development") {

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -18,6 +18,7 @@ import { useMountedState } from "react-use";
 import { useWarnImmediateReRender } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
 import { Immutable } from "@foxglove/studio";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { MessagePipelineProvider } from "@foxglove/studio-base/components/MessagePipeline";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import { useAppContext } from "@foxglove/studio-base/context/AppContext";
@@ -27,6 +28,7 @@ import PlayerSelectionContext, {
   IDataSourceFactory,
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import useIndexedDbRecents, { RecentRecord } from "@foxglove/studio-base/hooks/useIndexedDbRecents";
 import AnalyticsMetricsCollector from "@foxglove/studio-base/players/AnalyticsMetricsCollector";
 import {
@@ -52,6 +54,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const analytics = useAnalytics();
   const metricsCollector = useMemo(() => new AnalyticsMetricsCollector(analytics), [analytics]);
+  const [memorySaverEnabled] = useAppConfigurationValue<boolean>(AppSetting.MEMORY_SAVER_ENABLED);
 
   const [basePlayer, setBasePlayer] = useState<Player | undefined>();
 
@@ -171,6 +174,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
                 file: multiFile ? undefined : file,
                 files: multiFile ? fileList : undefined,
                 metricsCollector,
+                memorySaverEnabled,
               });
 
               setBasePlayer(newPlayer);
@@ -196,6 +200,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
               const newPlayer = foundSource.initialize({
                 file,
                 metricsCollector,
+                memorySaverEnabled,
               });
 
               setBasePlayer(newPlayer);
@@ -216,7 +221,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         enqueueSnackbar((error as Error).message, { variant: "error" });
       }
     },
-    [playerSources, metricsCollector, enqueueSnackbar, isMounted, addRecent],
+    [playerSources, metricsCollector, enqueueSnackbar, isMounted, addRecent, memorySaverEnabled],
   );
 
   // Select a recent entry by id

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -13,6 +13,7 @@ export type DataSourceFactoryInitializeArgs = {
   file?: File;
   files?: File[];
   params?: Record<string, string | undefined>;
+  memorySaverEnabled?: boolean;
 };
 
 export type DataSourceFactoryType = "file" | "connection" | "sample";

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -40,6 +40,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
       source,
       name: file.name,
       sourceId: this.id,
+      memorySaverEnabled: args.memorySaverEnabled,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/RemoteDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RemoteDataSourceFactory.tsx
@@ -102,6 +102,7 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
       // Use blank url params so the data source is set in the url
       urlParams: { url },
       sourceId: this.id,
+      memorySaverEnabled: args.memorySaverEnabled,
     });
   }
 

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
@@ -40,6 +40,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
       source,
       name: file.name,
       sourceId: this.id,
+      memorySaverEnabled: args.memorySaverEnabled,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
@@ -43,6 +43,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
       source,
       name,
       sourceId: this.id,
+      memorySaverEnabled: args.memorySaverEnabled,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -44,6 +44,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
       // Use blank url params so the data source is set in the url
       urlParams: {},
       sourceId: this.id,
+      memorySaverEnabled: args.memorySaverEnabled,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.ts
@@ -40,6 +40,7 @@ class UlogLocalDataSourceFactory implements IDataSourceFactory {
       source,
       name: file.name,
       sourceId: this.id,
+      memorySaverEnabled: args.memorySaverEnabled,
     });
   }
 }

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -20,6 +20,8 @@ export const appSettings = {
   layoutDebugging: "Layout debugging",
   layoutDebuggingDescription: "Show extra controls for developing and debugging layout storage.",
   light: "Light",
+  memorySaver: "Memory saver",
+  memorySaverDescription: "Reduces memory consumption",
   messageRate: "Message rate",
   newAppMenu: "Enable unified navigation",
   newAppMenuDescription: "Show the new menu and navigation.",

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -86,6 +86,8 @@ type IterablePlayerOptions = {
 
   // Set to _false_ to disable preloading. (default: true)
   enablePreload?: boolean;
+
+  memorySaverEnabled?: boolean;
 };
 
 type IterablePlayerState =
@@ -177,10 +179,18 @@ export class IterablePlayer implements Player {
   #resolveIsClosed: () => void = () => {};
 
   public constructor(options: IterablePlayerOptions) {
-    const { metricsCollector, urlParams, source, name, enablePreload, sourceId } = options;
+    const {
+      metricsCollector,
+      urlParams,
+      source,
+      name,
+      enablePreload,
+      sourceId,
+      memorySaverEnabled = false,
+    } = options;
 
     this.#iterableSource = source;
-    this.#bufferedSource = new BufferedIterableSource(source);
+    this.#bufferedSource = new BufferedIterableSource(source, { memorySaverEnabled });
     this.#name = name;
     this.#urlParams = urlParams;
     this.#metricsCollector = metricsCollector ?? new NoopMetricsCollector();


### PR DESCRIPTION
**User-Facing Changes**
Add experimental memory saver app setting

**Description**
Adds a new `Memory saver`  app setting (experimental section) which, when enabled, reduces memory consumption of the buffered iterable source by
- Evicting old blocks that are before the current read head, even if the cache is not yet full
- Limiting the max. buffered size to 50% of the default limit of 1GB

We may use some other memory saving strategies later, but for now I only started with these two
