### PR TITLE
Make `terminate` call `stopProducer`

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -207,7 +207,9 @@ class BufferedIterableSource<MessageType = unknown>
     log.debug("producer done");
   }
 
+  /** Calls stopProducer, clears cache, and terminates sources */
   public async terminate(): Promise<void> {
+    await this.stopProducer();
     this.#cache.clear();
     this.#source.removeAllListeners("loadedRangesChange");
     await this.#source.terminate();

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -1109,7 +1109,6 @@ export class IterablePlayer implements Player {
     this.#isPlaying = false;
     await this.#blockLoader?.stopLoading();
     await this.#blockLoadingProcess;
-    await this.#bufferImpl.stopProducer();
     await this.#bufferImpl.terminate();
     await this.#bufferedSource.terminate?.();
     await this.#playbackIterator?.return?.();


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
n/a
**Description**

Followup from #7560 feedback. Add `stopProducer` to `terminate` and remove `stopProducer` from `stateClose`. 


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
