### PR TITLE
Abort blockloader when player is closing

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -209,6 +209,7 @@ describe("BlockLoader", () => {
     };
 
     loader.setTopics(mockTopicSelection("a"));
+    let progressCount = 0;
     await loader.startLoading({
       progress: async (progress) => {
         expect(progress).toMatchObject({
@@ -231,8 +232,10 @@ describe("BlockLoader", () => {
             startTime: { sec: 0, nsec: 0 },
           },
         });
-
-        await loader.stopLoading();
+        // need to wait for second progress call to receive cache full error
+        if (++progressCount > 1) {
+          await loader.stopLoading();
+        }
       },
     });
     expect(consoleErrorMock.mock.calls[0] ?? []).toContain("cache-full");
@@ -504,6 +507,7 @@ describe("BlockLoader", () => {
     };
 
     loader.setTopics(mockTopicSelection("a"));
+    let progressCount = 0;
     await loader.startLoading({
       progress: async (progress) => {
         expect(progress).toMatchObject({
@@ -527,7 +531,10 @@ describe("BlockLoader", () => {
           },
         });
 
-        await loader.stopLoading();
+        // need to wait for second progress call to receive cache full error
+        if (++progressCount > 1) {
+          await loader.stopLoading();
+        }
       },
     });
     expect(consoleErrorMock.mock.calls[0] ?? []).toContain("cache-full");

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -154,8 +154,8 @@ export class BlockLoader {
 
   public async stopLoading(): Promise<void> {
     log.debug("Stop loading blocks");
-    this.#abortController.abort();
     this.#stopped = true;
+    this.#abortController.abort();
     this.#activeChangeCondvar.notifyAll();
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -154,6 +154,7 @@ export class BlockLoader {
 
   public async stopLoading(): Promise<void> {
     log.debug("Stop loading blocks");
+    this.#abortController.abort();
     this.#stopped = true;
     this.#activeChangeCondvar.notifyAll();
   }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- fix memory leak across data sources when blockloading was incomplete

**Description**

`#abortController.abort()` was not being called in `Blockloader.stopLoading` so the blockloader would need to finish loading before the player was closed.

We also might want to consider adding a timeout for a warning or error when `stateClose` is called on the player so that we know if the last player didn't close in a reasonable amount of time.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
