### PR TITLE
Fix erroneous re-fetching behavior in BlockLoader

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -97,18 +97,20 @@ export class BlockLoader {
 
     // Update all the blocks with any missing topics
     for (const block of this.#blocks) {
-      if (block) {
-        const blockTopics = Object.keys(block.messagesByTopic);
-        const needTopics = new Map(topics);
-        for (const topic of blockTopics) {
-          // We need the topic unless the subscription is identical to the subscription for this
-          // topic at the time the block was loaded.
-          if (this.#topics.get(topic) === topics.get(topic)) {
-            needTopics.delete(topic);
-          }
-        }
-        block.needTopics = needTopics;
+      if (!block) {
+        continue;
       }
+
+      const blockTopics = Object.keys(block.messagesByTopic);
+      const needTopics = new Map(topics);
+      for (const topic of blockTopics) {
+        // We need the topic unless the subscription is identical to the subscription for this
+        // topic at the time blocks were loaded.
+        if (_.isEqual(this.#topics.get(topic), topics.get(topic))) {
+          needTopics.delete(topic);
+        }
+      }
+      block.needTopics = needTopics;
     }
 
     this.#topics = topics;


### PR DESCRIPTION
**User-Facing Changes**
Performance improvements when unsubscribing from preloading topics.

**Description**
When the message slices feature was added (https://github.com/foxglove/studio/pull/6608) logic was introduced (https://github.com/foxglove/studio/pull/6608/files#diff-5e94fe4d94b2aef562c3f394450b474e4804f43b993a1487421c17ae4db78a85R104) to identify if blocks needed a topic. This logic used reference equality to compare the existing topic with the new requested topic. However, these topic lists are rarely referentially equal and so the BlockLoader would refresh topics which were still subscribed but had not changed. This would happen whenever un-subscribing to a topic or adding a new topic subscription - any preload topic change really.

This updates the logic to use deep equality to compare the topic subscriptions. If the subscriptions match then there's no need to re-fetch the topic again.

Discovered while working on: https://github.com/foxglove/studio/pull/7345 and seeing one plot refresh while adding series on another unrelated plot and topic.