### PR TITLE
Disable font-smoothing settings from MUI CssBaseline

### DIFF
--- a/packages/theme/src/components/MuiCssBaseline.ts
+++ b/packages/theme/src/components/MuiCssBaseline.ts
@@ -6,6 +6,10 @@ import { OverrideComponentReturn } from "../types";
 
 export const MuiCssBaseline: OverrideComponentReturn<"MuiCssBaseline"> = {
   styleOverrides: (theme) => ({
+    html: {
+      WebkitFontSmoothing: "unset",
+      MozOsxFontSmoothing: "unset",
+    },
     svg: {
       display: "block",
       maxWidth: "100%",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Use system default font smoothing settings rather than overriding them as MUI does.

This only affects places where we use the `<CssBaseline/>` from MUI (in the internal repo).

Before | After
--- | ---
<img width="219" alt="image" src="https://github.com/foxglove/studio/assets/14237/6e8b0d54-85ec-4719-81ea-79d98921d5c6"> | <img width="218" alt="image" src="https://github.com/foxglove/studio/assets/14237/bea36c36-56ad-4e14-bf03-0713c3134792">
