### PR TITLE
avoid creating temporary comlink proxies

### DIFF
--- a/packages/studio-base/src/panels/Plot/OffscreenCanvasRenderer.ts
+++ b/packages/studio-base/src/panels/Plot/OffscreenCanvasRenderer.ts
@@ -21,6 +21,9 @@ const registry = new FinalizationRegistry<() => void>((dispose) => {
 export class OffscreenCanvasRenderer {
   #canvas: OffscreenCanvas;
   #remote: Promise<Comlink.RemoteObject<ChartRenderer>>;
+  #remoteUpdate?: Comlink.Remote<ChartRenderer["update"]>;
+  #remoteGetElementsAtPixel?: Comlink.Remote<ChartRenderer["getElementsAtPixel"]>;
+  #remoteUpdateDatasets?: Comlink.Remote<ChartRenderer["updateDatasets"]>;
 
   #theme: Theme;
 
@@ -52,14 +55,23 @@ export class OffscreenCanvasRenderer {
   }
 
   public async update(action: Immutable<UpdateAction>): Promise<Bounds | undefined> {
-    return await (await this.#remote).update(action);
+    if (!this.#remoteUpdate) {
+      this.#remoteUpdate = (await this.#remote).update;
+    }
+    return await this.#remoteUpdate(action);
   }
 
   public async getElementsAtPixel(pixel: { x: number; y: number }): Promise<HoverElement[]> {
-    return await (await this.#remote).getElementsAtPixel(pixel);
+    if (!this.#remoteGetElementsAtPixel) {
+      this.#remoteGetElementsAtPixel = (await this.#remote).getElementsAtPixel;
+    }
+    return await this.#remoteGetElementsAtPixel(pixel);
   }
 
   public async updateDatasets(datasets: Dataset[]): Promise<Scale | undefined> {
-    return await (await this.#remote).updateDatasets(datasets);
+    if (!this.#remoteUpdateDatasets) {
+      this.#remoteUpdateDatasets = (await this.#remote).updateDatasets;
+    }
+    return await this.#remoteUpdateDatasets(datasets);
   }
 }

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -43,7 +43,9 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
   #xParsedPath?: Immutable<MessagePath>;
   #xValuesCursor?: BlockTopicCursor;
 
-  #datasetsBuilderRemote: Comlink.Remote<Comlink.RemoteObject<CustomDatasetsBuilderImpl>>;
+  #remoteUpdateData: Comlink.Remote<CustomDatasetsBuilderImpl["updateData"]>;
+  #remoteGetViewportDatasets: Comlink.Remote<CustomDatasetsBuilderImpl["getViewportDatasets"]>;
+  #remoteGetCsvData: Comlink.Remote<CustomDatasetsBuilderImpl["getCsvData"]>;
 
   #pendingDispatch: Immutable<UpdateDataAction>[] = [];
 
@@ -62,7 +64,9 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
     const { remote, dispose } =
       ComlinkWrap<Comlink.RemoteObject<CustomDatasetsBuilderImpl>>(worker);
 
-    this.#datasetsBuilderRemote = remote;
+    this.#remoteUpdateData = remote.updateData;
+    this.#remoteGetViewportDatasets = remote.getViewportDatasets;
+    this.#remoteGetCsvData = remote.getCsvData;
     registry.register(this, dispose);
   }
 
@@ -227,14 +231,14 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
     const dispatch = this.#pendingDispatch;
     if (dispatch.length > 0) {
       this.#pendingDispatch = [];
-      await this.#datasetsBuilderRemote.updateData(dispatch);
+      await this.#remoteUpdateData(dispatch);
     }
 
-    return await this.#datasetsBuilderRemote.getViewportDatasets(viewport);
+    return await this.#remoteGetViewportDatasets(viewport);
   }
 
   public async getCsvData(): Promise<CsvDataset[]> {
-    return await this.#datasetsBuilderRemote.getCsvData();
+    return await this.#remoteGetCsvData();
   }
 }
 

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -50,13 +50,15 @@ type TimestampSeriesItem = {
  * downsampled data.
  */
 export class TimestampDatasetsBuilder implements IDatasetsBuilder {
-  #datasetsBuilderRemote: Comlink.Remote<Comlink.RemoteObject<TimestampDatasetsBuilderImpl>>;
-
   #pendingDispatch: Immutable<UpdateDataAction>[] = [];
 
   #lastSeekTime = 0;
 
   #series: Immutable<TimestampSeriesItem[]> = [];
+
+  #remoteApplyActions: Comlink.Remote<TimestampDatasetsBuilderImpl["applyActions"]>;
+  #remoteGetViewportDatasets: Comlink.Remote<TimestampDatasetsBuilderImpl["getViewportDatasets"]>;
+  #remoteGetCsvData: Comlink.Remote<TimestampDatasetsBuilderImpl["getCsvData"]>;
 
   public constructor() {
     const worker = new Worker(
@@ -65,7 +67,9 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
     );
     const { remote, dispose } =
       ComlinkWrap<Comlink.RemoteObject<TimestampDatasetsBuilderImpl>>(worker);
-    this.#datasetsBuilderRemote = remote;
+    this.#remoteApplyActions = remote.applyActions;
+    this.#remoteGetViewportDatasets = remote.getViewportDatasets;
+    this.#remoteGetCsvData = remote.getCsvData;
 
     registry.register(this, dispose);
   }
@@ -194,15 +198,15 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
     const dispatch = this.#pendingDispatch;
     if (dispatch.length > 0) {
       this.#pendingDispatch = [];
-      await this.#datasetsBuilderRemote.applyActions(dispatch);
+      await this.#remoteApplyActions(dispatch);
     }
 
-    const datasets = await this.#datasetsBuilderRemote.getViewportDatasets(viewport);
+    const datasets = await this.#remoteGetViewportDatasets(viewport);
     return { datasetsByConfigIndex: datasets, pathsWithMismatchedDataLengths: emptyPaths };
   }
 
   public async getCsvData(): Promise<CsvDataset[]> {
-    return await this.#datasetsBuilderRemote.getCsvData();
+    return await this.#remoteGetCsvData();
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
@@ -21,7 +21,7 @@ import { Image as RosImage } from "../../ros";
 
 type WorkerService = (typeof import("./WorkerImageDecoder.worker"))["service"];
 export class WorkerImageDecoder {
-  #remote: Comlink.Remote<WorkerService>;
+  #remoteDecode: Comlink.Remote<WorkerService["decode"]>;
   #dispose: () => void;
 
   public constructor() {
@@ -31,7 +31,7 @@ export class WorkerImageDecoder {
         new URL("./WorkerImageDecoder.worker", import.meta.url),
       ),
     );
-    this.#remote = remote;
+    this.#remoteDecode = remote.decode;
     this.#dispose = dispose;
   }
 
@@ -42,7 +42,7 @@ export class WorkerImageDecoder {
     image: RosImage | RawImage,
     options: Partial<RawImageOptions>,
   ): Promise<ImageData> {
-    return await this.#remote.decode(image, options);
+    return await this.#remoteDecode(image, options);
   }
 
   public terminate(): void {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
@@ -103,21 +103,33 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
     // making the abort signal available within the worker.
     const { abort, ...rest } = args;
     const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(rest, abort);
+    let remoteNext: Comlink.Remote<IMessageCursor["next"]> | undefined;
+    let remoteNextBatch: Comlink.Remote<IMessageCursor["nextBatch"]> | undefined;
+    let remoteReadUntil: Comlink.Remote<IMessageCursor["readUntil"]> | undefined;
 
     const cursor: IMessageCursor = {
       async next() {
-        const messageCursor = await messageCursorPromise;
-        return await messageCursor.next();
+        if (!remoteNext) {
+          const messageCursor = await messageCursorPromise;
+          remoteNext = messageCursor.next;
+        }
+        return await remoteNext();
       },
 
       async nextBatch(durationMs: number) {
-        const messageCursor = await messageCursorPromise;
-        return await messageCursor.nextBatch(durationMs);
+        if (!remoteNextBatch) {
+          const messageCursor = await messageCursorPromise;
+          remoteNextBatch = messageCursor.nextBatch;
+        }
+        return await remoteNextBatch(durationMs);
       },
 
       async readUntil(end: Time) {
-        const messageCursor = await messageCursorPromise;
-        return await messageCursor.readUntil(end);
+        if (!remoteReadUntil) {
+          const messageCursor = await messageCursorPromise;
+          remoteReadUntil = messageCursor.readUntil;
+        }
+        return await remoteReadUntil(end);
       },
 
       async end() {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -104,21 +104,33 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
     // making the abort signal available within the worker.
     const { abort, ...rest } = args;
     const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(rest, abort);
+    let remoteNext: Comlink.Remote<IMessageCursor<Uint8Array>["next"]> | undefined;
+    let remoteNextBatch: Comlink.Remote<IMessageCursor<Uint8Array>["nextBatch"]> | undefined;
+    let remoteReadUntil: Comlink.Remote<IMessageCursor<Uint8Array>["readUntil"]> | undefined;
 
     const cursor: IMessageCursor<Uint8Array> = {
       async next() {
-        const messageCursor = await messageCursorPromise;
-        return await messageCursor.next();
+        if (!remoteNext) {
+          const messageCursor = await messageCursorPromise;
+          remoteNext = messageCursor.next;
+        }
+        return await remoteNext();
       },
 
       async nextBatch(durationMs: number) {
-        const messageCursor = await messageCursorPromise;
-        return await messageCursor.nextBatch(durationMs);
+        if (!remoteNextBatch) {
+          const messageCursor = await messageCursorPromise;
+          remoteNextBatch = messageCursor.nextBatch;
+        }
+        return await remoteNextBatch(durationMs);
       },
 
       async readUntil(end: Time) {
-        const messageCursor = await messageCursorPromise;
-        return await messageCursor.readUntil(end);
+        if (!remoteReadUntil) {
+          const messageCursor = await messageCursorPromise;
+          remoteReadUntil = messageCursor.readUntil;
+        }
+        return await remoteReadUntil(end);
       },
 
       async end() {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When using Comlink to wrap a remote interface, there is a subtle difference in usage which can lead to [new temporary proxy being created](https://github.com/foxglove/comlink/blob/9181fa505671b35b1e66e0a8361a6fc1bdd03307/src/comlink.ts#L499) for every function call:

```ts
const remote = comlink.wrap(new Worker("..."));
for (...) {
  await remote.someFunc();  // creates a temporary proxy on every call
}
```

This can be avoided by creating the proxy only once:
```ts
const remoteSomeFunc = remote.someFunc;  // create the proxy once
for (...) {
  await remoteSomeFunc();  // no temporary proxy created
}
```
The second usage is generally to be preferred as it avoids creating temporary proxies. While the performance overhead of creating temporary proxies is probably negligible, it does have some impact on garbage collection time as more objects have to be freed.

This PR changes all Comlink usage to avoid creation of temporary proxies. Since this pitfall is everything but obvious, we could also (or instead) consider to patch our Comlink fork to avoid temporary proxy creation.

Internal tracking issue: FG-6370







