### PR TITLE
Reduce limit of buffered messages from 1GB to 600 MB

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -101,7 +101,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     super();
 
     this.#source = source;
-    this.#maxTotalSizeBytes = opt?.maxTotalSize ?? 1073741824; // 1GB
+    this.#maxTotalSizeBytes = opt?.maxTotalSize ?? 629145600; // 600MB
     this.#maxBlockSizeBytes = opt?.maxBlockSize ?? 52428800; // 50MB
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -101,7 +101,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
     super();
 
     this.#source = source;
-    this.#maxTotalSizeBytes = opt?.maxTotalSize ?? 629145600; // 600MB
+    this.#maxTotalSizeBytes = opt?.maxTotalSize ?? 629145600; // 600MB (was 1GB, reduced to mitigate OOM issues)
     this.#maxBlockSizeBytes = opt?.maxBlockSize ?? 52428800; // 50MB
   }
 


### PR DESCRIPTION
**User-Facing Changes**
Reduce limit of buffered messages to mitigate OOM crashes

**Description**
This PR reduces the limit of buffered messages from 1GB to 600 MB. Previously, with the cache size for preloaded and buffered messages both being limited to 1GB, the app could go well beyond the 2GB JS heap limit at which the app eventually gets killed by the browser (or electron). By reducing the cache size of buffered messages, we make these OOM crashes less likely. The downside of this approach is that less messages can be buffered which can be noticed mainly by the amount of messages buffered behind the current playback cursor.