### PR TITLE
Propagate Plot worker errors to React

### DIFF
--- a/packages/studio-base/src/panels/Plot/OffscreenCanvasRenderer.ts
+++ b/packages/studio-base/src/panels/Plot/OffscreenCanvasRenderer.ts
@@ -24,13 +24,23 @@ export class OffscreenCanvasRenderer {
 
   #theme: Theme;
 
-  public constructor(canvas: OffscreenCanvas, theme: Theme) {
+  public constructor(
+    canvas: OffscreenCanvas,
+    theme: Theme,
+    { handleWorkerError }: { handleWorkerError?: (event: Event) => void } = {},
+  ) {
     this.#theme = theme;
     this.#canvas = canvas;
     const worker = new Worker(
       // foxglove-depcheck-used: babel-plugin-transform-import-meta
       new URL("./ChartRenderer.worker", import.meta.url),
     );
+    worker.onerror = (event) => {
+      handleWorkerError?.(event);
+    };
+    worker.onmessageerror = (event) => {
+      handleWorkerError?.(event);
+    };
 
     const { remote, dispose } = ComlinkWrap<Service<Comlink.RemoteObject<ChartRenderer>>>(worker);
 

--- a/packages/studio-base/src/panels/Plot/Plot.tsx
+++ b/packages/studio-base/src/panels/Plot/Plot.tsx
@@ -261,6 +261,7 @@ export function Plot(props: Props): JSX.Element {
     return unsub;
   }, [coordinator, getMessagePipelineState, subscribeMessagePipeline]);
 
+  // Crash the panel when a worker fails to load or encounters an error
   const handleWorkerError = useRethrow(
     useCallback((_err: Event) => {
       throw new Error(`Error encountered in plot worker`);

--- a/packages/studio-base/src/panels/Plot/Plot.tsx
+++ b/packages/studio-base/src/panels/Plot/Plot.tsx
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { debouncePromise } from "@foxglove/den/async";
 import { filterMap } from "@foxglove/den/collection";
+import { useRethrow } from "@foxglove/hooks";
 import { parseMessagePath } from "@foxglove/message-path";
 import { add as addTimes, fromSec, isTime, toSec } from "@foxglove/rostime";
 import { Immutable } from "@foxglove/studio";
@@ -260,14 +261,20 @@ export function Plot(props: Props): JSX.Element {
     return unsub;
   }, [coordinator, getMessagePipelineState, subscribeMessagePipeline]);
 
+  const handleWorkerError = useRethrow(
+    useCallback((_err: Event) => {
+      throw new Error(`Error encountered in plot worker`);
+    }, []),
+  );
+
   const datasetsBuilder = useMemo(() => {
     switch (xAxisMode) {
       case "timestamp":
-        return new TimestampDatasetsBuilder();
+        return new TimestampDatasetsBuilder({ handleWorkerError });
       case "index":
         return new IndexDatasetsBuilder();
       case "custom":
-        return new CustomDatasetsBuilder();
+        return new CustomDatasetsBuilder({ handleWorkerError });
       case "currentCustom":
         return new CurrentCustomDatasetsBuilder();
       default:
@@ -275,7 +282,7 @@ export function Plot(props: Props): JSX.Element {
     }
 
     return undefined;
-  }, [xAxisMode]);
+  }, [xAxisMode, handleWorkerError]);
 
   useEffect(() => {
     if (
@@ -314,12 +321,12 @@ export function Plot(props: Props): JSX.Element {
     canvasDiv.appendChild(canvas);
 
     const offscreenCanvas = canvas.transferControlToOffscreen();
-    setRenderer(new OffscreenCanvasRenderer(offscreenCanvas, theme));
+    setRenderer(new OffscreenCanvasRenderer(offscreenCanvas, theme, { handleWorkerError }));
 
     return () => {
       canvasDiv.removeChild(canvas);
     };
-  }, [canvasDiv, theme]);
+  }, [canvasDiv, theme, handleWorkerError]);
 
   useEffect(() => {
     if (!renderer || !datasetsBuilder || !canvasDiv) {

--- a/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/CustomDatasetsBuilder.ts
@@ -54,11 +54,17 @@ export class CustomDatasetsBuilder implements IDatasetsBuilder {
   #xCurrentBounds?: Bounds1D;
   #xFullBounds?: Bounds1D;
 
-  public constructor() {
+  public constructor({ handleWorkerError }: { handleWorkerError?: (event: Event) => void } = {}) {
     const worker = new Worker(
       // foxglove-depcheck-used: babel-plugin-transform-import-meta
       new URL("./CustomDatasetsBuilderImpl.worker", import.meta.url),
     );
+    worker.onerror = (event) => {
+      handleWorkerError?.(event);
+    };
+    worker.onmessageerror = (event) => {
+      handleWorkerError?.(event);
+    };
     const { remote, dispose } =
       ComlinkWrap<Comlink.RemoteObject<CustomDatasetsBuilderImpl>>(worker);
 

--- a/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
+++ b/packages/studio-base/src/panels/Plot/builders/TimestampDatasetsBuilder.ts
@@ -58,11 +58,17 @@ export class TimestampDatasetsBuilder implements IDatasetsBuilder {
 
   #series: Immutable<TimestampSeriesItem[]> = [];
 
-  public constructor() {
+  public constructor({ handleWorkerError }: { handleWorkerError?: (event: Event) => void } = {}) {
     const worker = new Worker(
       // foxglove-depcheck-used: babel-plugin-transform-import-meta
       new URL("./TimestampDatasetsBuilderImpl.worker", import.meta.url),
     );
+    worker.onerror = (event) => {
+      handleWorkerError?.(event);
+    };
+    worker.onmessageerror = (event) => {
+      handleWorkerError?.(event);
+    };
     const { remote, dispose } =
       ComlinkWrap<Comlink.RemoteObject<TimestampDatasetsBuilderImpl>>(worker);
     this.#datasetsBuilderRemote = remote;


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out

**Description**
Instead of silently failing with an error in the console, propagate worker errors to the React layer so they can crash the panel:

<img width="1092" alt="Screenshot 2024-02-13 at 3 26 22 PM" src="https://github.com/foxglove/studio/assets/14237/3de9bcc7-8d20-40c1-8203-a9a4c6a70562">
