### PR TITLE
Update vscode eslint setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "debug.javascript.autoAttachFilter": "onlyWithFlag",
   "debug.toolBarLocation": "docked",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
VSCode has changed how they store this setting:
https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own/77637765#77637765
