### PR TITLE
Move state transition bar down to avoid legend

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -231,8 +231,8 @@ function StateTransitions(props: Props) {
     paths.forEach((path, pathIndex) => {
       // y axis values are set based on the path we are rendering
       // negative makes each path render below the previous
-      const y = (pathIndex + 1) * 6 * -1;
-      outMinY = Math.min(outMinY ?? y, y - 3);
+      const y = (pathIndex + 1) * 6 * -3;
+      outMinY = Math.min(outMinY ?? y, y - 5);
 
       const blocksForPath = decodedBlocks.map((decodedBlock) => decodedBlock[path.value]);
 


### PR DESCRIPTION
**User-Facing Changes**
![Screenshot 2024-02-14 at 14 57 28](https://github.com/foxglove/studio/assets/924528/f4831f9d-5467-4370-92dc-5d7cb79a23b9)

**Description**
Offset state transition bar to avoid legend overlap.
