### PR TITLE
fix: foxglove websocket player incorrect startTime

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -203,6 +203,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (this.#closed) {
         return;
       }
+      log.info("opened connection");
       if (this.#connectionAttemptTimeout != undefined) {
         clearTimeout(this.#connectionAttemptTimeout);
       }
@@ -299,6 +300,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#serverPublishesTime = this.#serverCapabilities.includes(ServerCapability.time);
       this.#supportedEncodings = event.supportedEncodings;
       this.#datatypes = new Map();
+
+      // Clear the thopics which makes us request them again
+      // and has the side-effect that we don't emit without a time update
+      // fixme - this is annoying because it will thrash the display
+      this.#topics = undefined;
 
       // If the server publishes the time we clear any existing clockTime we might have and let the
       // server override
@@ -846,9 +852,16 @@ export default class FoxgloveWebSocketPlayer implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   #emitState = debouncePromise(() => {
+    // When the connection closes, we should not emit anoyher state update because it will override the startTime?
+    //
+
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
+
+    // the reason this does not break us on startup is because this #topics gate
+    // has stopped us from emitting anything until we have the list of topics
+    // so we never set the startTime to 0
 
     if (!this.#topics) {
       return this.#listener({
@@ -865,6 +878,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
 
     const currentTime = this.#getCurrentTime();
+    // currentTime starts as 0, then with sim time mode we get a new current time
+    // and this new currentTime is going to be > the start time and the start time is still set to 0
     if (!this.#startTime || isLessThan(currentTime, this.#startTime)) {
       this.#startTime = currentTime;
     }
@@ -1285,6 +1300,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   #resetSessionState(): void {
+    log.info("Reset session state");
     this.#startTime = undefined;
     this.#endTime = undefined;
     this.#clockTime = undefined;

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -203,7 +203,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (this.#closed) {
         return;
       }
-      log.info("opened connection");
       if (this.#connectionAttemptTimeout != undefined) {
         clearTimeout(this.#connectionAttemptTimeout);
       }
@@ -854,16 +853,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   #emitState = debouncePromise(() => {
-    // When the connection closes, we should not emit anoyher state update because it will override the startTime?
-    //
-
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
-
-    // the reason this does not break us on startup is because this #topics gate
-    // has stopped us from emitting anything until we have the list of topics
-    // so we never set the startTime to 0
 
     if (!this.#topics) {
       return this.#listener({
@@ -880,8 +872,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
 
     const currentTime = this.#getCurrentTime();
-    // currentTime starts as 0, then with sim time mode we get a new current time
-    // and this new currentTime is going to be > the start time and the start time is still set to 0
     if (!this.#startTime || isLessThan(currentTime, this.#startTime)) {
       this.#startTime = currentTime;
     }
@@ -1302,7 +1292,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   #resetSessionState(): void {
-    log.info("Reset session state");
+    log.debug("Reset session state");
     this.#startTime = undefined;
     this.#endTime = undefined;
     this.#clockTime = undefined;

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -301,11 +301,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this.#supportedEncodings = event.supportedEncodings;
       this.#datatypes = new Map();
 
-      // Clear the thopics which makes us request them again
-      // and has the side-effect that we don't emit without a time update
-      // fixme - this is annoying because it will thrash the display
-      this.#topics = undefined;
-
       // If the server publishes the time we clear any existing clockTime we might have and let the
       // server override
       if (this.#serverPublishesTime) {
@@ -603,6 +598,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this.#numTimeSeeks++;
         this.#parsedMessages = [];
         this.#parsedMessagesBytes = 0;
+      }
+
+      // Override any previous start/end time when we set a clockTime for the first time which means
+      // we've received the first "time" event and know the server controlled time.
+      if (!this.#clockTime) {
+        this.#startTime = time;
+        this.#endTime = time;
       }
 
       this.#clockTime = time;


### PR DESCRIPTION
**User-Facing Changes**
Fix the startTime behavior for foxglove websocket player when a connection is reset.

**Description**
The foxglove websocket player produces an incorrect _startTime_ (of 0) when a new session is started that uses "clock" time leading to incorrect plot displays like this: https://github.com/foxglove/studio/issues/7406

This behavior occurs because the state emit updates the `startTime` to the `currentTime` when the currentTime is less than the startTime:
https://github.com/foxglove/studio/blob/main/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts#L869

During a session reset, the currentTime is cleared and the #clockTime is cleared (https://github.com/foxglove/studio/blob/main/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts#L1290) so when the emit computes the currentTime it uses `ZERO_TIME` (https://github.com/foxglove/studio/blob/main/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts#L1186) to set startTime and never updates it again.

The reason this does _not_ happen for the first connection to the server is because topics are not yet available and the player emit bails early:
https://github.com/foxglove/studio/blob/main/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts#L853

On subsequent re-connections, topics are already available and the logic to set `startTime` runs before any clock message is received.

This PR updates the client `time` event handler to re-set the `startTime` and `endTime` on the first setting of `clockTime`. Since `clockTime` will be used for subsequent calls to `getCurrentTime` this results in a `startTime` that is properly updated to a server specified clock time instead of `ZERO_TIME`.

Fixes: #7406