### PR TITLE
(fix) handle empty min/maxYValue strings

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
@@ -332,8 +332,6 @@
           "timestampMethod": "headerStamp"
         }
       ],
-      "minYValue": "",
-      "maxYValue": "",
       "showLegend": true,
       "isSynced": true,
       "xAxisVal": "timestamp",
@@ -367,8 +365,6 @@
           "timestampMethod": "headerStamp"
         }
       ],
-      "minYValue": "",
-      "maxYValue": "",
       "showLegend": true,
       "isSynced": true,
       "xAxisVal": "timestamp",

--- a/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
@@ -184,12 +184,13 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
       },
       y: {
         max:
-          config.maxYValue == undefined || (typeof config.maxYValue === 'string' && config.maxYValue.length === 0)
-
+          config.maxYValue == undefined ||
+          (typeof config.maxYValue === "string" && config.maxYValue.length === 0)
             ? undefined
             : +config.maxYValue,
         min:
-          config.minYValue == undefined || (typeof config.minYValue === 'string' && config.minYValue.length === 0)
+          config.minYValue == undefined ||
+          (typeof config.minYValue === "string" && config.minYValue.length === 0)
             ? undefined
             : +config.minYValue,
       },

--- a/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
+++ b/packages/studio-base/src/panels/Plot/PlotCoordinator.ts
@@ -183,8 +183,15 @@ export class PlotCoordinator extends EventEmitter<EventTypes> {
         min: config.minXValue,
       },
       y: {
-        max: config.maxYValue == undefined ? undefined : +config.maxYValue,
-        min: config.minYValue == undefined ? undefined : +config.minYValue,
+        max:
+          config.maxYValue == undefined || (typeof config.maxYValue === 'string' && config.maxYValue.length === 0)
+
+            ? undefined
+            : +config.maxYValue,
+        min:
+          config.minYValue == undefined || (typeof config.minYValue === 'string' && config.minYValue.length === 0)
+            ? undefined
+            : +config.minYValue,
       },
     };
     const configYBoundsChanged =

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -596,6 +596,33 @@ export const WithJustMaxYValueLessThanMinimumValue: StoryObj = {
   },
 };
 
+export const WithEmptyStringMinMaxValue: StoryObj = {
+  render: function Story() {
+    return (
+      <PlotWrapper
+        config={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+          minYValue: "",
+          maxYValue: "",
+        }}
+      />
+    );
+  },
+
+  name: "with empty string min and max y values",
+
+  parameters: {
+    colorScheme: "light",
+  },
+};
+
 export const IndexBasedXAxisForArray: StoryObj = {
   render: function Story() {
     return (


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- FIX: Empty plot configuration string values for minYValue and maxYValue led to an initially rendered Y scale of 0-0

**Description**
The minYValue and maxYValue type currently supports number _or_ string, but empty strings were cast to 0 when creating the Y-bounds on the Plot for demo data. This led to y bounds of min: 0 and max: 0 (rather than defaulting to auto scale). I removed the empty string values from the test data and added a Storybook case to cover backwards compatibility.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
