### PR TITLE
Keep referentially stable blocks in TopicAliasingPlayer

### DIFF
--- a/packages/studio-base/src/players/TopicAliasingPlayer/AliasingStateProcessor.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/AliasingStateProcessor.ts
@@ -46,7 +46,7 @@ export class AliasingStateProcessor implements IStateProcessor {
     this.#inverseMapping = invertAliasMap(mapping);
 
     this.#blockProcessors = Array.from(mapping.entries()).map(
-      (entry) => new BlockTopicProcessor(entry[0], entry[1]),
+      ([topic, aliases]) => new BlockTopicProcessor(topic, aliases),
     );
   }
 
@@ -117,19 +117,16 @@ export class AliasingStateProcessor implements IStateProcessor {
         return undefined;
       }
 
-      const accumulatedMessagesByTopic = this.#blockProcessors.reduce((acc, processor) => {
+      const messagesByTopic = this.#blockProcessors.reduce((acc, processor) => {
         return {
           ...acc,
           ...processor.aliasBlock(block, idx),
         };
-      }, {});
+      }, block.messagesByTopic);
 
       return {
         ...block,
-        messagesByTopic: {
-          ...block.messagesByTopic,
-          ...accumulatedMessagesByTopic,
-        },
+        messagesByTopic,
       };
     });
   });

--- a/packages/studio-base/src/players/TopicAliasingPlayer/AliasingStateProcessor.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/AliasingStateProcessor.ts
@@ -16,6 +16,7 @@ import {
   TopicStats,
 } from "@foxglove/studio-base/players/types";
 
+import { BlockTopicProcessor } from "./BlockTopicProcessor";
 import { IStateProcessor } from "./IStateProcessor";
 
 export type TopicAliasMap = Map<string, string[]>;
@@ -30,13 +31,23 @@ type MessageBlocks = readonly (undefined | MessageBlock)[];
  */
 export class AliasingStateProcessor implements IStateProcessor {
   #problems: PlayerProblem[] = [];
+
+  /** Source topic to a list of aliases for the topic */
   #mapping: Im<TopicAliasMap>;
+
+  /** Aliased topic back to the source topic */
   #inverseMapping: Im<TopicAliasMap>;
+
+  #blockProcessors: BlockTopicProcessor[] = [];
 
   public constructor(mapping: Im<TopicAliasMap>, problems?: PlayerProblem[]) {
     this.#mapping = mapping;
     this.#problems = problems ?? [];
     this.#inverseMapping = invertAliasMap(mapping);
+
+    this.#blockProcessors = Array.from(mapping.entries()).map(
+      (entry) => new BlockTopicProcessor(entry[0], entry[1]),
+    );
   }
 
   /**
@@ -101,29 +112,24 @@ export class AliasingStateProcessor implements IStateProcessor {
   );
 
   #aliasBlocks = memoizeWeak((blocks: MessageBlocks): MessageBlocks => {
-    return blocks.map((block) => {
-      if (block == undefined) {
+    return blocks.map((block, idx) => {
+      if (!block) {
         return undefined;
       }
 
+      const accumulatedMessagesByTopic = this.#blockProcessors.reduce((acc, processor) => {
+        return {
+          ...acc,
+          ...processor.aliasBlock(block, idx),
+        };
+      }, {});
+
       return {
         ...block,
-        messagesByTopic: _.transform(
-          block.messagesByTopic,
-          (acc, messages, topic) => {
-            const mappings = this.#mapping.get(topic);
-            if (mappings) {
-              for (const mappedTopic of mappings) {
-                acc[mappedTopic] = messages.map((msg) => ({
-                  ...msg,
-                  topic: mappedTopic,
-                }));
-              }
-            }
-            acc[topic] = messages;
-          },
-          {} as Record<string, MessageEvent[]>,
-        ),
+        messagesByTopic: {
+          ...block.messagesByTopic,
+          ...accumulatedMessagesByTopic,
+        },
       };
     });
   });

--- a/packages/studio-base/src/players/TopicAliasingPlayer/BlockTopicProcessor.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/BlockTopicProcessor.ts
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { Immutable as Im, MessageEvent } from "@foxglove/studio";
+import type { MessageBlock } from "@foxglove/studio-base/players/types";
+
+type BlockItem = { original: Im<MessageEvent[]>; aliased: Record<string, MessageEvent[]> };
+type SparseArray<T> = (T | undefined)[];
+
+/**
+ * BlockTopicProcessor adds alias messages to blocks.
+ *
+ * It tries to keep referential stability for aliased messages by tracking the input messages on the
+ * original topic and storing the aliased message arrays to return them if the input messages are
+ * unchanged.
+ */
+export class BlockTopicProcessor {
+  #originalTopic: string;
+  #aliases: Im<string[]>;
+
+  #blocks: SparseArray<BlockItem> = [];
+
+  public constructor(originalTopic: string, aliases: Im<string[]>) {
+    this.#originalTopic = originalTopic;
+    this.#aliases = aliases;
+  }
+
+  /**
+   * Alias the block and return the aliased messages by topic. The aliases and the input messages
+   * are stored so if the block has already been aliased and is unchanged, then the existing aliased
+   * messages by topic are returned.
+   */
+  public aliasBlock(block: Im<MessageBlock>, index: number): Record<string, MessageEvent[]> {
+    const inputEvents = block.messagesByTopic[this.#originalTopic];
+    if (!inputEvents) {
+      this.#blocks[index] = undefined;
+      return {};
+    }
+
+    const existing = this.#blocks[index];
+    if (existing && existing.original === inputEvents) {
+      return existing.aliased;
+    }
+
+    const aliased: Record<string, MessageEvent[]> = {};
+    for (const alias of this.#aliases) {
+      aliased[alias] = inputEvents.map((event) => ({
+        ...event,
+        topic: alias,
+      }));
+    }
+
+    // Save the input events and the aliased data
+    this.#blocks[index] = {
+      original: inputEvents,
+      aliased,
+    };
+
+    return aliased;
+  }
+}

