### PR TITLE
Fix error memory estimation handling of null values

### DIFF
--- a/packages/studio-base/src/players/messageMemoryEstimation.test.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.test.ts
@@ -134,6 +134,18 @@ describe("memoryEstimationByObject", () => {
     expect(sizeInBytes).toBeGreaterThan(0);
   });
 
+  it("estimates size of null object to be greater than 0", () => {
+    // eslint-disable-next-line no-restricted-syntax
+    const sizeInBytes = estimateObjectSize(null);
+    expect(sizeInBytes).toBeGreaterThan(0);
+  });
+
+  it("estimates size of undefined object to be greater than 0", () => {
+    // eslint-disable-next-line no-restricted-syntax
+    const sizeInBytes = estimateObjectSize(null);
+    expect(sizeInBytes).toBeGreaterThan(0);
+  });
+
   it("correctly estimates the size for a simple object", () => {
     const sizeInBytes = estimateObjectSize({
       field1: 1, // 4 bytes, SMI (fits in pointer)

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -2,8 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Log from "@foxglove/log";
 import { MessageDefinitionMap } from "@foxglove/mcap-support/src/types";
 
+const log = Log.getLogger(__filename);
 /**
  * Values of the contants below are a (more or less) informed guesses and not guaranteed to be accurate.
  */
@@ -264,6 +266,6 @@ export function estimateObjectSize(obj: unknown): number {
       throw new Error(`Can't estimate size of type '${typeof obj}'`);
     }
   }
-  // Should never happen
-  return 0;
+  log.error(`Can't estimate size of type '${typeof obj}'`);
+  return SMALL_INTEGER_SIZE;
 }

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -256,10 +256,7 @@ export function estimateObjectSize(obj: unknown): number {
         propertiesSize = propertiesDictSize - numProps * COMPRESSED_POINTER_SIZE;
       }
 
-      const valuesSize: number = Object.values(obj).reduce(
-        (acc, val) => acc + estimateObjectSize(val),
-        0,
-      );
+      const valuesSize = Object.values(obj).reduce((acc, val) => acc + estimateObjectSize(val), 0);
       return OBJECT_BASE_SIZE + propertiesSize + valuesSize;
     }
     case "symbol":

--- a/packages/studio-base/src/players/messageMemoryEstimation.ts
+++ b/packages/studio-base/src/players/messageMemoryEstimation.ts
@@ -196,6 +196,11 @@ export function estimateMessageFieldSizes(
  * @returns Estimated size in bytes
  */
 export function estimateObjectSize(obj: unknown): number {
+  // catches null and undefined
+  // typeof null == "object"
+  if (obj == undefined) {
+    return SMALL_INTEGER_SIZE;
+  }
   switch (typeof obj) {
     case "undefined":
     case "boolean": {
@@ -238,7 +243,7 @@ export function estimateObjectSize(obj: unknown): number {
       }
 
       let propertiesSize = 0;
-      const numProps = Object.keys(obj!).length;
+      const numProps = Object.keys(obj).length;
       if (numProps > MAX_NUM_FAST_PROPERTIES) {
         // If there are too many properties, V8 stores Objects in dictionary mode (slow properties)
         // with each object having a self-contained dictionary. This dictionary contains the key, value
@@ -251,7 +256,10 @@ export function estimateObjectSize(obj: unknown): number {
         propertiesSize = propertiesDictSize - numProps * COMPRESSED_POINTER_SIZE;
       }
 
-      const valuesSize = Object.values(obj!).reduce((acc, val) => acc + estimateObjectSize(val), 0);
+      const valuesSize: number = Object.values(obj).reduce(
+        (acc, val) => acc + estimateObjectSize(val),
+        0,
+      );
       return OBJECT_BASE_SIZE + propertiesSize + valuesSize;
     }
     case "symbol":
@@ -259,4 +267,6 @@ export function estimateObjectSize(obj: unknown): number {
       throw new Error(`Can't estimate size of type '${typeof obj}'`);
     }
   }
+  // Should never happen
+  return 0;
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Fix errors decoding messages with null values

**Description**

We weren't handling `typeof null === "object"` in `estimateObjectSize`.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
