### PR TITLE
Fix progress memory info being overwritten

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -972,6 +972,7 @@ export class IterablePlayer implements Player {
 
     // set the latest value of the loaded ranges for the next emit state
     this.#progress = {
+      ...this.#progress,
       fullyLoadedFractionRanges: this.#bufferedSource.loadedRanges(),
       messageCache: this.#progress.messageCache,
     };


### PR DESCRIPTION
**User-Facing Changes**
Fix player memory reporting in performance panel

**Description**
Fixes the progress' memory info being cleared in idle state.