--- a/packages/studio-base/src/players/TopicAliasingPlayer/BlockTopicProcessor.ts
+++ b/packages/studio-base/src/players/TopicAliasingPlayer/BlockTopicProcessor.ts
@@ -5,7 +5,7 @@
 import type { Immutable as Im, MessageEvent } from "@foxglove/studio";
 import type { MessageBlock } from "@foxglove/studio-base/players/types";
 
-type BlockItem = { original: Im<MessageEvent[]>; aliased: Record<string, MessageEvent[]> };
+type BlockItem = { inputEvents: Im<MessageEvent[]>; aliased: Record<string, MessageEvent[]> };
 type SparseArray<T> = (T | undefined)[];
 
 /**
@@ -39,7 +39,7 @@ export class BlockTopicProcessor {
     }
 
     const existing = this.#blocks[index];
-    if (existing && existing.original === inputEvents) {
+    if (existing && existing.inputEvents === inputEvents) {
       return existing.aliased;
     }
 
@@ -53,7 +53,7 @@ export class BlockTopicProcessor {
 
     // Save the input events and the aliased data
     this.#blocks[index] = {
-      original: inputEvents,
+      inputEvents,
       aliased,
     };
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The AliasingStateProcessor (part of the TopicAliasingPlayer machinery) processes blocks to add the aliased MessageEvent arrays to `messageByTopic`. The existing behavior would receive a new set of blocks and update the aliased topic messages in all of them. This resulted in a new messages array reference for all aliased topics any time a new block is added. Changing the message array reference signals to downstream that the specific messages in the block for that topic have changed and can trigger work on those messages. In the case of plots, it causes the internal block cursors to think the data is changed and re-send all the block data for the series.

This change updates the `AliasingStateProcessor` with a new assistant - the `BlockTopicProcessor`. The BlockTopicProcessor remembers the aliased message arrays for the aliased topics and returns those if the source topic messages are unchanged (referentially stable). This allows downstream consumers to continue using the referential equality of message arrays to identify if the data is changed.