### PR TITLE
Store buffered messages as typed arrays

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -421,6 +421,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
+        deserializeMessages: false,
       });
       messageIteratorCount += 1;
 
@@ -485,6 +486,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
+        deserializeMessages: false,
       });
       messageIteratorCount += 1;
 
@@ -600,6 +602,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
+        deserializeMessages: false,
       });
       messageIteratorCount += 1;
 
@@ -657,6 +660,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
+        deserializeMessages: false,
       });
       messageIteratorCount += 1;
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -421,7 +421,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
-        deserializeMessages: false,
+        skipMessageDeserialization: true,
       });
       messageIteratorCount += 1;
 
@@ -486,7 +486,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
-        deserializeMessages: false,
+        skipMessageDeserialization: true,
       });
       messageIteratorCount += 1;
 
@@ -602,7 +602,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
-        deserializeMessages: false,
+        skipMessageDeserialization: true,
       });
       messageIteratorCount += 1;
 
@@ -660,7 +660,7 @@ describe("BufferedIterableSource", () => {
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
         consumptionType: "partial",
-        deserializeMessages: false,
+        skipMessageDeserialization: true,
       });
       messageIteratorCount += 1;
 

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -244,6 +244,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
         start: sourceReadStart,
         end: sourceReadEnd,
         consumptionType: args.consumptionType,
+        deserializeMessages: false,
       });
 
       // The cache is indexed on time, but iterator results that are problems might not have a time.

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -244,7 +244,7 @@ class CachingIterableSource extends EventEmitter<EventTypes> implements IIterabl
         start: sourceReadStart,
         end: sourceReadEnd,
         consumptionType: args.consumptionType,
-        deserializeMessages: false,
+        skipMessageDeserialization: true,
       });
 
       // The cache is indexed on time, but iterator results that are problems might not have a time.

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -57,6 +57,8 @@ export type MessageIteratorArgs = {
    * `partial` indicates that the caller plans to read the iterator but may not read all the messages
    */
   consumptionType?: "full" | "partial";
+
+  deserializeMessages?: boolean;
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -58,7 +58,10 @@ export type MessageIteratorArgs = {
    */
   consumptionType?: "full" | "partial";
 
-  deserializeMessages?: boolean;
+  /**
+   * Skip message deserialization and yield raw messages. Defaults to false.
+   */
+  skipMessageDeserialization?: boolean;
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -786,6 +786,7 @@ describe("IterablePlayer", () => {
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
+          deserializeMessages: false,
         },
       ],
       [
@@ -794,6 +795,7 @@ describe("IterablePlayer", () => {
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("bar", "foo"),
           consumptionType: "partial",
+          deserializeMessages: false,
         },
       ],
     ]);
@@ -831,6 +833,7 @@ describe("IterablePlayer", () => {
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
+          deserializeMessages: false,
         },
       ],
     ]);

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -786,7 +786,7 @@ describe("IterablePlayer", () => {
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
-          deserializeMessages: false,
+          skipMessageDeserialization: true,
         },
       ],
       [
@@ -795,7 +795,7 @@ describe("IterablePlayer", () => {
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("bar", "foo"),
           consumptionType: "partial",
-          deserializeMessages: false,
+          skipMessageDeserialization: true,
         },
       ],
     ]);
