### PR TITLE
Use different buffer ahead duration for local / remote sources

### DIFF
--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -41,6 +41,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
       source,
       name: file.name,
       sourceId: this.id,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
   }
 }

--- a/packages/studio-base/src/dataSources/RemoteDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RemoteDataSourceFactory.tsx
@@ -104,6 +104,7 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
       // Use blank url params so the data source is set in the url
       urlParams: { url },
       sourceId: this.id,
+      readAheadDuration: { sec: 10, nsec: 0 },
     });
   }
 

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
@@ -43,6 +43,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
       source,
       name: file.name,
       sourceId: this.id,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
@@ -46,6 +46,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
       source,
       name,
       sourceId: this.id,
+      readAheadDuration: { sec: 120, nsec: 0 },
     });
   }
 }

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -45,6 +45,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
       // Use blank url params so the data source is set in the url
       urlParams: {},
       sourceId: this.id,
+      readAheadDuration: { sec: 10, nsec: 0 },
     });
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -97,6 +97,9 @@ type IterablePlayerOptions = {
 
   // Set to _false_ to disable preloading. (default: true)
   enablePreload?: boolean;
+
+  // Max. time that messages will be buffered ahead for smoother playback. (default: 10sec)
+  readAheadDuration?: Time;
 };
 
 type IterablePlayerState =
@@ -195,7 +198,15 @@ export class IterablePlayer implements Player {
   #resolveIsClosed: () => void = () => {};
 
   public constructor(options: IterablePlayerOptions) {
-    const { metricsCollector, urlParams, source, name, enablePreload, sourceId } = options;
+    const {
+      metricsCollector,
+      urlParams,
+      source,
+      name,
+      enablePreload,
+      sourceId,
+      readAheadDuration = { sec: 10, nsec: 0 },
+    } = options;
 
     this.#iterableSource = source;
     if (source.sourceType === "deserialized") {
@@ -204,7 +215,7 @@ export class IterablePlayer implements Player {
     } else {
       const MEGABYTE_IN_BYTES = 1024 * 1024;
       const bufferInterface = new BufferedIterableSource(source, {
-        readAheadDuration: { sec: 120, nsec: 0 },
+        readAheadDuration,
         maxCacheSizeBytes: 600 * MEGABYTE_IN_BYTES,
       });
       this.#bufferImpl = bufferInterface;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Limits the read ahead duration for buffering messages to
- 10 seconds for remote sources
- 120 seconds for local files

For remote sources it is much shorter to avoid lots of data being downloaded which might potentially never be used.