### PR TITLE
Remove stale comment

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,7 +43,6 @@ const storybookConfig: StorybookConfig = {
     );
     return {
       ...config,
-      // context is required for ForkTsCheckerWebpackPlugin to find .storybook/tsconfig.json
       optimization: {
         ...config.optimization,
         minimize: false, // disabling minification improves build performance


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Removes a stale comment from webpack config. We used to override `context`, but that was removed in #5874.