@@ -833,7 +833,7 @@ describe("IterablePlayer", () => {
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
-          deserializeMessages: false,
+          skipMessageDeserialization: true,
         },
       ],
     ]);

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -177,7 +177,7 @@ export class IterablePlayer implements Player {
 
   #untilTime?: Time;
 
-  #deserializersByTopic: Record<string, (data: ArrayBufferView) => unknown> = {};
+  #deserializersBySchema: Record<string, (data: ArrayBufferView) => unknown> = {};
 
   /** Promise that resolves when the player is closed. Only used for testing currently */
   public readonly isClosed: Promise<void>;
@@ -508,7 +508,13 @@ export class IterablePlayer implements Player {
 
         uniqueTopics.set(topic.name, topic);
 
-        if (topic.messageEncoding && topic.schemaData && topic.schemaEncoding && topic.schemaName) {
+        if (
+          topic.messageEncoding != undefined &&
+          topic.schemaData != undefined &&
+          topic.schemaEncoding != undefined &&
+          topic.schemaName != undefined &&
+          this.#deserializersBySchema[topic.schemaName] == undefined
+        ) {
           const { deserialize } = parseChannel({
             messageEncoding: topic.messageEncoding,
             schema: {
@@ -517,7 +523,7 @@ export class IterablePlayer implements Player {
               name: topic.schemaName,
             },
           });
-          this.#deserializersByTopic[topic.name] = deserialize;
+          this.#deserializersBySchema[topic.schemaName] = deserialize;
         }
       }
 
@@ -679,17 +685,14 @@ export class IterablePlayer implements Player {
 
         if (iterResult.type === "message-event") {
           let msgEvent = iterResult.msgEvent;
-          if (iterResult.msgEvent.raw === true) {
-            const deserializer = this.#deserializersByTopic[iterResult.msgEvent.topic];
-            if (deserializer == undefined) {
-              throw new Error(
-                `Invariant. Deserializer for raw message on topic ${iterResult.msgEvent.topic} not found`,
-              );
-            }
+          if (iterResult.msgEvent.rawBytes === true) {
             msgEvent = {
               ...iterResult.msgEvent,
-              message: deserializer(iterResult.msgEvent.message as Uint8Array),
-              raw: false,
+              message: this.#deserializeMessage(
+                iterResult.msgEvent.schemaName,
+                iterResult.msgEvent.message as Uint8Array,
+              ),
+              rawBytes: false,
             };
           }
 
@@ -748,6 +751,16 @@ export class IterablePlayer implements Player {
         time: targetTime,
         abortSignal: this.#abort.signal,
       });
+
+      for (const messageEvent of messages) {
+        if (messageEvent.rawBytes === true) {
+          messageEvent.message = this.#deserializeMessage(
+            messageEvent.schemaName,
+            messageEvent.message as Uint8Array,
+          );
+          messageEvent.rawBytes = false;
+        }
+      }
 
       // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
       clearTimeout(seekAckTimeout);
@@ -965,17 +978,14 @@ export class IterablePlayer implements Player {
 
         if (iterResult.type === "message-event") {
           let msgEvent = iterResult.msgEvent;
-          if (iterResult.msgEvent.raw === true) {
-            const deserializer = this.#deserializersByTopic[iterResult.msgEvent.topic];
-            if (deserializer == undefined) {
-              throw new Error(
-                `Invariant. Deserializer for raw message on topic ${iterResult.msgEvent.topic} not found`,
-              );
-            }
+          if (iterResult.msgEvent.rawBytes === true) {
             msgEvent = {
               ...iterResult.msgEvent,
-              message: deserializer(iterResult.msgEvent.message as Uint8Array),
-              raw: false,
+              message: this.#deserializeMessage(
+                iterResult.msgEvent.schemaName,
+                iterResult.msgEvent.message as Uint8Array,
+              ),
+              rawBytes: false,
             };
           }
 
@@ -1153,5 +1163,13 @@ export class IterablePlayer implements Player {
         this.#queueEmitState();
       },
     });
+  }
+
+  #deserializeMessage(schemaName: string, message: Uint8Array): unknown {
+    const deserialize = this.#deserializersBySchema[schemaName];
+    if (deserialize == undefined) {
+      throw new Error(`Invariant. Deserializer for schema ${schemaName} not found`);
+    }
+    return deserialize(message);
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -145,7 +145,7 @@ export class McapIndexedIterableSource implements IIterableSource {
     const topics = args.topics;
     const start = args.start ?? this.#start;
     const end = args.end ?? this.#end;
-    const deserializeMessages = args.deserializeMessages ?? true;
+    const skipDeserialization = args.skipMessageDeserialization ?? false;
 
     if (topics.size === 0 || !start || !end) {
       return;
@@ -184,7 +184,7 @@ export class McapIndexedIterableSource implements IIterableSource {
         continue;
       }
       try {
-        if (!deserializeMessages) {
+        if (skipDeserialization) {
           yield {
             type: "message-event",
             msgEvent: {
@@ -194,7 +194,7 @@ export class McapIndexedIterableSource implements IIterableSource {
               message: message.data,
               sizeInBytes: message.data.byteLength,
               schemaName: channelInfo.schemaName ?? "",
-              raw: true,
+              rawBytes: true,
             },
           };
           continue;

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -210,6 +210,10 @@ export type Topic = {
   schemaName: string | undefined;
   // Name of the topic before topic aliasing, if any.
   aliasedFromName?: string;
+
+  schemaData?: Uint8Array;
+  schemaEncoding?: string;
+  messageEncoding?: string;
 };
 
 export type TopicWithSchemaName = Topic & { schemaName: string };

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -210,9 +210,11 @@ export type Topic = {
   schemaName: string | undefined;
   // Name of the topic before topic aliasing, if any.
   aliasedFromName?: string;
-
+  /** Schema data */
   schemaData?: Uint8Array;
+  /** Schema encoding */
   schemaEncoding?: string;
+  /** Message encoding */
   messageEncoding?: string;
 };
 

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -125,6 +125,8 @@ export type MessageEvent<T = unknown> = {
    * un-converted message event.
    */
   originalMessageEvent?: MessageEvent;
+
+  raw?: boolean;
 };
 
 export interface LayoutActions {

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -126,7 +126,10 @@ export type MessageEvent<T = unknown> = {
    */
   originalMessageEvent?: MessageEvent;
 
-  raw?: boolean;
+  /**
+   * Message is not deserialized and contains the raw bytes.
+   */
+  rawBytes?: boolean;
 };
 
 export interface LayoutActions {


### PR DESCRIPTION
**User-Facing Changes**
Store buffered messages as raw bytes to reduce javascript heap memory pressure

**Description**

Summary from @defunctzombie:

> Our current caching strategy for recently played messages (and upcoming messages) is to keep the deserialized messages in memory. The upside is that we have immediate access to the deserialized messages on seek and playback without having to deserialize the messages again. The downside is this caching uses valuable JS heap space. Instead of caching deserialized messages we can look at caching the message bytes (i.e. mcap message records) in typed arrays which are not subject to the same js heap limits.

While this PR reduces heap memory consumption, the downside is that buffered messages are now deserialized on the main thread which may cause a noticeable performance degradation. A possible solution for this would be to move the buffering layer to the worker thread where the iterable source is being read.