### PR TITLE
Use "data source" and `dataSource` consistently

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -371,7 +371,7 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
       return;
     }
 
-    // Apply any available datasource args
+    // Apply any available data source args
     if (unappliedSourceArgs.ds) {
       log.debug("Initialising source from url", unappliedSourceArgs);
       selectSource(unappliedSourceArgs.ds, {

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -99,31 +99,31 @@ function parseInput(value: string): { error?: string; parsedObject?: unknown } {
   return { error, parsedObject };
 }
 
-function selectDatasourceProfile(ctx: MessagePipelineContext) {
+function selectDataSourceProfile(ctx: MessagePipelineContext) {
   return ctx.playerState.profile;
 }
 
 function Publish(props: Props) {
   const { saveConfig, config } = props;
-  const { topics, datatypes: datasourceDatatypes, capabilities } = useDataSourceInfo();
+  const { topics, datatypes: dataSourceDatatypes, capabilities } = useDataSourceInfo();
   const { classes } = useStyles({ buttonColor: config.buttonColor });
   const [debouncedTopicName] = useDebounce(config.topicName ?? "", 500);
-  const datasourceProfile = useMessagePipeline(selectDatasourceProfile);
+  const dataSourceProfile = useMessagePipeline(selectDataSourceProfile);
 
   const datatypes = useMemo(() => {
-    // Add common ROS datatypes, depending on the datasource profile.
+    // Add common ROS datatypes, depending on the data source profile.
     const commonTypes: Record<string, MessageDefinition> | undefined = {
       ros1: CommonRosTypes.ros1,
       ros2: CommonRosTypes.ros2galactic,
-    }[datasourceProfile ?? ""];
+    }[dataSourceProfile ?? ""];
 
     if (commonTypes == undefined) {
-      return datasourceDatatypes;
+      return dataSourceDatatypes;
     }
 
-    // datasourceDatatypes is added after commonTypes to take precedence (override) any commonTypes of the same name
-    return new Map([...Object.entries(commonTypes), ...datasourceDatatypes]);
-  }, [datasourceProfile, datasourceDatatypes]);
+    // dataSourceDatatypes is added after commonTypes to take precedence (override) any commonTypes of the same name
+    return new Map([...Object.entries(commonTypes), ...dataSourceDatatypes]);
+  }, [dataSourceProfile, dataSourceDatatypes]);
 
   const publish = usePublisher({
     name: "Publish",

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -284,13 +284,9 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
         alignItems="center"
         style={{ padding: "min(5%, 8px)", textAlign: "center" }}
       >
-        {!canPublish && (
-          <EmptyState>
-            Please connect to a datasource that supports publishing in order to use this panel
-          </EmptyState>
-        )}
+        {!canPublish && <EmptyState>Connect to a data source that supports publishing</EmptyState>}
         {canPublish && !hasTopic && (
-          <EmptyState>Please select a publish topic in the panel settings</EmptyState>
+          <EmptyState>Select a publish topic in the panel settings</EmptyState>
         )}
         {enabled && <DirectionalPad onAction={setCurrentAction} disabled={!enabled} />}
       </Stack>

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -590,7 +590,7 @@ export class IterablePlayer implements Player {
     this.#setState(this.#isPlaying ? "play" : "idle");
   }
 
-  // Read a small amount of data from the datasource with the hope of producing a message or two.
+  // Read a small amount of data from the data source with the hope of producing a message or two.
   // Without an initial read, the user would be looking at a blank layout since no messages have yet
   // been delivered.
   async #stateStartPlay() {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- N/A

**Description**
- Use "data source" and `dataSource` vs. "datasource" and `datasource` consistently across the codebase and UI
- Also cleaned up Teleop panel's empty state messaging to be consistent with others (no "please")