### PR TITLE
Remember the dataset range for IndexDatasetsBuilder

### DIFF
--- a/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
@@ -38,6 +38,8 @@ const emptyPaths = new Set<string>();
 export class IndexDatasetsBuilder implements IDatasetsBuilder {
   #seriesByKey = new Map<SeriesConfigKey, IndexDatasetsSeries>();
 
+  #range?: Bounds1D;
+
   public handlePlayerState(state: Immutable<PlayerState>): Bounds1D | undefined {
     const activeData = state.activeData;
     if (!activeData) {
@@ -46,7 +48,9 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
 
     const msgEvents = activeData.messages;
     if (msgEvents.length === 0) {
-      return;
+      // When there are no new messages we keep returning the same bounds as before since our
+      // datasets have not changed.
+      return this.#range;
     }
 
     const range: Bounds1D = { min: 0, max: 0 };
@@ -79,7 +83,7 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
       range.max = Math.max(range.max, series.dataset.data.length - 1);
     }
 
-    return range;
+    return (this.#range = range);
   }
 
   public setSeries(series: Immutable<SeriesItem[]>): void {


### PR DESCRIPTION

**User-Facing Changes**
The plot x-axis is correctly sized to the data when using the "index" mode.

**Description**
When the builder receives state with no update it should still return the dataset range so that the rendering update continues to use the range for the dataset rather than falling back to automatic bounds for chartjs. This avoid having "gaps" at the start or end of the plot and sizing the plot to the data.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
