### PR TITLE
variable slider: Add debounce for applying global variable update

### DIFF
--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -35,11 +35,19 @@ function VariableSliderPanel(props: Props): JSX.Element {
   const { min = 0, max = 10, step = 1 } = sliderProps;
   const globalVariableValue = globalVariables[globalVariableName];
   const theme = useTheme();
+  const [sliderValue, setSliderValue] = React.useState<number | number[]>(
+    typeof globalVariableValue === "number" ? globalVariableValue : 0,
+  );
 
   useVariableSliderSettings(config, saveConfig);
 
-  const sliderOnChange = useCallback(
-    (_event: Event, value: number | number[]) => {
+  const sliderOnChange = useCallback((_event: Event, value: number | number[]) => {
+    setSliderValue(value);
+  }, []);
+
+  const sliderOnChangeCommitted = useCallback(
+    (_event: unknown, value: number | number[]) => {
+      setSliderValue(value);
       if (value !== globalVariableValue) {
         setGlobalVariables({ [globalVariableName]: value });
       }
@@ -69,11 +77,12 @@ function VariableSliderPanel(props: Props): JSX.Element {
           max={max}
           step={step}
           marks={marks}
-          value={typeof globalVariableValue === "number" ? globalVariableValue : 0}
+          value={sliderValue}
           onChange={sliderOnChange}
+          onChangeCommitted={sliderOnChangeCommitted}
         />
         <Typography variant="h5" style={{ marginTop: theme.spacing(-2.5) }}>
-          {typeof globalVariableValue === "number" ? globalVariableValue : 0}
+          {sliderValue}
         </Typography>
       </Stack>
     </Stack>

--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -12,7 +12,8 @@
 //   You may not use this file except in compliance with the License.
 
 import { Slider, Typography, useTheme } from "@mui/material";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -35,24 +36,27 @@ function VariableSliderPanel(props: Props): JSX.Element {
   const { min = 0, max = 10, step = 1 } = sliderProps;
   const globalVariableValue = globalVariables[globalVariableName];
   const theme = useTheme();
-  const [sliderValue, setSliderValue] = React.useState<number | number[]>(
+  const [sliderValue, setSliderValue] = useState<number | number[]>(
     typeof globalVariableValue === "number" ? globalVariableValue : 0,
   );
 
   useVariableSliderSettings(config, saveConfig);
 
-  const sliderOnChange = useCallback((_event: Event, value: number | number[]) => {
-    setSliderValue(value);
-  }, []);
-
-  const sliderOnChangeCommitted = useCallback(
-    (_event: unknown, value: number | number[]) => {
-      setSliderValue(value);
+  const updateVariable = useCallback(
+    (value: number | number[]) => {
       if (value !== globalVariableValue) {
         setGlobalVariables({ [globalVariableName]: value });
       }
     },
     [globalVariableName, globalVariableValue, setGlobalVariables],
+  );
+  const updateVariableDebounced = useDebouncedCallback(updateVariable, 250);
+  const sliderOnChange = useCallback(
+    (_event: Event, value: number | number[]) => {
+      setSliderValue(value);
+      updateVariableDebounced(value);
+    },
+    [setSliderValue, updateVariableDebounced],
   );
 
   const marks = [
@@ -79,7 +83,6 @@ function VariableSliderPanel(props: Props): JSX.Element {
           marks={marks}
           value={sliderValue}
           onChange={sliderOnChange}
-          onChangeCommitted={sliderOnChangeCommitted}
         />
         <Typography variant="h5" style={{ marginTop: theme.spacing(-2.5) }}>
           {sliderValue}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When adjusting the slider value, use a debounced function for applying the new value to the global variable. This will prevent the global variable from changing frequently while the slider is being moved which in turn might prevent some heavy processing depending on how the variable is being used.
