### PR TITLE
Plot: don't subscribe to empty field names

### DIFF
--- a/packages/studio-base/src/panels/Plot/subscription.test.ts
+++ b/packages/studio-base/src/panels/Plot/subscription.test.ts
@@ -19,6 +19,7 @@ describe("subscription", () => {
 
     it("ignores path without a property", () => {
       expect(toPayload("/foo")).toEqual(undefined);
+      expect(toPayload("/foo.")).toEqual(undefined);
     });
 
     it("subscribes to one field", () => {

--- a/packages/studio-base/src/panels/Plot/subscription.ts
+++ b/packages/studio-base/src/panels/Plot/subscription.ts
@@ -15,7 +15,7 @@ export function pathToSubscribePayload(path: Immutable<RosPath>): SubscribePaylo
   const { messagePath: parts, topicName: topic } = path;
 
   const firstField = parts.find(typeIsName);
-  if (firstField == undefined || firstField.type !== "name") {
+  if (firstField == undefined || firstField.type !== "name" || firstField.name.length === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The underlying logic would likely ignore these but it is good to avoid creating a subscription for an empty field name.