### PR TITLE
Lower maximum frame size in websocket player

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -88,9 +88,9 @@ type MessageDefinitionMap = Map<string, MessageDefinition>;
  * emit a frame more than once per second. In the websocket player this was causing
  * an accumulation of messages that were waiting to be emitted, this could keep growing
  * indefinitely if the rate at which we emit a frame is low enough.
- * 1500MB
+ * 600MB - same as buffered data
  */
-const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 15e8;
+const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 6e8;
 
 export default class FoxgloveWebSocketPlayer implements Player {
   readonly #sourceId: string;

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -88,9 +88,9 @@ type MessageDefinitionMap = Map<string, MessageDefinition>;
  * emit a frame more than once per second. In the websocket player this was causing
  * an accumulation of messages that were waiting to be emitted, this could keep growing
  * indefinitely if the rate at which we emit a frame is low enough.
- * 600MB - same as buffered data
+ * 400MB
  */
-const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 6e8;
+const CURRENT_FRAME_MAXIMUM_SIZE_BYTES = 400 * 1024 * 1024;
 
 export default class FoxgloveWebSocketPlayer implements Player {
   readonly #sourceId: string;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Reduce OOM crashing on live datasources when application is slow or under an inactive tab


**Description**

Lower max size of single frame in websocket player from 1500MB to 600MB. Initially my thinking was to make this about the same as the Blockloading cache limit (2GB, at the time). However, that thinking wasn't quite correct because there is only ever really one instance of the block data, but in this case there could be a current frame being processed that's 1.5GB and a frame being built up that hasn't been emitted that's 1.5GB. This on top of the normal memory usage from panels would be enough to kill apps. So I lowered it to something that seems a bit more reasonable when taking into account that two frames could exist at a time that are this size. 

When studio is too slow to emit a frame from the websocket worker, messages accumulate in the next frame. The larger the next frame grows, the more time it could take to process the next frame, thus causing the following frame to also grow larger, etc. This change doesn't fix this issue but should reduce OOMs when there is an accumulation of data in panels as well as in frames, and keep the UI responsive and processing messages so as to not build up memory pressure more. 


<!-- link relevant GitHub issues -->
FG-6238
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
