### PR TITLE
Bring back contrast color for points

### DIFF
--- a/packages/studio-base/src/panels/Plot/Plot.tsx
+++ b/packages/studio-base/src/panels/Plot/Plot.tsx
@@ -83,6 +83,12 @@ const useStyles = makeStyles()((theme) => ({
     },
   },
   canvasDiv: { width: "100%", height: "100%", overflow: "hidden", cursor: "crosshair" },
+  verticalBarWrapper: {
+    width: "100%",
+    height: "100%",
+    overflow: "hidden",
+    position: "relative",
+  },
 }));
 
 type Props = {
@@ -240,8 +246,8 @@ export function Plot(props: Props): JSX.Element {
   const { globalVariables } = useGlobalVariables();
 
   useEffect(() => {
-    coordinator?.handleConfig(config, globalVariables);
-  }, [coordinator, config, globalVariables]);
+    coordinator?.handleConfig(config, theme.palette.mode, globalVariables);
+  }, [coordinator, config, globalVariables, theme.palette.mode]);
 
   // This effect must come after the one above it so the coordinator gets the latest config before
   // the latest player state and can properly initialize if the player state already contains the
@@ -686,6 +692,33 @@ export function Plot(props: Props): JSX.Element {
             hoveredValuesBySeriesIndex={hoveredValuesBySeriesIndex}
           />
         )}
+        <Tooltip
+          arrow={false}
+          classes={{ tooltip: classes.tooltip }}
+          open={tooltipContent != undefined}
+          placement="right"
+          title={tooltipContent ?? <></>}
+          disableInteractive
+          followCursor
+          TransitionComponent={Fade}
+          TransitionProps={{ timeout: 0 }}
+        >
+          <div className={classes.verticalBarWrapper}>
+            <div
+              className={classes.canvasDiv}
+              ref={setCanvasDiv}
+              onWheel={onWheel}
+              onMouseMove={onMouseMove}
+              onMouseOut={onMouseOut}
+              onClick={onClick}
+            />
+            <VerticalBars
+              coordinator={coordinator}
+              hoverComponentId={subscriberId}
+              xAxisIsPlaybackTime={xAxisVal === "timestamp"}
+            />
+          </div>
+        </Tooltip>
         {showResetViewButton && (
           <div className={classes.resetZoomButton}>
             <Button
@@ -698,33 +731,8 @@ export function Plot(props: Props): JSX.Element {
             </Button>
           </div>
         )}
-        <Tooltip
-          arrow={false}
-          classes={{ tooltip: classes.tooltip }}
-          open={tooltipContent != undefined}
-          placement="right"
-          title={tooltipContent ?? <></>}
-          disableInteractive
-          followCursor
-          TransitionComponent={Fade}
-          TransitionProps={{ timeout: 0 }}
-        >
-          <div
-            className={classes.canvasDiv}
-            ref={setCanvasDiv}
-            onWheel={onWheel}
-            onMouseMove={onMouseMove}
-            onMouseOut={onMouseOut}
-            onClick={onClick}
-          />
-        </Tooltip>
         <PanelContextMenu getItems={getPanelContextMenuItems} />
       </Stack>
-      <VerticalBars
-        coordinator={coordinator}
-        hoverComponentId={subscriberId}
-        xAxisIsPlaybackTime={xAxisVal === "timestamp"}
-      />
       <KeyListener global keyDownHandlers={keyDownHandlers} keyUpHandlers={keyUphandlers} />
     </Stack>
   );

--- a/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
@@ -135,7 +135,11 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
     this.#queueDispatchRender();
   }
 
