### PR TITLE
Move setSeries to an update action

### DIFF
--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -213,7 +213,10 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
       };
     });
 
-    void this.#datasetsBuilderRemote.setSeries(series);
+    this.#pendingDataDispatch.push({
+      type: "update-series-config",
+      seriesItems: series,
+    });
   }
 
   public async getViewportDatasets(

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -45,7 +45,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
   #datasetsBuilderWorker: Worker;
   #datasetsBuilderRemote: Comlink.Remote<Comlink.RemoteObject<CustomDatasetsBuilderImpl>>;
 
-  #pendingDataDispatch: Immutable<UpdateDataAction>[] = [];
+  #pendingDispatch: Immutable<UpdateDataAction>[] = [];
 
   #lastSeekTime = 0;
 
@@ -76,7 +76,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
     const msgEvents = activeData.messages;
     if (msgEvents.length > 0) {
       if (didSeek) {
-        this.#pendingDataDispatch.push({
+        this.#pendingDispatch.push({
           type: "reset-current-x",
         });
         this.#xCurrentBounds = undefined;
@@ -89,7 +89,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
           : undefined;
         const pathItems = readMessagePathItems(msgEvents, this.#xParsedPath, mathFn);
 
-        this.#pendingDataDispatch.push({
+        this.#pendingDispatch.push({
           type: "append-current-x",
           items: pathItems,
         });
@@ -104,14 +104,14 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
           ? mathFunctions[series.config.parsed.modifier]
           : undefined;
         if (didSeek) {
-          this.#pendingDataDispatch.push({
+          this.#pendingDispatch.push({
             type: "reset-current",
             series: series.config.key,
           });
         }
 
         const pathItems = readMessagePathItems(msgEvents, series.config.parsed, mathFn);
-        this.#pendingDataDispatch.push({
+        this.#pendingDispatch.push({
           type: "append-current",
           series: series.config.key,
           items: pathItems,
@@ -127,7 +127,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
           : undefined;
 
         if (this.#xValuesCursor.nextWillReset(blocks)) {
-          this.#pendingDataDispatch.push({
+          this.#pendingDispatch.push({
             type: "reset-full-x",
           });
         }
@@ -136,7 +136,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
         while ((messageEvents = this.#xValuesCursor.next(blocks)) != undefined) {
           const pathItems = readMessagePathItems(messageEvents, this.#xParsedPath, mathFn);
 
-          this.#pendingDataDispatch.push({
+          this.#pendingDispatch.push({
             type: "append-full-x",
             items: pathItems,
           });
@@ -153,7 +153,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
           : undefined;
 
         if (series.blockCursor.nextWillReset(blocks)) {
-          this.#pendingDataDispatch.push({
+          this.#pendingDispatch.push({
             type: "reset-full",
             series: series.config.key,
           });
@@ -163,7 +163,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
         while ((messageEvents = series.blockCursor.next(blocks)) != undefined) {
           const pathItems = readMessagePathItems(messageEvents, series.config.parsed, mathFn);
 
-          this.#pendingDataDispatch.push({
+          this.#pendingDispatch.push({
             type: "append-full",
             series: series.config.key,
             items: pathItems,
@@ -195,11 +195,11 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
       this.#xValuesCursor = undefined;
     }
 
-    this.#pendingDataDispatch.push({
+    this.#pendingDispatch.push({
       type: "reset-current-x",
     });
 
-    this.#pendingDataDispatch.push({
+    this.#pendingDispatch.push({
       type: "reset-full-x",
     });
   }
@@ -213,7 +213,7 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
       };
     });
 
-    this.#pendingDataDispatch.push({
+    this.#pendingDispatch.push({
       type: "update-series-config",
       seriesItems: series,
     });
@@ -222,9 +222,9 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
   public async getViewportDatasets(
     viewport: Immutable<Viewport>,
   ): Promise<GetViewportDatasetsResult> {
-    const dispatch = this.#pendingDataDispatch;
+    const dispatch = this.#pendingDispatch;
     if (dispatch.length > 0) {
-      this.#pendingDataDispatch = [];
+      this.#pendingDispatch = [];
       await this.#datasetsBuilderRemote.updateData(dispatch);
     }
 

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilderImpl.ts
@@ -75,7 +75,13 @@ type UpdateSeriesFullAction = {
   items: ValueItem[];
 };
 
+type UpdateSeriesConfigAction = {
+  type: "update-series-config";
+  seriesItems: SeriesItem[];
+};
+
 export type UpdateDataAction =
+  | UpdateSeriesConfigAction
   | ResetSeriesFullAction
   | ResetSeriesCurrentAction
   | ResetCurrentXAction
@@ -100,25 +106,6 @@ export class CustomDatasetsBuilderImpl {
     for (const action of actions) {
       this.#applyAction(action);
     }
-  }
-
-  public setSeries(series: Immutable<SeriesItem[]>): void {
-    // Make a new map so we drop series which are no longer present
-    const newSeries = new Map();
-
-    for (const config of series) {
-      let existingSeries = this.#seriesByKey.get(config.key);
-      if (!existingSeries) {
-        existingSeries = {
-          config,
-          current: [],
-          full: [],
-        };
-      }
-      newSeries.set(config.key, existingSeries);
-      existingSeries.config = config;
-    }
-    this.#seriesByKey = newSeries;
   }
 
   public getViewportDatasets(viewport: Immutable<Viewport>): GetViewportDatasetsResult {
@@ -417,7 +404,30 @@ export class CustomDatasetsBuilderImpl {
             series.current.splice(0, idx);
           }
         }
+        break;
       }
