### PR TITLE
Fix a handful of plot issues

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -100,7 +100,7 @@ describe("downsampleTimeseries", () => {
       ]),
       bounds,
     );
-    expect(result).toEqual([0, 2, 1, 3]);
+    expect(result).toEqual([0, 1, 2, 3]);
   });
 
   it("should keep entry/exit datum to an interval", () => {

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -119,6 +119,21 @@ describe("downsampleTimeseries", () => {
     );
     expect(result).toEqual([0, 1, 2, 3, 4]);
   });
+
+  it("should not produce out-of-order points", () => {
+    const result = downsampleTimeseries(
+      iterateObjects([
+        { x: 0, y: 15, value: 0 },
+        { x: 1, y: 100, value: 0 },
+        { x: 2, y: 10, value: 0 },
+        { x: 3, y: 15, value: 0 },
+      ]),
+      bounds,
+      6, // two intervals
+    );
+    expect(result).toEqual([...result].sort((a, b) => a - b));
+    expect(result).toEqual([0, 1, 2]);
+  });
 });
 
 describe("downsampleScatter", () => {

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -129,22 +129,25 @@ export function continueDownsample(
     // create a new interval when encountering a new label to preserve the transition from one label to another
     if (intFirst?.xPixel !== x || (intLast?.label != undefined && intLast.label !== datum.label)) {
       // add the min value from previous interval if it doesn't match the first or last of that interval
+      const newPoints: number[] = [];
       if (intMin && intMin.yPixel !== intFirst?.yPixel && intMin.yPixel !== intLast?.yPixel) {
-        indices.push(intMin.index);
+        newPoints.push(intMin.index);
       }
 
       // add the max value from previous interval if it doesn't match the first or last of that interval
       if (intMax && intMax.yPixel !== intFirst?.yPixel && intMax.yPixel !== intLast?.yPixel) {
-        indices.push(intMax.index);
+        newPoints.push(intMax.index);
       }
 
       // add the last value if it doesn't match the first
       if (intLast && intFirst?.yPixel !== intLast.yPixel) {
-        indices.push(intLast.index);
+        newPoints.push(intLast.index);
       }
 
       // always add the first datum of an new interval
-      indices.push(index);
+      newPoints.push(index);
+
+      indices.push(...newPoints.sort((a, b) => a - b));
 
       intFirst = { xPixel: x, yPixel: y, index, label };
       intLast = { xPixel: x, yPixel: y, index, label };

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -96,7 +96,8 @@ export function finishDownsample(state: DownsampleState): number[] {
     indices.push(intLast.index);
   }
 
-  return indices;
+  // Ensure that the indices are in the same order they appeared in the dataset
+  return indices.sort((a, b) => a - b);
 }
 
 /**

--- a/packages/studio-base/src/panels/Plot/blocks.test.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.test.ts
@@ -205,18 +205,4 @@ describe("processBlocks", () => {
       expect(newData).toEqual([block]);
     }
   });
-
-  it("should start from beginning when blocks before cursor are emptied", () => {
-    // ssss| -> s|eee
-    const { state } = processBlocks([block, block, block, block], subscriptions, initial);
-    const {
-      state: { messages, cursors },
-      resetTopics,
-      newData,
-    } = processBlocks([block, {}, {}, {}], subscriptions, state);
-    expect(messages[0]?.[FAKE_TOPIC]).toEqual(1);
-    expect(cursors[FAKE_TOPIC]).toEqual(1);
-    expect(resetTopics).toEqual([FAKE_TOPIC]);
-    expect(newData).toEqual([block]);
-  });
 });

--- a/packages/studio-base/src/panels/Plot/blocks.ts
+++ b/packages/studio-base/src/panels/Plot/blocks.ts
@@ -58,52 +58,6 @@ type Update = {
   shouldReset: boolean;
 };
 
-function calculateUpdate(
-  payload: SubscribePayload,
-  cursors: Cursors,
-  blocks: readonly MessageBlock[],
-  blocksWithStatuses: [MessageBlock, FirstMessages][],
-): Update {
-  const { topic } = payload;
-  const currentCursor = cursors[topic] ?? 0;
-
-  // 1. check for any new, non-empty unsent blocks
-  const lastNew = R.findLastIndex(
-    (block) => block[topic] != undefined,
-    blocks.slice(currentCursor),
-  );
-  const newCursor = lastNew === -1 ? currentCursor : lastNew + currentCursor + 1;
-
-  // 2. check whether any blocks below the current cursor have changed
-  const changes = blocksWithStatuses.map(([block, status]) => {
-    const oldFirst = status[topic];
-    return !R.equals(oldFirst, block[topic]?.[0]?.message) && oldFirst != undefined;
-  });
-  const lastChanged = R.findLastIndex(R.identity, changes);
-  const haveChanged = lastChanged !== -1;
-
-  if (!haveChanged || lastChanged >= currentCursor) {
-    return {
-      topic,
-      range: [currentCursor, haveChanged ? Math.min(newCursor, lastChanged + 1) : newCursor],
-      shouldReset: false,
-    };
-  }
-
-  return {
-    ...calculateUpdate(
-      payload,
-      {
-        ...cursors,
-        [topic]: 0,
-      },
-      blocks,
-      blocksWithStatuses,
-    ),
-    shouldReset: true,
-  };
-}
-
 /**
  * Inspect the state of `blocks` to determine what data needs to be sent to the
  * plot worker.
@@ -122,7 +76,38 @@ export function processBlocks(
   const blocksWithStatuses = R.zip(blocks, messages);
 
   const updates: Update[] = R.pipe(
-    R.map((v: SubscribePayload): Update => calculateUpdate(v, cursors, blocks, blocksWithStatuses)),
+    R.map((v: SubscribePayload): Update => {
+      const { topic } = v;
+      const currentCursor = cursors[topic] ?? 0;
+
+      // 1. check for any new, non-empty unsent blocks
+      const lastNew = R.findLastIndex((block) => {
+        const data = block[topic];
+        return data != undefined && data.length !== 0;
+      }, blocks.slice(currentCursor));
+      const newCursor = lastNew === -1 ? currentCursor : lastNew + currentCursor + 1;
+
+      // 2. check whether any blocks below the current cursor have changed
+      const changes = blocksWithStatuses.map(([block, status]) => {
+        const oldFirst = status[topic];
+        return !R.equals(oldFirst, block[topic]?.[0]?.message) && oldFirst != undefined;
+      });
+      const lastChanged = R.findLastIndex(R.identity, changes);
+      const haveChanged = lastChanged !== -1;
+
+      if (!haveChanged || lastChanged >= currentCursor) {
+        return {
+          topic,
+          range: [currentCursor, haveChanged ? Math.min(newCursor, lastChanged + 1) : newCursor],
+          shouldReset: false,
+        };
+      }
+      return {
+        topic,
+        range: [0, lastChanged + 1],
+        shouldReset: true,
+      };
+    }),
     // filter out any topics that neither changed nor had new data
     R.filter(({ shouldReset, range: [start, end] }: Update) => shouldReset || start !== end),
   )(subscriptions);

--- a/packages/studio-base/src/panels/Plot/processor/downsample.test.ts
+++ b/packages/studio-base/src/panels/Plot/processor/downsample.test.ts
@@ -114,7 +114,9 @@ describe("updateSource", () => {
     expect(after.cursor).toEqual(10);
   });
 
-  it("uses scatter plot algorithm on scatter dataset", () => {
+  // Extremely small viewport, force downsampler to remove some
+  const scatterViewport = createViewport(50, 50, 0, 100);
+  it("uses scatter plot algorithm when showLine disabled", () => {
     const before = initSource();
     const after = updateSource(
       {
@@ -123,7 +125,7 @@ describe("updateSource", () => {
       },
       {
         raw: createDataset(50),
-        view: FAKE_VIEWPORT,
+        view: scatterViewport,
         viewBounds: FAKE_BOUNDS,
         maxPoints: MAX_POINTS,
       },
@@ -134,8 +136,30 @@ describe("updateSource", () => {
     if (dataset == undefined) {
       throw new Error("can't happen");
     }
-    expect(dataset.pointRadius).toEqual(undefined);
-    expect(getTypedLength(dataset.data)).toEqual(50);
+    expect(getTypedLength(dataset.data)).toBeLessThan(50);
+  });
+
+  it("uses scatter plot algorithm on scatter dataset", () => {
+    const before = initSource();
+    const after = updateSource(
+      createPath(FAKE_PATH),
+      {
+        raw: {
+          ...createDataset(50),
+          showLine: false,
+        },
+        view: scatterViewport,
+        viewBounds: FAKE_BOUNDS,
+        maxPoints: MAX_POINTS,
+      },
+      before,
+    );
+
+    const { dataset } = after;
+    if (dataset == undefined) {
+      throw new Error("can't happen");
+    }
+    expect(getTypedLength(dataset.data)).toBeLessThan(50);
   });
 });
 
@@ -229,6 +253,30 @@ describe("updatePath", () => {
     );
     expect(after.current.cursor).toEqual(15);
     expect(after.blocks.cursor).toEqual(10);
+  });
+
+  it("returns a partial view of a scatter dataset", () => {
+    const before = initPath();
+    const after = updatePath(
+      createPath(FAKE_PATH),
+      {
+        blockData: {
+          ...createDataset(100),
+          showLine: false,
+        },
+        currentData: undefined,
+        view: createViewport(25, 25, 0, 50),
+        viewBounds: createBounds(0, 50),
+        maxPoints: MAX_POINTS,
+      },
+      before,
+    );
+    expect(after.isPartial).toEqual(true);
+    const { dataset } = after;
+    if (dataset == undefined) {
+      throw new Error("can't happen");
+    }
+    expect(getTypedLength(dataset.data)).toBeLessThan(50);
   });
 });
 

--- a/packages/studio-base/src/panels/Plot/processor/downsample.ts
+++ b/packages/studio-base/src/panels/Plot/processor/downsample.ts
@@ -324,7 +324,7 @@ export function updateSource(
   }
 
   // The downsampling algorithm only works for series plots, not scatter plots.
-  if (path.showLine === false) {
+  if (path.showLine === false || raw.showLine === false) {
     const indices = downsampleScatter(iterateTyped(raw.data), view);
     const resolved = resolveTypedIndices(raw.data, indices);
     if (resolved == undefined) {
@@ -419,6 +419,23 @@ function updatePartialView(path: PlotPath, params: PathParameters, state: PathSt
   };
 
   const mergedData = mergeTyped(blockData?.data ?? [], currentData?.data ?? []);
+  if (blockData?.showLine === false || currentData?.showLine === false) {
+    const indices = downsampleScatter(iterateTyped(mergedData), view);
+    const resolved = resolveTypedIndices(mergedData, indices);
+    if (resolved == undefined) {
+      return state;
+    }
+
+    return {
+      ...state,
+      isPartial: true,
+      dataset: {
+        ...(blockData ?? currentData),
+        data: resolved,
+      },
+    };
+  }
+
   const data = applyTransforms(sliceBounds(mergedData, partialBounds), path);
   const downsampled = downsampleDataset(data, view, maxPoints);
   if (downsampled == undefined) {

--- a/packages/studio-base/src/panels/Plot/processor/downsample.ts
+++ b/packages/studio-base/src/panels/Plot/processor/downsample.ts
@@ -97,15 +97,27 @@ const ZOOM_RESET_FACTOR = 0.2;
 const downsampleDataset = (
   data: TypedData[],
   view: PlotViewport,
-  numPoints?: number,
-): TypedData[] | undefined => {
-  const indices = downsampleTimeseries(iterateTyped(data), view, numPoints);
+  maxPoints: number,
+): TypedDataSet | undefined => {
+  const numPoints = getTypedLength(data);
+  if (numPoints <= maxPoints) {
+    return {
+      data,
+    };
+  }
+
+  const indices = downsampleTimeseries(iterateTyped(data), view, maxPoints);
   const resolved = resolveTypedIndices(data, indices);
   if (resolved == undefined) {
     return undefined;
   }
 
-  return resolved;
+  return {
+    // When data is downsampled, we do not want to render points in order to
+    // make it clear to the user that we've downsampled
+    pointRadius: 0,
+    data: resolved,
+  };
 };
 
 /**
@@ -306,7 +318,7 @@ export function updateSource(
       ...initSource(),
       dataset: {
         ...raw,
-        data: downsampled,
+        ...downsampled,
       },
     };
   }
@@ -408,19 +420,6 @@ function updatePartialView(path: PlotPath, params: PathParameters, state: PathSt
 
   const mergedData = mergeTyped(blockData?.data ?? [], currentData?.data ?? []);
   const data = applyTransforms(sliceBounds(mergedData, partialBounds), path);
-  const numSliced = getTypedLength(data);
-  if (numSliced <= maxPoints) {
-    return {
-      ...state,
-      isPartial: true,
-      dataset: {
-        ...(blockData ?? currentData),
-        // pointRadius will be default
-        data,
-      },
-    };
-  }
-
   const downsampled = downsampleDataset(data, view, maxPoints);
   if (downsampled == undefined) {
     return state;
@@ -431,8 +430,7 @@ function updatePartialView(path: PlotPath, params: PathParameters, state: PathSt
     isPartial: true,
     dataset: {
       ...(blockData ?? currentData),
-      pointRadius: 0,
-      data: downsampled,
+      ...downsampled,
     },
   };
 }

--- a/packages/studio-base/src/panels/Plot/processor/downsample.ts
+++ b/packages/studio-base/src/panels/Plot/processor/downsample.ts
@@ -419,9 +419,12 @@ function updatePartialView(path: PlotPath, params: PathParameters, state: PathSt
   };
 
   const mergedData = mergeTyped(blockData?.data ?? [], currentData?.data ?? []);
+  const data = applyTransforms(sliceBounds(mergedData, partialBounds), path);
+
+  // Scatter plots use a different downsampling algorithm
   if (blockData?.showLine === false || currentData?.showLine === false) {
-    const indices = downsampleScatter(iterateTyped(mergedData), view);
-    const resolved = resolveTypedIndices(mergedData, indices);
+    const indices = downsampleScatter(iterateTyped(data), view);
+    const resolved = resolveTypedIndices(data, indices);
     if (resolved == undefined) {
       return state;
     }
@@ -436,7 +439,6 @@ function updatePartialView(path: PlotPath, params: PathParameters, state: PathSt
     };
   }
 
-  const data = applyTransforms(sliceBounds(mergedData, partialBounds), path);
   const downsampled = downsampleDataset(data, view, maxPoints);
   if (downsampled == undefined) {
     return state;


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue where plotting a signal with the header stamp would result in misleading output.
Revert a "fix" that was intended to handle missing block data more safely.
Fix an issue where downsampled plot data points could appear out of order.

**Description**

This PR fixes ~three~ four separate issues:
1. #7193 caused a regression for topic aliases. I'm just going to revert it for now.
2. We were incorrectly showing the dots for signals that use header stamps. I centralized the logic that downsamples entire signals at once and ensured they correctly detect when we actually can just render the raw points.
3. (Unrelated to the customer issues) Our downsampler occasionally reversed the order of points inside of a single interval. We now sort the points inside of an interval.
4. It turns out that `showLine` can also appear on `TypedDataset`s and not just on the path, which is news to me. This caused an issue where we were hiding points (with `pointRadius=0`) that were not connected by a line.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