-  public handleConfig(config: Immutable<PlotConfig>, globalVariables: GlobalVariables): void {
+  public handleConfig(
+    config: Immutable<PlotConfig>,
+    colorScheme: "light" | "dark",
+    globalVariables: GlobalVariables,
+  ): void {
     this.#isTimeseriesPlot = config.xAxisVal === "timestamp";
     if (!this.#isTimeseriesPlot) {
       this.#currentSeconds = undefined;
@@ -194,7 +198,7 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
     // Config changes to yBounds always takes precedence over user interaction changes like pan/zoom
     this.#updateAction.yBounds = this.#configBounds.y;
 
-    this.#datasetsBuilder.setConfig(config, globalVariables);
+    this.#datasetsBuilder.setConfig(config, colorScheme, globalVariables);
     this.#queueDispatchRender();
   }
 

--- a/packages/studio-base/src/panels/Plot/builders/CurrentCustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CurrentCustomDatasetsBuilder.ts
@@ -14,7 +14,7 @@ import { fillInGlobalVariablesInPath } from "@foxglove/studio-base/components/Me
 import { Bounds1D } from "@foxglove/studio-base/components/TimeBasedChart/types";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { PlayerState } from "@foxglove/studio-base/players/types";
-import { getLineColor } from "@foxglove/studio-base/util/plotColors";
+import { getLineColor, getContrastColor } from "@foxglove/studio-base/util/plotColors";
 
 import { CsvDataset, GetViewportDatasetsResult, IDatasetsBuilder } from "./IDatasetsBuilder";
 import { Dataset } from "../ChartRenderer";
@@ -137,7 +137,11 @@ export class CurrentCustomDatasetsBuilder implements IDatasetsBuilder {
     this.#pathsWithMismatchedDataLengths.clear();
   }
 
-  public setConfig(config: Immutable<PlotConfig>, globalVariables: GlobalVariables): void {
+  public setConfig(
+    config: Immutable<PlotConfig>,
+    colorScheme: "light" | "dark",
+    globalVariables: GlobalVariables,
+  ): void {
     // Make a new map so we drop series which are no longer present
     const newSeries = new Map();
 
@@ -168,16 +172,17 @@ export class CurrentCustomDatasetsBuilder implements IDatasetsBuilder {
 
       const color = getLineColor(path.color, idx);
       const lineSize = path.lineSize ?? 1.0;
+      const showLine = path.showLine ?? true;
 
       existingSeries.dataset = {
         ...existingSeries.dataset,
         borderColor: color,
-        showLine: path.showLine ?? true,
+        showLine,
         fill: false,
         borderWidth: lineSize,
         pointRadius: lineSize * 1.2,
         pointHoverRadius: 3,
-        pointBackgroundColor: color,
+        pointBackgroundColor: showLine ? getContrastColor(colorScheme, color) : color,
         pointBorderColor: "transparent",
       };
 

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.test.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.test.ts
@@ -148,6 +148,7 @@ describe("CustomDatasetsBuilder", () => {
           },
         ],
       }),
+      "light",
       {},
     );
 
@@ -238,16 +239,16 @@ describe("CustomDatasetsBuilder", () => {
       datasets: [
         expect.objectContaining({
           data: [
-            { x: 0, y: 0 },
-            { x: 1, y: 1 },
-            { x: 2, y: 2 },
+            { x: 0, y: 0, value: 0 },
+            { x: 1, y: 1, value: 1 },
+            { x: 2, y: 2, value: 2 },
           ],
           showLine: true,
           pointRadius: 1.2,
           fill: false,
         }),
         expect.objectContaining({
-          data: [{ x: 0, y: 4 }],
+          data: [{ x: 0, y: 4, value: 4 }],
         }),
       ],
     });
@@ -274,6 +275,7 @@ describe("CustomDatasetsBuilder", () => {
           },
         ],
       }),
+      "light",
       {},
     );
 
