### PR TITLE
[Image Panel] Update empty state to match other panels

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -97,7 +97,7 @@ const NO_IMAGE_TOPICS_HUD_ITEM: HUDItem = {
   id: "NO_IMAGE_TOPICS",
   group: IMAGE_MODE_HUD_GROUP_ID,
   getMessage: () => t3D("noImageTopicsAvailable"),
-  displayType: "notice",
+  displayType: "empty",
 };
 interface ImageModeEventMap extends THREE.Object3DEventMap {
   hasModifiedViewChanged: object;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageMode.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { fireEvent, screen, userEvent, waitFor } from "@storybook/testing-library";
 import { useCallback, useMemo, useState } from "react";
 import { useAsync } from "react-use";
@@ -34,7 +34,7 @@ export default {
   title: "panels/ThreeDeeRender/Images",
   component: ImagePanel,
   parameters: { colorScheme: "light" },
-};
+} as Meta;
 
 const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }): JSX.Element => {
   const topics: Topic[] = [
@@ -178,12 +178,12 @@ const ImageModeRosImage = ({ imageType }: { imageType: "raw" | "png" }): JSX.Ele
   );
 };
 
-export const ImageModeRosRawImage: StoryObj<React.ComponentProps<typeof ImageModeRosImage>> = {
+export const ImageModeRosRawImage: StoryObj<typeof ImageModeRosImage> = {
   render: ImageModeRosImage,
   args: { imageType: "raw" },
 };
 
-export const ImageModeRosPngImage: StoryObj<React.ComponentProps<typeof ImageModeRosImage>> = {
+export const ImageModeRosPngImage: StoryObj<typeof ImageModeRosImage> = {
   render: ImageModeRosImage,
   args: { imageType: "png" },
 };
@@ -404,21 +404,17 @@ const ImageModeFoxgloveImage = ({
   );
 };
 
-export const ImageModeFoxgloveRawImage: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
+export const ImageModeFoxgloveRawImage: StoryObj<typeof ImageModeFoxgloveImage> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
 };
 
-export const ImageModeFoxglovePngImage: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
+export const ImageModeFoxglovePngImage: StoryObj<typeof ImageModeFoxgloveImage> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "png" },
 };
 
-export const DownloadRawImage: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const DownloadRawImage: StoryObj<typeof ImageModeFoxgloveImage> = {
   render: function Story(args) {
     const [src, setSrc] = useState<string | undefined>();
     const [filename, setFilename] = useState<string | undefined>();
@@ -451,93 +447,81 @@ export const DownloadRawImage: StoryObj<React.ComponentProps<typeof ImageModeFox
   },
 };
 
-export const DownloadPngImage: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const DownloadPngImage: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png" },
 };
 
-export const DownloadPngImageFlipH: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
-  {
-    ...DownloadRawImage,
-    args: { imageType: "png", flipHorizontal: true },
-  };
+export const DownloadPngImageFlipH: StoryObj<typeof ImageModeFoxgloveImage> = {
+  ...DownloadRawImage,
+  args: { imageType: "png", flipHorizontal: true },
+};
 
-export const DownloadPngImageFlipV: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
-  {
-    ...DownloadRawImage,
-    args: { imageType: "png", flipVertical: true },
-  };
+export const DownloadPngImageFlipV: StoryObj<typeof ImageModeFoxgloveImage> = {
+  ...DownloadRawImage,
+  args: { imageType: "png", flipVertical: true },
+};
 
-export const DownloadPngImageFlipHV: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
-  {
-    ...DownloadRawImage,
-    args: { imageType: "png", flipHorizontal: true, flipVertical: true },
-  };
+export const DownloadPngImageFlipHV: StoryObj<typeof ImageModeFoxgloveImage> = {
+  ...DownloadRawImage,
+  args: { imageType: "png", flipHorizontal: true, flipVertical: true },
+};
 
-export const DownloadPngImage90: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const DownloadPngImage90: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 90 },
 };
 
-export const DownloadPngImage180: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const DownloadPngImage180: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 180 },
 };
 
-export const DownloadPngImage270: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const DownloadPngImage270: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 270 },
 };
 
-export const DownloadPngImage90FlipH: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
+export const DownloadPngImage90FlipH: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 90, flipHorizontal: true },
 };
 
-export const DownloadPngImage90FlipV: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
+export const DownloadPngImage90FlipV: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 90, flipVertical: true },
 };
 
-export const DownloadPngImage90FlipHV: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
+export const DownloadPngImage90FlipHV: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "png", rotation: 90, flipHorizontal: true, flipVertical: true },
 };
 
-export const DownloadMono16Image: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const DownloadMono16Image: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "raw_mono16" },
 };
