### PR TITLE
Adjust settings tree behavior to allow horizontal scrolling

### DIFF
--- a/packages/studio-base/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete/Autocomplete.tsx
@@ -71,6 +71,9 @@ const useStyles = makeStyles()((theme) => ({
       color: theme.palette.error.main,
     },
   },
+  popper: {
+    maxWidth: `calc(100vw - ${theme.spacing(2)})`,
+  },
 }));
 
 const EMPTY_SET = new Set<number>();
@@ -99,8 +102,14 @@ const getOptionLabel = (item: string | FzfResultItem) =>
 // the width. We want to set the minWidth to allow the popper to grow wider than the input field width,
 // so we can show long topic paths and autocomplete entries.
 const CustomPopper = function (props: PopperProps) {
-  const width = props.style?.width ?? 0;
-  return <Popper {...props} style={{ minWidth: width }} placement="bottom-start" />;
+  const { classes, cx } = useStyles();
+  return (
+    <Popper
+      {...props}
+      className={cx(props.className, classes.popper)}
+      style={{ minWidth: props.style?.width ?? 0 }}
+    />
+  );
 };
 
 /**
@@ -204,6 +213,7 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
       className={className}
       componentsProps={{
         paper: { elevation: 8 },
+        popper: { placement: "bottom-start" },
       }}
       getOptionLabel={getOptionLabel}
       disableCloseOnSelect

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -2,18 +2,17 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Divider, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useUnmount } from "react-use";
+import { makeStyles } from "tss-react/mui";
 
-import { SettingsTree } from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import { ActionMenu } from "@foxglove/studio-base/components/PanelSettings/ActionMenu";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import { ShareJsonModal } from "@foxglove/studio-base/components/ShareJsonModal";
-import Stack from "@foxglove/studio-base/components/Stack";
 import {
   LayoutState,
   useCurrentLayoutActions,
@@ -36,16 +35,34 @@ const singlePanelIdSelector = (state: LayoutState) =>
 
 const selectIncrementSequenceNumber = (store: PanelStateStore) => store.incrementSequenceNumber;
 
-const EMPTY_SETTINGS_TREE: SettingsTree = Object.freeze({
-  actionHandler: () => undefined,
-  nodes: {},
-});
+// const EMPTY_SETTINGS_TREE: SettingsTree = Object.freeze({
+//   actionHandler: () => undefined,
+//   nodes: {},
+// });
+
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "flex",
+    position: "relative",
+    flexDirection: "column",
+    height: "100%",
+    flex: "auto",
+  },
+  toolbar: {
+    display: "flex",
+    paddingLeft: theme.spacing(0.75),
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+}));
 
 export default function PanelSettings({
   selectedPanelIdsForTests,
 }: React.PropsWithChildren<{
   selectedPanelIdsForTests?: readonly string[];
 }>): JSX.Element {
+  const { classes } = useStyles();
   const { t } = useTranslation("panelSettings");
   const singlePanelId = useCurrentLayoutSelector(singlePanelIdSelector);
   const {
@@ -143,48 +160,33 @@ export default function PanelSettings({
   const showTitleField = panelInfo != undefined && panelInfo.hasCustomToolbar !== true;
   const title = panelInfo?.title ?? t("unknown");
 
+  if (!settingsTree) {
+    return (
+      <div className={classes.root}>
+        <EmptyState>{t("panelDoesNotHaveSettings")}</EmptyState>
+      </div>
+    );
+  }
+
   return (
-    <Stack fullHeight flex="auto" gap={1}>
+    <div className={classes.root}>
       {shareModal}
-      <Stack gap={2} justifyContent="flex-start" flex="auto">
-        <Stack flex="auto">
-          {settingsTree && (
-            <>
-              <Stack
-                paddingLeft={0.75}
-                direction="row"
-                alignItems="center"
-                justifyContent="space-between"
-              >
-                <Typography variant="subtitle2">{t("panelName", { title })}</Typography>
-                <ActionMenu
-                  key={1}
-                  fontSize="small"
-                  allowShare={panelType !== TAB_PANEL_TYPE}
-                  onReset={resetToDefaults}
-                  onShare={() => {
-                    setShowShareModal(true);
-                  }}
-                />
-              </Stack>
-              <Divider />
-            </>
-          )}
-          {settingsTree != undefined || showTitleField ? (
-            <SettingsTreeEditor
-              variant="panel"
-              key={selectedPanelId}
-              settings={settingsTree ?? EMPTY_SETTINGS_TREE}
-            />
-          ) : (
-            <Stack flex="auto" alignItems="center" justifyContent="center" paddingX={1}>
-              <Typography variant="body2" color="text.secondary" align="center">
-                {t("panelDoesNotHaveSettings")}
-              </Typography>
-            </Stack>
-          )}
-        </Stack>
-      </Stack>
-    </Stack>
+      <header className={classes.toolbar}>
+        <Typography variant="subtitle2">{t("panelName", { title })}</Typography>
+        <ActionMenu
+          key={1}
+          fontSize="small"
+          allowShare={panelType !== TAB_PANEL_TYPE}
+          onReset={resetToDefaults}
+          onShare={() => {
+            setShowShareModal(true);
+          }}
+        />
+      </header>
+
+      {showTitleField && (
+        <SettingsTreeEditor variant="panel" key={selectedPanelId} settings={settingsTree} />
+      )}
+    </div>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -58,6 +58,7 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => ({
   fieldWrapper: {
     minWidth: theme.spacing(14),
     marginRight: theme.spacing(0.5),
+
     [`&.${classes.error} .MuiInputBase-root, .MuiInputBase-root.${classes.error}`]: {
       outline: `1px ${theme.palette.error.main} solid`,
       outlineOffset: -1,
@@ -75,7 +76,6 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => ({
   styledToggleButtonGroup: {
     backgroundColor: theme.palette.action.hover,
     gap: theme.spacing(0.25),
-    overflowX: "auto",
 
     "& .MuiToggleButtonGroup-grouped": {
       margin: theme.spacing(0.55),

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   fieldGrid: {
     display: "grid",
-    gridTemplateColumns: "minmax(20%, 20ch) auto",
+    gridTemplateColumns: "max-content minmax(180px, 2fr)",
     columnGap: theme.spacing(1),
   },
   textField: {
@@ -114,7 +114,7 @@ export default function SettingsTreeEditor({
     filterText.length === 0 && panelInfo?.hasCustomToolbar !== true && variant !== "log";
 
   return (
-    <Stack fullHeight>
+    <Stack flex="auto" overflow="auto">
       {settings.enableFilter === true && (
         <header className={classes.appBar}>
           <TextField

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -25,6 +25,8 @@ import { filterTreeNodes, prepareSettingsNodes } from "./utils";
 const useStyles = makeStyles()((theme) => ({
   appBar: {
     top: 0,
+    rigtht: 0,
+    left: 0,
     marginRight: 1,
     zIndex: theme.zIndex.appBar,
     padding: theme.spacing(0.5),
@@ -33,7 +35,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   fieldGrid: {
     display: "grid",
-    gridTemplateColumns: "max-content minmax(180px, 2fr)",
+    gridTemplateColumns: "minmax(96px, auto) minmax(180px, 2fr)",
     columnGap: theme.spacing(1),
   },
   textField: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   fieldGrid: {
     display: "grid",
-    gridTemplateColumns: "minmax(96px, auto) minmax(180px, 2fr)",
+    gridTemplateColumns: `minmax(${theme.spacing(6)}, auto) minmax(${theme.spacing(12)}, 1fr)`,
     columnGap: theme.spacing(1),
   },
   textField: {

--- a/packages/studio-base/src/components/Sidebars/Sidebar.tsx
+++ b/packages/studio-base/src/components/Sidebars/Sidebar.tsx
@@ -2,16 +2,32 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import CloseIcon from "@mui/icons-material/Close";
-import { Badge, BadgeProps, Divider, IconButton, Tab, Tabs } from "@mui/material";
+import { Dismiss12Filled } from "@fluentui/react-icons";
+import {
+  Badge,
+  BadgeProps,
+  Divider,
+  IconButton,
+  Tab,
+  Tabs,
+  tabClasses,
+  tabsClasses,
+} from "@mui/material";
 import { makeStyles } from "tss-react/mui";
-
-import Stack from "@foxglove/studio-base/components/Stack";
 
 const useStyles = makeStyles()((theme) => ({
   root: {
+    display: "flex",
+    flexDirection: "column",
+    flexShrink: 0,
+    overflow: "hidden",
     boxSizing: "content-box",
     backgroundColor: theme.palette.background.paper,
+  },
+  toolbar: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   badgeRoot: {
     display: "flex",
@@ -40,11 +56,11 @@ const useStyles = makeStyles()((theme) => ({
     overflow: "hidden",
     paddingLeft: theme.spacing(0.25),
 
-    ".MuiTabs-indicator": {
+    [`.${tabsClasses.indicator}`]: {
       transform: "scaleX(0.5)",
       height: 2,
     },
-    ".MuiTab-root": {
+    [`.${tabClasses.root}`]: {
       minHeight: 30,
       minWidth: theme.spacing(4),
       padding: theme.spacing(0, 1),
@@ -57,7 +73,7 @@ const useStyles = makeStyles()((theme) => ({
     },
   },
   iconButton: {
-    padding: theme.spacing(0.91125), // round out the overall height to 30px
+    padding: theme.spacing(1.125),
     color: theme.palette.text.secondary,
     borderRadius: 0,
 
@@ -102,16 +118,14 @@ export function Sidebar<K extends string>({
   const SelectedComponent = (activeTab && items.get(activeTab)?.component) ?? Noop;
 
   return (
-    <Stack
+    <div
+      data-tourid={`sidebar-${anchor}`}
       className={cx(classes.root, {
         [classes.anchorLeft]: anchor === "left",
         [classes.anchorRight]: anchor === "right",
       })}
-      flexShrink={0}
-      overflow="hidden"
-      data-tourid={`sidebar-${anchor}`}
     >
-      <Stack direction="row" justifyContent="space-between" alignItems="center">
+      <div className={classes.toolbar}>
         <Tabs
           className={classes.tabs}
           textColor="inherit"
@@ -148,18 +162,17 @@ export function Sidebar<K extends string>({
         <IconButton
           className={classes.iconButton}
           onClick={onClose}
-          size="small"
           data-testid={`sidebar-close-${anchor}`}
         >
-          <CloseIcon fontSize="inherit" />
+          <Dismiss12Filled />
         </IconButton>
-      </Stack>
+      </div>
       <Divider />
       {activeTab != undefined && (
         <div className={classes.tabContent}>
           <SelectedComponent />
         </div>
       )}
-    </Stack>
+    </div>
   );
 }

--- a/packages/studio-base/src/components/Sidebars/Sidebar.tsx
+++ b/packages/studio-base/src/components/Sidebars/Sidebar.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Dismiss12Filled } from "@fluentui/react-icons";
+import { Dismiss12Regular } from "@fluentui/react-icons";
 import {
   Badge,
   BadgeProps,
@@ -164,7 +164,7 @@ export function Sidebar<K extends string>({
           onClick={onClose}
           data-testid={`sidebar-close-${anchor}`}
         >
-          <Dismiss12Filled />
+          <Dismiss12Regular />
         </IconButton>
       </div>
       <Divider />


### PR DESCRIPTION
**User-Facing Changes**
None

#### Before

https://github.com/foxglove/studio/assets/924528/e1d067fe-bd73-453d-a487-e33f7a648df3

#### After

https://github.com/foxglove/studio/assets/924528/60498d34-19ac-4314-87d6-f950a2c11c52

**Description**
Instead of allowing settings sidebar to be infinitely collapsed until the label/form is not visible set a min width on them and allow horizontal scrolling


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
