### PR TITLE
Improvements to message path autocomplete

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -136,7 +136,7 @@ export const AutocompleteScalarFromFullTopic: MsgPathInputStoryObj = {
 
 export const AutocompleteWithFilterSuggestions: MsgPathInputStoryObj = {
   render: MessagePathInputStory,
-  args: { path: "/some_topic/st" },
+  args: { path: "stateitems" },
   play: clickInput,
 };
 

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -134,7 +134,7 @@ export const AutocompleteScalarFromFullTopic: MsgPathInputStoryObj = {
   },
 };
 
-export const AutocompleteWithFilterSuggestions: MsgPathInputStoryObj = {
+export const AutocompleteWithFilterAndArraySuggestions: MsgPathInputStoryObj = {
   render: MessagePathInputStory,
   args: { path: "stateitems" },
   play: clickInput,

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -134,6 +134,12 @@ export const AutocompleteScalarFromFullTopic: MsgPathInputStoryObj = {
   },
 };
 
+export const AutocompleteWithFilterSuggestions: MsgPathInputStoryObj = {
+  render: MessagePathInputStory,
+  args: { path: "/some_topic/st" },
+  play: clickInput,
+};
+
 export const AutocompleteMessagePath: MsgPathInputStoryObj = {
   render: MessagePathInputStory,
   args: { path: "/some_topic/location.po" },

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -16,15 +16,11 @@ import * as _ from "lodash-es";
 import { CSSProperties, useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
-import { MessageDefinitionField } from "@foxglove/message-definition";
-import { Immutable } from "@foxglove/studio";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
 import useGlobalVariables, {
   GlobalVariables,
 } from "@foxglove/studio-base/hooks/useGlobalVariables";
-import { Topic } from "@foxglove/studio-base/players/types";
-import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 import { RosPath, RosPrimitive } from "./constants";
 import {
@@ -34,75 +30,7 @@ import {
   validTerminatingStructureItem,
   StructureTraversalResult,
 } from "./messagePathsForDatatype";
-import parseRosPath, { quoteFieldNameIfNeeded, quoteTopicNameIfNeeded } from "./parseRosPath";
-
-// To show an input field with an autocomplete so the user can enter message paths, use:
-//
-//  <MessagePathInput path={this.state.path} onChange={path => this.setState({ path })} />
-//
-// To limit the autocomplete items to only certain types of values, you can use
-//
-//  <MessagePathInput types={["message", "array", "primitives"]} />
-//
-// Or use actual ROS primitive types:
-//
-//  <MessagePathInput types={["uint16", "float64"]} />
-//
-// If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
-// which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
-// avoid creating anonymous functions on every render (which will prevent the component from
-// rendering unnecessarily).
-
-// Get a list of Message Path strings for all of the fields (recursively) in a list of topics
-function getFieldPaths(
-  topics: Immutable<Topic[]>,
-  datatypes: Immutable<RosDatatypes>,
-): Map<string, MessageDefinitionField> {
-  const output = new Map<string, MessageDefinitionField>();
-  for (const topic of topics) {
-    if (topic.schemaName == undefined) {
-      continue;
-    }
-    addFieldPathsForType(
-      quoteTopicNameIfNeeded(topic.name),
-      topic.schemaName,
-      datatypes,
-      [],
-      output,
-    );
-  }
-  return output;
-}
-
-function addFieldPathsForType(
-  curPath: string,
-  typeName: string,
-  datatypes: Immutable<RosDatatypes>,
-  seenTypes: string[],
-  output: Map<string, Immutable<MessageDefinitionField>>,
-): void {
-  const msgdef = datatypes.get(typeName);
-  if (msgdef) {
-    for (const field of msgdef.definitions) {
-      if (seenTypes.includes(field.type)) {
-        continue;
-      }
-      if (field.isConstant !== true) {
-        const fieldPath = `${curPath}.${quoteFieldNameIfNeeded(field.name)}`;
-        output.set(fieldPath, field);
-        if (field.isComplex === true) {
-          addFieldPathsForType(
-            fieldPath,
-            field.type,
-            datatypes,
-            [...seenTypes, field.type],
-            output,
-          );
-        }
-      }
-    }
-  }
-}
+import parseRosPath, { quoteTopicNameIfNeeded } from "./parseRosPath";
 
 export function tryToSetDefaultGlobalVar(
   variableName: string,
@@ -188,6 +116,24 @@ const useStyles = makeStyles()({
   root: { flexGrow: 1 },
 });
 
+/**
+ * To show an input field with an autocomplete so the user can enter message paths, use:
+ *
+ *  <MessagePathInput path={this.state.path} onChange={path => this.setState({ path })} />
+ *
+ * To limit the autocomplete items to only certain types of values, you can use
+ *
+ *  <MessagePathInput types={["message", "array", "primitives"]} />
+ *
+ * Or use actual ROS primitive types:
+ *
+ *  <MessagePathInput types={["uint16", "float64"]} />
+ *
+ * If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
+ * which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
+ * avoid creating anonymous functions on every render (which will prevent the component from
+ * rendering unnecessarily).
+ */
 export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
   props: MessagePathInputBaseProps,
 ) {
@@ -207,7 +153,34 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     variant = "standard",
   } = props;
   const { classes } = useStyles();
-  const topicFields = useMemo(() => getFieldPaths(topics, datatypes), [datatypes, topics]);
+
+  const messagePathStructuresForDataype = useMemo(
+    () => messagePathStructures(datatypes),
+    [datatypes],
+  );
+  const allStructureItemsByPath = useMemo(
+    () =>
+      new Map(
+        topics.flatMap((topic) => {
+          if (topic.schemaName == undefined) {
+            return [];
+          }
+          const structureItem = messagePathStructuresForDataype[topic.schemaName];
+          if (structureItem == undefined) {
+            return [];
+          }
+          const allPaths = messagePathsForStructure(structureItem, {
+            validTypes,
+            noMultiSlices,
+          });
+          return allPaths.map((item) => [
+            quoteTopicNameIfNeeded(topic.name) + item.path,
+            item.terminatingStructureItem,
+          ]);
+        }),
+      ),
+    [messagePathStructuresForDataype, noMultiSlices, topics, validTypes],
+  );
 
   const onChangeProp = props.onChange;
   const onChange = useCallback(
@@ -240,8 +213,9 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 
       // Check if accepting this completion would result in a path to a non-complex field.
       const completedPath = completeStart + rawValue + completeEnd;
-      const completedField = topicFields.get(completedPath);
-      const isSimpleField = completedField != undefined && completedField.isComplex !== true;
+      const completedField = allStructureItemsByPath.get(completedPath);
+      const isSimpleField =
+        completedField != undefined && completedField.structureType === "primitive";
 
       // If we're dealing with a topic name, and we cannot validly end in a message type,
       // add a "." so the user can keep typing to autocomplete the message path.
@@ -265,7 +239,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
         autocomplete.blur();
       }
     },
-    [onChangeProp, path, props.index, topicFields, validTypes],
+    [onChangeProp, path, props.index, allStructureItemsByPath, validTypes],
   );
 
   const rosPath = useMemo(() => parseRosPath(path), [path]);
@@ -278,11 +252,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     const { topicName } = rosPath;
     return topics.find(({ name }) => name === topicName);
   }, [rosPath, topics]);
