### PR TITLE
Use deep merge for workspace persistence

### DIFF
--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -77,6 +77,8 @@ function createWorkspaceContextStore(
         return _.pick(state, ["featureTours", "playbackControls", "sidebars"]);
       },
       merge(persistedState, currentState) {
+        // Use a deep merge to ensure that defaults are filled in for nested values if the values
+        // were not present in localStorage.
         return _.merge(currentState, persistedState);
       },
     }),

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -76,6 +76,9 @@ function createWorkspaceContextStore(
         // include and restore when persisting to and from localStorage.
         return _.pick(state, ["featureTours", "playbackControls", "sidebars"]);
       },
+      merge(persistedState, currentState) {
+        return _.merge(currentState, persistedState);
+      },
     }),
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Relates to https://github.com/foxglove/studio/pull/7443. I noticed that sometimes I would get an `undefined` value for speed, which led to this problem:
<img width="585" alt="image" src="https://github.com/foxglove/studio/assets/14237/c37da1b6-00e2-4894-b388-f086000f90ee">

You could reproduce this by editing the local storage value to have `"playbackControls":{"repeat":false}`.

This deep merge should result in using the default 1.0 if the speed was not present in local storage. (if I am using zustand correctly...)