### PR TITLE
MUI Alert stlying and storybooks

### DIFF
--- a/packages/theme/src/components/MuiAlert.stories.tsx
+++ b/packages/theme/src/components/MuiAlert.stories.tsx
@@ -5,7 +5,7 @@
 import { AlertProps, AlertTitle, Alert as MuiAlert, Stack } from "@mui/material";
 import { Meta, StoryObj } from "@storybook/react";
 
-const severities = ["error", "info", "success", "warning"] as AlertProps["severity"][];
+const colors = ["error", "info", "success", "warning", "primary"] as AlertProps["color"][];
 
 export default {
   component: MuiAlert,
@@ -16,10 +16,10 @@ export default {
   decorators: [
     (_, { args: { showTitle, ...args } }) => (
       <Stack gap={2} padding={2}>
-        {severities.map((severity) => (
-          <MuiAlert key={severity} variant={args.variant} severity={severity}>
-            {showTitle === true && <AlertTitle>{severity}</AlertTitle>}
-            This is a {severity} alert — check it out!
+        {colors.map((color) => (
+          <MuiAlert key={color} variant={args.variant} color={color}>
+            {showTitle === true && <AlertTitle>{color}</AlertTitle>}
+            This is a {color} alert — check it out!
           </MuiAlert>
         ))}
       </Stack>

--- a/packages/theme/src/components/MuiAlert.stories.tsx
+++ b/packages/theme/src/components/MuiAlert.stories.tsx
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { AlertProps, AlertTitle, Alert as MuiAlert, Stack } from "@mui/material";
+import { Meta, StoryObj } from "@storybook/react";
+
+const severities = ["error", "info", "success", "warning"] as AlertProps["severity"][];
+
+export default {
+  component: MuiAlert,
+  title: "Theme/Feedback/Alert",
+  args: {
+    showTitle: false,
+  },
+  decorators: [
+    (_, { args: { showTitle, ...args } }) => (
+      <Stack gap={2} padding={2}>
+        {severities.map((severity) => (
+          <MuiAlert key={severity} variant={args.variant} severity={severity}>
+            {showTitle === true && <AlertTitle>{severity}</AlertTitle>}
+            This is a {severity} alert — check it out!
+          </MuiAlert>
+        ))}
+      </Stack>
+    ),
+  ],
+} as Meta<AlertProps & { showTitle?: boolean }>;
+
+type Story = StoryObj<AlertProps & { showTitle?: boolean }>;
+
+export const StandardVariant: Story = {
+  args: { variant: "standard" },
+};
+
+export const OutlinedVariant: Story = {
+  args: { variant: "outlined" },
+};
+
+export const FilledVariant: Story = {
+  args: { variant: "filled" },
+};
+
+export const Description: Story = {
+  args: { showTitle: true },
+};

--- a/packages/theme/src/components/MuiAlert.tsx
+++ b/packages/theme/src/components/MuiAlert.tsx
@@ -2,10 +2,28 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import {
+  ErrorCircle20Regular,
+  Info20Regular,
+  CheckmarkCircle20Regular,
+  Warning20Regular,
+} from "@fluentui/react-icons";
+
 import { OverrideComponentReturn } from "../types";
 
 export const MuiAlert: OverrideComponentReturn<"MuiAlert"> = {
+  defaultProps: {
+    iconMapping: {
+      error: <ErrorCircle20Regular />,
+      info: <Info20Regular />,
+      success: <CheckmarkCircle20Regular />,
+      warning: <Warning20Regular />,
+    },
+  },
   styleOverrides: {
+    message: {
+      lineHeight: "1.5",
+    },
     standard: {
       border: "1px solid",
     },
@@ -19,7 +37,7 @@ export const MuiAlert: OverrideComponentReturn<"MuiAlert"> = {
       borderColor: theme.palette.info.main,
     }),
     standardSuccess: ({ theme }) => ({
-      border: theme.palette.info.main,
+      borderColor: theme.palette.success.main,
     }),
   },
 };

--- a/packages/theme/src/components/MuiAlert.tsx
+++ b/packages/theme/src/components/MuiAlert.tsx
@@ -8,8 +8,33 @@ import {
   CheckmarkCircle20Regular,
   Warning20Regular,
 } from "@fluentui/react-icons";
+import { alertClasses, PaletteOptions } from "@mui/material";
+// import { AlertProps } from "@mui/material";
+import { darken, lighten } from "@mui/system";
 
 import { OverrideComponentReturn } from "../types";
+
+declare module "@mui/material/Alert" {
+  interface AlertPropsColorOverrides {
+    primary: true;
+  }
+  interface AlertClasses {
+    standardPrimary: string;
+    outlinedPrimary: string;
+    filledPrimary: string;
+  }
+}
+
+// Attempt to replicate MUI theme color variations
+// https://github.com/mui/material-ui/tree/master/packages/mui-material/src/Alert/Alert.js#L45-L46
+
+function getColor(mode: PaletteOptions["mode"], color: string, opacity: number) {
+  return mode === "light" ? darken(color, opacity) : lighten(color, opacity);
+}
+
+function getBackgroundColor(mode: PaletteOptions["mode"], color: string, opacity: number) {
+  return mode === "light" ? lighten(color, opacity) : darken(color, opacity);
+}
 
 export const MuiAlert: OverrideComponentReturn<"MuiAlert"> = {
   defaultProps: {
@@ -24,9 +49,32 @@ export const MuiAlert: OverrideComponentReturn<"MuiAlert"> = {
     message: {
       lineHeight: "1.5",
     },
+    filledPrimary: ({ theme }) => ({
+      backgroundColor:
+        theme.palette.mode === "dark" ? theme.palette.primary.dark : theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    outlinedPrimary: ({ theme }) => ({
+      color: getColor(theme.palette.mode, theme.palette.primary.light, 0.6),
+      border: `1px solid ${theme.palette.primary.light}`,
+
+      [`& .${alertClasses.icon}`]: {
+        color: theme.palette.primary.main,
+      },
+    }),
     standard: {
       border: "1px solid",
     },
+    standardPrimary: ({ theme }) => ({
+      borderColor: theme.palette.primary.main,
+      color: getColor(theme.palette.mode, theme.palette.primary.main, 0.6),
+      backgroundColor: getBackgroundColor(theme.palette.mode, theme.palette.primary.main, 0.9),
+
+      [`& .${alertClasses.icon}`]: {
+        color: theme.palette.primary.main,
+      },
+    }),
     standardWarning: ({ theme }) => ({
       borderColor: theme.palette.warning.main,
     }),

--- a/packages/theme/src/components/MuiAlert.tsx
+++ b/packages/theme/src/components/MuiAlert.tsx
@@ -8,31 +8,8 @@ import {
   CheckmarkCircle20Regular,
   Warning20Regular,
 } from "@fluentui/react-icons";
-import { alertClasses, PaletteOptions, darken, lighten } from "@mui/material";
 
 import { OverrideComponentReturn } from "../types";
-
-declare module "@mui/material/Alert" {
-  interface AlertPropsColorOverrides {
-    primary: true;
-  }
-  interface AlertClasses {
-    standardPrimary: string;
-    outlinedPrimary: string;
-    filledPrimary: string;
-  }
-}
-
-// Attempt to replicate MUI theme color variations
-// https://github.com/mui/material-ui/tree/master/packages/mui-material/src/Alert/Alert.js#L45-L46
-
-function getColor(mode: PaletteOptions["mode"], color: string, opacity: number) {
-  return mode === "light" ? darken(color, opacity) : lighten(color, opacity);
-}
-
-function getBackgroundColor(mode: PaletteOptions["mode"], color: string, opacity: number) {
-  return mode === "light" ? lighten(color, opacity) : darken(color, opacity);
-}
 
 export const MuiAlert: OverrideComponentReturn<"MuiAlert"> = {
   defaultProps: {
@@ -47,32 +24,9 @@ export const MuiAlert: OverrideComponentReturn<"MuiAlert"> = {
     message: {
       lineHeight: "1.5",
     },
-    filledPrimary: ({ theme }) => ({
-      backgroundColor:
-        theme.palette.mode === "dark" ? theme.palette.primary.dark : theme.palette.primary.main,
-      color: theme.palette.primary.contrastText,
-      fontWeight: theme.typography.fontWeightMedium,
-    }),
-    outlinedPrimary: ({ theme }) => ({
-      color: getColor(theme.palette.mode, theme.palette.primary.light, 0.6),
-      border: `1px solid ${theme.palette.primary.light}`,
-
-      [`& .${alertClasses.icon}`]: {
-        color: theme.palette.primary.main,
-      },
-    }),
     standard: {
       border: "1px solid",
     },
-    standardPrimary: ({ theme }) => ({
-      borderColor: theme.palette.primary.main,
-      color: getColor(theme.palette.mode, theme.palette.primary.main, 0.6),
-      backgroundColor: getBackgroundColor(theme.palette.mode, theme.palette.primary.main, 0.9),
-
-      [`& .${alertClasses.icon}`]: {
-        color: theme.palette.primary.main,
-      },
-    }),
     standardWarning: ({ theme }) => ({
       borderColor: theme.palette.warning.main,
     }),

--- a/packages/theme/src/components/MuiAlert.tsx
+++ b/packages/theme/src/components/MuiAlert.tsx
@@ -8,9 +8,7 @@ import {
   CheckmarkCircle20Regular,
   Warning20Regular,
 } from "@fluentui/react-icons";
-import { alertClasses, PaletteOptions } from "@mui/material";
-// import { AlertProps } from "@mui/material";
-import { darken, lighten } from "@mui/system";
+import { alertClasses, PaletteOptions, darken, lighten } from "@mui/material";
 
 import { OverrideComponentReturn } from "../types";
 


### PR DESCRIPTION
**User-Facing Changes**
None

<img width="1235" alt="Screen Shot 2023-12-19 at 3 31 59 pm" src="https://github.com/foxglove/studio/assets/924528/384980ef-b49b-4042-98c9-2073103e5a6d">

<img width="1235" alt="Screen Shot 2023-12-19 at 3 32 18 pm" src="https://github.com/foxglove/studio/assets/924528/f05d2c11-3888-4df7-ba2f-26ecd8fb245f">


**Description**
Tune MUI alert styles and add storybooks

Related to FG-5814