-
-  const messagePathStructuresForDataype = useMemo(
-    () => messagePathStructures(datatypes),
-    [datatypes],
-  );
 
   const structureTraversalResult = useMemo((): StructureTraversalResult | undefined => {
     if (!topic || !rosPath?.messagePath) {
@@ -319,8 +288,8 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
   );
 
   const topicNamesAndFieldsAutocompleteItems = useMemo(
-    () => topicNamesAutocompleteItems.concat(Array.from(topicFields.keys())),
-    [topicFields, topicNamesAutocompleteItems],
+    () => topicNamesAutocompleteItems.concat(Array.from(allStructureItemsByPath.keys())),
+    [allStructureItemsByPath, topicNamesAutocompleteItems],
   );
 
   const autocompleteType = useMemo(() => {
@@ -408,10 +377,12 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
                   validTypes,
                   noMultiSlices,
                   messagePath: rosPath.messagePath,
-                }).filter(
-                  // .header.seq is pretty useless but shows up everryyywhere.
-                  (msgPath) => msgPath !== "" && !msgPath.endsWith(".header.seq"),
-                ),
+                })
+                  .filter(
+                    // .header.seq is pretty useless but shows up everryyywhere.
+                    (item) => item.path !== "" && !item.path.endsWith(".header.seq"),
+                  )
+                  .map((item) => item.path),
 
           autocompleteRange: {
             start: rosPath.topicNameRepr.length + initialFilterLength,

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -16,6 +16,7 @@ import * as _ from "lodash-es";
 import { CSSProperties, useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
+import { filterMap } from "@foxglove/den/collection";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
 import useGlobalVariables, {
@@ -173,10 +174,13 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
             validTypes,
             noMultiSlices,
           });
-          return allPaths.map((item) => [
-            quoteTopicNameIfNeeded(topic.name) + item.path,
-            item.terminatingStructureItem,
-          ]);
+          return filterMap(allPaths, (item) => {
+            if (item.path === "") {
+              // Plain topic items will be added via `topicNamesAutocompleteItems`
+              return undefined;
+            }
+            return [quoteTopicNameIfNeeded(topic.name) + item.path, item.terminatingStructureItem];
+          });
         }),
       ),
     [messagePathStructuresForDataype, noMultiSlices, topics, validTypes],