+      case "update-series-config":
+        this.#updateSeriesConfigAction(action.seriesItems);
+        break;
     }
+  }
+
+  #updateSeriesConfigAction(series: Immutable<SeriesItem[]>): void {
+    // Make a new map so we drop series which are no longer present
+    const newSeries = new Map();
+
+    for (const config of series) {
+      let existingSeries = this.#seriesByKey.get(config.key);
+      if (!existingSeries) {
+        existingSeries = {
+          config,
+          current: [],
+          full: [],
+        };
+      }
+      newSeries.set(config.key, existingSeries);
+      existingSeries.config = config;
+    }
+    this.#seriesByKey = newSeries;
   }
 }

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -180,7 +180,10 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
       };
     });
 
-    void this.#datasetsBuilderRemote.setSeries(series);
+    this.#pendingDataDispatch.push({
+      type: "update-series-config",
+      seriesItems: series,
+    });
   }
 
   public async getViewportDatasets(

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -52,7 +52,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
   #datasetsBuilderWorker: Worker;
   #datasetsBuilderRemote: Comlink.Remote<Comlink.RemoteObject<TimestampDatasetsBuilderImpl>>;
 
-  #pendingDataDispatch: Immutable<UpdateDataAction>[] = [];
+  #pendingDispatch: Immutable<UpdateDataAction>[] = [];
 
   #lastSeekTime = 0;
 
@@ -85,7 +85,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
           : undefined;
 
         if (didSeek) {
-          this.#pendingDataDispatch.push({
+          this.#pendingDispatch.push({
             type: "reset-current",
             series: series.config.key,
           });
@@ -99,7 +99,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
           mathFn,
         );
 
-        this.#pendingDataDispatch.push({
+        this.#pendingDispatch.push({
           type: "append-current",
           series: series.config.key,
           items: pathItems,
@@ -118,7 +118,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
     // identify if series need resetting because
     for (const series of this.#series) {
       if (series.blockCursor.nextWillReset(blocks)) {
-        this.#pendingDataDispatch.push({
+        this.#pendingDispatch.push({
           type: "reset-full",
           series: series.config.key,
         });
@@ -157,7 +157,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
           continue;
         }
 
-        this.#pendingDataDispatch.push({
+        this.#pendingDispatch.push({
           type: "append-full",
           series: series.config.key,
           items: pathItems,
@@ -180,7 +180,7 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
       };
     });
 
-    this.#pendingDataDispatch.push({
+    this.#pendingDispatch.push({
       type: "update-series-config",
       seriesItems: series,
     });
@@ -189,9 +189,9 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
   public async getViewportDatasets(
     viewport: Immutable<Viewport>,
   ): Promise<GetViewportDatasetsResult> {
-    const dispatch = this.#pendingDataDispatch;
+    const dispatch = this.#pendingDispatch;
     if (dispatch.length > 0) {
-      this.#pendingDataDispatch = [];
+      this.#pendingDispatch = [];
       await this.#datasetsBuilderRemote.applyActions(dispatch);
     }
 


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
The TimestampDatasetsBuilder and CustomDatasetsBuilder need to send the series configuration to their respective workers. Prior to this change this was done with a call to `setSeries` on the exposed RPC interface with a _void_ since this call happened in an async function that did not wait. This change moves the call into an update action so it can be dispatched with an await like the other pending update actions and be captured by whatever error mechanism captures the async function containing the dispatched calls.

---
I think this is a good change given our current dispatch structure but it did make me realize that we could use the browser postMessage calls as our queue manager rather than async/await these dispatches over RPC. Practically we don't care about the response value from the receiver - only that we sent it to the receiver. I suppose there is an aspect around getting the latest downsampled datasets that cares that the receiver has gotten all the latest updates (at least for series config). Nothing I would change in our structure yet but something to think about with respect to how we leverage workers.