### PR TITLE
unindexed mcap: Fix double transfer of array buffers

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -284,7 +284,7 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
           resultMessages.push({
             type: "message-event" as const,
             connectionId: channelId,
-            msgEvent,
+            msgEvent: structuredClone(msgEvent),
           });
         }
       }
@@ -308,7 +308,7 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
     for (const [, msgEvents] of this.#msgEventsByChannel) {
       for (const msgEvent of msgEvents) {
         if (compare(msgEvent.receiveTime, args.time) <= 0 && needTopics.has(msgEvent.topic)) {
-          msgEventsByTopic.set(msgEvent.topic, msgEvent);
+          msgEventsByTopic.set(msgEvent.topic, structuredClone(msgEvent));
         }
       }
     }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -284,6 +284,8 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
           resultMessages.push({
             type: "message-event" as const,
             connectionId: channelId,
+            // We copy the message event here as we are transferring the underlying array buffer
+            // to the main thread which invalidates it.
             msgEvent: structuredClone(msgEvent),
           });
         }
@@ -308,6 +310,8 @@ export class McapUnindexedIterableSource implements ISerializedIterableSource {
     for (const [, msgEvents] of this.#msgEventsByChannel) {
       for (const msgEvent of msgEvents) {
         if (compare(msgEvent.receiveTime, args.time) <= 0 && needTopics.has(msgEvent.topic)) {
+          // We copy the message event here as we are transferring the underlying array buffer
+          // to the main thread which invalidates it.
           msgEventsByTopic.set(msgEvent.topic, structuredClone(msgEvent));
         }
       }


### PR DESCRIPTION
**User-Facing Changes**
None (regression hasn't been released yet)

**Description**
Fixes message array buffers being invalidated as they are transferred. The unindexed mcap iterable source stores messages in memory, so we cannot transfer these buffers away. Solution: `structureClone` these message events in the message iterator.