### PR TITLE
New method for estimating message memory size

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -35,6 +35,7 @@ export class McapIndexedIterableSource implements IIterableSource {
   #start?: Time;
   #end?: Time;
   #messageSizeEstimates: Record<string, number> = {};
+  #slicedMessageSizeEstimate: Record<string, number> = {};
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -140,10 +141,8 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
 
     const topicNames = Array.from(topics.keys());
-
-    // Clear the cache for existing size estimates such that the message size per topic is
-    // re-evaluated again (as subscription options might have changed).
-    this.#messageSizeEstimates = {};
+    // Clear the cache for existing size estimate of sliced topics such that these topics are re-evaluated again.
+    this.#slicedMessageSizeEstimate = {};
 
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
@@ -167,7 +166,11 @@ export class McapIndexedIterableSource implements IIterableSource {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
         const spec = args.topics.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
-        const estimatedMemorySize = this.#estimateMessageSize(channelInfo.channel.topic, payload);
+        const estimatedMemorySize = this.#estimateMessageSize(
+          channelInfo.channel.topic,
+          spec?.fields == undefined ? "full" : "sliced",
+          payload,
+        );
         const sizeInBytes =
           spec?.fields == undefined
             ? Math.max(message.data.byteLength, estimatedMemorySize)
@@ -222,7 +225,7 @@ export class McapIndexedIterableSource implements IIterableSource {
           const deserializedMessage = channelInfo.parsedChannel.deserialize(message.data);
           const sizeInBytes = Math.max(
             message.data.byteLength,
-            this.#estimateMessageSize(channelInfo.channel.topic, deserializedMessage),
+            this.#estimateMessageSize(channelInfo.channel.topic, "full", deserializedMessage),
           );
           messages.push({
             topic: channelInfo.channel.topic,
@@ -243,14 +246,20 @@ export class McapIndexedIterableSource implements IIterableSource {
     return messages;
   }
 
-  #estimateMessageSize(topic: string, msg: unknown): number {
-    const cachedSize = this.#messageSizeEstimates[topic];
+  #estimateMessageSize(topic: string, type: "full" | "sliced", msg: unknown): number {
+    const cachedSize =
+      type === "full" ? this.#messageSizeEstimates[topic] : this.#slicedMessageSizeEstimate[topic];
     if (cachedSize != undefined) {
       return cachedSize;
     }
 
     const sizeEstimate = estimateObjectSize(msg);
-    this.#messageSizeEstimates[topic] = sizeEstimate;
+    if (type === "full") {
+      this.#messageSizeEstimates[topic] = sizeEstimate;
+    } else {
+      this.#slicedMessageSizeEstimate[topic] = sizeEstimate;
+    }
+
     return sizeEstimate;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -34,8 +34,7 @@ export class McapIndexedIterableSource implements IIterableSource {
   >();
   #start?: Time;
   #end?: Time;
-  #messageSizeEstimates: Record<string, number> = {};
-  #slicedMessageSizeEstimate: Record<string, number> = {};
+  #messageSizeEstimates: Record<string /* subscription hash */, number> = {};
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -140,9 +139,22 @@ export class McapIndexedIterableSource implements IIterableSource {
       return;
     }
 
+    // Determine the subscription hash which is used to lookup message size estimates.
+    // This is done here to avoid doing this repeatedly when iterating over messages.
+    const topicsWithSubscriptionHash = new Map(
+      Array.from(topics, ([topic, subscribePayload]) => [
+        topic,
+        {
+          ...subscribePayload,
+          // The subscription hash is the topic name appended by + seperated message slicing fields (if any).
+          subscriptionHash: subscribePayload.fields
+            ? topic + "+" + subscribePayload.fields.join("+")
+            : topic,
+        },
+      ]),
+    );
+
     const topicNames = Array.from(topics.keys());
-    // Clear the cache for existing size estimate of sliced topics such that these topics are re-evaluated again.
-    this.#slicedMessageSizeEstimate = {};
 
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
@@ -164,11 +176,10 @@ export class McapIndexedIterableSource implements IIterableSource {
       }
       try {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
-        const spec = args.topics.get(channelInfo.channel.topic);
+        const spec = topicsWithSubscriptionHash.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
         const estimatedMemorySize = this.#estimateMessageSize(
-          channelInfo.channel.topic,
-          spec?.fields == undefined ? "full" : "sliced",
+          spec?.subscriptionHash ?? channelInfo.channel.topic,
           payload,
         );
         const sizeInBytes =
@@ -225,7 +236,7 @@ export class McapIndexedIterableSource implements IIterableSource {
           const deserializedMessage = channelInfo.parsedChannel.deserialize(message.data);
           const sizeInBytes = Math.max(
             message.data.byteLength,
-            this.#estimateMessageSize(channelInfo.channel.topic, "full", deserializedMessage),
+            this.#estimateMessageSize(channelInfo.channel.topic, deserializedMessage),
           );
           messages.push({
             topic: channelInfo.channel.topic,
@@ -246,20 +257,14 @@ export class McapIndexedIterableSource implements IIterableSource {
     return messages;
   }
 
-  #estimateMessageSize(topic: string, type: "full" | "sliced", msg: unknown): number {
-    const cachedSize =
-      type === "full" ? this.#messageSizeEstimates[topic] : this.#slicedMessageSizeEstimate[topic];
+  #estimateMessageSize(subscriptionHash: string, msg: unknown): number {
+    const cachedSize = this.#messageSizeEstimates[subscriptionHash];
     if (cachedSize != undefined) {
       return cachedSize;
     }
 
     const sizeEstimate = estimateObjectSize(msg);
-    if (type === "full") {
-      this.#messageSizeEstimates[topic] = sizeEstimate;
-    } else {
-      this.#slicedMessageSizeEstimate[topic] = sizeEstimate;
-    }
-
+    this.#messageSizeEstimates[subscriptionHash] = sizeEstimate;
     return sizeEstimate;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -16,10 +16,7 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
-import {
-  OBJECT_BASE_SIZE,
-  estimateMessageFieldSizes,
-} from "@foxglove/studio-base/players/messageMemoryEstimation";
+import { MessageMemoryEstimator } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -33,13 +30,11 @@ export class McapIndexedIterableSource implements IIterableSource {
       channel: McapTypes.Channel;
       parsedChannel: ParsedChannel;
       schemaName: string | undefined;
-      // Guesstimate of the memory size in bytes of a deserialized message object
-      approxDeserializedMsgSize: number;
-      msgSizeByField: Record<string, number>;
     }
   >();
   #start?: Time;
   #end?: Time;
+  #messageMemoryEstimator = new MessageMemoryEstimator();
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -62,7 +57,6 @@ export class McapIndexedIterableSource implements IIterableSource {
     const datatypes: RosDatatypes = new Map();
     const problems: PlayerProblem[] = [];
     const publishersByTopic = new Map<string, Set<string>>();
-    const estimatedObjectSizeByType = new Map<string, number>();
 
     for (const channel of this.#reader.channelsById.values()) {
       const schema = this.#reader.schemasById.get(channel.schemaId);
@@ -75,23 +69,8 @@ export class McapIndexedIterableSource implements IIterableSource {
       }
 
       let parsedChannel;
-      let approxDeserializedMsgSize;
-      let msgSizeByField;
       try {
         parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
-        // Determine the size of each schema sub-field. This is going to be used for estimating
-        // the size of sliced messages.
-        msgSizeByField = estimateMessageFieldSizes(
-          parsedChannel.datatypes,
-          schema?.name ?? "",
-          estimatedObjectSizeByType,
-        );
-        // Since we know already the sizes of each individual sub-field, we just sum them up to get the
-        // total message size. Note that the minimum size is OBJECT_BASE_SIZE.
-        approxDeserializedMsgSize = Object.values(msgSizeByField).reduce(
-          (acc, fieldSize) => acc + fieldSize,
-          OBJECT_BASE_SIZE,
-        );
       } catch (error) {
         problems.push({
           severity: "error",
@@ -104,8 +83,6 @@ export class McapIndexedIterableSource implements IIterableSource {
         channel,
         parsedChannel,
         schemaName: schema?.name,
-        approxDeserializedMsgSize,
-        msgSizeByField,
       });
 
       let topic = topicsByName.get(channel.topic);
@@ -163,20 +140,7 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
 
     const topicNames = Array.from(topics.keys());
-
-    // Estimate memory size for sliced messages. We pre-calculate the total size here to avoid
-    // multiple field-size lookups when iterating over messages.
-    const slicedMsgSizeByChannelId: Record<number, number> = {};
-    for (const [channelId, channelInfo] of this.#channelInfoById.entries()) {
-      const fields = args.topics.get(channelInfo.channel.topic)?.fields;
-      if (fields != undefined) {
-        const sizeInBytes = fields.reduce(
-          (acc, field) => acc + (channelInfo.msgSizeByField[field] ?? 0),
-          OBJECT_BASE_SIZE,
-        );
-        slicedMsgSizeByChannelId[channelId] = sizeInBytes;
-      }
-    }
+    this.#messageMemoryEstimator = new MessageMemoryEstimator(); // Reset cache for now as slicing options might have changed
 
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
@@ -200,10 +164,14 @@ export class McapIndexedIterableSource implements IIterableSource {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
         const spec = args.topics.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
+        const estimatedMemorySize = this.#messageMemoryEstimator.estimateMsgObjectSizeInBytes(
+          payload,
+          channelInfo.channel.topic,
+        );
         const sizeInBytes =
           spec?.fields == undefined
-            ? Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize)
-            : slicedMsgSizeByChannelId[message.channelId] ?? OBJECT_BASE_SIZE;
+            ? Math.max(message.data.byteLength, estimatedMemorySize)
+            : estimatedMemorySize;
 
         yield {
           type: "message-event",
@@ -251,12 +219,20 @@ export class McapIndexedIterableSource implements IIterableSource {
         }
 
         try {
+          const deserializedMessage = channelInfo.parsedChannel.deserialize(message.data);
+          const sizeInBytes = Math.max(
+            message.data.byteLength,
+            this.#messageMemoryEstimator.estimateMsgObjectSizeInBytes(
+              deserializedMessage,
+              channelInfo.channel.topic,
+            ),
+          );
           messages.push({
             topic: channelInfo.channel.topic,
             receiveTime: fromNanoSec(message.logTime),
             publishTime: fromNanoSec(message.publishTime),
-            message: channelInfo.parsedChannel.deserialize(message.data),
-            sizeInBytes: Math.max(message.data.byteLength, channelInfo.approxDeserializedMsgSize),
+            message: deserializedMessage,
+            sizeInBytes,
             schemaName: channelInfo.schemaName ?? "",
           });
         } catch (err) {

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -35,7 +35,6 @@ export class McapIndexedIterableSource implements IIterableSource {
   #start?: Time;
   #end?: Time;
   #messageSizeEstimates: Record<string, number> = {};
-  #slicedMessageSizeEstimate: Record<string, number> = {};
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -141,8 +140,10 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
 
     const topicNames = Array.from(topics.keys());
-    // Clear the cache for existing size estimate of sliced topics such that these topics are re-evaluated again.
-    this.#slicedMessageSizeEstimate = {};
+
+    // Clear the cache for existing size estimates such that the message size per topic is
+    // re-evaluated again (as subscription options might have changed).
+    this.#messageSizeEstimates = {};
 
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
@@ -166,11 +167,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
         const spec = args.topics.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
-        const estimatedMemorySize = this.#estimateMessageSize(
-          channelInfo.channel.topic,
-          spec?.fields == undefined ? "full" : "sliced",
-          payload,
-        );
+        const estimatedMemorySize = this.#estimateMessageSize(channelInfo.channel.topic, payload);
         const sizeInBytes =
           spec?.fields == undefined
             ? Math.max(message.data.byteLength, estimatedMemorySize)
@@ -225,7 +222,7 @@ export class McapIndexedIterableSource implements IIterableSource {
           const deserializedMessage = channelInfo.parsedChannel.deserialize(message.data);
           const sizeInBytes = Math.max(
             message.data.byteLength,
-            this.#estimateMessageSize(channelInfo.channel.topic, "full", deserializedMessage),
+            this.#estimateMessageSize(channelInfo.channel.topic, deserializedMessage),
           );
           messages.push({
             topic: channelInfo.channel.topic,
@@ -246,20 +243,14 @@ export class McapIndexedIterableSource implements IIterableSource {
     return messages;
   }
 
-  #estimateMessageSize(topic: string, type: "full" | "sliced", msg: unknown): number {
-    const cachedSize =
-      type === "full" ? this.#messageSizeEstimates[topic] : this.#slicedMessageSizeEstimate[topic];
+  #estimateMessageSize(topic: string, msg: unknown): number {
+    const cachedSize = this.#messageSizeEstimates[topic];
     if (cachedSize != undefined) {
       return cachedSize;
     }
 
     const sizeEstimate = estimateObjectSize(msg);
-    if (type === "full") {
-      this.#messageSizeEstimates[topic] = sizeEstimate;
-    } else {
-      this.#slicedMessageSizeEstimate[topic] = sizeEstimate;
-    }
-
+    this.#messageSizeEstimates[topic] = sizeEstimate;
     return sizeEstimate;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -16,7 +16,7 @@ import {
   IteratorResult,
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
-import { MessageMemoryEstimator } from "@foxglove/studio-base/players/messageMemoryEstimation";
+import { estimateObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -34,7 +34,8 @@ export class McapIndexedIterableSource implements IIterableSource {
   >();
   #start?: Time;
   #end?: Time;
-  #messageMemoryEstimator = new MessageMemoryEstimator();
+  #messageSizeEstimates: Record<string, number> = {};
+  #slicedMessageSizeEstimate: Record<string, number> = {};
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -140,7 +141,8 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
 
     const topicNames = Array.from(topics.keys());
-    this.#messageMemoryEstimator = new MessageMemoryEstimator(); // Reset cache for now as slicing options might have changed
+    // Clear the cache for existing size estimate of sliced topics such that these topics are re-evaluated again.
+    this.#slicedMessageSizeEstimate = {};
 
     for await (const message of this.#reader.readMessages({
       startTime: toNanoSec(start),
@@ -164,9 +166,10 @@ export class McapIndexedIterableSource implements IIterableSource {
         const msg = channelInfo.parsedChannel.deserialize(message.data) as Record<string, unknown>;
         const spec = args.topics.get(channelInfo.channel.topic);
         const payload = spec?.fields != undefined ? pickFields(msg, spec.fields) : msg;
-        const estimatedMemorySize = this.#messageMemoryEstimator.estimateMsgObjectSizeInBytes(
-          payload,
+        const estimatedMemorySize = this.#estimateMessageSize(
           channelInfo.channel.topic,
+          spec?.fields == undefined ? "full" : "sliced",
+          payload,
         );
         const sizeInBytes =
           spec?.fields == undefined
@@ -222,10 +225,7 @@ export class McapIndexedIterableSource implements IIterableSource {
           const deserializedMessage = channelInfo.parsedChannel.deserialize(message.data);
           const sizeInBytes = Math.max(
             message.data.byteLength,
-            this.#messageMemoryEstimator.estimateMsgObjectSizeInBytes(
-              deserializedMessage,
-              channelInfo.channel.topic,
-            ),
+            this.#estimateMessageSize(channelInfo.channel.topic, "full", deserializedMessage),
           );
           messages.push({
             topic: channelInfo.channel.topic,
@@ -244,5 +244,22 @@ export class McapIndexedIterableSource implements IIterableSource {
     }
     messages.sort((a, b) => compare(a.receiveTime, b.receiveTime));
     return messages;
+  }
+
+  #estimateMessageSize(topic: string, type: "full" | "sliced", msg: unknown): number {
+    const cachedSize =
+      type === "full" ? this.#messageSizeEstimates[topic] : this.#slicedMessageSizeEstimate[topic];
+    if (cachedSize != undefined) {
+      return cachedSize;
+    }
+
+    const sizeEstimate = estimateObjectSize(msg);
+    if (type === "full") {
+      this.#messageSizeEstimates[topic] = sizeEstimate;
+    } else {
+      this.#slicedMessageSizeEstimate[topic] = sizeEstimate;
+    }
+
+    return sizeEstimate;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -257,6 +257,13 @@ export class McapIndexedIterableSource implements IIterableSource {
     return messages;
   }
 
+  /**
+   * Returns the cached size estimate for the given {@link subscriptionHash}. Estimates the size
+   * of the given {@link msg} object and updates the cache if no such cache entry exists.
+   * @param subscriptionHash Subscription hash
+   * @param msg Deserialized message object
+   * @returns Size estimate in bytes
+   */
   #estimateMessageSize(subscriptionHash: string, msg: unknown): number {
     const cachedSize = this.#messageSizeEstimates[subscriptionHash];
     if (cachedSize != undefined) {

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -17,7 +17,12 @@ import {
   MessageIteratorArgs,
 } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
 import { estimateObjectSize } from "@foxglove/studio-base/players/messageMemoryEstimation";
-import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
+import {
+  PlayerProblem,
+  SubscribePayload,
+  Topic,
+  TopicStats,
+} from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 const log = Logger.getLogger(__filename);
@@ -34,7 +39,7 @@ export class McapIndexedIterableSource implements IIterableSource {
   >();
   #start?: Time;
   #end?: Time;
-  #messageSizeEstimates: Record<string /* subscription hash */, number> = {};
+  #messageSizeEstimateByHash: Record<string /* subscription hash */, number> = {};
 
   public constructor(reader: McapIndexedReader) {
     this.#reader = reader;
@@ -146,10 +151,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         topic,
         {
           ...subscribePayload,
-          // The subscription hash is the topic name appended by + seperated message slicing fields (if any).
-          subscriptionHash: subscribePayload.fields
-            ? topic + "+" + subscribePayload.fields.join("+")
-            : topic,
+          subscriptionHash: computeSubscriptionHash(topic, subscribePayload),
         },
       ]),
     );
@@ -265,13 +267,21 @@ export class McapIndexedIterableSource implements IIterableSource {
    * @returns Size estimate in bytes
    */
   #estimateMessageSize(subscriptionHash: string, msg: unknown): number {
-    const cachedSize = this.#messageSizeEstimates[subscriptionHash];
+    const cachedSize = this.#messageSizeEstimateByHash[subscriptionHash];
     if (cachedSize != undefined) {
       return cachedSize;
     }
 
     const sizeEstimate = estimateObjectSize(msg);
-    this.#messageSizeEstimates[subscriptionHash] = sizeEstimate;
+    this.#messageSizeEstimateByHash[subscriptionHash] = sizeEstimate;
     return sizeEstimate;
   }
+}
+
+// Computes the subscription hash for a given topic & subscription payload pair.
+// In the simplest case, when there are no message slicing fields, the subscription hash is just
+// the topic name. If there are slicing fields, the hash is computed as the topic name appended
+// by "+" seperated message slicing fields.
+function computeSubscriptionHash(topic: string, subscribePayload: SubscribePayload): string {
+  return subscribePayload.fields ? topic + "+" + subscribePayload.fields.join("+") : topic;
 }

--- a/packages/studio-base/src/players/messageMemoryEstimation.test.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.test.ts
@@ -6,9 +6,10 @@ import {
   estimateMessageObjectSize,
   estimateMessageFieldSizes,
   OBJECT_BASE_SIZE,
+  estimateObjectSize,
 } from "./messageMemoryEstimation";
 
-describe("memoryEstimation", () => {
+describe("memoryEstimationBySchema", () => {
   it("size for empty schema is greater than 0", () => {
     const sizeInBytes = estimateMessageObjectSize(new Map(), "", new Map());
     expect(sizeInBytes).toBeGreaterThan(0);
@@ -124,5 +125,52 @@ describe("memoryEstimation", () => {
       OBJECT_BASE_SIZE,
     );
     expect(fieldSizesSum).toEqual(msgSizeInBytes);
+  });
+});
+
+describe("memoryEstimationByObject", () => {
+  it("estimates the size of an empty object to be greater than 0", () => {
+    const sizeInBytes = estimateObjectSize({});
+    expect(sizeInBytes).toBeGreaterThan(0);
+  });
+
+  it("correctly estimates the size for a simple object", () => {
+    const sizeInBytes = estimateObjectSize({
+      field1: 1, // 4 bytes, SMI (fits in pointer)
+      field2: true, // 4 bytes, pointer to "true" Oddball
+      field3: 1.23, // 16 bytes, 4 bytes pointer to 12 byte heap number
+    });
+    const expectedSize = 36; // 12 (base size) + 4 (smi) + 4 (boolean) + 16 (heap number)
+    expect(sizeInBytes).toEqual(expectedSize);
+  });
+
+  it("correctly estimates the size of an object with an array", () => {
+    const sizeInBytes = estimateObjectSize({
+      field1: [1, 2, 3, 4, 5, 6], // 52 bytes, 4 byte pointer to 48 byte array object (24 byte header + 6 * 4 (SMI)
+      field2: true, // 4 bytes, pointer to "true" Oddball
+      field3: 1.23, // 16 bytes, 4 bytes pointer to 12 byte heap number
+    });
+
+    const expectedSize = 84; // 12 (base size) + 52 (array) + 4 (boolean) + 16 (heap number)
+    expect(sizeInBytes).toEqual(expectedSize);
+  });
+
+  it("correctly estimates the size of an object with a string", () => {
+    const sizeInBytes = estimateObjectSize({
+      n: 1, // 4 bytes, SMI (fits in pointer)
+      str: "abcdef", // 24 bytes, 4 byte pointer to 20 byte string object (12 byte header and 8 bytes content)
+    });
+    const expectedSize = 40; // 12 (base size) + 4 (smi) + 24 (string)
+    expect(sizeInBytes).toEqual(expectedSize);
+  });
+
+  it("correctly estimates the size of an object with an array of objects", () => {
+    const obj = new Array(20).fill(0).map((_, i) => ({
+      n: i, // 4 bytes, SMI (fits in pointer)
+      str: `${i}`.padStart(9, "_"), // 24 bytes, 4 byte pointer to 24 byte string object (12 byte header and 12 bytes content)
+    }));
+    const sizeInBytes = estimateObjectSize({ obj });
+    const expectedSize = 920; // 12 + 4 (pointer to array) + 24 (array header) + 20 * 44 (array content)
+    expect(sizeInBytes).toEqual(expectedSize);
   });
 });

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -9,6 +9,9 @@ import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
  */
 const COMPRESSED_POINTER_SIZE = 4; // Pointers use 4 bytes (also on 64-bit systems) due to pointer compression
 export const OBJECT_BASE_SIZE = 3 * COMPRESSED_POINTER_SIZE; // 3 compressed pointers
+// Arrays have an additional length property (1 pointer) and a backing store header (2 pointers)
+// See https://stackoverflow.com/a/70550693.
+const ARRAY_BASE_SIZE = OBJECT_BASE_SIZE + 3 * COMPRESSED_POINTER_SIZE;
 const TYPED_ARRAY_BASE_SIZE = 25 * COMPRESSED_POINTER_SIZE; // byteLength, byteOffset, ..., see https://stackoverflow.com/a/45808835
 const SMALL_INTEGER_SIZE = COMPRESSED_POINTER_SIZE; // Small integers (up to 31 bits), pointer tagging
 const HEAP_NUMBER_SIZE = 8 + 2 * COMPRESSED_POINTER_SIZE; // 4-byte map pointer + 8-byte payload + property pointer
@@ -187,29 +190,51 @@ export function estimateMessageFieldSizes(
   return sizeByField;
 }
 
-function estimateObjectSize(obj: unknown): number {
+/**
+ * Estimate the size in bytes of an arbitrary object or primitive.
+ * @param obj Object or primitive to estimate the size for
+ * @returns Estimated size in bytes
+ */
+export function estimateObjectSize(obj: unknown): number {
   switch (typeof obj) {
-    case "number":
+    case "undefined":
     case "boolean": {
       return SMALL_INTEGER_SIZE;
+    }
+    case "number": {
+      return Number.isInteger(obj) ? SMALL_INTEGER_SIZE : HEAP_NUMBER_SIZE;
     }
     case "bigint": {
       return HEAP_NUMBER_SIZE;
     }
     case "string": {
-      return obj.length;
+      // The string length is rounded up to the next multiple of 4.
+      return COMPRESSED_POINTER_SIZE + OBJECT_BASE_SIZE + Math.ceil(obj.length / 4) * 4;
     }
     case "object": {
       if (Array.isArray(obj)) {
-        if (obj.length === 0) {
-          return OBJECT_BASE_SIZE;
-        }
-
         return (
-          OBJECT_BASE_SIZE + obj.length * (COMPRESSED_POINTER_SIZE + estimateObjectSize(obj[0]))
+          COMPRESSED_POINTER_SIZE +
+          ARRAY_BASE_SIZE +
+          Object.values(obj).reduce((acc, val) => acc + estimateObjectSize(val), 0)
         );
       } else if (ArrayBuffer.isView(obj)) {
         return TYPED_ARRAY_BASE_SIZE + obj.byteLength;
+      } else if (obj instanceof Set) {
+        return (
+          COMPRESSED_POINTER_SIZE +
+          OBJECT_BASE_SIZE +
+          Array.from(obj.values()).reduce((acc, val) => acc + estimateObjectSize(val), 0)
+        );
+      } else if (obj instanceof Map) {
+        return (
+          COMPRESSED_POINTER_SIZE +
+          OBJECT_BASE_SIZE +
+          Array.from(obj.entries()).reduce(
+            (acc, [key, val]) => acc + estimateObjectSize(key) + estimateObjectSize(val),
+            0,
+          )
+        );
       }
 
       let propertiesSize = 0;
@@ -222,33 +247,16 @@ function estimateObjectSize(obj: unknown): number {
         // medium.com/@bpmxmqd/v8-engine-jsobject-structure-analysis-and-memory-optimization-ideas-be30cfcdcd16
         const propertiesDictSize =
           16 + 5 * 8 + 2 ** Math.ceil(Math.log2((numProps + 2) * 1.5)) * 3 * 4;
-        propertiesSize = propertiesDictSize;
-      } else {
-        propertiesSize = COMPRESSED_POINTER_SIZE * numProps;
+        // In return, properties are no longer stored in the properties array, so we subtract that.
+        propertiesSize = propertiesDictSize - numProps * COMPRESSED_POINTER_SIZE;
       }
 
       const valuesSize = Object.values(obj!).reduce((acc, val) => acc + estimateObjectSize(val), 0);
       return OBJECT_BASE_SIZE + propertiesSize + valuesSize;
     }
     case "symbol":
-    case "undefined":
     case "function": {
-      throw new Error(`Can't estimate size for type ${typeof obj}`);
+      throw new Error(`Can't estimate size of type '${typeof obj}'`);
     }
-  }
-}
-
-export class MessageMemoryEstimator {
-  #cachedSizeEstimateByTopic: Record<string, number> = {};
-
-  public estimateMsgObjectSizeInBytes(msg: unknown, topic: string): number {
-    const cachedSizeEstimate = this.#cachedSizeEstimateByTopic[topic];
-    if (cachedSizeEstimate != undefined) {
-      return cachedSizeEstimate;
-    }
-
-    const objectSizeEstimate = estimateObjectSize(msg);
-    this.#cachedSizeEstimateByTopic[topic] = objectSizeEstimate;
-    return objectSizeEstimate;
   }
 }

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -186,3 +186,69 @@ export function estimateMessageFieldSizes(
 
   return sizeByField;
 }
+
+function estimateObjectSize(obj: unknown): number {
+  switch (typeof obj) {
+    case "number":
+    case "boolean": {
+      return SMALL_INTEGER_SIZE;
+    }
+    case "bigint": {
+      return HEAP_NUMBER_SIZE;
+    }
+    case "string": {
+      return obj.length;
+    }
+    case "object": {
+      if (Array.isArray(obj)) {
+        if (obj.length === 0) {
+          return OBJECT_BASE_SIZE;
+        }
+
+        return (
+          OBJECT_BASE_SIZE + obj.length * (COMPRESSED_POINTER_SIZE + estimateObjectSize(obj[0]))
+        );
+      } else if (ArrayBuffer.isView(obj)) {
+        return TYPED_ARRAY_BASE_SIZE + obj.byteLength;
+      }
+
+      let propertiesSize = 0;
+      const numProps = Object.keys(obj!).length;
+      if (numProps > MAX_NUM_FAST_PROPERTIES) {
+        // If there are too many properties, V8 stores Objects in dictionary mode (slow properties)
+        // with each object having a self-contained dictionary. This dictionary contains the key, value
+        // and details of properties. Below we estimate the size of this additional dictionary. Formula
+        // adapted from
+        // medium.com/@bpmxmqd/v8-engine-jsobject-structure-analysis-and-memory-optimization-ideas-be30cfcdcd16
+        const propertiesDictSize =
+          16 + 5 * 8 + 2 ** Math.ceil(Math.log2((numProps + 2) * 1.5)) * 3 * 4;
+        propertiesSize = propertiesDictSize;
+      } else {
+        propertiesSize = COMPRESSED_POINTER_SIZE * numProps;
+      }
+
+      const valuesSize = Object.values(obj!).reduce((acc, val) => acc + estimateObjectSize(val), 0);
+      return OBJECT_BASE_SIZE + propertiesSize + valuesSize;
+    }
+    case "symbol":
+    case "undefined":
+    case "function": {
+      throw new Error(`Can't estimate size for type ${typeof obj}`);
+    }
+  }
+}
+
+export class MessageMemoryEstimator {
+  #cachedSizeEstimateByTopic: Record<string, number> = {};
+
+  public estimateMsgObjectSizeInBytes(msg: unknown, topic: string): number {
+    const cachedSizeEstimate = this.#cachedSizeEstimateByTopic[topic];
+    if (cachedSizeEstimate != undefined) {
+      return cachedSizeEstimate;
+    }
+
+    const objectSizeEstimate = estimateObjectSize(msg);
+    this.#cachedSizeEstimateByTopic[topic] = objectSizeEstimate;
+    return objectSizeEstimate;
+  }
+}


### PR DESCRIPTION
**User-Facing Changes**
Improve memory estimation to make OOM crashes less likely

**Description**
For estimating the size of a deserialized message, we currently use a schema-based approach where the message schema definition is analyzed to get an idea on what fields are to be expected in the message and how big the message might be. This however falls short on dynamic messages with arrays or strings as we cannot know the array or string size upfront. For these messages, we conservatively assumed an empty array size and a fixed string size, which in some cases leads to a large underestimation of the actual message size.

This PR introduces a new estimation method that estimates the memory size of a deserialized message by iterating over its properties. Unlike the schema-based estimation, this new method iterates on the properties of a deserialized message and can thus more accurately estimate the size of dynamic messages. The size estimates are cached for each topic as it would be quite expensive to do estimate the size for every message. 
Caching also has its disadvantages however, namely that a topic's first message size estimate will be used for subsequent messages on that topic which might not reflect reality (e.g. consider two publishers publishing pointclouds of various sizes to the same topic). 

Experimental results have shown that the proposed new size estimation method produces more accurate size estimates than the current schema-based estimation method, especially when the message schema contains dynamic types (arrays or strings).
