### PR TITLE
Fix synced annotations when an unavailable annotation topic is in the layout

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -342,6 +342,7 @@ export class ImageMode
    * Also auto-select a new calibration topic to match the new image topic.
    */
   #handleTopicsChanged = () => {
+    this.#annotations.handleTopicsChanged(this.renderer.topics);
     if (this.getImageModeSettings().imageTopic != undefined) {
       return;
     }
@@ -355,7 +356,6 @@ export class ImageMode
     if (imageTopic) {
       this.setImageTopic(imageTopic);
     }
-    this.#annotations.handleTopicsChanged(this.renderer.topics);
   };
 
   /** Sets specified image topic on the config and updates calibration topic if a match is found.

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -355,6 +355,7 @@ export class ImageMode
     if (imageTopic) {
       this.setImageTopic(imageTopic);
     }
+    this.#annotations.handleTopicsChanged(this.renderer.topics);
   };
 
   /** Sets specified image topic on the config and updates calibration topic if a match is found.

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/MessageHandler.test.ts
@@ -364,6 +364,7 @@ describe("MessageHandler: synchronized = true", () => {
       },
       hud,
     );
+    messageHandler.setAvailableAnnotationTopics(["annotations1", "annotations2"]);
     const time = 2n;
 
     const image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
@@ -397,6 +398,43 @@ describe("MessageHandler: synchronized = true", () => {
     expect(state.missingAnnotationTopics).toEqual(["annotations2"]);
   });
 
+  it("shows state with image and annotation if one of two visible image annotation topics is unavailable", () => {
+    const hud = new HUDItemManager(() => {});
+    const messageHandler = new MessageHandler(
+      {
+        synchronize: true,
+        annotations: {
+          annotations1: { visible: true },
+          annotations2: { visible: true },
+        },
+      },
+      hud,
+    );
+    messageHandler.setAvailableAnnotationTopics(["annotations1"]);
+    const time = 2n;
+
+    const image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
+      timestamp: fromNanoSec(time),
+    });
+
+    const annotation1 = createCircleAnnotations([time]);
+    const annotationMessage1 = wrapInMessageEvent(
+      "annotations1",
+      "foxglove.ImageAnnotations",
+      0n,
+      annotation1,
+    );
+
+    messageHandler.handleRawImage(image);
+    messageHandler.handleAnnotations(annotationMessage1 as MessageEvent<ImageAnnotations>);
+    const state = messageHandler.getRenderStateAndUpdateHUD();
+
+    expect(state.image).not.toBeUndefined();
+    expect(state.annotationsByTopic?.get("annotations1")).not.toBeUndefined();
+    expect(state.annotationsByTopic?.get("annotations2")).toBeUndefined();
+    expect(state.presentAnnotationTopics).toBeUndefined();
+    expect(state.missingAnnotationTopics).toBeUndefined();
+  });
   it("shows most recent image and annotations with same timestamps", () => {
     const hud = new HUDItemManager(() => {});
     const messageHandler = new MessageHandler(
@@ -456,6 +494,7 @@ describe("MessageHandler: synchronized = true", () => {
       },
       hud,
     );
+    messageHandler.setAvailableAnnotationTopics(["annotations"]);
 
     const time = 2n;
 
@@ -507,6 +546,7 @@ describe("MessageHandler: synchronized = true", () => {
       },
       hud,
     );
+    messageHandler.setAvailableAnnotationTopics(["annotations1", "annotations2"]);
     const time = 2n;
 
     const image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
@@ -903,6 +943,7 @@ describe("MessageHandler: hud item display", () => {
       },
       hud,
     );
+    messageHandler.setAvailableAnnotationTopics(["annotations1", "annotations2"]);
     const time = 2n;
 
     const image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {
@@ -946,6 +987,7 @@ describe("MessageHandler: hud item display", () => {
       },
       hud,
     );
+    messageHandler.setAvailableAnnotationTopics(["annotations1", "annotations2"]);
     const time = 2n;
 
     const image = wrapInMessageEvent<RawImage>("image", "foxglove.RawImage", 0n, {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -101,6 +101,22 @@ export class ImageAnnotations extends THREE.Object3D {
     ];
   }
 
+  public handleTopicsChanged(topics: readonly Topic[] | undefined): void {
+    if (!topics) {
+      return;
+    }
+    const availableAnnotationTopics = [];
+
+    for (const topic of topics) {
+      if (!topicIsConvertibleToSchema(topic, ALL_SUPPORTED_ANNOTATION_SCHEMAS)) {
+        continue;
+      }
+      availableAnnotationTopics.push(topic.name);
+    }
+
+    this.#context.messageHandler.setAvailableAnnotationTopics(availableAnnotationTopics);
+  }
+
   #filterMessageQueue<T>(msgs: MessageEvent<T>[]): MessageEvent<T>[] {
     // if sync annotations not active, only take the last message for each topic
     if (this.#context.config().synchronize !== true) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/annotations/ImageAnnotations.ts
@@ -6,6 +6,7 @@ import { t } from "i18next";
 import * as THREE from "three";
 import { Opaque } from "ts-essentials";
 
+import { filterMap } from "@foxglove/den/collection";
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { ImageAnnotations as FoxgloveImageAnnotations } from "@foxglove/schemas";
 import { Immutable, MessageEvent, SettingsTreeAction, Topic } from "@foxglove/studio";
@@ -105,14 +106,12 @@ export class ImageAnnotations extends THREE.Object3D {
     if (!topics) {
       return;
     }
-    const availableAnnotationTopics = [];
-
-    for (const topic of topics) {
-      if (!topicIsConvertibleToSchema(topic, ALL_SUPPORTED_ANNOTATION_SCHEMAS)) {
-        continue;
+    const availableAnnotationTopics = filterMap(topics, (topic) => {
+      if (topicIsConvertibleToSchema(topic, ALL_SUPPORTED_ANNOTATION_SCHEMAS)) {
+        return topic.name;
       }
-      availableAnnotationTopics.push(topic.name);
-    }
+      return undefined;
+    });
 
     this.#context.messageHandler.setAvailableAnnotationTopics(availableAnnotationTopics);
   }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix synced annotations when an unavailable annotation topic is in the layout

**Description**

When sync annotations is enabled and there is an unavailable annotation topic that is visible in the layout, then the panel will never show an image and always say waiting for synchronization. This is because the messagehandler doesn't know which visible topics are available. This updates `ImageAnnotations` to `setAvailableAnnotationTopics` on the `messageHandler` when the topics change.


<!-- link relevant GitHub issues -->
FG-6243
https://github.com/foxglove/community/issues/908
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
