### PR TITLE
Fix Image panel memory leak when disposing while decoding an image

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
@@ -20,6 +20,8 @@ import { Image as RosImage } from "../../ros";
 export class WorkerImageDecoder {
   #worker: Worker;
   #remote: Comlink.Remote<(typeof import("./WorkerImageDecoder.worker"))["service"]>;
+  /** Aborts the current decode promise. */
+  #abort?: () => void;
 
   public constructor() {
     this.#worker = new Worker(
@@ -36,10 +38,23 @@ export class WorkerImageDecoder {
     image: RosImage | RawImage,
     options: Partial<RawImageOptions>,
   ): Promise<ImageData> {
-    return await this.#remote.decode(image, options);
+    return await new Promise((resolve, reject) => {
+      this.#abort = reject;
+      void this.#remote.decode(image, options).then((decodedImage) => {
+        resolve(decodedImage);
+      });
+    });
   }
 
   public terminate(): void {
+    /** Need to abort as well as terminate because the worker.terminate() call
+     * causes the promise to be neither resolved nor rejected. This creates a circular
+     * reference loop with the `.then` functions within the renderable, causing the
+     * Renderer to never be garbage collected because it's linked to this ongoing
+     * promise and worker.
+     */
+    this.#abort?.();
     this.#worker.terminate();
+    this.#abort = undefined;
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Fix Image panel memory leak when unmounting while decoding an image

**Description**

Terminating the worker while the promise hasn't been resolved results in the promise never getting resolved nor rejected. This promise is referenced within the renderable itself and has callbacks within the renderable. This promise being linked to the global worker object and the renderable cause the entire renderer to not be disposed, leaving multiple instances in memory. This abort lets the promise resolve and clean itself up so that it doesn't keep it's associations in memory.


<!-- link relevant GitHub issues -->
sam/fg-6148-dataset-live-stream-raw-images-leads-to-oom
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
