### PR TITLE
Show transform section settings error when there is an error adding a transform

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -109,6 +109,7 @@ const NO_FRAME_SELECTED = "NO_FRAME_SELECTED";
 const TF_OVERFLOW = "TF_OVERFLOW";
 const CYCLE_DETECTED = "CYCLE_DETECTED";
 const FOLLOW_FRAME_NOT_FOUND = "FOLLOW_FRAME_NOT_FOUND";
+const ADD_TRANSFORM_ERROR = "ADD_TRANSFORM_ERROR";
 
 // An extensionId for creating the top-level settings nodes such as "Topics" and
 // "Custom Layers"
@@ -978,21 +979,37 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   #addFrameTransform(transform: FrameTransform): void {
     const parentId = transform.parent_frame_id;
     const childId = transform.child_frame_id;
-    const stamp = toNanoSec(transform.timestamp);
-    const t = transform.translation;
-    const q = transform.rotation;
+    try {
+      const stamp = toNanoSec(transform.timestamp);
+      const t = transform.translation;
+      const q = transform.rotation;
 
-    this.addTransform(parentId, childId, stamp, t, q);
+      this.addTransform(parentId, childId, stamp, t, q);
+    } catch (err) {
+      this.settings.errors.add(
+        ["transforms"],
+        ADD_TRANSFORM_ERROR,
+        `Error adding transform for frame ${childId}: ${err.message}`,
+      );
+    }
   }
 
   #addTransformMessage(tf: TransformStamped): void {
     const normalizedParentId = this.normalizeFrameId(tf.header.frame_id);
     const normalizedChildId = this.normalizeFrameId(tf.child_frame_id);
-    const stamp = toNanoSec(tf.header.stamp);
-    const t = tf.transform.translation;
-    const q = tf.transform.rotation;
+    try {
+      const stamp = toNanoSec(tf.header.stamp);
+      const t = tf.transform.translation;
+      const q = tf.transform.rotation;
 
-    this.addTransform(normalizedParentId, normalizedChildId, stamp, t, q);
+      this.addTransform(normalizedParentId, normalizedChildId, stamp, t, q);
+    } catch (err) {
+      this.settings.errors.add(
+        ["transforms"],
+        ADD_TRANSFORM_ERROR,
+        `Error adding transform for frame ${normalizedChildId}: ${err.message}`,
+      );
+    }
   }
 
   // Create a new transform and add it to the renderer's TransformTree


### PR DESCRIPTION
User-facing changes:

 - Fix: error when adding transform will not cause 3D panel to crash

Description:

Wrapped `addTransform` methods along with `toNanoSec` in try/catch and show error on transform section.