### PR TITLE
Fix dragging topic names with special characters to the Image panel

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
@@ -25,6 +25,8 @@ export type DraggedMessagePath = {
   isTopic: boolean;
   /** True if the path represents a primitive value inside a message. */
   isLeaf: boolean;
+  /** The name of the top-level topic being dragged */
+  topicName: string;
 };
 
 export type MessagePathDropStatus = {

--- a/packages/studio-base/src/components/TopicList/MessagePathRow.tsx
+++ b/packages/studio-base/src/components/TopicList/MessagePathRow.tsx
@@ -42,8 +42,9 @@ export function MessagePathRow({
       rootSchemaName: topic.schemaName,
       isTopic: false,
       isLeaf,
+      topicName: topic.name,
     }),
-    [fullPath, isLeaf, topic.schemaName],
+    [fullPath, isLeaf, topic.name, topic.schemaName],
   );
 
   const { connectDragSource, connectDragPreview, cursor, isDragging, draggedItemCount } =

--- a/packages/studio-base/src/components/TopicList/TopicList.tsx
+++ b/packages/studio-base/src/components/TopicList/TopicList.tsx
@@ -75,6 +75,7 @@ function getDraggedMessagePath(treeItem: TopicListItem): DraggedMessagePath {
         rootSchemaName: treeItem.item.item.schemaName,
         isTopic: true,
         isLeaf: false,
+        topicName: treeItem.item.item.name,
       };
     case "schema":
       return {
@@ -82,6 +83,7 @@ function getDraggedMessagePath(treeItem: TopicListItem): DraggedMessagePath {
         rootSchemaName: treeItem.item.item.topic.schemaName,
         isTopic: false,
         isLeaf: treeItem.item.item.suffix.isLeaf,
+        topicName: treeItem.item.item.topic.name,
       };
   }
 }

--- a/packages/studio-base/src/components/TopicList/TopicRow.tsx
+++ b/packages/studio-base/src/components/TopicList/TopicRow.tsx
@@ -40,6 +40,7 @@ export function TopicRow({
       rootSchemaName: topic.schemaName,
       isTopic: true,
       isLeaf: false,
+      topicName: topic.name,
     }),
     [topic.name, topic.schemaName],
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -659,10 +659,10 @@ export class ImageMode
       return;
     }
     if (this.supportedImageSchemas.has(path.rootSchemaName)) {
-      draft.imageMode.imageTopic = path.path;
+      draft.imageMode.imageTopic = path.topicName;
     } else if (this.#annotations.supportedAnnotationSchemas.has(path.rootSchemaName)) {
       draft.imageMode.annotations ??= {};
-      draft.imageMode.annotations[path.path] = { visible: true };
+      draft.imageMode.annotations[path.topicName] = { visible: true };
     }
   };
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue with dragging and dropping topics into the Image panel if the topic names contain special characters.

**Description**
The `path` field is quoted, but the Image panel uses an unquoted topic name in its config, so drag & drop would result in an invalid config if the topic name required quotes. This fixes the issue by adding a new `topicName` field to pass through the unmodified topic name.