### PR TITLE
Fix community Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     <a href="https://github.com/foxglove/studio/releases"><img src="https://img.shields.io/github/v/release/foxglove/studio?label=version" /></a>
     <a href="https://github.com/foxglove/studio/blob/main/LICENSE"><img src="https://img.shields.io/github/license/foxglove/studio" /></a>
     <a href="https://github.com/orgs/foxglove/discussions"><img src="https://img.shields.io/github/discussions/foxglove/community.svg?logo=github" /></a>
-    <a href="https://foxglove.dev/join-slack"><img src="https://img.shields.io/badge/chat-slack-purple.svg?logo=slack" /></a>
+    <a href="https://foxglove.dev/slack"><img src="https://img.shields.io/badge/chat-slack-purple.svg?logo=slack" /></a>
     <br />
     <br />
     <a href="https://foxglove.dev/download">Download</a>

--- a/packages/studio-base/README.md
+++ b/packages/studio-base/README.md
@@ -15,4 +15,4 @@ For a full list of the package's exports, reference its [`index.ts` file](https:
 
 ## Stay in touch
 
-Join us in [Slack](https://foxglove.dev/join-slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join us in [Slack](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -6,4 +6,4 @@ See https://docs.foxglove.dev/docs/visualization/extensions/introduction
 
 ## Stay in touch
 
-Join us in [Slack](https://foxglove.dev/join-slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join us in [Slack](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
`/join-slack` was an old link but no longer works, `/slack` is correct.