### PR TITLE
Gauge and indicator panels no longer preload topics unnecessarily

### DIFF
--- a/packages/studio-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/studio-base/src/panels/Gauge/Gauge.tsx
@@ -241,7 +241,7 @@ export function Gauge({ context }: Props): JSX.Element {
 
   useEffect(() => {
     if (state.parsedPath?.topicName != undefined) {
-      context.subscribe([state.parsedPath.topicName]);
+      context.subscribe([{ topic: state.parsedPath.topicName, preload: false }]);
     }
     return () => {
       context.unsubscribeAll();

--- a/packages/studio-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/studio-base/src/panels/Indicator/Indicator.tsx
@@ -209,7 +209,7 @@ export function Indicator({ context }: Props): JSX.Element {
 
   useEffect(() => {
     if (state.parsedPath?.topicName != undefined) {
-      context.subscribe([state.parsedPath.topicName]);
+      context.subscribe([{ topic: state.parsedPath.topicName, preload: false }]);
     }
     return () => {
       context.unsubscribeAll();


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix: gauge and indicator panels no longer preload topics unnecessarily

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
