### PR TITLE
Reduce max. buffer size from 2G to 600MB

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -200,10 +200,10 @@ export class IterablePlayer implements Player {
       this.#bufferImpl = new BufferedIterableSource(source);
       this.#bufferedSource = new DeserializedSourceWrapper(this.#bufferImpl);
     } else {
-      const GIGABYTE_IN_BYTES = 1024 * 1024 * 1024;
+      const MEGABYTE_IN_BYTES = 1024 * 1024;
       const bufferInterface = new BufferedIterableSource(source, {
         readAheadDuration: { sec: 120, nsec: 0 },
-        maxCacheSizeBytes: 2 * GIGABYTE_IN_BYTES,
+        maxCacheSizeBytes: 600 * MEGABYTE_IN_BYTES,
       });
       this.#bufferImpl = bufferInterface;
       this.#bufferedSource = new DeserializingIterableSource(bufferInterface);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Reverts the max. buffered size to 600 MB. We have seen [issues with Chrome on Linux](https://issues.chromium.org/u/1/issues/324519298) where allocation of Uint8Arrays can cause the app to crash. Reducing the max. buffered size mitigates these issues.