### PR TITLE
Fix for settings changes causing another decoding of images unnecessarily

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/math.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/math.ts
@@ -55,15 +55,6 @@ export function approxEquals(a: number, b: number, epsilon = 0.00001): boolean {
   return Math.abs(a - b) < epsilon;
 }
 
-export function vecEqual<T>(a: T[], b: T[]): boolean {
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 export function vec3TupleApproxEquals(
   a: THREE.Vector3Tuple,
   b: THREE.Vector3Tuple,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -110,6 +110,8 @@ export const ALL_SUPPORTED_IMAGE_SCHEMAS = new Set([
   ...COMPRESSED_IMAGE_DATATYPES,
 ]);
 
+const SUPPORTED_RAW_IMAGE_SCHEMAS = new Set([...RAW_IMAGE_DATATYPES, ...ROS_IMAGE_DATATYPES]);
+
 const ALL_SUPPORTED_CALIBRATION_SCHEMAS = new Set([
   ...CAMERA_INFO_DATATYPES,
   ...CAMERA_CALIBRATION_DATATYPES,
@@ -397,8 +399,14 @@ export class ImageMode
 
     const settings = this.getImageModeSettings();
 
-    const { imageTopic, calibrationTopic, synchronize, flipHorizontal, flipVertical, rotation } =
-      settings;
+    const {
+      imageTopic: imageTopicName,
+      calibrationTopic,
+      synchronize,
+      flipHorizontal,
+      flipVertical,
+      rotation,
+    } = settings;
 
     const imageTopics = filterMap(this.renderer.topics ?? [], (topic) => {
       if (!topicIsConvertibleToSchema(topic, this.supportedImageSchemas)) {
@@ -418,21 +426,21 @@ export class ImageMode
     );
 
     // Sort calibration topics with prefixes matching the image topic to the top.
-    if (imageTopic) {
-      sortPrefixMatchesToFront(calibrationTopics, imageTopic, (option) => option.label);
+    if (imageTopicName) {
+      sortPrefixMatchesToFront(calibrationTopics, imageTopicName, (option) => option.label);
     }
 
     // add unselected camera calibration option
     calibrationTopics.unshift({ label: "None", value: undefined });
 
     const imageTopicExists = !(
-      imageTopic && !imageTopics.some((topic) => topic.value === imageTopic)
+      imageTopicName && !imageTopics.some((topic) => topic.value === imageTopicName)
     );
     this.renderer.settings.errors.errorIfFalse(
       imageTopicExists,
       IMAGE_TOPIC_PATH,
       IMAGE_TOPIC_UNAVAILABLE,
-      `${imageTopic} is not available`,
+      `${imageTopicName} is not available`,
     );
 
     const calibrationTopicExists = !(
@@ -476,7 +484,7 @@ export class ImageMode
     fields.imageTopic = {
       label: t3D("topic"),
       input: "select",
-      value: imageTopic,
+      value: imageTopicName,
       options: imageTopics,
       error: imageTopicError,
     };
@@ -514,21 +522,30 @@ export class ImageMode
       ],
     };
 
-    const colorModeFields = colorModeSettingsFields({
-      config: settings as ImageModeConfig,
+    const imageTopic =
+      imageTopicName != undefined ? this.renderer.topicsByName?.get(imageTopicName) : undefined;
+    const isRawImageTopic =
+      imageTopic != undefined &&
+      topicIsConvertibleToSchema(imageTopic, SUPPORTED_RAW_IMAGE_SCHEMAS);
 
-      defaults: {
-        gradient: DEFAULT_CONFIG.gradient,
-      },
-      modifiers: {
-        supportsPackedRgbModes: false,
-        supportsRgbaFieldsMode: false,
-        hideFlatColor: true,
-        hideExplicitAlpha: true,
-      },
-    });
+    // color settings only apply to raw image topics, so we can hide them otherwise
+    if (isRawImageTopic) {
+      const colorModeFields = colorModeSettingsFields({
+        config: settings as ImageModeConfig,
 
-    Object.assign(fields, colorModeFields);
+        defaults: {
+          gradient: DEFAULT_CONFIG.gradient,
+        },
+        modifiers: {
+          supportsPackedRgbModes: false,
+          supportsRgbaFieldsMode: false,
+          hideFlatColor: true,
+          hideExplicitAlpha: true,
+        },
+      });
+
+      Object.assign(fields, colorModeFields);
+    }
 
     return [
       {
@@ -664,7 +681,7 @@ export class ImageMode
     if (newState.missingAnnotationTopics) {
       this.#removeImageRenderable();
     }
-    if (newState.image != undefined && newState.image !== oldState?.image) {
+    if (newState.image != undefined && newState.image.message !== oldState?.image?.message) {
       this.#handleImageChange(newState.image, newState.image.message);
     }
     if (newState.cameraInfo != undefined && newState.cameraInfo !== oldState?.cameraInfo) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -433,9 +433,8 @@ export class ImageMode
     // add unselected camera calibration option
     calibrationTopics.unshift({ label: "None", value: undefined });
 
-    const imageTopicExists = !(
-      imageTopicName && !imageTopics.some((topic) => topic.value === imageTopicName)
-    );
+    const imageTopicExists =
+      !imageTopicName || imageTopics.some((topic) => topic.value === imageTopicName);
     this.renderer.settings.errors.errorIfFalse(
       imageTopicExists,
       IMAGE_TOPIC_PATH,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -22,8 +22,6 @@ import { CameraInfo } from "../../ros";
 import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
 
-const EMPTY_ARRAY: unknown[] = [];
-
 const log = Logger.getLogger(__filename);
 export interface ImageRenderableSettings extends Partial<ColorModeSettings> {
   visible: boolean;
@@ -157,7 +155,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     if (
       prevSettings.colorMode !== newSettings.colorMode ||
       prevSettings.flatColor !== newSettings.flatColor ||
-      !_.isEqual(prevSettings.gradient ?? EMPTY_ARRAY, newSettings.gradient ?? EMPTY_ARRAY) ||
+      !_.isEqual(prevSettings.gradient, newSettings.gradient) ||
       prevSettings.colorMap !== newSettings.colorMap ||
       prevSettings.minValue !== newSettings.minValue ||
       prevSettings.maxValue !== newSettings.maxValue

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import * as _ from "lodash-es";
 import * as THREE from "three";
 import { assert } from "ts-essentials";
 
@@ -11,7 +12,6 @@ import { toNanoSec } from "@foxglove/rostime";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { BaseUserData, Renderable } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderable";
 import { stringToRgba } from "@foxglove/studio-base/panels/ThreeDeeRender/color";
-import { vecEqual } from "@foxglove/studio-base/panels/ThreeDeeRender/math";
 import { WorkerImageDecoder } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder";
 import { projectPixel } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/projections";
 import { RosValue } from "@foxglove/studio-base/players/types";
@@ -157,7 +157,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     if (
       prevSettings.colorMode !== newSettings.colorMode ||
       prevSettings.flatColor !== newSettings.flatColor ||
-      !vecEqual(prevSettings.gradient ?? EMPTY_ARRAY, newSettings.gradient ?? EMPTY_ARRAY) ||
+      !_.isEqual(prevSettings.gradient ?? EMPTY_ARRAY, newSettings.gradient ?? EMPTY_ARRAY) ||
       prevSettings.colorMap !== newSettings.colorMap ||
       prevSettings.minValue !== newSettings.minValue ||
       prevSettings.maxValue !== newSettings.maxValue

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -11,6 +11,7 @@ import { toNanoSec } from "@foxglove/rostime";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
 import { BaseUserData, Renderable } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderable";
 import { stringToRgba } from "@foxglove/studio-base/panels/ThreeDeeRender/color";
+import { vecEqual } from "@foxglove/studio-base/panels/ThreeDeeRender/math";
 import { WorkerImageDecoder } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder";
 import { projectPixel } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/projections";
 import { RosValue } from "@foxglove/studio-base/players/types";
@@ -20,6 +21,8 @@ import { decodeCompressedImageToBitmap } from "./decodeImage";
 import { CameraInfo } from "../../ros";
 import { DECODE_IMAGE_ERR_KEY, IMAGE_TOPIC_PATH } from "../ImageMode/constants";
 import { ColorModeSettings } from "../colorMode";
+
+const EMPTY_ARRAY: unknown[] = [];
 
 const log = Logger.getLogger(__filename);
 export interface ImageRenderableSettings extends Partial<ColorModeSettings> {
@@ -154,7 +157,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     if (
       prevSettings.colorMode !== newSettings.colorMode ||
       prevSettings.flatColor !== newSettings.flatColor ||
-      prevSettings.gradient !== newSettings.gradient ||
+      !vecEqual(prevSettings.gradient ?? EMPTY_ARRAY, newSettings.gradient ?? EMPTY_ARRAY) ||
       prevSettings.colorMap !== newSettings.colorMap ||
       prevSettings.minValue !== newSettings.minValue ||
       prevSettings.maxValue !== newSettings.maxValue

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { t } from "i18next";
+import * as _ from "lodash-es";
 import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
@@ -25,7 +26,6 @@ import {
 import { SettingsTreeEntry } from "../SettingsManager";
 import { makeRgba, rgbaGradient, rgbaToCssString, stringToRgba } from "../color";
 import { POSES_IN_FRAME_DATATYPES } from "../foxglove";
-import { vecEqual } from "../math";
 import { normalizeHeader, normalizePose, normalizeTime } from "../normalizeMessages";
 import {
   PoseArray,
@@ -416,8 +416,8 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     const axisOrArrowSettingsChanged =
       settings.type !== prevSettings.type ||
       settings.axisScale !== prevSettings.axisScale ||
-      !vecEqual(settings.arrowScale, prevSettings.arrowScale) ||
-      !vecEqual(settings.gradient, prevSettings.gradient) ||
+      !_.isEqual(settings.arrowScale, prevSettings.arrowScale) ||
+      !_.isEqual(settings.gradient, prevSettings.gradient) ||
       (renderable.userData.arrows.length === 0 && renderable.userData.axes.length === 0);
 
     renderable.userData.settings = settings;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { t } from "i18next";
+import * as _ from "lodash-es";
 import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
@@ -24,7 +25,6 @@ import {
 import { SettingsTreeEntry } from "../SettingsManager";
 import { makeRgba, rgbaToCssString, stringToRgba } from "../color";
 import { POSE_IN_FRAME_DATATYPES } from "../foxglove";
-import { vecEqual } from "../math";
 import {
   normalizeHeader,
   normalizeMatrix6,
@@ -325,7 +325,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
     const axisOrArrowSettingsChanged =
       settings.type !== prevSettings.type ||
       settings.axisScale !== prevSettings.axisScale ||
-      !vecEqual(settings.arrowScale, prevSettings.arrowScale) ||
+      !_.isEqual(settings.arrowScale, prevSettings.arrowScale) ||
       settings.color !== prevSettings.color ||
       (!renderable.userData.arrow && !renderable.userData.axis);
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Fix changing image settings causing extra decode of image. Notably this was a problem for changing settings with video topics.
- remove colormode settings for non-raw images in ImageMode settings

**Description**

The cause of the issue was the emitState image change logic comparing a non-referentially stable value, and also the gradient in the settings being a non-referentially stable value. Both of these paths are activated by the chancing of the setting and can cause the same image to be decoded again.


<!-- link relevant GitHub issues -->
FG-6127
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
