### PR TITLE
fix: Don't process markers in hidden namespaces

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -166,9 +166,8 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     }
 
     const topicSettings = this.renderer.config.topics[this.topic] as
-      | LayerSettingsMarker
+      | Partial<LayerSettingsMarker>
       | undefined;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const nsSettings = topicSettings?.namespaces?.[marker.ns];
     if (nsSettings?.visible === false) {
       return;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -165,6 +165,13 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
       renderable = undefined;
     }
 
+    const nsSettings = (this.renderer.config.topics[this.topic] as LayerSettingsMarker).namespaces[
+      marker.ns
+    ];
+    if (nsSettings?.visible === false) {
+      return;
+    }
+
     if (!renderable) {
       renderable = this.#createMarkerRenderable(marker, receiveTime);
       if (!renderable) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -165,9 +165,11 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
       renderable = undefined;
     }
 
-    const nsSettings = (this.renderer.config.topics[this.topic] as LayerSettingsMarker).namespaces[
-      marker.ns
-    ];
+    const topicSettings = this.renderer.config.topics[this.topic] as
+      | LayerSettingsMarker
+      | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const nsSettings = topicSettings?.namespaces?.[marker.ns];
     if (nsSettings?.visible === false) {
       return;
     }


### PR DESCRIPTION
Skip processing markers in hidden namespaces to improve 3D panel performance