-export const DownloadMono16ImageCustomMinMax: StoryObj<
-  React.ComponentProps<typeof ImageModeFoxgloveImage>
-> = {
+export const DownloadMono16ImageCustomMinMax: StoryObj<typeof ImageModeFoxgloveImage> = {
   ...DownloadRawImage,
   args: { imageType: "raw_mono16", minValue: 10000, maxValue: 20000 },
 };
 
-export const ImageModeResizeHandled: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> =
-  {
-    render: ImageModeFoxgloveImage,
-    args: { imageType: "raw" },
+export const ImageModeResizeHandled: StoryObj<typeof ImageModeFoxgloveImage> = {
+  render: ImageModeFoxgloveImage,
+  args: { imageType: "raw" },
 
-    play: async () => {
-      const canvas = document.querySelector("canvas")!;
-      // Input attaches resize listener to parent element, so we need to resize that.
-      const parentEl = canvas.parentElement!;
-      await delay(30);
-      parentEl.style.width = "50%";
-      canvas.dispatchEvent(new Event("resize"));
-      await delay(30);
-    },
-  };
+  play: async () => {
+    const canvas = document.querySelector("canvas")!;
+    // Input attaches resize listener to parent element, so we need to resize that.
+    const parentEl = canvas.parentElement!;
+    await delay(30);
+    parentEl.style.width = "50%";
+    canvas.dispatchEvent(new Event("resize"));
+    await delay(30);
+  },
+};
 
-export const ImageModePick: StoryObj<React.ComponentProps<typeof ImageModeFoxgloveImage>> = {
+export const ImageModePick: StoryObj<typeof ImageModeFoxgloveImage> = {
   render: ImageModeFoxgloveImage,
   args: { imageType: "raw" },
 
@@ -1105,12 +1089,23 @@ export const RationalPolynomialDistortion: StoryObj = {
 const ImageModeEmptyLayout = ({
   type,
 }: {
-  type: "no-topics" | "no-messages" | "image-topic-DNE";
+  type: "no-topics" | "no-image-topics" | "no-messages" | "image-topic-DNE";
 }): JSX.Element => {
   let fixture: Fixture | undefined;
   let calibrationTopic: string | undefined = "calibration";
   switch (type) {
     case "no-topics":
+      fixture = {
+        topics: [],
+        frame: {},
+        capabilities: [],
+        activeData: {
+          currentTime: { sec: 0, nsec: 0 },
+        },
+      };
+      break;
+    case "no-image-topics":
+      calibrationTopic = undefined;
       fixture = {
         topics: [],
         frame: {},
@@ -1161,21 +1156,23 @@ const ImageModeEmptyLayout = ({
   );
 };
 
-export const ImageModeEmptyNoTopics: StoryObj<React.ComponentProps<typeof ImageModeEmptyLayout>> = {
+export const ImageModeEmptyNoTopics: StoryObj<typeof ImageModeEmptyLayout> = {
   render: ImageModeEmptyLayout,
   args: { type: "no-topics" },
 };
 
-export const ImageModeEmptyNoMessages: StoryObj<React.ComponentProps<typeof ImageModeEmptyLayout>> =
-  {
-    render: ImageModeEmptyLayout,
-    args: { type: "no-messages" },
-  };
+export const ImageModeEmptyNoImageTopics: StoryObj<typeof ImageModeEmptyLayout> = {
+  render: ImageModeEmptyLayout,
+  args: { type: "no-topics" },
+};
+
+export const ImageModeEmptyNoMessages: StoryObj<typeof ImageModeEmptyLayout> = {
+  render: ImageModeEmptyLayout,
+  args: { type: "no-messages" },
+};
 
 // when calibration == "None", then we display an empty state when only the image topic does not exist
-export const ImageModeEmptyOnlyImageTopicDNE: StoryObj<
-  React.ComponentProps<typeof ImageModeEmptyLayout>
-> = {
+export const ImageModeEmptyOnlyImageTopicDNE: StoryObj<typeof ImageModeEmptyLayout> = {
   render: ImageModeEmptyLayout,
   args: { type: "image-topic-DNE" },
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageMode/ImageOnlyMode.stories.tsx
@@ -303,12 +303,12 @@ const ImageWith3D = (initialConfig: ImageModeConfig): JSX.Element => {
   );
 };
 
-export const ImageOnlyModeOff: StoryObj<React.ComponentProps<typeof ImageWith3D>> = {
+export const ImageOnlyModeOff: StoryObj<typeof ImageWith3D> = {
   render: ImageWith3D,
   args: { imageTopic: "camera/img", calibrationTopic: "camera/calibration" },
 };
 
-export const ImageOnlyModeOn: StoryObj<React.ComponentProps<typeof ImageWith3D>> = {
+export const ImageOnlyModeOn: StoryObj<typeof ImageWith3D> = {
   render: ImageWith3D,
   args: { imageTopic: "camera/img", calibrationTopic: undefined },
   play: async ({ canvasElement }) => {
@@ -318,16 +318,12 @@ export const ImageOnlyModeOn: StoryObj<React.ComponentProps<typeof ImageWith3D>>
   },
 };
 
-export const ImageOnlyModeOffWithAutoSelectedTopics: StoryObj<
-  React.ComponentProps<typeof ImageWith3D>
-> = {
+export const ImageOnlyModeOffWithAutoSelectedTopics: StoryObj<typeof ImageWith3D> = {
   render: ImageWith3D,
   args: { imageTopic: undefined, calibrationTopic: undefined },
 };
 
-export const ImageOnlyModeOffWithAutoSelectedCalibration: StoryObj<
-  React.ComponentProps<typeof ImageWith3D>
-> = {
+export const ImageOnlyModeOffWithAutoSelectedCalibration: StoryObj<typeof ImageWith3D> = {
   render: ImageWith3D,
   args: { imageTopic: "abc", calibrationTopic: undefined },
   play: async () => {


### PR DESCRIPTION
**User-Facing Changes**
Present "No image topics available" as empty state instead of a notice


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
