### PR TITLE
fix: Synchronize state color and props color

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -175,6 +175,12 @@ export function useColorPickerControl(props: ColorPickerProps) {
     setEditedValue(hex ?? "");
   }, [hex]);
 
+
+  // Synchronize props and state
+  if (hex !== editedValue) {
+    setEditedValue(hex!);
+  }
+
   return {
     alphaType,
     swatchColor,


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**

Click the Clear color button. The color value remains unchanged The local status is not synchronized with the external status
Before repair:

[scrnli_2024_2_22 10-35-40.webm](https://github.com/foxglove/studio/assets/70568691/cb999fe1-a6a0-4b48-9809-6601a42494de)

After restoration:

[scrnli_2024_2_22 10-36-33.webm](https://github.com/foxglove/studio/assets/70568691/3e4df779-03e8-40ca-b5e4-ee36451697f7)


Repair scheme:
![image](https://github.com/foxglove/studio/assets/70568691/24f8084f-ccea-497d-8aba-2ba8099f3fe0)
<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
