### PR TITLE
Move CompatibilityBanner into StudioApp

### DIFF
--- a/packages/studio-base/src/StudioApp.tsx
+++ b/packages/studio-base/src/StudioApp.tsx
@@ -6,6 +6,7 @@ import { Fragment, Suspense, useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
+import { CompatibilityBanner } from "@foxglove/studio-base/components/CompatibilityBanner";
 import { useSharedRootContext } from "@foxglove/studio-base/context/SharedRootContext";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 import ProblemsContextProvider from "@foxglove/studio-base/providers/ProblemsContextProvider";
@@ -75,6 +76,7 @@ export function StudioApp(): JSX.Element {
 
   return (
     <MaybeLaunchPreference>
+      <CompatibilityBanner isDismissable />
       <MultiProvider providers={providers}>
         <DocumentTitleAdapter />
         <SendNotificationToastAdapter />

--- a/packages/studio-base/src/components/CompatibilityBanner.stories.tsx
+++ b/packages/studio-base/src/components/CompatibilityBanner.stories.tsx
@@ -13,13 +13,15 @@ export default {
 
 export const OldChrome: StoryObj = {
   render: () => {
-    return <CompatibilityBanner isChrome currentVersion={42} isDismissable />;
+    return <CompatibilityBanner overrideIsChrome overrideCurrentVersion={42} isDismissable />;
   },
 };
 
 export const UnsupportedBrowser: StoryObj = {
   render: () => {
-    return <CompatibilityBanner isChrome={false} currentVersion={42} isDismissable />;
+    return (
+      <CompatibilityBanner overrideIsChrome={false} overrideCurrentVersion={42} isDismissable />
+    );
   },
 };
 
@@ -27,7 +29,11 @@ export const Undismissable: StoryObj = {
   render: () => {
     return (
       <div style={{ height: "100vh" }}>
-        <CompatibilityBanner isChrome={false} currentVersion={42} isDismissable={false} />
+        <CompatibilityBanner
+          overrideIsChrome={false}
+          overrideCurrentVersion={42}
+          isDismissable={false}
+        />
       </div>
     );
   },

--- a/packages/studio-base/src/components/CompatibilityBanner.tsx
+++ b/packages/studio-base/src/components/CompatibilityBanner.tsx
@@ -144,20 +144,27 @@ function CompatibilityBannerBase({
 }
 
 export function CompatibilityBanner({
-  isChrome,
-  currentVersion,
+  overrideIsChrome,
+  overrideCurrentVersion,
   isDismissable,
 }: {
-  isChrome: boolean;
-  currentVersion: number;
   isDismissable: boolean;
+  /** For stories */
+  overrideIsChrome?: boolean;
+  /** For stories */
+  overrideCurrentVersion?: number;
 }): JSX.Element | ReactNull {
+  const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)\./);
+  const chromeVersion =
+    overrideCurrentVersion ?? (chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0);
+  const isChrome = overrideIsChrome ?? chromeVersion !== 0;
+
   const { classes } = useStyles();
   const { i18n } = useTranslation();
   const muiTheme = createMuiTheme("dark", i18n.language);
   const [showBanner, setShowBanner] = useState(true);
 
-  if (!showBanner || currentVersion >= MINIMUM_CHROME_VERSION) {
+  if (!showBanner || chromeVersion >= MINIMUM_CHROME_VERSION) {
     return ReactNull;
   }
 

--- a/packages/studio-web/package.json
+++ b/packages/studio-web/package.json
@@ -7,21 +7,16 @@
     "@foxglove/studio-base": "workspace:*"
   },
   "devDependencies": {
-    "@fluentui/react-icons": "2.0.226",
     "@foxglove/log": "workspace:*",
     "@foxglove/theme": "workspace:*",
     "@foxglove/tsconfig": "2.0.0",
-    "@mui/material": "5.15.6",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
-    "@storybook/react": "7.6.12",
     "@types/copy-webpack-plugin": "10.1.0",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "11.0.0",
     "html-webpack-plugin": "5.6.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-i18next": "14.0.1",
-    "tss-react": "4.9.3",
     "webpack": "5.90.1",
     "webpack-dev-server": "4.15.1"
   }

--- a/packages/studio-web/src/index.tsx
+++ b/packages/studio-web/src/index.tsx
@@ -7,9 +7,9 @@ import ReactDOM from "react-dom";
 
 import Logger from "@foxglove/log";
 import type { IDataSourceFactory } from "@foxglove/studio-base";
+import { CompatibilityBanner } from "@foxglove/studio-base/components/CompatibilityBanner";
 import CssBaseline from "@foxglove/studio-base/components/CssBaseline";
 
-import { CompatibilityBanner } from "./CompatibilityBanner";
 import { canRenderApp } from "./canRenderApp";
 
 const log = Logger.getLogger(__filename);
@@ -41,18 +41,8 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
     throw new Error("missing #root element");
   }
 
-  const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)\./);
-  const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
-  const isChrome = chromeVersion !== 0;
-
   const canRender = canRenderApp();
-  const banner = (
-    <CompatibilityBanner
-      isChrome={isChrome}
-      currentVersion={chromeVersion}
-      isDismissable={canRender}
-    />
-  );
+  const banner = <CompatibilityBanner isDismissable={canRender} />;
 
   if (!canRender) {
     // eslint-disable-next-line react/no-deprecated
@@ -88,10 +78,7 @@ export async function main(getParams: () => Promise<MainParams> = async () => ({
   // eslint-disable-next-line react/no-deprecated
   ReactDOM.render(
     <StrictMode>
-      <LogAfterRender>
-        {banner}
-        {rootElement}
-      </LogAfterRender>
+      <LogAfterRender>{rootElement}</LogAfterRender>
     </StrictMode>,
     rootEl,
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2667,22 +2667,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/studio-web@workspace:packages/studio-web"
   dependencies:
-    "@fluentui/react-icons": 2.0.226
     "@foxglove/log": "workspace:*"
     "@foxglove/studio-base": "workspace:*"
     "@foxglove/theme": "workspace:*"
     "@foxglove/tsconfig": 2.0.0
-    "@mui/material": 5.15.6
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.11
-    "@storybook/react": 7.6.12
     "@types/copy-webpack-plugin": 10.1.0
     clean-webpack-plugin: 4.0.0
     copy-webpack-plugin: 11.0.0
     html-webpack-plugin: 5.6.0
     react: 18.2.0
     react-dom: 18.2.0
-    react-i18next: 14.0.1
-    tss-react: 4.9.3
     webpack: 5.90.1
     webpack-dev-server: 4.15.1
   languageName: unknown


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Move the banner into StudioApp so that it is scoped to the StudioApp instead of rendering outside the whole WebRoot.

Resolves FG-5687