### PR TITLE
fix: Sync props color to state

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -11,6 +11,7 @@ import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
 
 import Stack from "@foxglove/studio-base/components/Stack";
+import * as _ from "lodash-es";
 
 const useStyles = makeStyles()((theme) => ({
   picker: {
@@ -174,6 +175,11 @@ export function useColorPickerControl(props: ColorPickerProps) {
   const onInputBlur = useCallback(() => {
     setEditedValue(hex ?? "");
   }, [hex]);
+
+  // Synchronize props and state
+  if (hex !== editedValue && _.isString(hex)) {
+    setEditedValue(hex);
+  }
 
   return {
     alphaType,

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -4,6 +4,7 @@
 
 import TagIcon from "@mui/icons-material/Tag";
 import { TextField } from "@mui/material";
+import * as _ from "lodash-es";
 import { useCallback, useState, useMemo } from "react";
 import { HexAlphaColorPicker, HexColorPicker } from "react-colorful";
 import tinycolor from "tinycolor2";
@@ -11,7 +12,6 @@ import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
 
 import Stack from "@foxglove/studio-base/components/Stack";
-import * as _ from "lodash-es";
 
 const useStyles = makeStyles()((theme) => ({
   picker: {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
Click the Clear color button. The color value remains unchanged The local status is not synchronized with the external status
Before repair:

https://github.com/foxglove/studio/assets/70568691/27e3a712-7bcb-40c8-b0c6-d109637d640c


After restoration:


https://github.com/foxglove/studio/assets/70568691/77a50333-74e4-4c33-a336-25b2002ffa57




**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
