### PR TITLE
Fix issues with disabled plot series

### DIFF
--- a/packages/studio-base/src/panels/Plot/Plot.tsx
+++ b/packages/studio-base/src/panels/Plot/Plot.tsx
@@ -344,6 +344,7 @@ export function Plot(props: Props): JSX.Element {
 
     return () => {
       resizeObserver.disconnect();
+      plotCoordinator.destroy();
     };
   }, [canvasDiv, datasetsBuilder, renderer]);
 

--- a/packages/studio-base/src/panels/Plot/builders/CurrentCustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CurrentCustomDatasetsBuilder.ts
@@ -157,6 +157,7 @@ export class CurrentCustomDatasetsBuilder implements IDatasetsBuilder {
         };
       }
 
+      existingSeries.enabled = item.enabled;
       existingSeries.dataset = {
         ...existingSeries.dataset,
         borderColor: item.color,
@@ -182,6 +183,7 @@ export class CurrentCustomDatasetsBuilder implements IDatasetsBuilder {
     const datasets: Dataset[] = [];
     for (const series of this.#seriesByKey.values()) {
       if (!series.enabled) {
+        datasets.push({ data: [] });
         continue;
       }
 
@@ -205,10 +207,6 @@ export class CurrentCustomDatasetsBuilder implements IDatasetsBuilder {
     }
 
     return datasets;
-  }
-
-  public destroy(): void {
-    // no-op this builder does not use a worker
   }
 }
 

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -231,10 +231,6 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
   public async getCsvData(): Promise<CsvDataset[]> {
     return await this.#datasetsBuilderRemote.getCsvData();
   }
-
-  public destroy(): void {
-    this.#datasetsBuilderWorker.terminate();
-  }
 }
 
 function readMessagePathItems(

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
@@ -125,10 +125,6 @@ export class CustomDatasetsBuilderImpl {
     const datasets: Dataset[] = [];
     const pathsWithMismatchedDataLengths = new Set<string>();
     for (const series of this.#seriesByKey.values()) {
-      if (!series.config.enabled) {
-        continue;
-      }
-
       const { showLine, color, contrastColor } = series.config;
       const dataset: Dataset = {
         borderColor: color,
@@ -141,6 +137,12 @@ export class CustomDatasetsBuilderImpl {
         pointBorderColor: "transparent",
         data: [],
       };
+
+      datasets.push(dataset);
+
+      if (!series.config.enabled) {
+        continue;
+      }
 
       // Create the full dataset by pairing full y-values with their x-value peers
       // And then pairing current y-values with their x-value peers
@@ -230,8 +232,6 @@ export class CustomDatasetsBuilderImpl {
           });
         }
       }
-
-      datasets.push(dataset);
 
       if (
         this.#xValues.full.length !== series.full.length ||

--- a/packages/studio-base/src/panels/Plot/builders/IDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IDatasetsBuilder.ts
@@ -80,8 +80,6 @@ interface IDatasetsBuilder {
   getViewportDatasets(viewport: Immutable<Viewport>): Promise<GetViewportDatasetsResult>;
 
   getCsvData(): Promise<CsvDataset[]>;
-
-  destroy(): void;
 }
 
 export type { IDatasetsBuilder };

--- a/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
@@ -103,6 +103,7 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
         };
       }
 
+      existingSeries.enabled = item.enabled;
       existingSeries.dataset = {
         ...existingSeries.dataset,
         borderColor: item.color,
@@ -128,6 +129,7 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
     const datasets: Dataset[] = [];
     for (const series of this.#seriesByKey.values()) {
       if (!series.enabled) {
+        datasets.push({ data: [] });
         continue;
       }
 
@@ -151,10 +153,6 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
     }
 
     return datasets;
-  }
-
-  public destroy(): void {
-    // no-op this builder does not use a worker
   }
 }
 

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -171,10 +171,6 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
   public async getCsvData(): Promise<CsvDataset[]> {
     return await this.#datasetsBuilderRemote.getCsvData();
   }
-
-  public destroy(): void {
-    this.#datasetsBuilderWorker.terminate();
-  }
 }
 
 function readMessagePathItems(

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilderImpl.ts
@@ -98,10 +98,6 @@ export class TimestampDatasetsBuilderImpl {
     const datasets: Dataset[] = [];
     const numSeries = this.#seriesByKey.size;
     for (const series of this.#seriesByKey.values()) {
-      if (!series.config.enabled) {
-        continue;
-      }
-
       const { color, contrastColor, showLine } = series.config;
       const dataset: Dataset = {
         borderColor: color,
@@ -114,6 +110,12 @@ export class TimestampDatasetsBuilderImpl {
         pointBorderColor: "transparent",
         data: [],
       };
+
+      datasets.push(dataset);
+
+      if (!series.config.enabled) {
+        continue;
+      }
 
       // Copy so we can set the .index property for downsampling
       // If downsampling algos change to not need the .index then we can get rid of some copies
@@ -251,8 +253,6 @@ export class TimestampDatasetsBuilderImpl {
           value: item.value,
         });
       }
-
-      datasets.push(dataset);
     }
 
     return datasets;


### PR DESCRIPTION
**User-Facing Changes**
Fixed issues with disabled series in the Plot panel.

**Description**
- Add `PlotCoordinator.destroy()` to fix an issue where switching from Timestamp to Index mode would still show the timestamp data (because the old coordinator rendered after the new one)
- Ensure all builders include an empty dataset in `getViewportDatasets` for disabled series
- Ensure all builders keep track of the new `enabled` setting in `setSeries` (even if the series did not otherwise change)
