### PR TITLE
Call terminate on the buffered source to clear its caches when closing the player

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -1106,6 +1106,7 @@ export class IterablePlayer implements Player {
     await this.#blockLoader?.stopLoading();
     await this.#blockLoadingProcess;
     await this.#bufferImpl.stopProducer();
+    await this.#bufferImpl.terminate();
     await this.#bufferedSource.terminate?.();
     await this.#playbackIterator?.return?.();
     this.#playbackIterator = undefined;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- mitigate memory leak when selecting a new source

**Description**

Calls `terminate` on the `BufferedIterableSource` when closing the player, so that it can clear its child caches. This is important to do because the previous player remains in react state after a new source is selected. It is difficult to fix this more directly, so in the meantime its important for the footprint of that previous player to be as small as possible. 


<!-- link relevant GitHub issues -->
Partially addresses FG-6539
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
