### PR TITLE
Add memory info to player state

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -53,7 +53,7 @@ describe("BlockLoader", () => {
     });
 
     await loader.startLoading({
-      progress: async (progress) => {
+      progress: async (progress, cacheSize) => {
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [],
           messageCache: {
@@ -61,11 +61,12 @@ describe("BlockLoader", () => {
             startTime: { sec: 0, nsec: 0 },
           },
         });
+        expect(cacheSize).toEqual(0);
         await loader.stopLoading();
       },
     });
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 
   it("should load the source into blocks", async () => {
@@ -106,7 +107,7 @@ describe("BlockLoader", () => {
     loader.setTopics(mockTopicSelection("a"));
     let count = 0;
     await loader.startLoading({
-      progress: async (progress) => {
+      progress: async (progress, cacheSize) => {
         if (++count < 5) {
           return;
         }
@@ -159,12 +160,13 @@ describe("BlockLoader", () => {
             startTime: { sec: 0, nsec: 0 },
           },
         });
+        expect(cacheSize).toEqual(4);
 
         await loader.stopLoading();
       },
     });
 
-    expect.assertions(1);
+    expect.assertions(2);
   });
 
   it("should not load messages past max cache size", async () => {

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -6,7 +6,7 @@ import { MessageEvent } from "@foxglove/studio";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
 import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
 
-import { BlockLoader } from "./BlockLoader";
+import { BlockLoader, MEMORY_INFO_PRELOADED_MSGS } from "./BlockLoader";
 import {
   GetBackfillMessagesArgs,
   IIterableSource,
@@ -53,20 +53,22 @@ describe("BlockLoader", () => {
     });
 
     await loader.startLoading({
-      progress: async (progress, cacheSize) => {
+      progress: async (progress) => {
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [],
           messageCache: {
             blocks: [undefined, undefined, undefined, undefined],
             startTime: { sec: 0, nsec: 0 },
           },
+          memoryInfo: {
+            [MEMORY_INFO_PRELOADED_MSGS]: 0,
+          },
         });
-        expect(cacheSize).toEqual(0);
         await loader.stopLoading();
       },
     });
 
-    expect.assertions(2);
+    expect.assertions(1);
   });
 
   it("should load the source into blocks", async () => {
@@ -107,7 +109,7 @@ describe("BlockLoader", () => {
     loader.setTopics(mockTopicSelection("a"));
     let count = 0;
     await loader.startLoading({
-      progress: async (progress, cacheSize) => {
+      progress: async (progress) => {
         if (++count < 5) {
           return;
         }
@@ -159,14 +161,16 @@ describe("BlockLoader", () => {
             ],
             startTime: { sec: 0, nsec: 0 },
           },
+          memoryInfo: {
+            [MEMORY_INFO_PRELOADED_MSGS]: 4,
+          },
         });
-        expect(cacheSize).toEqual(4);
 
         await loader.stopLoading();
       },
     });
 
-    expect.assertions(2);
+    expect.assertions(1);
   });
 
   it("should not load messages past max cache size", async () => {
@@ -207,7 +211,7 @@ describe("BlockLoader", () => {
     loader.setTopics(mockTopicSelection("a"));
     await loader.startLoading({
       progress: async (progress) => {
-        expect(progress).toEqual({
+        expect(progress).toMatchObject({
           fullyLoadedFractionRanges: [
             {
               start: 0,
@@ -314,6 +318,9 @@ describe("BlockLoader", () => {
               ],
               startTime: { sec: 0, nsec: 0 },
             },
+            memoryInfo: {
+              [MEMORY_INFO_PRELOADED_MSGS]: 4,
+            },
           });
           await loader.stopLoading();
         }
@@ -354,6 +361,9 @@ describe("BlockLoader", () => {
                 },
               ],
               startTime: { sec: 0, nsec: 0 },
+            },
+            memoryInfo: {
+              [MEMORY_INFO_PRELOADED_MSGS]: 4,
             },
           });
           await loader.stopLoading();
@@ -435,6 +445,9 @@ describe("BlockLoader", () => {
               ],
               startTime: { sec: 0, nsec: 0 },
             },
+            memoryInfo: {
+              [MEMORY_INFO_PRELOADED_MSGS]: 0,
+            },
           });
 
           // eslint-disable-next-line require-yield
@@ -493,7 +506,7 @@ describe("BlockLoader", () => {
     loader.setTopics(mockTopicSelection("a"));
     await loader.startLoading({
       progress: async (progress) => {
-        expect(progress).toEqual({
+        expect(progress).toMatchObject({
           fullyLoadedFractionRanges: [
             {
               start: 0,
@@ -558,6 +571,9 @@ describe("BlockLoader", () => {
                 },
               ],
               startTime: { sec: 0, nsec: 0 },
+            },
+            memoryInfo: {
+              [MEMORY_INFO_PRELOADED_MSGS]: 10,
             },
           });
 

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -25,6 +25,8 @@ import { IIterableSource, MessageIteratorArgs } from "./IIterableSource";
 
 const log = Log.getLogger(__filename);
 
+export const MEMORY_INFO_PRELOADED_MSGS = "Preloaded messages";
+
 type BlockLoaderArgs = {
   cacheSizeBytes: number;
   source: IIterableSource;
@@ -42,7 +44,7 @@ type CacheBlock = MessageBlock & {
 type Blocks = (CacheBlock | undefined)[];
 
 type LoadArgs = {
-  progress: (progress: Progress, cacheSize: number) => void;
+  progress: (progress: Progress) => void;
 };
 
 /**
@@ -185,7 +187,7 @@ export class BlockLoader {
 
     // Ignore changing the blocks if the topic list is empty
     if (topics.size === 0) {
-      args.progress(this.#calculateProgress(topics), this.#cacheSize());
+      args.progress(this.#calculateProgress(topics, this.#cacheSize()));
       return;
     }
 
@@ -334,7 +336,7 @@ export class BlockLoader {
             });
             // We need to emit progress here so the player will emit a new state
             // containing the problem.
-            progress(this.#calculateProgress(topics), totalBlockSizeBytes);
+            progress(this.#calculateProgress(topics, totalBlockSizeBytes));
             return;
           }
         }
@@ -367,7 +369,7 @@ export class BlockLoader {
         // (The size of new messages is already added above).
         totalBlockSizeBytes -= overridenBlockMessagesSize;
 
-        progress(this.#calculateProgress(topics), totalBlockSizeBytes);
+        progress(this.#calculateProgress(topics, totalBlockSizeBytes));
       }
 
       await cursor.end();
@@ -375,7 +377,7 @@ export class BlockLoader {
     }
   }
 
-  #calculateProgress(topics: TopicSelection): Progress {
+  #calculateProgress(topics: TopicSelection, currentCacheSize: number): Progress {
     const fullyLoadedFractionRanges = simplify(
       filterMap(this.#blocks, (thisBlock, blockIndex) => {
         if (!thisBlock) {
@@ -404,6 +406,9 @@ export class BlockLoader {
       messageCache: {
         blocks: this.#blocks.slice(),
         startTime: this.#start,
+      },
+      memoryInfo: {
+        [MEMORY_INFO_PRELOADED_MSGS]: currentCacheSize,
       },
     };
   }

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -42,7 +42,7 @@ type CacheBlock = MessageBlock & {
 type Blocks = (CacheBlock | undefined)[];
 
 type LoadArgs = {
-  progress: (progress: Progress) => void;
+  progress: (progress: Progress, cacheSize: number) => void;
 };
 
 /**
@@ -185,7 +185,7 @@ export class BlockLoader {
 
     // Ignore changing the blocks if the topic list is empty
     if (topics.size === 0) {
-      args.progress(this.#calculateProgress(topics));
+      args.progress(this.#calculateProgress(topics), this.#cacheSize());
       return;
     }
 
@@ -334,7 +334,7 @@ export class BlockLoader {
             });
             // We need to emit progress here so the player will emit a new state
             // containing the problem.
-            progress(this.#calculateProgress(topics));
+            progress(this.#calculateProgress(topics), totalBlockSizeBytes);
             return;
           }
         }
@@ -367,7 +367,7 @@ export class BlockLoader {
         // (The size of new messages is already added above).
         totalBlockSizeBytes -= overridenBlockMessagesSize;
 
-        progress(this.#calculateProgress(topics));
+        progress(this.#calculateProgress(topics), totalBlockSizeBytes);
       }
 
       await cursor.end();

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -218,7 +218,7 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
     return this.#source.loadedRanges();
   }
 
-  public getBufferedAmount(): number {
+  public getCacheSize(): number {
     return this.#source.getCacheSize();
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -218,6 +218,10 @@ class BufferedIterableSource extends EventEmitter<EventTypes> implements IIterab
     return this.#source.loadedRanges();
   }
 
+  public getBufferedAmount(): number {
+    return this.#source.getCacheSize();
+  }
+
   public messageIterator(
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -119,6 +119,10 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     return this.#loadedRangesCache;
   }
 
+  public getCacheSize(): number {
+    return this.#totalSizeBytes;
+  }
+
   public async *messageIterator(
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -26,7 +26,6 @@ import {
   AdvertiseOptions,
   Player,
   PlayerCapabilities,
-  PlayerMemoryInfo,
   PlayerMetricsCollectorInterface,
   PlayerPresence,
   PlayerState,
@@ -68,6 +67,8 @@ const MAX_BLOCKS = 400;
 // Amount to seek into the data source from the start when loading the player. The purpose of this
 // is to provide some initial data to subscribers.
 const SEEK_ON_START_NS = BigInt(99 * 1e6);
+
+const MEMORY_INFO_BUFFERED_MSGS = "Buffered messages";
 
 type IterablePlayerOptions = {
   metricsCollector?: PlayerMetricsCollectorInterface;
@@ -148,7 +149,6 @@ export class IterablePlayer implements Player {
   #publishedTopics = new Map<string, Set<string>>();
   #seekTarget?: Time;
   #presence = PlayerPresence.INITIALIZING;
-  #memoryInfo?: PlayerMemoryInfo;
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
@@ -805,7 +805,6 @@ export class IterablePlayer implements Player {
         sourceId: this.#sourceId,
         parameters: this.#urlParams,
       },
-      memoryInfo: this.#memoryInfo,
     };
 
     await this.#listener(data);
@@ -986,10 +985,10 @@ export class IterablePlayer implements Player {
       this.#progress = {
         fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
         messageCache: this.#progress.messageCache,
-      };
-      this.#memoryInfo = {
-        ...this.#memoryInfo,
-        bufferedMsgsSize: this.#bufferedSource.getBufferedAmount(),
+        memoryInfo: {
+          ...this.#progress.memoryInfo,
+          [MEMORY_INFO_BUFFERED_MSGS]: this.#bufferedSource.getCacheSize(),
+        },
       };
       this.#queueEmitState();
     };
@@ -1041,11 +1040,10 @@ export class IterablePlayer implements Player {
         this.#progress = {
           fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
           messageCache: this.#progress.messageCache,
-        };
-        // Update the player's memory info
-        this.#memoryInfo = {
-          ...this.#memoryInfo,
-          bufferedMsgsSize: this.#bufferedSource.getBufferedAmount(),
+          memoryInfo: {
+            ...this.#progress.memoryInfo,
+            [MEMORY_INFO_BUFFERED_MSGS]: this.#bufferedSource.getCacheSize(),
+          },
         };
 
         // If subscriptions changed, update to the new subscriptions
@@ -1087,14 +1085,14 @@ export class IterablePlayer implements Player {
 
   async #startBlockLoading() {
     await this.#blockLoader?.startLoading({
-      progress: async (progress, cacheSize) => {
+      progress: async (progress) => {
         this.#progress = {
           fullyLoadedFractionRanges: this.#progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache,
-        };
-        this.#memoryInfo = {
-          ...this.#memoryInfo,
-          preloadedMsgsSize: cacheSize,
+          memoryInfo: {
+            ...this.#progress.memoryInfo,
+            ...progress.memoryInfo,
+          },
         };
         // If we are in playback, we will let playback queue state updates
         if (this.#state === "play") {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -26,6 +26,7 @@ import {
   AdvertiseOptions,
   Player,
   PlayerCapabilities,
+  PlayerMemoryInfo,
   PlayerMetricsCollectorInterface,
   PlayerPresence,
   PlayerState,
@@ -147,6 +148,7 @@ export class IterablePlayer implements Player {
   #publishedTopics = new Map<string, Set<string>>();
   #seekTarget?: Time;
   #presence = PlayerPresence.INITIALIZING;
+  #memoryInfo?: PlayerMemoryInfo;
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
@@ -803,6 +805,7 @@ export class IterablePlayer implements Player {
         sourceId: this.#sourceId,
         parameters: this.#urlParams,
       },
+      memoryInfo: this.#memoryInfo,
     };
 
     await this.#listener(data);
@@ -984,6 +987,10 @@ export class IterablePlayer implements Player {
         fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
         messageCache: this.#progress.messageCache,
       };
+      this.#memoryInfo = {
+        ...this.#memoryInfo,
+        bufferedMsgsSize: this.#bufferedSource.getBufferedAmount(),
+      };
       this.#queueEmitState();
     };
 
@@ -1035,6 +1042,11 @@ export class IterablePlayer implements Player {
           fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
           messageCache: this.#progress.messageCache,
         };
+        // Update the player's memory info
+        this.#memoryInfo = {
+          ...this.#memoryInfo,
+          bufferedMsgsSize: this.#bufferedSource.getBufferedAmount(),
+        };
 
         // If subscriptions changed, update to the new subscriptions
         if (this.#allTopics !== allTopics) {
@@ -1075,12 +1087,15 @@ export class IterablePlayer implements Player {
 
   async #startBlockLoading() {
     await this.#blockLoader?.startLoading({
-      progress: async (progress) => {
+      progress: async (progress, cacheSize) => {
         this.#progress = {
           fullyLoadedFractionRanges: this.#progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache,
         };
-
+        this.#memoryInfo = {
+          ...this.#memoryInfo,
+          preloadedMsgsSize: cacheSize,
+        };
         // If we are in playback, we will let playback queue state updates
         if (this.#state === "play") {
           return;

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -94,6 +94,14 @@ export type PlayerURLState = Immutable<{
   parameters?: Record<string, string>;
 }>;
 
+// Contains details about a Player's memory usage
+export type PlayerMemoryInfo = Readonly<{
+  // Size in bytes of all buffered messages.
+  bufferedMsgsSize?: number;
+  // Size in bytes of all preloaded messages.
+  preloadedMsgsSize?: number;
+}>;
+
 export type PlayerState = {
   // Information about the player's presence or connection status, for the UI to show a loading indicator.
   presence: PlayerPresence;
@@ -130,6 +138,9 @@ export type PlayerState = {
 
   /** State to serialize into the active URL. */
   urlState?: PlayerURLState;
+
+  // Memory stats holding detailed information about the player's current memory usage
+  memoryInfo?: PlayerMemoryInfo;
 };
 
 export type PlayerStateActiveData = {

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -94,14 +94,6 @@ export type PlayerURLState = Immutable<{
   parameters?: Record<string, string>;
 }>;
 
-// Contains details about a Player's memory usage
-export type PlayerMemoryInfo = Readonly<{
-  // Size in bytes of all buffered messages.
-  bufferedMsgsSize?: number;
-  // Size in bytes of all preloaded messages.
-  preloadedMsgsSize?: number;
-}>;
-
 export type PlayerState = {
   // Information about the player's presence or connection status, for the UI to show a loading indicator.
   presence: PlayerPresence;
@@ -138,9 +130,6 @@ export type PlayerState = {
 
   /** State to serialize into the active URL. */
   urlState?: PlayerURLState;
-
-  // Memory stats holding detailed information about the player's current memory usage
-  memoryInfo?: PlayerMemoryInfo;
 };
 
 export type PlayerStateActiveData = {
@@ -285,6 +274,9 @@ export type Progress = Readonly<{
   // A raw view into the cached binary data stored by the MemoryCacheDataProvider. Only present when
   // using the RandomAccessPlayer.
   readonly messageCache?: BlockCache;
+
+  /** Memory usage information, e.g. the memory size occupied by preloaded or buffered messages. */
+  readonly memoryInfo?: Record<string, number>;
 }>;
 
 export type SubscriptionPreloadType =


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds a new `memoryInfo` object to `PlayerState` which holds information of the current amount of buffered and preloaded messages. This mainly applies for non-live data sources where messages can be buffered (for smoother playback) or preloaded (e.g. for plots).


Part of FG-6099