### PR TITLE
Fix issues with invalid plot series

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -26,7 +26,7 @@ export default {
 export const SingleItemSingleDataset: StoryObj = {
   render: function Story() {
     const data: TimeBasedChartTooltipData = {
-      datasetIndex: 0,
+      configIndex: 0,
       value: 3,
       constantName: "ACTIVE",
     };
@@ -60,7 +60,7 @@ export const SingleItemSingleDatasetLight: StoryObj = {
 export const SingleItemMultiDataset: StoryObj = {
   render: function Story() {
     const data: TimeBasedChartTooltipData = {
-      datasetIndex: 0,
+      configIndex: 0,
       value: 3,
       constantName: "ACTIVE",
     };
@@ -71,7 +71,7 @@ export const SingleItemMultiDataset: StoryObj = {
           <TimeBasedChartTooltipContent
             multiDataset={true}
             content={[data]}
-            labelsByDatasetIndex={{ "0": "/some/topic.path", "1": "Series B" }}
+            labelsByConfigIndex={{ "0": "/some/topic.path", "1": "Series B" }}
           />
         }
         placement="top"
@@ -100,7 +100,7 @@ export const SingleItemMultiDatasetLight: StoryObj = {
 export const MultipleItemsSingleDataset: StoryObj = {
   render: function Story() {
     const data: TimeBasedChartTooltipData = {
-      datasetIndex: 0,
+      configIndex: 0,
       value: 3,
       constantName: "ACTIVE",
     };
@@ -135,12 +135,12 @@ export const MultipleItemsMultipleDataset: StoryObj = {
   render: function Story() {
     const data: TimeBasedChartTooltipData[] = [
       {
-        datasetIndex: 0,
+        configIndex: 0,
         value: 3,
         constantName: "ACTIVE",
       },
       {
-        datasetIndex: 1,
+        configIndex: 1,
         value: 4,
         constantName: "ACTIVE",
       },
@@ -152,8 +152,8 @@ export const MultipleItemsMultipleDataset: StoryObj = {
           <TimeBasedChartTooltipContent
             multiDataset={true}
             content={data}
-            colorsByDatasetIndex={{ "0": "chartreuse", "1": "yellow" }}
-            labelsByDatasetIndex={{ "0": "Series A", "1": "Series B" }}
+            colorsByConfigIndex={{ "0": "chartreuse", "1": "yellow" }}
+            labelsByConfigIndex={{ "0": "Series A", "1": "Series B" }}
           />
         }
         placement="top"

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -20,15 +20,15 @@ import { Immutable } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 export type TimeBasedChartTooltipData = {
-  datasetIndex: number;
+  configIndex: number;
   value: number | bigint | boolean | string;
   constantName?: string;
 };
 
 type Props = Immutable<{
-  colorsByDatasetIndex?: Record<string, undefined | string>;
+  colorsByConfigIndex?: Record<string, undefined | string>;
   content: TimeBasedChartTooltipData[];
-  labelsByDatasetIndex?: Record<string, undefined | string>;
+  labelsByConfigIndex?: Record<string, undefined | string>;
   // Flag indicating the containing chart has multiple datasets
   multiDataset: boolean;
 }>;
@@ -86,7 +86,12 @@ function OverflowMessage(): JSX.Element {
 export default function TimeBasedChartTooltipContent(
   props: PropsWithChildren<Props>,
 ): React.ReactElement {
-  const { colorsByDatasetIndex, content, labelsByDatasetIndex, multiDataset } = props;
+  const {
+    colorsByConfigIndex: colorsByDatasetIndex,
+    content,
+    labelsByConfigIndex: labelsByDatasetIndex,
+    multiDataset,
+  } = props;
   const { classes, cx } = useStyles();
 
   // Compute whether there are multiple items for the dataset so we can show the user
@@ -106,7 +111,7 @@ export default function TimeBasedChartTooltipContent(
 
     // group items by path
     for (const item of content) {
-      const datasetIndex = item.datasetIndex;
+      const datasetIndex = item.configIndex;
       const existing = out.get(datasetIndex);
       if (existing) {
         existing.hasMultipleValues = true;
@@ -120,7 +125,7 @@ export default function TimeBasedChartTooltipContent(
     }
 
     // Sort by datasetIndex to keep the displayed values in the same order as the settings
-    return _.sortBy([...out.entries()], ([, items]) => items.tooltip.datasetIndex);
+    return _.sortBy([...out.entries()], ([, items]) => items.tooltip.configIndex);
   }, [content, multiDataset]);
 
   // If the chart contains only one dataset, we don't need to render the dataset label - saving space

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -358,7 +358,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
       tooltipItems.push({
         item: {
-          datasetIndex: element.datasetIndex,
+          configIndex: element.datasetIndex,
           value: value ?? (states ?? []).join(", "),
           constantName,
         },
@@ -731,8 +731,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       <TimeBasedChartTooltipContent
         content={activeTooltip.data}
         multiDataset={datasetsLength > 1}
-        colorsByDatasetIndex={colorsByDatasetIndex}
-        labelsByDatasetIndex={labelsByDatasetIndex}
+        colorsByConfigIndex={colorsByDatasetIndex}
+        labelsByConfigIndex={labelsByDatasetIndex}
       />
     ) : undefined;
   }, [activeTooltip, colorsByDatasetIndex, datasetsLength, labelsByDatasetIndex]);

--- a/packages/studio-base/src/panels/Plot/ChartRenderer.ts
+++ b/packages/studio-base/src/panels/Plot/ChartRenderer.ts
@@ -55,7 +55,7 @@ type ChartType = Chart<"scatter", Datum[]>;
 
 export type HoverElement = {
   data: Datum;
-  datasetIndex: number;
+  configIndex: number;
 };
 
 export type Size = { width: number; height: number };
@@ -370,7 +370,7 @@ export class ChartRenderer {
 
       out.push({
         data,
-        datasetIndex: element.datasetIndex,
+        configIndex: element.datasetIndex,
       });
     }
 

--- a/packages/studio-base/src/panels/Plot/Plot.tsx
+++ b/packages/studio-base/src/panels/Plot/Plot.tsx
@@ -399,7 +399,7 @@ export function Plot(props: Props): JSX.Element {
         const tooltipValue = typeof value === "object" && isTime(value) ? toSec(value) : value;
 
         tooltipItems.push({
-          datasetIndex: element.datasetIndex,
+          configIndex: element.configIndex,
           value: tooltipValue,
         });
       }
@@ -475,8 +475,8 @@ export function Plot(props: Props): JSX.Element {
       <TimeBasedChartTooltipContent
         content={activeTooltip.data}
         multiDataset={numSeries > 1}
-        colorsByDatasetIndex={colorsByDatasetIndex}
-        labelsByDatasetIndex={labelsByDatasetIndex}
+        colorsByConfigIndex={colorsByDatasetIndex}
+        labelsByConfigIndex={labelsByDatasetIndex}
       />
     ) : undefined;
   }, [activeTooltip, colorsByDatasetIndex, labelsByDatasetIndex, numSeries]);
@@ -635,7 +635,7 @@ export function Plot(props: Props): JSX.Element {
 
     const values = new Array(config.paths.length).fill(undefined);
     for (const item of activeTooltip.data) {
-      values[item.datasetIndex] ??= item.value;
+      values[item.configIndex] ??= item.value;
     }
 
     return values;

--- a/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
@@ -19,7 +19,7 @@ import { Bounds } from "@foxglove/studio-base/types/Bounds";
 import delay from "@foxglove/studio-base/util/delay";
 import { getContrastColor, getLineColor } from "@foxglove/studio-base/util/plotColors";
 
-import { InteractionEvent, Scale, UpdateAction } from "./ChartRenderer";
+import { Dataset, InteractionEvent, Scale, UpdateAction } from "./ChartRenderer";
 import { OffscreenCanvasRenderer } from "./OffscreenCanvasRenderer";
 import {
   CsvDataset,
@@ -45,6 +45,8 @@ type EventTypes = {
   /** Rendering updated the viewport. `canReset` is true if the viewport can be reset. */
   viewportChange(canReset: boolean): void;
 };
+
+const replaceUndefinedWithEmptyDataset = (dataset: Dataset | undefined) => dataset ?? { data: [] };
 
 /**
  * PlotCoordinator interfaces commands and updates between the dataset builder and the chart
@@ -434,7 +436,7 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
     this.#latestXScale = await this.#renderer.updateDatasets(
       // Use Array.from to fill in any `undefined` entries with an empty dataset (`map` would not
       // work for sparse arrays)
-      Array.from(result.datasetsByConfigIndex, (dataset) => dataset ?? { data: [] }),
+      Array.from(result.datasetsByConfigIndex, replaceUndefinedWithEmptyDataset),
     );
     if (this.#isDestroyed()) {
       return;

--- a/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
@@ -431,7 +431,11 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
     if (this.#isDestroyed()) {
       return;
     }
-    this.#latestXScale = await this.#renderer.updateDatasets(result.datasets);
+    this.#latestXScale = await this.#renderer.updateDatasets(
+      // Use Array.from to fill in any `undefined` entries with an empty dataset (`map` would not
+      // work for sparse arrays)
+      Array.from(result.datasetsByConfigIndex, (dataset) => dataset ?? { data: [] }),
+    );
     if (this.#isDestroyed()) {
       return;
     }

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
@@ -125,6 +125,9 @@ export class CustomDatasetsBuilderImpl {
     const datasets: Dataset[] = [];
     const pathsWithMismatchedDataLengths = new Set<string>();
     for (const series of this.#seriesByKey.values()) {
+      if (!series.config.enabled) {
+        continue;
+      }
       const { showLine, color, contrastColor } = series.config;
       const dataset: Dataset = {
         borderColor: color,
@@ -138,11 +141,7 @@ export class CustomDatasetsBuilderImpl {
         data: [],
       };
 
-      datasets.push(dataset);
-
-      if (!series.config.enabled) {
-        continue;
-      }
+      datasets[series.config.configIndex] = dataset;
 
       // Create the full dataset by pairing full y-values with their x-value peers
       // And then pairing current y-values with their x-value peers
@@ -241,7 +240,7 @@ export class CustomDatasetsBuilderImpl {
       }
     }
 
-    return { datasets, pathsWithMismatchedDataLengths };
+    return { datasetsByConfigIndex: datasets, pathsWithMismatchedDataLengths };
   }
 
   public getCsvData(): CsvDataset[] {

--- a/packages/studio-base/src/panels/Plot/builders/IDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IDatasetsBuilder.ts
@@ -63,7 +63,11 @@ export type CsvDataset = {
 };
 
 export type GetViewportDatasetsResult = {
-  datasets: Dataset[];
+  /**
+   * Indices correspond to original indices of series in `config.paths`. Array may be sparse if
+   * series are invalid (parsing fails) or if they are disabled.
+   */
+  datasetsByConfigIndex: readonly (Dataset | undefined)[];
   pathsWithMismatchedDataLengths: ReadonlySet<string>;
 };
 

--- a/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/IndexDatasetsBuilder.ts
@@ -27,6 +27,7 @@ type DatumWithReceiveTime = Datum & {
 };
 
 type IndexDatasetsSeries = {
+  configIndex: number;
   enabled: boolean;
   messagePath: string;
   parsed: Immutable<RosPath>;
@@ -94,6 +95,7 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
       let existingSeries = this.#seriesByKey.get(item.key);
       if (!existingSeries) {
         existingSeries = {
+          configIndex: item.configIndex,
           enabled: item.enabled,
           messagePath: item.messagePath,
           parsed: item.parsed,
@@ -103,6 +105,7 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
         };
       }
 
+      existingSeries.configIndex = item.configIndex;
       existingSeries.enabled = item.enabled;
       existingSeries.dataset = {
         ...existingSeries.dataset,
@@ -128,15 +131,12 @@ export class IndexDatasetsBuilder implements IDatasetsBuilder {
   public async getViewportDatasets(): Promise<GetViewportDatasetsResult> {
     const datasets: Dataset[] = [];
     for (const series of this.#seriesByKey.values()) {
-      if (!series.enabled) {
-        datasets.push({ data: [] });
-        continue;
+      if (series.enabled) {
+        datasets[series.configIndex] = series.dataset;
       }
-
-      datasets.push(series.dataset);
     }
 
-    return { datasets, pathsWithMismatchedDataLengths: emptyPaths };
+    return { datasetsByConfigIndex: datasets, pathsWithMismatchedDataLengths: emptyPaths };
   }
 
   public async getCsvData(): Promise<CsvDataset[]> {

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -193,7 +193,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
     }
 
     const datasets = await this.#datasetsBuilderRemote.getViewportDatasets(viewport);
-    return { datasets, pathsWithMismatchedDataLengths: emptyPaths };
+    return { datasetsByConfigIndex: datasets, pathsWithMismatchedDataLengths: emptyPaths };
   }
 
   public async getCsvData(): Promise<CsvDataset[]> {

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilderImpl.ts
@@ -92,6 +92,9 @@ export class TimestampDatasetsBuilderImpl {
     const datasets: Dataset[] = [];
     const numSeries = this.#seriesByKey.size;
     for (const series of this.#seriesByKey.values()) {
+      if (!series.config.enabled) {
+        continue;
+      }
       const { color, contrastColor, showLine } = series.config;
       const dataset: Dataset = {
         borderColor: color,
@@ -105,11 +108,7 @@ export class TimestampDatasetsBuilderImpl {
         data: [],
       };
 
-      datasets.push(dataset);
-
-      if (!series.config.enabled) {
-        continue;
-      }
+      datasets[series.config.configIndex] = dataset;
 
       // Copy so we can set the .index property for downsampling
       // If downsampling algos change to not need the .index then we can get rid of some copies


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out

**Description**
Fixed bugs with series that are invalid (fail to parse) causing tooltips and current values to display on a different series. (Similar to #7342 but for invalid series)

Approach: instead of each builder handling its own `data: []` defaults (added in #7342), the builders use the series' `configIndex` to output `datasetsByConfigIndex`. The coordinator fills in missing entries with `data: []` before passing to the renderer.

https://github.com/foxglove/studio/assets/14237/c8f6ba28-8eb9-46d8-a3cc-6b914c7aab93

