### PR TITLE
Apply TimestampDatasetsBuilder in smaller batches

### DIFF
--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -161,7 +161,13 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
     const dispatch = this.#pendingDataDispatch;
     if (dispatch.length > 0) {
       this.#pendingDataDispatch = [];
-      await this.#datasetsBuilderRemote.updateData(dispatch);
+
+      // The pending data dispatches can contain a lot of data points (from block data)
+      // By breaking them up into individual updates the postMessage calls are smaller and avoid
+      // locking up the main thread.
+      for (const item of dispatch) {
+        await this.#datasetsBuilderRemote.applyAction(item);
+      }
     }
 
     const datasets = await this.#datasetsBuilderRemote.getViewportDatasets(viewport);

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilderImpl.ts
@@ -69,12 +69,6 @@ const compareDatum = (a: Datum, b: Datum) => a.x - b.x;
 export class TimestampDatasetsBuilderImpl {
   #seriesByKey = new Map<SeriesConfigKey, Series>();
 
-  public updateData(actions: Immutable<UpdateDataAction[]>): void {
-    for (const action of actions) {
-      this.#applyAction(action);
-    }
-  }
-
   public setSeries(series: Immutable<SeriesItem[]>): void {
     // Make a new map so we drop series which are no longer present
     const newSeries = new Map();
@@ -279,7 +273,7 @@ export class TimestampDatasetsBuilderImpl {
     return datasets;
   }
 
-  #applyAction(action: Immutable<UpdateDataAction>): void {
+  public applyAction(action: Immutable<UpdateDataAction>): void {
     switch (action.type) {
       case "reset-current": {
         const series = this.#seriesByKey.get(action.series);


### PR DESCRIPTION

**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
This allows the main thread to continue being responsive since it does not need to send a giant postMessage of all block data.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