@@ -365,16 +367,16 @@ describe("CustomDatasetsBuilder", () => {
       datasets: [
         expect.objectContaining({
           data: [
-            { x: 0, y: 0 },
-            { x: 1, y: 1 },
-            { x: 2, y: 2 },
+            { x: 0, y: 0, value: 0 },
+            { x: 1, y: 1, value: 1 },
+            { x: 2, y: 2, value: 2 },
           ],
           showLine: true,
           pointRadius: 1.2,
           fill: false,
         }),
         expect.objectContaining({
-          data: [{ x: 0, y: 4 }],
+          data: [{ x: 0, y: 4, value: 4 }],
           showLine: true,
           pointRadius: 1.2,
           fill: false,
@@ -402,6 +404,7 @@ describe("CustomDatasetsBuilder", () => {
           },
         ],
       }),
+      "light",
       {},
     );
 
@@ -488,11 +491,11 @@ describe("CustomDatasetsBuilder", () => {
       datasets: [
         expect.objectContaining({
           data: [
-            { x: 0, y: 10 },
-            { x: 1, y: 11 },
-            { x: 2, y: 12 },
-            { x: 3, y: 13 },
-            { x: 4, y: 14 },
+            { x: 0, y: 10, value: 10 },
+            { x: 1, y: 11, value: 11 },
+            { x: 2, y: 12, value: 12 },
+            { x: 3, y: 13, value: 13 },
+            { x: 4, y: 14, value: 14 },
           ],
           showLine: true,
           pointRadius: 1.2,
@@ -500,8 +503,8 @@ describe("CustomDatasetsBuilder", () => {
         }),
         expect.objectContaining({
           data: [
-            { x: 0, y: 20 },
-            { x: 1, y: 21 },
+            { x: 0, y: 20, value: 20 },
+            { x: 1, y: 21, value: 21 },
           ],
         }),
       ],

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -16,7 +16,7 @@ import { Bounds1D } from "@foxglove/studio-base/components/TimeBasedChart/types"
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { PlayerState } from "@foxglove/studio-base/players/types";
 import { unionBounds1D } from "@foxglove/studio-base/types/Bounds";
-import { getLineColor } from "@foxglove/studio-base/util/plotColors";
+import { getContrastColor, getLineColor } from "@foxglove/studio-base/util/plotColors";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 import { BlockTopicCursor } from "./BlockTopicCursor";
@@ -40,6 +40,8 @@ type SeriesItem = {
   messagePath: string;
   parsed: RosPath;
   color: string;
+  /** Used for points when lines are also shown to provide extra contrast */
+  contrastColor: string;
   timestampMethod: TimestampMethod;
   showLine: boolean;
   lineSize: number;
@@ -205,7 +207,11 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
     });
   }
 
-  public setConfig(config: Immutable<PlotConfig>, globalVariables: GlobalVariables): void {
+  public setConfig(
+    config: Immutable<PlotConfig>,
+    colorScheme: "light" | "dark",
+    globalVariables: GlobalVariables,
+  ): void {
     this.#seriesConfigs = filterMap(
       config.paths,
       (path, idx): Immutable<SeriesItem> | undefined => {
@@ -232,12 +238,13 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
         // It is important to keep the existing block cursor for the same series to avoid re-processing
         // the blocks again when the series remains.
         const existing = this.#seriesConfigs.find((item) => _.isEqual(item.key, key));
-
+        const color = getLineColor(path.color, idx);
         return {
           key,
           messagePath: path.value,
           parsed: filledParsed,
-          color: getLineColor(path.color, idx),
+          color,
+          contrastColor: getContrastColor(colorScheme, color),
           lineSize: path.lineSize ?? 1.0,
           timestampMethod: path.timestampMethod,
           showLine: path.showLine ?? true,

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
@@ -35,6 +35,8 @@ export type SeriesConfig = {
   key: SeriesConfigKey;
   messagePath: string;
   color: string;
+  /** Used for points when lines are also shown to provide extra contrast */
+  contrastColor: string;
   showLine: boolean;
   lineSize: number;
   enabled: boolean;
@@ -141,14 +143,15 @@ export class CustomDatasetsBuilderImpl {
         continue;
       }
 
+      const { showLine, color, contrastColor } = series.config;
       const dataset: Dataset = {
-        borderColor: series.config.color,
-        showLine: series.config.showLine,
+        borderColor: color,
+        showLine,
         fill: false,
         borderWidth: series.config.lineSize,
         pointRadius: series.config.lineSize * 1.2,
         pointHoverRadius: 3,
-        pointBackgroundColor: series.config.color,
+        pointBackgroundColor: showLine ? contrastColor : color,
         pointBorderColor: "transparent",
         data: [],
       };

--- a/packages/studio-base/src/panels/Plot/builders/IDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IDatasetsBuilder.ts
@@ -44,7 +44,11 @@ export type GetViewportDatasetsResult = {
 interface IDatasetsBuilder {
   handlePlayerState(state: Immutable<PlayerState>): Bounds1D | undefined;
 
-  setConfig(config: Immutable<PlotConfig>, globalVariables: GlobalVariables): void;
+  setConfig(
+    config: Immutable<PlotConfig>,
+    colorScheme: "light" | "dark",
+    globalVariables: GlobalVariables,
+  ): void;
 
   getViewportDatasets(viewport: Immutable<Viewport>): Promise<GetViewportDatasetsResult>;
 

--- a/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
@@ -14,7 +14,7 @@ import { fillInGlobalVariablesInPath } from "@foxglove/studio-base/components/Me
 import { Bounds1D } from "@foxglove/studio-base/components/TimeBasedChart/types";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { PlayerState } from "@foxglove/studio-base/players/types";
-import { getLineColor } from "@foxglove/studio-base/util/plotColors";
+import { getContrastColor, getLineColor } from "@foxglove/studio-base/util/plotColors";
 
 import { CsvDataset, GetViewportDatasetsResult, IDatasetsBuilder } from "./IDatasetsBuilder";
 import { Dataset } from "../ChartRenderer";
@@ -84,7 +84,11 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
     return range;
   }
 
-  public setConfig(config: Immutable<PlotConfig>, globalVariables: GlobalVariables): void {
+  public setConfig(
+    config: Immutable<PlotConfig>,
+    colorScheme: "light" | "dark",
+    globalVariables: GlobalVariables,
+  ): void {
     // Make a new map so we drop series which are no longer present
     const newSeries = new Map();
 
@@ -115,16 +119,17 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
 
       const color = getLineColor(path.color, idx);
       const lineSize = path.lineSize ?? 1.0;
+      const showLine = path.showLine ?? true;
 
       existingSeries.dataset = {
         ...existingSeries.dataset,
         borderColor: color,
-        showLine: path.showLine ?? true,
+        showLine,
         fill: false,
         borderWidth: lineSize,
         pointRadius: lineSize * 1.2,
         pointHoverRadius: 3,
-        pointBackgroundColor: color,
+        pointBackgroundColor: showLine ? getContrastColor(colorScheme, color) : color,
         pointBorderColor: "transparent",
       };
 

--- a/packages/studio-base/src/panels/Plot/builders/TimeseriesDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimeseriesDatasetsBuilder.ts
@@ -15,7 +15,7 @@ import { fillInGlobalVariablesInPath } from "@foxglove/studio-base/components/Me
 import { Bounds1D } from "@foxglove/studio-base/components/TimeBasedChart/types";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { PlayerState } from "@foxglove/studio-base/players/types";
-import { getLineColor } from "@foxglove/studio-base/util/plotColors";
+import { getContrastColor, getLineColor } from "@foxglove/studio-base/util/plotColors";
 import { TimestampMethod, getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import { BlockTopicCursor } from "./BlockTopicCursor";
@@ -40,6 +40,8 @@ type SeriesItem = {
   messagePath: string;
   parsed: RosPath;
   color: string;
+  /** Used for points when lines are also shown to provide extra contrast */
+  contrastColor: string;
   timestampMethod: TimestampMethod;
   showLine: boolean;
   lineSize: number;
@@ -154,7 +156,11 @@ export class TimeseriesDatasetsBuilder implements IDatasetsBuilder {
     return { min, max };
   }
 
-  public setConfig(config: Immutable<PlotConfig>, globalVariables: GlobalVariables): void {
+  public setConfig(
+    config: Immutable<PlotConfig>,
+    colorScheme: "light" | "dark",
+    globalVariables: GlobalVariables,
+  ): void {
     this.#seriesConfigs = filterMap(
       config.paths,
       (path, idx): Immutable<SeriesItem> | undefined => {
@@ -181,12 +187,13 @@ export class TimeseriesDatasetsBuilder implements IDatasetsBuilder {
         // It is important to keep the existing block cursor for the same series to avoid re-processing
         // the blocks again when the series remains.
         const existing = this.#seriesConfigs.find((item) => _.isEqual(item.key, key));
-
+        const color = getLineColor(path.color, idx);
         return {
           key,
           messagePath: path.value,
           parsed: filledParsed,
-          color: getLineColor(path.color, idx),
+          color,
+          contrastColor: getContrastColor(colorScheme, color),
           lineSize: path.lineSize ?? 1.0,
           timestampMethod: path.timestampMethod,
           showLine: path.showLine ?? true,

--- a/packages/studio-base/src/panels/Plot/builders/TimeseriesDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimeseriesDatasetsBuilderImpl.ts
@@ -37,6 +37,8 @@ export type SeriesConfig = {
   key: SeriesConfigKey;
   messagePath: string;
   color: string;
+  /** Used for points when lines are also shown to provide extra contrast */
+  contrastColor: string;
   timestampMethod: TimestampMethod;
   showLine: boolean;
   lineSize: number;
@@ -125,14 +127,15 @@ export class TimeseriesDatasetsBuilderImpl {
         continue;
       }
 
+      const { color, contrastColor, showLine } = series.config;
       const dataset: Dataset = {
-        borderColor: series.config.color,
-        showLine: series.config.showLine,
+        borderColor: color,
+        showLine,
         fill: false,
         borderWidth: series.config.lineSize,
         pointRadius: series.config.lineSize * 1.2,
         pointHoverRadius: 3,
-        pointBackgroundColor: series.config.color,
+        pointBackgroundColor: showLine ? contrastColor : color,
         pointBorderColor: "transparent",
         data: [],
       };

--- a/packages/studio-base/src/util/plotColors.ts
+++ b/packages/studio-base/src/util/plotColors.ts
@@ -52,3 +52,7 @@ export const darkColor: (_: string) => string = _.memoize((color: string): strin
 export function getLineColor(color: string | undefined, index: number): string {
   return color ?? lineColors[index % lineColors.length]!;
 }
+
+export function getContrastColor(colorScheme: "light" | "dark", color: string): string {
+  return colorScheme === "light" ? darkColor(color) : lightColor(color);
+}


### PR DESCRIPTION
**User-Facing Changes**
N/A - feature branch

**Description**
- Bring back contrast color for points. Only use it when showLines is true.
- Fix a bug where the hover/currenttime vertical bars were going over the legend when it was in Left or Top position.