### PR TITLE
Transfer array buffers of serialized back fill messsages

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
@@ -18,6 +18,8 @@ import type {
 } from "./IIterableSource";
 import { IteratorCursor } from "./IteratorCursor";
 
+const pickTransferableBuffer = (msg: MessageEvent<Uint8Array>) => msg.message.buffer;
+
 export class WorkerSerializedIterableSourceWorker implements ISerializedIterableSource {
   #source: ISerializedIterableSource;
 
@@ -47,10 +49,7 @@ export class WorkerSerializedIterableSourceWorker implements ISerializedIterable
       ...args,
       abortSignal,
     });
-    return Comlink.transfer(
-      messages,
-      messages.map((msg) => msg.message.buffer),
-    );
+    return Comlink.transfer(messages, messages.map(pickTransferableBuffer));
   }
 
   public getMessageCursor(

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
@@ -43,10 +43,14 @@ export class WorkerSerializedIterableSourceWorker implements ISerializedIterable
     // clonable (and needs to signal across the worker boundary)
     abortSignal?: AbortSignal,
   ): Promise<MessageEvent<Uint8Array>[]> {
-    return await this.#source.getBackfillMessages({
+    const messages = await this.#source.getBackfillMessages({
       ...args,
       abortSignal,
     });
+    return Comlink.transfer(
+      messages,
+      messages.map((msg) => msg.message.buffer),
+    );
   }
 
   public getMessageCursor(


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Small performance optimization when retrieving raw (serialized) back fill messages from the worker. Rather than copying, array buffers are now transferred.
