### PR TITLE
Use partial subscriptions for index and currentCustom

### DIFF
--- a/packages/studio-base/src/panels/Plot/Plot.tsx
+++ b/packages/studio-base/src/panels/Plot/Plot.tsx
@@ -544,6 +544,10 @@ export function Plot(props: Props): JSX.Element {
   // managing the lifecycle of the subscriptions. The renderer will correlate input message data to
   // the correct series.
   useEffect(() => {
+    // The index and currentCustom modes only need the latest message on each topic so we use
+    // partial subscribe mode for those to avoid preloading data that we don't need
+    const preloadType = xAxisMode === "index" || xAxisMode === "currentCustom" ? "partial" : "full";
+
     const subscriptions = filterMap(series, (item): SubscribePayload | undefined => {
       if (isReferenceLinePlotPathType(item)) {
         return;
@@ -554,13 +558,19 @@ export function Plot(props: Props): JSX.Element {
         return;
       }
 
-      return pathToSubscribePayload(fillInGlobalVariablesInPath(parsed, globalVariables));
+      return pathToSubscribePayload(
+        fillInGlobalVariablesInPath(parsed, globalVariables),
+        preloadType,
+      );
     });
 
     if ((xAxisMode === "custom" || xAxisMode === "currentCustom") && xAxisPath) {
       const parsed = parseRosPath(xAxisPath.value);
       if (parsed) {
-        const sub = pathToSubscribePayload(fillInGlobalVariablesInPath(parsed, globalVariables));
+        const sub = pathToSubscribePayload(
+          fillInGlobalVariablesInPath(parsed, globalVariables),
+          preloadType,
+        );
         if (sub) {
           subscriptions.push(sub);
         }

--- a/packages/studio-base/src/panels/Plot/subscription.test.ts
+++ b/packages/studio-base/src/panels/Plot/subscription.test.ts
@@ -14,7 +14,7 @@ describe("subscription", () => {
         throw new Error(`invalid path: ${path}`);
       }
 
-      return pathToSubscribePayload(parsed);
+      return pathToSubscribePayload(parsed, "full");
     };
 
     it("ignores path without a property", () => {

--- a/packages/studio-base/src/panels/Plot/subscription.ts
+++ b/packages/studio-base/src/panels/Plot/subscription.ts
@@ -7,11 +7,17 @@ import type {
   MessagePathPart,
   RosPath,
 } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
-import type { SubscribePayload } from "@foxglove/studio-base/players/types";
+import type {
+  SubscribePayload,
+  SubscriptionPreloadType,
+} from "@foxglove/studio-base/players/types";
 
 const typeIsName = (part: Immutable<MessagePathPart>) => part.type === "name";
 
-export function pathToSubscribePayload(path: Immutable<RosPath>): SubscribePayload | undefined {
+export function pathToSubscribePayload(
+  path: Immutable<RosPath>,
+  preloadType: SubscriptionPreloadType,
+): SubscribePayload | undefined {
   const { messagePath: parts, topicName: topic } = path;
 
   const firstField = parts.find(typeIsName);
@@ -40,7 +46,7 @@ export function pathToSubscribePayload(path: Immutable<RosPath>): SubscribePaylo
 
   return {
     topic,
-    preloadType: "full",
+    preloadType,
     fields: Array.from(fields),
   };
 }


### PR DESCRIPTION

**User-Facing Changes**
None - not worth calling out

**Description**
These modes only need the latest message to build the series. We avoid expensive preloading by using partial subscriptions.