--- a/packages/studio-base/src/components/MessagePathSyntax/fixture.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/fixture.ts
@@ -72,12 +72,16 @@ export const MessagePathInputStoryFixture: Fixture = {
           { name: "foo_id", type: "uint32", isArray: false },
         ],
       },
+      "msgs/StateData": {
+        definitions: [{ name: "value", type: "float32", isArray: false }],
+      },
       "msgs/OtherState": {
         definitions: [
           { name: "id", type: "int32", isArray: false },
           { name: "speed", type: "float32", isArray: false },
           { name: "name", type: "string", isArray: false },
           { name: "valid", type: "bool", isArray: false },
+          { name: "data", type: "msgs/StateData", isArray: true },
         ],
       },
       "msgs/Log": {

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -428,7 +428,9 @@ describe("messagePathsForStructure", () => {
   const structures = messagePathStructures(datatypes);
 
   it("returns all possible message paths when not passing in `validTypes`", () => {
-    expect(messagePathsForStructure(unwrap(structures["pose_msgs/PoseDebug"]))).toEqual([
+    expect(
+      messagePathsForStructure(unwrap(structures["pose_msgs/PoseDebug"])).map(({ path }) => path),
+    ).toEqual([
       "",
       ".header",
       ".header.frame_id",
@@ -447,37 +449,40 @@ describe("messagePathsForStructure", () => {
       ".some_pose.header.stamp.sec",
       ".some_pose.x",
     ]);
-    expect(messagePathsForStructure(unwrap(structures["msgs/Log"]))).toEqual(["", ".id"]);
+    expect(
+      messagePathsForStructure(unwrap(structures["msgs/Log"])).map(({ path }) => path),
+    ).toEqual(["", ".id"]);
 
-    expect(messagePathsForStructure(unwrap(structures["tf/tfMessage"]))).toEqual([
+    expect(
+      messagePathsForStructure(unwrap(structures["tf/tfMessage"])).map(({ path }) => path),
+    ).toEqual([
       "",
       ".transforms",
-      ".transforms[0]",
-      ".transforms[0].child_frame_id",
-      ".transforms[0].header",
-      ".transforms[0].header.frame_id",
-      ".transforms[0].header.seq",
-      ".transforms[0].header.stamp",
-      ".transforms[0].header.stamp.nsec",
-      ".transforms[0].header.stamp.sec",
-      ".transforms[0].transform",
-      ".transforms[0].transform.rotation",
-      ".transforms[0].transform.translation",
+      '.transforms[:]{child_frame_id==""}',
+      '.transforms[:]{child_frame_id==""}.child_frame_id',
+      '.transforms[:]{child_frame_id==""}.header',
+      '.transforms[:]{child_frame_id==""}.header.frame_id',
+      '.transforms[:]{child_frame_id==""}.header.seq',
+      '.transforms[:]{child_frame_id==""}.header.stamp',
+      '.transforms[:]{child_frame_id==""}.header.stamp.nsec',
+      '.transforms[:]{child_frame_id==""}.header.stamp.sec',
+      '.transforms[:]{child_frame_id==""}.transform',
+      '.transforms[:]{child_frame_id==""}.transform.rotation',
+      '.transforms[:]{child_frame_id==""}.transform.translation',
     ]);
 
-    expect(messagePathsForStructure(unwrap(structures["visualization_msgs/MarkerArray"]))).toEqual([
-      "",
-      ".markers",
-      ".markers[:]{id==0}",
-      ".markers[:]{id==0}.id",
-    ]);
+    expect(
+      messagePathsForStructure(unwrap(structures["visualization_msgs/MarkerArray"])).map(
+        ({ path }) => path,
+      ),
+    ).toEqual(["", ".markers", ".markers[:]{id==0}", ".markers[:]{id==0}.id"]);
   });
 
   it("returns an array of possible message paths for the given `validTypes`", () => {
     expect(
       messagePathsForStructure(unwrap(structures["pose_msgs/PoseDebug"]), {
         validTypes: ["float64"],
-      }),
+      }).map(({ path }) => path),
     ).toEqual([".some_pose.dummy_array[:]", ".some_pose.x"]);
   });
 
@@ -486,7 +491,7 @@ describe("messagePathsForStructure", () => {
       messagePathsForStructure(unwrap(structures["pose_msgs/PoseDebug"]), {
         validTypes: ["float64"],
         noMultiSlices: true,
-      }),
+      }).map(({ path }) => path),
     ).toEqual([".some_pose.dummy_array[0]", ".some_pose.x"]);
   });
 });

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { unwrap } from "@foxglove/den/monads";
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 import {
@@ -493,6 +494,48 @@ describe("messagePathsForStructure", () => {
         noMultiSlices: true,
       }).map(({ path }) => path),
     ).toEqual([".some_pose.dummy_array[0]", ".some_pose.x"]);
+  });
+
+  it("preserves existing filters matching isTypicalFilterName", () => {
+    expect(
+      messagePathsForStructure(unwrap(structures["tf/tfMessage"]), {
+        messagePath: parseRosPath('/tf.transforms[:]{child_frame_id=="foo"}')!.messagePath,
+      }).map(({ path }) => path),
+    ).toEqual([
+      "",
+      ".transforms",
+      '.transforms[:]{child_frame_id=="foo"}',
+      '.transforms[:]{child_frame_id=="foo"}.child_frame_id',
+      '.transforms[:]{child_frame_id=="foo"}.header',
+      '.transforms[:]{child_frame_id=="foo"}.header.frame_id',
+      '.transforms[:]{child_frame_id=="foo"}.header.seq',
+      '.transforms[:]{child_frame_id=="foo"}.header.stamp',
+      '.transforms[:]{child_frame_id=="foo"}.header.stamp.nsec',
+      '.transforms[:]{child_frame_id=="foo"}.header.stamp.sec',
+      '.transforms[:]{child_frame_id=="foo"}.transform',
+      '.transforms[:]{child_frame_id=="foo"}.transform.rotation',
+      '.transforms[:]{child_frame_id=="foo"}.transform.translation',
+    ]);
+
+    expect(
+      messagePathsForStructure(unwrap(structures["tf/tfMessage"]), {
+        messagePath: parseRosPath("/tf.transforms[:]{header.stamp.sec==0}")!.messagePath,
+      }).map(({ path }) => path),
+    ).toEqual([
+      "",
+      ".transforms",
+      '.transforms[:]{child_frame_id==""}',
+      '.transforms[:]{child_frame_id==""}.child_frame_id',
+      '.transforms[:]{child_frame_id==""}.header',
+      '.transforms[:]{child_frame_id==""}.header.frame_id',
+      '.transforms[:]{child_frame_id==""}.header.seq',
+      '.transforms[:]{child_frame_id==""}.header.stamp',
+      '.transforms[:]{child_frame_id==""}.header.stamp.nsec',
+      '.transforms[:]{child_frame_id==""}.header.stamp.sec',
+      '.transforms[:]{child_frame_id==""}.transform',
+      '.transforms[:]{child_frame_id==""}.transform.rotation',
+      '.transforms[:]{child_frame_id==""}.transform.translation',
+    ]);
   });
 });
 


### PR DESCRIPTION
**User-Facing Changes**
Improved autocomplete suggestions when typing message path syntax.

**Description**
The logic that generated the initial combined (topics+paths) list of suggestions was bespoke and did not account for array fields. This PR changes it to use the existing `messagePathsForStructure` function (with some additional info returned). It also updates `messagePathsForStructure` to extend the typicalFilterName logic to strings, and fix a bug where quotes in string filters (`...{field=="value"}`) were being deleted.

Follow-up to #1971 & #3190

Before | After
--- | ---
I am not sure why the header sub-fields were not shown: <br><img width="274" alt="image" src="https://github.com/foxglove/studio/assets/14237/bb610276-8653-4338-b70a-44ae3e5d50a2"> | <img width="291" alt="image" src="https://github.com/foxglove/studio/assets/14237/e3c1c551-ad48-4a17-9cba-00a1dc30b324">
<img width="219" alt="image" src="https://github.com/foxglove/studio/assets/14237/be154462-f800-43ac-a1db-9b74d2ab2b44"> | Filter and array indexing suggestions are now shown:<br> <img width="299" alt="image" src="https://github.com/foxglove/studio/assets/14237/f724e7cb-1da2-47bd-bc2f-7399b9cc1de0">
